### PR TITLE
Add info on --state-id to migration guide

### DIFF
--- a/docs/src/_reference/v2-migration.md
+++ b/docs/src/_reference/v2-migration.md
@@ -1070,6 +1070,9 @@ If for any reason you wish to keep sourcing or writing setting values to depreca
   </tr>
 </table>
 
+
+## CLI and API Changes
+
 #### Use `--state-id` instead of `--job-id`
 In 2.0, many references to "Job ID" in our code and docs were changed to the more accurate name of "State ID".
 

--- a/docs/src/_reference/v2-migration.md
+++ b/docs/src/_reference/v2-migration.md
@@ -1069,3 +1069,8 @@ If for any reason you wish to keep sourcing or writing setting values to depreca
    </td>
   </tr>
 </table>
+
+#### Use `--state-id` instead of `--job-id`
+In 2.0, many references to "Job ID" in our code and docs were changed to the more accurate name of "State ID".
+
+If you are explicitly providing a `--job-id` option to any scripted or otherwise automated CLI workflows, these commands should be updated to use the `--state-id` option instead.


### PR DESCRIPTION
Adds a section to the 2.0 migration guide on CLI and API changes, which currently just has information about updating commands using the `--job-id` to use `--state-id` instead.

Closes #6100 