### PR TITLE
Update invoke to fire start event later

### DIFF
--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -113,8 +113,8 @@ def invoke(
         raise err
 
     if list_commands:
-        tracker.track_command_event(cli_tracking.COMPLETED)
         do_list_commands(plugin)
+        tracker.track_command_event(cli_tracking.COMPLETED)
         return
 
     invoker = invoker_factory(project, plugin, plugins_service=plugins_service)

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -140,7 +140,6 @@ def invoke(
         tracker.track_command_event(cli_tracking.COMPLETED)
     else:
         tracker.track_command_event(cli_tracking.FAILED)
-        tracker.track_command_event(cli_tracking.FAILED)
     sys.exit(exit_code)
 
 

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -78,6 +78,7 @@ def invoke(
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#invoke
     """
     tracker = Tracker(project)
+    # the `started` event is delayed until we've had a chance to try to resolve the requested plugin
     tracker.add_contexts(
         cli_context_builder(
             "invoke",
@@ -108,6 +109,7 @@ def invoke(
         tracker.add_contexts(PluginsTrackingContext([(plugin, command_name)]))
         tracker.track_command_event(cli_tracking.STARTED)
     except PluginNotFoundError:
+        # if the plugin is not found, we fire started and aborted tracking events together to keep tracking consistent
         tracker.track_command_event(cli_tracking.STARTED)
         tracker.track_command_event(cli_tracking.ABORTED)
         raise

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -78,17 +78,17 @@ def invoke(
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#invoke
     """
     tracker = Tracker(project)
-    cmd_ctx = cli_context_builder(
-        "invoke",
-        None,
-        plugin_type=plugin_type,
-        dump=dump,
-        list_commands=list_commands,
-        containers=containers,
-        print_var=print_var,
+    tracker.add_contexts(
+        cli_context_builder(
+            "invoke",
+            None,
+            plugin_type=plugin_type,
+            dump=dump,
+            list_commands=list_commands,
+            containers=containers,
+            print_var=print_var,
+        )
     )
-    with tracker.with_contexts(cmd_ctx):
-        tracker.track_command_event(cli_tracking.STARTED)
 
     try:
         plugin_name, command_name = plugin_name.split(":")
@@ -105,12 +105,15 @@ def invoke(
         plugin = plugins_service.find_plugin(
             plugin_name, plugin_type=plugin_type, invokable=True
         )
+        tracker.add_contexts(PluginsTrackingContext([(plugin, command_name)]))
+        tracker.track_command_event(cli_tracking.STARTED)
     except PluginNotFoundError as err:
-        with tracker.with_contexts(cmd_ctx):
-            tracker.track_command_event(cli_tracking.ABORTED)
+        tracker.track_command_event(cli_tracking.STARTED)
+        tracker.track_command_event(cli_tracking.ABORTED)
         raise err
 
     if list_commands:
+        tracker.track_command_event(cli_tracking.COMPLETED)
         do_list_commands(plugin)
         return
 
@@ -130,17 +133,14 @@ def invoke(
             )
         )
     except Exception as invoke_err:
-        with tracker.with_contexts(cmd_ctx):
-            tracker.track_command_event(cli_tracking.FAILED)
+        tracker.track_command_event(cli_tracking.FAILED)
         raise invoke_err
 
-    with tracker.with_contexts(
-        cmd_ctx, PluginsTrackingContext([(plugin, command_name)])
-    ):
-        if exit_code == 0:
-            tracker.track_command_event(cli_tracking.COMPLETED)
-        else:
-            tracker.track_command_event(cli_tracking.FAILED)
+    if exit_code == 0:
+        tracker.track_command_event(cli_tracking.COMPLETED)
+    else:
+        tracker.track_command_event(cli_tracking.FAILED)
+        tracker.track_command_event(cli_tracking.FAILED)
     sys.exit(exit_code)
 
 

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -110,7 +110,7 @@ def invoke(
     except PluginNotFoundError:
         tracker.track_command_event(cli_tracking.STARTED)
         tracker.track_command_event(cli_tracking.ABORTED)
-        raise err
+        raise
 
     if list_commands:
         do_list_commands(plugin)

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -107,7 +107,7 @@ def invoke(
         )
         tracker.add_contexts(PluginsTrackingContext([(plugin, command_name)]))
         tracker.track_command_event(cli_tracking.STARTED)
-    except PluginNotFoundError as err:
+    except PluginNotFoundError:
         tracker.track_command_event(cli_tracking.STARTED)
         tracker.track_command_event(cli_tracking.ABORTED)
         raise err


### PR DESCRIPTION
This updates the telemetry for invoke to not fire the first event until *after* we've tried to obtain plugin context. If we're able to find the requested plugin, it will be present in the PluginsContext for the start event. 

This also cleans up the use of the tracker and does away `with` contexts use.

closes #6093 