### PR TITLE
Change URL to point folks to next steps in the docs

### DIFF
--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -136,7 +136,7 @@ class ProjectInitService:
         click.secho("  cd ", nl=False)
         click.secho(self.project_name, fg="magenta")
         click.echo("  Visit ", nl=False)
-        click.secho("https://meltano.com/", fg="cyan", nl=False)
+        click.secho("https://docs.meltano.com/getting-started#create-your-meltano-project", fg="cyan", nl=False)
         click.echo(" to learn where to go from here")
 
     def join_with_project_base(self, filename):


### PR DESCRIPTION
@tayloramurphy I'm bringing this over from https://gitlab.com/meltano/meltano/-/issues/3093#note_750992714 (now https://github.com/meltano/internal-general/issues/326). Not sure if this is where this should point but wanted to at least get this rolling since meltano.com no longer shows a quickstart. Did you have thoughts on this?