### PR TITLE
Don't log active environment on every command

### DIFF
--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -71,7 +71,7 @@ def cli(  # noqa: WPS231
         # activate environment
         if selected_environment:
             project.activate_environment(selected_environment)
-            logger.info(
+            logger.debug(
                 "Environment '%s' is active", selected_environment  # noqa: WPS323
             )
 


### PR DESCRIPTION
Small quality of life change, we log what environment is active on **every**, **single** , **command**:

```
(speedrun1) ➜ my-meltano-project (main) ✗  meltano config tap-gitlab set projects "meltano/meltano meltano/tap-gitlab"
2022-06-08T02:15:11.639672Z [info     ] Environment 'dev' is active
Extractor 'tap-gitlab' setting 'projects' was set in the active environment in `meltano.yml`: 'meltano/meltano meltano/tap-gitla

(speedrun1) ➜ my-meltano-project (main) ✗ meltano config tap-gitlab

2022-06-08T02:12:07.579018Z [info     ] Environment 'dev' is active
{
  "api_url": "https://gitlab.com",
  "private_token": "my_private_token",
  "groups": "",
  "projects": "meltano/meltano meltano/tap-gitlab",
  "ultimate_license": false,
  "fetch_merge_request_commits": false,
  "fetch_pipelines_extended": false,
  "start_date": "2022-05-01T00:00:00Z"
}
```
