### PR TITLE
Fix defect where `pipeline-schedules` endpoint returned 500 error

### DIFF
--- a/src/meltano/api/controllers/orchestrations.py
+++ b/src/meltano/api/controllers/orchestrations.py
@@ -494,9 +494,11 @@ def get_pipeline_schedules():
     formatted_schedules = []
 
     for schedule in schedules:
-        if schedule.job and jobs_in_list:
+        if schedule.get("job") and jobs_in_list:
+            # we only return API results for scheduled jobs if the feature flag is explicitly enabled
+            # as the UI is not job aware yet.
             formatted_schedules.append(schedule)
-        elif schedule.elt_schedule:
+        elif not schedule.get("job"):  # a legacy elt task
             finder = JobFinder(schedule["name"])
             state_job = finder.latest(db.session)
             schedule["has_error"] = state_job.has_error() if state_job else False


### PR DESCRIPTION
Switch to checking for `job` key in orchestrations pipelines api since `schedule` here is actually a dict and not a `Schedule` object.... and so we don't have a `job` or `elt_schedule` attr to call.

Before:
```
➜  ~ http http://localhost:5555/api/v1/orchestrations/pipeline-schedules
HTTP/1.1 500 INTERNAL SERVER ERROR
Connection: close
Content-Length: 206
Content-Type: application/json
Date: Mon, 13 Jun 2022 17:49:42 GMT
Server: gunicorn/19.10.0
X-MELTANO-VERSION: 2.0.1

{
    "code": "500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.",
    "error": true
}
```

After: 
```
➜  ~ http http://localhost:5555/api/v1/orchestrations/pipeline-schedules
HTTP/1.1 200 OK
Connection: close
Content-Length: 629
Content-Type: application/json
Date: Mon, 13 Jun 2022 17:42:08 GMT
Server: gunicorn/19.10.0
X-MELTANO-VERSION: 2.0.1

[
    {
        "ended_at": "Tue, 07 Jun 2022 00:07:34 GMT",
        "extractor": "tap-gitlab",
        "has_error": false,
        "has_ever_succeeded": true,
        "interval": "@hourly",
        "is_running": false,
        "loader": "target-jsonl",
        "name": "elt-test-schedule",
        "start_date": "2021-12-04",
        "started_at": "Tue, 07 Jun 2022 00:07:33 GMT",
        "state_id": "elt-test-schedule",
        "transform": "skip",
        "trigger": "cli"
    },
    {
        "ended_at": null,
        "extractor": "tap-gitlab",
        "has_error": false,
        "has_ever_succeeded": null,
        "interval": "@weekly",
        "is_running": false,
        "loader": "target-jsonl",
        "name": "gitlab-to-jsonl2",
        "start_date": "2022-04-25",
        "started_at": null,
        "state_id": "gitlab-to-jsonl2",
        "transform": "skip",
        "trigger": null
    }
]
```

closes #6163 