### PR TITLE
Basic GitHub CI with pytest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/.github/workflows"
+    schedule:
+      interval: daily
+      time: "12:00"
+      timezone: "UTC"
+    reviewers: [meltano-engineering]
+    labels: [deps]
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers: [meltano-engineering]
+    labels: [deps]

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,0 +1,3 @@
+pip==22.1.2
+poetry==1.1.13
+virtualenv==20.14.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,6 @@ jobs:
         - { tox-env: py, python-version: "3.7", os: "ubuntu-latest" }
         - { tox-env: py, python-version: "3.8", os: "ubuntu-latest" }
         - { tox-env: py, python-version: "3.9", os: "ubuntu-latest" }
-        - { tox-env: py, python-version: "3.10", os: "ubuntu-latest" }
-        - { tox-env: py, python-version: "3.10", os: "ubuntu-latest", external: true }
-        - { tox-env: doctest, python-version: "3.10", os: "ubuntu-latest" }
         - { tox-env: lint, python-version: "3.8", os: "ubuntu-latest" }
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,9 @@ jobs:
       run: |
         poetry run coverage run --parallel -m pytest -m "$PYTEST_MARKERS"
 
-    # Note: coverage files not found: https://github.com/meltano/meltano/issues/5989
     - name: Upload coverage data
       if: always() && (matrix.python-version == '3.9')
       uses: actions/upload-artifact@v3.1.0
       with:
-        name: coverage-data
+        name: coverage-data-"${{ matrix.python-version }}"
         path: ".coverage.*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     name: Pytest on py${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:
-      PYTEST_MARKERS: concurrent
+      PYTEST_MARKERS: not concurrent
 
     steps:
     - name: Check out the repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,53 +56,10 @@ jobs:
       run: |
         poetry run pytest -v --cov-report= --cov meltano -m "$PYTEST_MARKERS"
 
+    # Note: coverage files not found: https://github.com/meltano/meltano/issues/5989
     - name: Upload coverage data
       if: always() && (matrix.python-version == '3.9')
       uses: actions/upload-artifact@v3.1.0
       with:
         name: coverage-data
         path: ".coverage.*"
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs: tests
-    steps:
-    - name: Check out the repository
-      uses: actions/checkout@v3.0.2
-
-    - name: Install Poetry
-      run: |
-        pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
-        poetry --version
-
-    - name: Set up Python
-      uses: actions/setup-python@v3.1.2
-      with:
-        python-version: '3.10'
-        cache: 'poetry'
-
-    - name: Upgrade pip
-      run: |
-        pip install --constraint=.github/workflows/constraints.txt pip
-        pip --version
-
-    - name: Download coverage data
-      uses: actions/download-artifact@v3.0.0
-      with:
-        name: coverage-data
-
-    - name: Install Dependencies
-      run: |
-        poetry env use "3.10"
-        poetry install
-
-    - name: Combine coverage data and display human readable report
-      run: |
-        poetry run tox -e combine_coverage
-
-    - name: Create coverage report
-      run: |
-        poetry run tox -e coverage_xml
-
-    - name: Upload coverage report
-      uses: codecov/codecov-action@v3.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     name: Test on ${{ matrix.python-version }} (${{ matrix.tox-env }}${{ matrix.external && ', external' || '' }}) / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.external || false }}
+    env:
+      PYTEST_MARKERS: not concurrent
     strategy:
       fail-fast: false
       matrix:
@@ -19,7 +21,6 @@ jobs:
         - { tox-env: py, python-version: "3.7", os: "ubuntu-latest" }
         - { tox-env: py, python-version: "3.8", os: "ubuntu-latest" }
         - { tox-env: py, python-version: "3.9", os: "ubuntu-latest" }
-        - { tox-env: lint, python-version: "3.8", os: "ubuntu-latest" }
 
     steps:
     - name: Check out the repository
@@ -51,9 +52,9 @@ jobs:
         poetry env use "${{ matrix.python-version }}"
         poetry install
 
-    - name: Run tox
+    - name: Run pytest
       run: |
-        poetry run tox -e ${{ matrix.tox-env }} --${{ matrix.external && ' -m "external"' || '' }}${{ matrix.doctest && ' --doctest-modules singer_sdk' }}
+        poetry run pytest -v --cov-report= --cov meltano -m "$PYTEST_MARKERS"
 
     - name: Upload coverage data
       if: always() && (matrix.tox-env == 'py')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,110 @@
