### PR TITLE
fix telemetry is_ci_environment

### DIFF
--- a/src/meltano/core/tracking/environment.py
+++ b/src/meltano/core/tracking/environment.py
@@ -58,6 +58,7 @@ class EnvironmentContext(SelfDescribingJson):
                 "is_ci_environment": any(
                     # True if 'true', 'TRUE', 'True', or '1'
                     os.environ.get(marker, "").lower()[:1] in ["1", "t"]
+                    for marker in ci_markers
                 ),
                 "python_version": platform.python_version(),
                 "python_implementation": platform.python_implementation(),

--- a/src/meltano/core/tracking/environment.py
+++ b/src/meltano/core/tracking/environment.py
@@ -56,8 +56,7 @@ class EnvironmentContext(SelfDescribingJson):
                 "meltano_version": meltano.__version__,
                 "is_dev_build": not release_marker_path.exists(),
                 "is_ci_environment": any(
-                    os.environ.get(marker, "").lower()[:1] in "1t"
-                    for marker in ci_markers
+                    os.environ.get(marker) for marker in ci_markers
                 ),
                 "python_version": platform.python_version(),
                 "python_implementation": platform.python_implementation(),

--- a/src/meltano/core/tracking/environment.py
+++ b/src/meltano/core/tracking/environment.py
@@ -56,7 +56,8 @@ class EnvironmentContext(SelfDescribingJson):
                 "meltano_version": meltano.__version__,
                 "is_dev_build": not release_marker_path.exists(),
                 "is_ci_environment": any(
-                    os.environ.get(marker) for marker in ci_markers
+                    # True if 'true', 'TRUE', 'True', or '1'
+                    os.environ.get(marker, "").lower()[:1] in ["1", "t"]
                 ),
                 "python_version": platform.python_version(),
                 "python_implementation": platform.python_implementation(),


### PR DESCRIPTION
There might be something I'm not considering but it sounds like the default behavior is that `GITHUB_ACTIONS` for github or `CI` for GitLab/CircleCI/etc. is set to true. [Github docs ](https://docs.github.com/en/actions/learn-github-actions/environment-variables) say `Always set to true when GitHub Actions is running the workflow`. I could check that its value is true but I think the presence of the env var means CI in these cases.