### PR TITLE
Move GE and Sqlfluff docs to Hub

### DIFF
--- a/docs/src/_concepts/plugins.md
+++ b/docs/src/_concepts/plugins.md
@@ -754,49 +754,7 @@ export DBT__UPDATE='{"transform/dbt_project.yml": false}'
 ### Utilities
 
 If none of the other plugin types address your needs, any [pip package](https://pip.pypa.io/en/stable/) that exposes an executable can be added to your project as a utility.
-Meltano includes a selection of discoverable utilities, or you can easily add your own custom utility.
-
-#### Discoverable Utilities
-
-##### SQLFluff
-
-[SQLFluff](https://docs.sqlfluff.com/en/stable/) is a linting tool for SQL files, often used with dbt to enforce SQL code standards. From the documentation:
-
-> Bored of not having a good SQL linter that works with whichever dialect you’re working with? SQLFluff is an extensible and modular linter designed to help you write good SQL and catch errors and bad SQL before it hits your database.
-
-Install with Meltano:
-
-```bash
-meltano add utility sqlfluff
-# now try it out!
-meltano invoke sqlfluff --help
-```
-
-##### Great Expectations
-
-[Great Expectations](https://docs.greatexpectations.io/docs/) helps data teams eliminate pipeline debt, through data testing, documentation, and profiling. From the documentation:
-
-> Great Expectations is the leading tool for validating, documenting, and profiling your data to maintain quality and improve communication between teams. Head over to our [getting started](https://docs.greatexpectations.io/docs/tutorials/getting_started/intro) tutorial.
-
-Install with Meltano:
-
-```bash
-meltano add utility great_expectations
-# now try it out!
-meltano invoke great_expectations --help
-```
-
-If you are using Great Expectations to validate data in a database or warehouse, you
-might need to install the appropriate drivers. Common options are supported by Great Expectations
-as pip extras, and any additional packages you may want can be added too by configuring
-a custom `pip_url` for the `great_expectations` utility:
-
-```bash
-# set the _pip_url extra setting
-meltano config great_expectations set _pip_url "great_expectations[redshift]; awscli"
-# re-install the great_expectations plugin for changes to take effect
-meltano install utility great_expectations
-```
+Meltano has a selection of available utilities listed on [MeltanoHub](https://hub.meltano.com/utilities), or you can easily add your own custom utility.
 
 #### Custom Utilities
 


### PR DESCRIPTION
Related to https://github.com/meltano/hub/issues/253 and https://github.com/meltano/hub/pull/531

This removes these docs and puts them on the Hub (not necessary in the case of SQLfluff)