### PR TITLE
ci: ignore failure on assignment failure and/or legacy jobs with 5xx errors

### DIFF
--- a/.github/workflows/assign-to-projects.yml
+++ b/.github/workflows/assign-to-projects.yml
@@ -16,5 +16,6 @@ jobs:
     - name: Assign NEW issues and NEW pull requests to Product Roadmap
       uses: srggrs/assign-one-project-github-action@1.2.1
       if: github.event.action == 'opened'
+      continue-on-error: true  # https://github.com/meltano/meltano/issues/6008
       with:
         project: 'https://github.com/orgs/meltano/projects/4/'

--- a/.gitlab/ci/sample_code.gitlab-ci.yml
+++ b/.gitlab/ci/sample_code.gitlab-ci.yml
@@ -2,6 +2,7 @@
   extends: .parallel:python_version
   stage: test
   image: python:$PYTHON_VERSION
+  allow_failure: true  # https://github.com/meltano/meltano/issues/6006
   variables:
     # `postgres` service configuration
     POSTGRES_ADDRESS: postgres


### PR DESCRIPTION
This ignores failures from `homepage_sample_code` and the other sample project that is frequently seeing `5xx` errors.

This also addressed #6008 and will continue on failure in the meanwhile, so we don't block merges.