### PR TITLE
Fix telemetry project ID generation, fix CI pylint step

### DIFF
--- a/.gitlab/ci/test.gitlab-ci.yml
+++ b/.gitlab/ci/test.gitlab-ci.yml
@@ -27,12 +27,11 @@ lint_python:
       - PYTHON_IMAGE_VERSION: ["3.8"]
   before_script: []
   script:
-    - git remote add meltano https://gitlab.com/meltano/meltano.git || return 0
+    - git remote add meltano https://github.com/meltano/meltano.git || return 0
     - |
-      git fetch meltano $CI_DEFAULT_BRANCH;
-      echo "Comparing to $CI_DEFAULT_BRANCH";
-      REF="meltano/${CI_DEFAULT_BRANCH}";
-    - 'declare FILES=$(git diff --name-only ${CI_COMMIT_SHA} $REF | grep "\.py$")'
+      git fetch meltano main;
+      echo "Comparing to main";
+    - 'declare FILES=$(git diff --name-only ${CI_COMMIT_SHA} meltano/main | grep "\.py$")'
     - |
       if [ -n "${FILES}" ]; then
         echo "Changed files are\n$FILES";

--- a/src/meltano/core/tracking/ga_tracker.py
+++ b/src/meltano/core/tracking/ga_tracker.py
@@ -81,9 +81,16 @@ class GoogleAnalyticsTracker:  # noqa: WPS214, WPS230
             The project_id.
         """
         project_id_str = self.settings_service.get("project_id")
-        try:
-            project_id = uuid.UUID(project_id_str or "", version=4)
-        except ValueError:
+        if project_id_str:
+            try:
+                # Project ID might already be a UUID
+                project_id = uuid.UUID(project_id_str)
+            except ValueError:
+                # If the project ID is not a UUID, then we hash it, and use the hash to make a UUID
+                project_id = uuid.UUID(
+                    hashlib.sha256(project_id_str.encode()).hexdigest()[::2]
+                )
+        else:
             project_id = uuid.uuid4()
 
             if self.send_anonymous_usage_stats:


### PR DESCRIPTION
Closes #3418
Closes #5960

This does not [specify the `project_id_source` as discussed here](https://gitlab.com/meltano/meltano/-/issues/3502#note_961726807) - that will come later, after Google Analytics has been removed.