+name: Test
+
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  tests:
+    name: Test on ${{ matrix.python-version }} (${{ matrix.tox-env }}${{ matrix.external && ', external' || '' }}) / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.external || false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { tox-env: py, python-version: "3.7", os: "ubuntu-latest" }
+        - { tox-env: py, python-version: "3.8", os: "ubuntu-latest" }
+        - { tox-env: py, python-version: "3.9", os: "ubuntu-latest" }
+        - { tox-env: py, python-version: "3.10", os: "ubuntu-latest" }
+        - { tox-env: py, python-version: "3.10", os: "ubuntu-latest", external: true }
+        - { tox-env: doctest, python-version: "3.10", os: "ubuntu-latest" }
+        - { tox-env: lint, python-version: "3.8", os: "ubuntu-latest" }
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v3.0.2
+
+    - name: Install Poetry
+      env:
+        PIP_CONSTRAINT: .github/workflows/constraints.txt
+      run: |
+        pipx install poetry
+        poetry --version
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3.1.2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+        cache: 'poetry'
+
+    - name: Upgrade pip
+      env:
+        PIP_CONSTRAINT: .github/workflows/constraints.txt
+      run: |
+        pip install pip
+        pip --version
+
+    - name: Install Dependencies
+      run: |
+        poetry env use "${{ matrix.python-version }}"
+        poetry install
+
+    - name: Run tox
+      run: |
+        poetry run tox -e ${{ matrix.tox-env }} --${{ matrix.external && ' -m "external"' || '' }}${{ matrix.doctest && ' --doctest-modules singer_sdk' }}
+
+    - name: Upload coverage data
+      if: always() && (matrix.tox-env == 'py')
+      uses: actions/upload-artifact@v3.1.0
+      with:
+        name: coverage-data
+        path: ".coverage.*"
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v3.0.2
+
+    - name: Install Poetry
+      run: |
+        pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+        poetry --version
+
+    - name: Set up Python
+      uses: actions/setup-python@v3.1.2
+      with:
+        python-version: '3.10'
+        cache: 'poetry'
+
+    - name: Upgrade pip
+      run: |
+        pip install --constraint=.github/workflows/constraints.txt pip
+        pip --version
+
+    - name: Download coverage data
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: coverage-data
+
+    - name: Install Dependencies
+      run: |
+        poetry env use "3.10"
+        poetry install
+
+    - name: Combine coverage data and display human readable report
+      run: |
+        poetry run tox -e combine_coverage
+
+    - name: Create coverage report
+      run: |
+        poetry run tox -e coverage_xml
+
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v3.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Run pytest
       run: |
-        poetry run pytest -v --cov-report= --cov meltano -m "$PYTEST_MARKERS"
+        poetry run coverage run --parallel -m pytest -m "$PYTEST_MARKERS"
 
     # Note: coverage files not found: https://github.com/meltano/meltano/issues/5989
     - name: Upload coverage data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,5 @@ jobs:
       if: always() && (matrix.python-version == '3.9')
       uses: actions/upload-artifact@v3.1.0
       with:
-        name: coverage-data-"${{ matrix.python-version }}"
+        name: coverage-data
         path: ".coverage.*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,18 @@ on:
 
 jobs:
   tests:
-    name: Pytest on py${{ matrix.python-version }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.external || false }}
-    env:
-      PYTEST_MARKERS: not concurrent
     strategy:
-      fail-fast: false
       matrix:
         include:
         - { python-version: "3.7", os: "ubuntu-latest" }
         - { python-version: "3.8", os: "ubuntu-latest" }
         - { python-version: "3.9", os: "ubuntu-latest" }
+      fail-fast: false
+
+    name: Pytest on py${{ matrix.python-version }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    env:
+      PYTEST_MARKERS: concurrent
 
     steps:
     - name: Check out the repository
@@ -57,7 +57,7 @@ jobs:
         poetry run pytest -v --cov-report= --cov meltano -m "$PYTEST_MARKERS"
 
     - name: Upload coverage data
-      if: always() && (matrix.tox-env == 'py')
+      if: always() && (matrix.python-version == '3.9')
       uses: actions/upload-artifact@v3.1.0
       with:
         name: coverage-data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    name: Test on ${{ matrix.python-version }} (${{ matrix.tox-env }}${{ matrix.external && ', external' || '' }}) / ${{ matrix.os }}
+    name: Pytest on py${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.external || false }}
     env:
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { tox-env: py, python-version: "3.7", os: "ubuntu-latest" }
-        - { tox-env: py, python-version: "3.8", os: "ubuntu-latest" }
-        - { tox-env: py, python-version: "3.9", os: "ubuntu-latest" }
+        - { python-version: "3.7", os: "ubuntu-latest" }
+        - { python-version: "3.8", os: "ubuntu-latest" }
+        - { python-version: "3.9", os: "ubuntu-latest" }
 
     steps:
     - name: Check out the repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,48 @@ jobs:
       with:
         name: coverage-data
         path: ".coverage.*"
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v3.0.2
+
+    - name: Install Poetry
+      run: |
+        pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+        poetry --version
+
+    - name: Set up Python
+      uses: actions/setup-python@v3.1.2
+      with:
+        python-version: '3.9'
+        cache: 'poetry'
+
+    - name: Upgrade pip
+      run: |
+        pip install --constraint=.github/workflows/constraints.txt pip
+        pip --version
+
+    - name: Download coverage data
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: coverage-data
+
+    - name: Install Dependencies
+      run: |
+        poetry env use "3.9"
+        poetry install
+
+    - name: Combine coverage data and display human readable report
+      run: |
+        poetry run coverage combine
+        poetry run coverage report --show-missing
+
+    - name: Create coverage report
+      run: |
+        poetry run coverage xml
+
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v3.1.0


### PR DESCRIPTION
Adapted from @edgarrmondragon's recent work on the SDK: https://github.com/meltano/sdk/pull/679

Bringing native GitHub pytest workflows, to allow us faster iteration.

- Workflow setup time (installing poetry, pip, etc.): approx. 22 secons.
- Pytest runtime: 7-10 min
- Total runtime: approx 11 min