### PR TITLE
Use `MY_GITHUB_TOKEN` env var

### DIFF
--- a/.github/workflows/assign-to-projects.yml
+++ b/.github/workflows/assign-to-projects.yml
@@ -6,7 +6,7 @@ on:
   pull_request_target:
     types: [opened]
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   assign_one_project:


### PR DESCRIPTION
I think the action wants the variable to be called exactly that: https://github.com/srggrs/assign-one-project-github-action#organisation-or-user-project

Closes #5992 