### PR TITLE
Bump discovery version in `plugin_discovery_service.py`

### DIFF
--- a/src/meltano/core/plugin_discovery_service.py
+++ b/src/meltano/core/plugin_discovery_service.py
@@ -36,7 +36,7 @@ class DiscoveryUnavailableError(Exception):
 
 # Increment this version number whenever the schema of discovery.yml is changed.
 # See https://www.meltano.com/docs/contributor-guide.html#discovery-yml-version for more information.
-VERSION = 20
+VERSION = 21
 
 
 class DiscoveryFile(Canonical):


### PR DESCRIPTION
This is follow up to hotfix: https://github.com/meltano/meltano/pull/6050