### PR TITLE
snowplow env context python impl missing

### DIFF
--- a/src/meltano/core/tracking/environment.py
+++ b/src/meltano/core/tracking/environment.py
@@ -60,6 +60,7 @@ class EnvironmentContext(SelfDescribingJson):
                     for marker in ci_markers
                 ),
                 "python_version": platform.python_version(),
+                "python_implementation": platform.python_implementation(),
                 **self.system_info,
                 **self.process_info,
             },


### PR DESCRIPTION
@pandemicsyn I was getting bad events with `"message":"$.python_implementation: is missing but it is required"` when I ran `invoke` locally with snowplow micro. I see them pass validation after making this change.