### PR TITLE
Make Poetry include `.release_marker`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ classifiers = [
 ]
 include = [
   "LICENSE",
-  "*.m5o"
+  "*.m5o",
+  ".release_marker",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Assuming that Poetry doesn't need the full path for `include`, this should fix the problem of `.release_marker` not being installed by `poetry install`. Marked as draft because I have not had the time to test it yet.

Closes #6021