### PR TITLE
fix: Remove lock files using glob expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 
+- [#5979](https://github.com/meltano/meltano/issues/5979) Fixes `meltano remove` bug where lock files were not removed if they include a variant in the file name.
+
 ### Breaks
 
 

--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -600,6 +600,7 @@ Specifically, [plugins](/concepts/plugins#project-plugins) will be removed from 
 - [`meltano.yml` project file](/concepts/project)
 - Installation found in the [`.meltano` directory](/concepts/project#meltano-directory) under `.meltano/<plugin_type>/<plugin_name>`
 - `plugin_settings` table in the [system database](/concepts/project#system-database)
+- `./plugins/<plugin type>/` lock file directory
 
 ### How to Use
 

--- a/src/meltano/core/plugin_location_remove.py
+++ b/src/meltano/core/plugin_location_remove.py
@@ -146,7 +146,10 @@ class LockedDefinitionRemoveManager(PluginLocationRemoveManager):
         """
         lockfile_dir = project.root_plugins_dir(plugin.type)
         glob_expr = f"{plugin.name}*.lock"
-        super().__init__(plugin, str(lockfile_dir / glob_expr))
+        super().__init__(
+            plugin,
+            str(lockfile_dir.relative_to(project.root).joinpath(glob_expr)),
+        )
 
         self.paths = list(lockfile_dir.glob(glob_expr))
 

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -89,6 +89,14 @@ class TestPluginRemoveService:
                 subject.project.meltano_dir().joinpath(plugin.type, plugin.name)
             )
 
+            # check removed lock files
+            lock_file_paths = list(
+                subject.project.root_plugins_dir(plugin.type).glob(
+                    f"{plugin.name}*.lock"
+                )
+            )
+            assert all(not path.exists() for path in lock_file_paths)
+
     def test_remove_not_added_or_installed(self, subject: PluginRemoveService):
         plugins = list(subject.plugins_service.plugins())
         removed_plugins, total_plugins = subject.remove_plugins(plugins)


### PR DESCRIPTION
Install this version

```bash
pipx install \
    --force \
    --suffix="@5979" \
    --python=python3.9 \
    'meltano @ git+https://github.com/meltano/meltano.git@5979-meltano-remove-lock-file-bug'
```

Try it out

```bash
$ export MELTANO_FF_LOCK_FILES=1
$ meltano@5979 add extractor tap-stackexchange
...

$ meltano@5979 remove extractor tap-stackexchange
2022-06-02T16:20:15.641835Z [info     ] Environment 'dev' is active

Removing extractor 'tap-stackexchange'...

Reset extractor 'tap-stackexchange' plugin settings in the system database
Removed extractor 'tap-stackexchange' from meltano.yml
Removed extractor 'tap-stackexchange' from .meltano/extractors
Removed extractor 'tap-stackexchange' from /Users/edgarramirez/edgar/meltano-dataops/plugins/extractors/tap-stackexchange*.lock
```

Closes #5979 