### PR TITLE
fix: Ensure `LockfileAlreadyExistsError` wraps a `ProjectPlugin`

### DIFF
--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 from structlog.stdlib import get_logger
 
-from meltano.core.plugin.base import BasePlugin, PluginRef, StandalonePlugin, Variant
+from meltano.core.plugin.base import PluginRef, StandalonePlugin, Variant
+from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project import Project
 
 logger = get_logger(__name__)
@@ -38,11 +39,11 @@ class PluginLockService:
         Args:
             project: The Meltano project.
         """
-        self.projet = project
+        self.project = project
 
     def save(
         self,
-        plugin: BasePlugin,
+        plugin: ProjectPlugin,
         *,
         overwrite: bool = False,
         exists_ok: bool = False,
@@ -58,12 +59,15 @@ class PluginLockService:
             LockfileAlreadyExistsError: If the lockfile already exists and is not
                 flagged for overwriting.
         """
-        variant = None if plugin.variant == Variant.DEFAULT_NAME else plugin.variant
+        base_plugin = plugin.parent
+        variant = (
+            None if base_plugin.variant == Variant.DEFAULT_NAME else base_plugin.variant
+        )
 
-        logger.info(f"Locking a {type(plugin)}")
+        logger.info(f"Locking a {type(base_plugin)}")
 
-        plugin_def = plugin.definition
-        path = self.projet.plugin_lock_path(
+        plugin_def = base_plugin.definition
+        path = self.project.plugin_lock_path(
             plugin_def.type,
             plugin_def.name,
             variant_name=variant,
@@ -76,13 +80,13 @@ class PluginLockService:
                 plugin,
             )
 
-        variant = plugin_def.find_variant(plugin.variant)
+        variant = plugin_def.find_variant(base_plugin.variant)
         locked_def = StandalonePlugin.from_variant(
             variant,
-            plugin.name,
-            plugin.namespace,
-            plugin.type,
-            label=plugin.label,
+            base_plugin.name,
+            base_plugin.namespace,
+            base_plugin.type,
+            label=base_plugin.label,
         )
 
         with path.open("w") as lockfile:

--- a/src/meltano/core/project_add_service.py
+++ b/src/meltano/core/project_add_service.py
@@ -82,7 +82,7 @@ class ProjectAddService:
 
             if lock and not added.is_custom():
                 self.plugins_service.lock_service.save(
-                    added.parent,
+                    added,
                     exists_ok=plugin.inherit_from is not None,
                 )
 

--- a/tests/meltano/core/test_plugin_lock_service.py
+++ b/tests/meltano/core/test_plugin_lock_service.py
@@ -1,7 +1,11 @@
 import pytest
 
 from meltano.core.plugin.base import BasePlugin, PluginDefinition, PluginType
-from meltano.core.plugin_lock_service import PluginLockService
+from meltano.core.plugin.project_plugin import ProjectPlugin
+from meltano.core.plugin_lock_service import (
+    LockfileAlreadyExistsError,
+    PluginLockService,
+)
 from meltano.core.project import Project
 
 
@@ -14,7 +18,8 @@ class TestPluginLockService:
     ):
         return PluginLockService(project)
 
-    def test_save(self, subject: PluginLockService, project: Project):
+    @pytest.fixture
+    def plugin(self):
         plugin_definition = PluginDefinition(
             PluginType.EXTRACTORS,
             name="tap-locked",
@@ -37,11 +42,32 @@ class TestPluginLockService:
             ],
         )
         variant = plugin_definition.find_variant("meltano")
-        plugin = BasePlugin(plugin_definition, variant)
-        assert plugin.variant == "meltano"
+        base_plugin = BasePlugin(plugin_definition, variant)
 
-        lock_path = project.plugin_lock_path(plugin.type, plugin.name, "meltano")
+        plugin = ProjectPlugin(
+            base_plugin.type,
+            base_plugin.name,
+            variant=variant,
+        )
+        plugin.parent = base_plugin
+        return plugin
+
+    def test_save(
+        self,
+        subject: PluginLockService,
+        project: Project,
+        plugin: ProjectPlugin,
+    ):
+        lock_path = project.plugin_lock_path(
+            plugin.type,
+            plugin.name,
+            plugin.variant.name,
+        )
         assert not lock_path.exists()
 
         subject.save(plugin)
         assert lock_path.exists()
+
+        with pytest.raises(LockfileAlreadyExistsError) as exc_info:
+            subject.save(plugin)
+            assert exc_info == plugin

--- a/tests/meltano/core/test_plugin_lock_service.py
+++ b/tests/meltano/core/test_plugin_lock_service.py
@@ -70,4 +70,5 @@ class TestPluginLockService:
 
         with pytest.raises(LockfileAlreadyExistsError) as exc_info:
             subject.save(plugin)
-            assert exc_info == plugin
+
+        assert exc_info.value.plugin == plugin  # noqa: WPS441


### PR DESCRIPTION
Closes #6061
