### PR TITLE
Attach env and project contexts to structured events

### DIFF
--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -72,6 +72,7 @@ def add(  # noqa: WPS238
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#add
     """
     tracker = Tracker(project)
+    legacy_tracker = LegacyTracker(project, context_overrides=tracker.contexts)
     tracker.add_contexts(
         cli_context_builder(
             "add",
@@ -117,7 +118,6 @@ def add(  # noqa: WPS238
     add_service = ProjectAddService(project, plugins_service=plugins_service)
 
     plugins: list[ProjectPlugin] = []
-    legacy_tracker = LegacyTracker(project)
     for plugin in plugin_names:
         try:
             plugins.append(

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -109,6 +109,8 @@ async def elt(
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#elt
     """
     tracker = Tracker(project)
+    legacy_tracker = LegacyTracker(project, context_overrides=tracker.contexts)
+
     cmd_ctx = cli_context_builder(
         "elt",
         None,
@@ -168,7 +170,6 @@ async def elt(
         session.close()
 
     tracker.track_command_event(cli_tracking.COMPLETED)
-    legacy_tracker = LegacyTracker(project)
     legacy_tracker.track_meltano_elt(
         extractor=extractor, loader=loader, transform=transform
     )

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -41,6 +41,7 @@ def install(project, plugin_type, plugin_name, clean, parallelism):
     \b\nRead more at https://www.meltano.com/docs/command-line-interface.html#install
     """
     tracker = Tracker(project)
+    legacy_tracker = LegacyTracker(project, context_overrides=tracker.contexts)
     tracker.add_contexts(
         cli_context_builder(
             "install",
@@ -79,7 +80,6 @@ def install(project, plugin_type, plugin_name, clean, parallelism):
 
     success = install_plugins(project, plugins, parallelism=parallelism, clean=clean)
 
-    legacy_tracker = LegacyTracker(project)
     legacy_tracker.track_meltano_install()
 
     if not success:

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -127,6 +127,7 @@ def invoke(
                 command_name,
                 containers,
                 print_var=print_var,
+                tracker=tracker,
             )
         )
     except Exception as invoke_err:
@@ -191,7 +192,7 @@ async def _invoke(
     finally:
         session.close()
 
-    tracker = LegacyTracker(project, tracker.contexts)
+    tracker = LegacyTracker(project, context_overrides=tracker.contexts)
     tracker.track_meltano_invoke(
         plugin_name=plugin_name, plugin_args=" ".join(plugin_args)
     )

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -78,6 +78,7 @@ def invoke(
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#invoke
     """
     tracker = Tracker(project)
+    legacy_tracker = LegacyTracker(project, context_overrides=tracker.contexts)
     # the `started` event is delayed until we've had a chance to try to resolve the requested plugin
     tracker.add_contexts(
         cli_context_builder(
@@ -132,7 +133,7 @@ def invoke(
                 command_name,
                 containers,
                 print_var=print_var,
-                tracker=tracker,
+                legacy_tracker=legacy_tracker,
             )
         )
     except Exception as invoke_err:
@@ -156,7 +157,7 @@ async def _invoke(
     command_name: str,
     containers: bool,
     print_var: list | None = None,
-    tracker: Tracker = None,
+    legacy_tracker: LegacyTracker = None,
 ):
     if command_name is not None:
         command = invoker.find_command(command_name)
@@ -193,8 +194,7 @@ async def _invoke(
     finally:
         session.close()
 
-    tracker = LegacyTracker(project, context_overrides=tracker.contexts)
-    tracker.track_meltano_invoke(
+    legacy_tracker.track_meltano_invoke(
         plugin_name=plugin_name, plugin_args=" ".join(plugin_args)
     )
 

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -154,6 +154,7 @@ async def _invoke(
     command_name: str,
     containers: bool,
     print_var: list | None = None,
+    tracker: Tracker = None,
 ):
     if command_name is not None:
         command = invoker.find_command(command_name)
@@ -190,7 +191,7 @@ async def _invoke(
     finally:
         session.close()
 
-    tracker = LegacyTracker(project)
+    tracker = LegacyTracker(project, tracker.contexts)
     tracker.track_meltano_invoke(
         plugin_name=plugin_name, plugin_args=" ".join(plugin_args)
     )

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -90,6 +90,8 @@ async def run(
             change_console_log_level()
 
     tracker = Tracker(project)
+    legacy_tracker = LegacyTracker(project, context_overrides=tracker.contexts)
+
     cmd_ctx = cli_context_builder(
         "run",
         None,
@@ -127,7 +129,6 @@ async def run(
             raise err
         tracker.track_command_event(cli_tracking.COMPLETED)
 
-    legacy_tracker = LegacyTracker(project)
     legacy_tracker.track_meltano_run(blocks)
 
 

--- a/src/meltano/core/legacy_tracking/legacy_tracker.py
+++ b/src/meltano/core/legacy_tracking/legacy_tracker.py
@@ -55,7 +55,7 @@ class LegacyTracker:  # noqa: WPS214, WPS230
             request_timeout=self.request_timeout,
         )
         if context_overrides:
-            self.tracker.context_overrides = context_overrides
+            self.tracker.contexts = context_overrides
 
         project_context = ProjectContext(project, self.tracker.client_id)
         self.project_id = project_context.project_uuid

--- a/src/meltano/core/legacy_tracking/legacy_tracker.py
+++ b/src/meltano/core/legacy_tracking/legacy_tracker.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from snowplow_tracker import SelfDescribingJson
+
 from meltano.core.project import Project
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.schedule import Schedule
@@ -20,7 +22,7 @@ MEASUREMENT_PROTOCOL_URI = "https://www.google-analytics.com/collect"
 DEBUG_MEASUREMENT_PROTOCOL_URI = "https://www.google-analytics.com/debug/collect"
 
 
-class LegacyTracker:
+class LegacyTracker:  # noqa: WPS214, WPS230
     """Legacy tracker for Meltano."""
 
     def __init__(
@@ -28,6 +30,7 @@ class LegacyTracker:
         project: Project,
         tracking_id: str = None,
         request_timeout: float = None,
+        context_overrides: tuple[SelfDescribingJson] = None,
     ):
         """Create a new Google Analytics tracker.
 
@@ -35,6 +38,7 @@ class LegacyTracker:
             project: Meltano project.
             tracking_id: Unique identifier for tracking. Defaults to None.
             request_timeout: For GA requests. Defaults to None.
+            context_overrides: A list of explicit context overrides that will be set on the underlying Tracker.
         """
         self.project = project
         self.settings_service = ProjectSettingsService(self.project)
@@ -50,6 +54,8 @@ class LegacyTracker:
             project,
             request_timeout=self.request_timeout,
         )
+        if context_overrides:
+            self.tracker.context_overrides = context_overrides
 
         project_context = ProjectContext(project, self.tracker.client_id)
         self.project_id = project_context.project_uuid

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -268,7 +268,7 @@ class Tracker:  # noqa: WPS214 - too many methods 16 > 15
                 category=category,
                 action=action,
                 label=str(self.project_id),
-                contexts=self.contexts,
+                context=self.contexts,
             )
         except Exception as err:
             logger.debug(

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -10,7 +10,7 @@ import uuid
 from contextlib import contextmanager
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 from urllib.parse import urlparse
 
 import tzlocal
@@ -76,7 +76,7 @@ class TelemetrySettings(NamedTuple):
 
 
 # TODO: Can we store some of this info to make future invocations faster?
-class Tracker:
+class Tracker:  # noqa: WPS214 - too many methods 16 > 15
     """Meltano tracker backed by Snowplow."""
 
     def __init__(
@@ -268,6 +268,7 @@ class Tracker:
                 category=category,
                 action=action,
                 label=str(self.project_id),
+                contexts=self.contexts,
             )
         except Exception as err:
             logger.debug(
@@ -384,7 +385,7 @@ class Tracker:
                 new_analytics_json_file,
             )
 
-    def _uuid_from_str(self, from_val: Optional[Any], warn: bool) -> uuid.UUID | None:
+    def _uuid_from_str(self, from_val: Any | None, warn: bool) -> uuid.UUID | None:
         """Safely convert string to a UUID. Return None if invalid UUID.
 
         Args:


### PR DESCRIPTION
Originally, I was going to merge the LegacyTracker back into Tracker and just have a single unified tracker that just exposed a legacy method. But since the whole original intention was to have two separate paths in case we break things with the unstructured events... I ended up NOT going that route to keep them "seperated". 

This basically just steals the contexts present in Tracker() after initializations and uses those to initialize LegacyTracker(). Lastly, I also updated the `Tracker().track_struct_event` to include the ProjectContext and EnvironmentContext.

The end result is that both trackers have the same ProjectContext and EnvironmentContext. This allows @pnadolny13 to more easily tie both structured and unstructered events together into a single "cli session".

Freebie: This also means that tearing the LegacyTracker out and removing it once and for all is remains *really* easy to do.

closes #6057 