### PR TITLE
Add assign action for Product Roadmap

### DIFF
--- a/.github/workflows/assign-to-projects.yml
+++ b/.github/workflows/assign-to-projects.yml
@@ -6,7 +6,8 @@ on:
   pull_request_target:
     types: [opened]
 env:
-  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
 jobs:
   assign_one_project:

--- a/.github/workflows/assign-to-projects.yml
+++ b/.github/workflows/assign-to-projects.yml
@@ -8,7 +8,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest

--- a/.github/workflows/assign-to-projects.yml
+++ b/.github/workflows/assign-to-projects.yml
@@ -1,0 +1,20 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to Product Roadmap Project
+    steps:
+    - name: Assign NEW issues and NEW pull requests to Product Roadmap
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/meltano/projects/4/'


### PR DESCRIPTION
This PR adds the https://github.com/marketplace/actions/assign-to-one-project GitHub action to assign all new PRs and Issues to the Product Roadmap project https://github.com/orgs/meltano/projects/4/views/2