### PR TITLE
Add hub_url setting and send X-Project-Id header

### DIFF
--- a/docs/src/_reference/settings.md
+++ b/docs/src/_reference/settings.md
@@ -42,7 +42,7 @@ By default, Meltano shares anonymous usage data with the Meltano team using Goog
 We also provide some of this data back to the community via [MeltanoHub](https://hub.meltano.com/) to help users understand the overall usage of plugins within Meltano.
 
 If enabled, Meltano will use the value of the [`project_id` setting](#project-id) to uniquely identify your project in Google Analytics.
-This project ID is also sent along when Meltano loads the remote `discovery.yml` manifest from the URL identified by the [`discovery_url` setting](#discovery-url).
+This project ID is also sent along when Meltano requests available plugins from the URLs identified by the [`hub_url`](#hub-url) or [`discovery_url` setting](#discovery-url).
 
 If you'd like to send the tracking data to a different Google Analytics account than the one run by the Meltano team,
 the Tracking IDs can be configured using the `tracking_ids.*` settings below.
@@ -237,10 +237,27 @@ meltano config meltano set project_readonly true
 export MELTANO_PROJECT_READONLY=true
 ```
 
+### <a name="hub-url"></a>`hub_url`
+
+- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_HUB_URL`
+- Default: [`https://hub.meltano.com`](https://hub.meltano.com)
+
+Where Meltano can find the Hub that lists all [discoverable plugins](/concepts/plugins#discoverable-plugins).
+
+This manifest is used by [`meltano discover`](/reference/command-line-interface#discover) and [`meltano add`](/reference/command-line-interface#add), among others.
+
+#### How to use
+
+```bash
+meltano config meltano set hub_url http://localhost:4000
+
+export MELTANO_HUB_URL=http://localhost:4000
+```
+
 ### <a name="discovery-url"></a>`discovery_url`
 
 - [Environment variable](/guide/configuration#configuring-settings): `MELTANO_DISCOVERY_URL`
-- Default: [`https://www.meltano.com/discovery.yml`](https://www.meltano.com/discovery.yml)
+- Default: [`https://discovery.meltano.com/discovery.yml`](https://discovery.meltano.com/discovery.yml)
 
 Where Meltano can find the `discovery.yml` manifest that lists all [discoverable plugins](/concepts/plugins#discoverable-plugins) that are supported out of the box.
 

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -20,6 +20,8 @@ settings:
   env_specific: true
 - name: discovery_url
   value: https://discovery.meltano.com/discovery.yml
+- name: hub_url
+  value: https://hub.meltano.com
 - name: discovery_url_auth
 - name: elt.buffer_size
   kind: integer

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -19,6 +19,7 @@ from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.factory import base_plugin_factory
 from meltano.core.plugin_discovery_service import PluginRepository
 from meltano.core.project import Project
+from meltano.core.project_settings_service import ProjectSettingsService
 
 from .schema import IndexedPlugin, VariantRef
 
@@ -85,8 +86,6 @@ class HubPluginVariantNotFound(Exception):
 class MeltanoHubService(PluginRepository):
     """PluginRepository implementation for the Meltano Hub."""
 
-    BASE_URL = "https://hub.meltano.com/meltano/api/v1"
-
     def __init__(self, project: Project) -> None:
         """Initialize the service.
 
@@ -102,6 +101,23 @@ class MeltanoHubService(PluginRepository):
             }
         )
 
+        self.settings_service = ProjectSettingsService(self.project)
+
+        if self.settings_service.get("send_anonymous_usage_stats"):
+            project_id = self.settings_service.get("project_id")
+
+            self.session.headers["X-Project-ID"] = project_id
+
+    @property
+    def hub_api_url(self):
+        """Return the URL of the Hub API.
+
+        Returns:
+            The URL of the Hub API.
+        """
+        hub_url = self.settings_service.get("hub_url")
+        return f"{hub_url}/meltano/api/v1"
+
     def plugin_type_endpoint(self, plugin_type: PluginType) -> str:
         """Return the list endpoint for the given plugin type.
 
@@ -111,7 +127,7 @@ class MeltanoHubService(PluginRepository):
         Returns:
             The endpoint for the given plugin type.
         """
-        return f"{self.BASE_URL}/plugins/{plugin_type.value}/index"
+        return f"{self.hub_api_url}/plugins/{plugin_type.value}/index"
 
     def plugin_endpoint(
         self,
@@ -129,7 +145,7 @@ class MeltanoHubService(PluginRepository):
         Returns:
             The endpoint for the given plugin type.
         """
-        url = f"{self.BASE_URL}/plugins/{plugin_type.value}/{plugin_name}"
+        url = f"{self.hub_api_url}/plugins/{plugin_type.value}/{plugin_name}"
         if variant_name:
             url = f"{url}--{variant_name}"
 


### PR DESCRIPTION
Added to ease fixing https://github.com/meltano/meltano/issues/6011 and testing https://github.com/meltano/hub/pull/530:

```
MELTANO_HUB_URL=http://localhost:4000 meltano discover            
MELTANO_HUB_URL=http://localhost:4000 meltano add utility superset
```