### PR TITLE
Improve CLI performance by avoiding unnecessary imports

### DIFF
--- a/src/meltano/api/api_blueprint.py
+++ b/src/meltano/api/api_blueprint.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from flask import Blueprint
 from flask_login import current_user
+
 from meltano.api.security import block_if_api_auth_required, users
 
 VERSION = 1

--- a/src/meltano/api/api_blueprint.py
+++ b/src/meltano/api/api_blueprint.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from flask import Blueprint
 from flask_login import current_user
 
-from meltano.api.security import block_if_api_auth_required, users
+from meltano.api.security.auth import block_if_api_auth_required
+from meltano.api.security.identity import users
 
 VERSION = 1
 

--- a/src/meltano/api/app.py
+++ b/src/meltano/api/app.py
@@ -66,7 +66,7 @@ def create_app(config: dict = {}) -> Flask:  # noqa: WPS210,WPS213,B006
     from .json import setup_json
     from .mail import mail
     from .models import db
-    from .security import security, setup_security, users
+    from .security import setup_security
     from .security.oauth import setup_oauth
 
     db.init_app(app)

--- a/src/meltano/api/app.py
+++ b/src/meltano/api/app.py
@@ -111,7 +111,6 @@ def create_app(config: dict = {}) -> Flask:  # noqa: WPS210,WPS213,B006
         logger.debug("Notifications are disabled.")
 
     # Google Analytics setup
-    LegacyTracker(project)
 
     @app.before_request
     def setup_js_context():

--- a/src/meltano/api/app.py
+++ b/src/meltano/api/app.py
@@ -60,8 +60,6 @@ def create_app(config: dict = {}) -> Flask:  # noqa: WPS210,WPS213,B006
     logger.addHandler(file_handler)
 
     # 1) Extensions
-    security_options = {}
-
     from .executor import setup_executor
     from .json import setup_json
     from .mail import mail

--- a/src/meltano/api/app.py
+++ b/src/meltano/api/app.py
@@ -113,7 +113,7 @@ def create_app(config: dict = {}) -> Flask:  # noqa: WPS210,WPS213,B006
         logger.debug("Notifications are disabled.")
 
     # Google Analytics setup
-    tracker = LegacyTracker(project)
+    LegacyTracker(project)
 
     @app.before_request
     def setup_js_context():

--- a/src/meltano/api/config.py
+++ b/src/meltano/api/config.py
@@ -2,10 +2,7 @@ import os
 
 from meltano.api.headers import *
 from meltano.core.project import Project
-from meltano.core.project_settings_service import (
-    ProjectSettingsService,
-    SettingValueStore,
-)
+from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.utils import truthy
 
 # Flask

--- a/src/meltano/api/config.py
+++ b/src/meltano/api/config.py
@@ -1,5 +1,3 @@
-import datetime
-import logging
 import os
 
 from meltano.api.headers import *

--- a/src/meltano/api/controllers/root.py
+++ b/src/meltano/api/controllers/root.py
@@ -8,17 +8,16 @@ from flask import (
     current_app,
     g,
     jsonify,
-    make_response,
     redirect,
     render_template,
     request,
 )
 from flask_login import current_user
-from flask_security import logout_user, roles_required
+from flask_security import roles_required
 from jinja2 import TemplateNotFound
 from meltano.api.api_blueprint import APIBlueprint
 from meltano.api.security.auth import block_if_readonly, passes_authentication_checks
-from meltano.core.project import Project, ProjectReadonly
+from meltano.core.project import Project
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.utils import truthy
 

--- a/src/meltano/api/controllers/root.py
+++ b/src/meltano/api/controllers/root.py
@@ -1,7 +1,5 @@
 import logging
-import subprocess
 from functools import wraps
-from urllib.parse import urlsplit
 
 import meltano
 import requests

--- a/src/meltano/api/controllers/root.py
+++ b/src/meltano/api/controllers/root.py
@@ -1,20 +1,13 @@
 import logging
 from functools import wraps
 
-import meltano
 import requests
-from flask import (
-    Blueprint,
-    current_app,
-    g,
-    jsonify,
-    redirect,
-    render_template,
-    request,
-)
+from flask import Blueprint, current_app, g, jsonify, redirect, render_template, request
 from flask_login import current_user
 from flask_security import roles_required
 from jinja2 import TemplateNotFound
+
+import meltano
 from meltano.api.api_blueprint import APIBlueprint
 from meltano.api.security.auth import block_if_readonly, passes_authentication_checks
 from meltano.core.project import Project

--- a/src/meltano/api/controllers/settings.py
+++ b/src/meltano/api/controllers/settings.py
@@ -1,12 +1,10 @@
 from flask import jsonify, request
-from flask_principal import Need, Permission
-from flask_restful import Api, Resource, fields, marshal, marshal_with
+from flask_restful import Api, Resource, fields, marshal_with
 from flask_security import roles_required
 from sqlalchemy.orm import joinedload
-from werkzeug.exceptions import Forbidden
 
 from meltano.api.api_blueprint import APIBlueprint
-from meltano.api.models.security import Role, RolePermissions, RolesUsers, User, db
+from meltano.api.models.security import Role, RolePermissions, User, db
 from meltano.api.security import users
 from meltano.api.security.auth import block_if_readonly
 

--- a/src/meltano/api/controllers/settings.py
+++ b/src/meltano/api/controllers/settings.py
@@ -5,8 +5,8 @@ from sqlalchemy.orm import joinedload
 
 from meltano.api.api_blueprint import APIBlueprint
 from meltano.api.models.security import Role, RolePermissions, User, db
-from meltano.api.security import users
 from meltano.api.security.auth import block_if_readonly
+from meltano.api.security.identity import users
 
 from .settings_helper import SettingsHelper
 

--- a/src/meltano/api/controllers/settings.py
+++ b/src/meltano/api/controllers/settings.py
@@ -2,12 +2,13 @@ from flask import jsonify, request
 from flask_principal import Need, Permission
 from flask_restful import Api, Resource, fields, marshal, marshal_with
 from flask_security import roles_required
+from sqlalchemy.orm import joinedload
+from werkzeug.exceptions import Forbidden
+
 from meltano.api.api_blueprint import APIBlueprint
 from meltano.api.models.security import Role, RolePermissions, RolesUsers, User, db
 from meltano.api.security import users
 from meltano.api.security.auth import block_if_readonly
-from sqlalchemy.orm import joinedload
-from werkzeug.exceptions import Forbidden
 
 from .settings_helper import SettingsHelper
 
@@ -51,7 +52,7 @@ def test(name):
             connection for connection in connections if connection["name"] == name
         )
     # this is a really broad exception catch, this will swallow sneaky errors
-    except Exception as e:
+    except Exception:
         found_connection = {}
 
     return jsonify(found_connection)

--- a/src/meltano/api/controllers/settings_helper.py
+++ b/src/meltano/api/controllers/settings_helper.py
@@ -1,7 +1,4 @@
 import json
-import os
-from os.path import join
-from pathlib import Path
 
 from meltano.core.project import Project
 

--- a/src/meltano/api/controllers/utils.py
+++ b/src/meltano/api/controllers/utils.py
@@ -1,4 +1,3 @@
-
 from werkzeug.utils import secure_filename
 
 from .errors import InvalidFileNameError

--- a/src/meltano/api/controllers/utils.py
+++ b/src/meltano/api/controllers/utils.py
@@ -1,4 +1,3 @@
-import re
 
 from werkzeug.utils import secure_filename
 

--- a/src/meltano/api/events/notification_events.py
+++ b/src/meltano/api/events/notification_events.py
@@ -2,13 +2,11 @@ import logging
 
 from blinker import ANY
 from flask import render_template, url_for
-from flask_mail import Message
 
 from meltano.api.mail import MailService, mail
 from meltano.api.models.subscription import Subscription, SubscriptionEventType
 from meltano.api.signals import PipelineSignals
-from meltano.core.plugin import PluginDefinition, PluginType
-from meltano.core.plugin_discovery_service import PluginDiscoveryService
+from meltano.core.plugin import PluginType
 from meltano.core.project import Project
 from meltano.core.project_plugins_service import ProjectPluginsService
 

--- a/src/meltano/api/executor/__init__.py
+++ b/src/meltano/api/executor/__init__.py
@@ -2,6 +2,7 @@ import logging
 import subprocess
 
 from flask_executor import Executor
+
 from meltano.api.models import db
 from meltano.api.signals import PipelineSignals
 from meltano.core.meltano_invoker import MeltanoInvoker

--- a/src/meltano/api/executor/__init__.py
+++ b/src/meltano/api/executor/__init__.py
@@ -1,8 +1,5 @@
-import datetime
 import logging
-import os
 import subprocess
-from functools import partial
 
 from flask_executor import Executor
 from meltano.api.models import db

--- a/src/meltano/api/json.py
+++ b/src/meltano/api/json.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Iterable, Mapping
 from enum import Enum
 
 import humps

--- a/src/meltano/api/json.py
+++ b/src/meltano/api/json.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 import humps
 from flask import current_app, json, request
+
 from meltano.core.utils import compose
 
 

--- a/src/meltano/api/models/subscription.py
+++ b/src/meltano/api/models/subscription.py
@@ -2,9 +2,10 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
+from sqlalchemy.orm import validates
+
 from meltano.core import utils
 from meltano.core.sqlalchemy import GUID
-from sqlalchemy.orm import validates
 
 from . import db
 

--- a/src/meltano/api/security/__init__.py
+++ b/src/meltano/api/security/__init__.py
@@ -1,26 +1,19 @@
-from flask import current_app, jsonify, make_response, redirect, request
-from flask_login import current_user, user_logged_in
-from flask_principal import Identity, identity_loaded
-from flask_security import Security, login_required
-from flask_security.utils import login_user
+from flask_login import user_logged_in
+from flask_principal import identity_loaded
 
 from meltano.core.project_settings_service import ProjectSettingsService
 
-from .auth import (
-    _identity_loaded_hook,
-    _user_logged_in_hook,
-    block_if_api_auth_required,
-    unauthorized_callback,
-)
-from .forms import MeltanoConfirmRegisterForm, MeltanoLoginForm, MeltanoRegisterFrom
-from .identity import FreeUser, create_dev_user, users
-
-# normally one would setup the extension accordingly, but it
-# seems Security.init_app() overwrites all the configuration
-security = Security()
+from .auth import _identity_loaded_hook, _user_logged_in_hook, unauthorized_callback
 
 
 def setup_security(app, project):
+    from meltano.api.security.forms import (
+        MeltanoConfirmRegisterForm,
+        MeltanoLoginForm,
+        MeltanoRegisterFrom,
+    )
+    from meltano.api.security.identity import FreeUser, users
+
     options = {
         "login_form": MeltanoLoginForm,
         "register_form": MeltanoRegisterFrom,
@@ -37,6 +30,11 @@ def setup_security(app, project):
         # and has no roles
         pass
 
+    from flask_security import Security
+
+    security = Security()
+    # normally one would setup the extension accordingly, but it
+    # seems Security.init_app() overwrites all the configuration
     security.init_app(app, users, **options)
     security.unauthorized_handler(unauthorized_callback)
     user_logged_in.connect_via(app)(_user_logged_in_hook)

--- a/src/meltano/api/security/__init__.py
+++ b/src/meltano/api/security/__init__.py
@@ -3,6 +3,7 @@ from flask_login import current_user, user_logged_in
 from flask_principal import Identity, identity_loaded
 from flask_security import Security, login_required
 from flask_security.utils import login_user
+
 from meltano.core.project_settings_service import ProjectSettingsService
 
 from .auth import (

--- a/src/meltano/api/security/__init__.py
+++ b/src/meltano/api/security/__init__.py
@@ -1,6 +1,3 @@
-import urllib.parse
-from datetime import timedelta
-from functools import wraps
 
 from flask import current_app, jsonify, make_response, redirect, request
 from flask_login import current_user, user_logged_in

--- a/src/meltano/api/security/__init__.py
+++ b/src/meltano/api/security/__init__.py
@@ -1,4 +1,3 @@
-
 from flask import current_app, jsonify, make_response, redirect, request
 from flask_login import current_user, user_logged_in
 from flask_principal import Identity, identity_loaded

--- a/src/meltano/api/security/auth.py
+++ b/src/meltano/api/security/auth.py
@@ -3,16 +3,14 @@ from datetime import datetime
 from fnmatch import fnmatch
 from functools import wraps
 
-from flask import current_app, jsonify, request
+from flask import jsonify, request
 from flask_login import current_user
 from flask_principal import Need, Permission
-from flask_security import auth_required
 from meltano.api.models import db
 from meltano.core.project import Project
 from meltano.core.project_settings_service import ProjectSettingsService
 from werkzeug.exceptions import Forbidden
 
-from .identity import FreeUser
 
 HTTP_READONLY_CODE = 499
 

--- a/src/meltano/api/security/auth.py
+++ b/src/meltano/api/security/auth.py
@@ -6,11 +6,11 @@ from functools import wraps
 from flask import jsonify, request
 from flask_login import current_user
 from flask_principal import Need, Permission
+from werkzeug.exceptions import Forbidden
+
 from meltano.api.models import db
 from meltano.core.project import Project
 from meltano.core.project_settings_service import ProjectSettingsService
-from werkzeug.exceptions import Forbidden
-
 
 HTTP_READONLY_CODE = 499
 

--- a/src/meltano/api/security/identity.py
+++ b/src/meltano/api/security/identity.py
@@ -1,8 +1,9 @@
 from datetime import date
 
-from flask_security import AnonymousUser, SQLAlchemyUserDatastore
+from flask_security import SQLAlchemyUserDatastore
 from flask_security.utils import hash_password
-from meltano.api.models.security import Role, RolePermissions, User, db
+
+from meltano.api.models.security import Role, User, db
 
 users = SQLAlchemyUserDatastore(db, User, Role)
 

--- a/src/meltano/api/security/oauth.py
+++ b/src/meltano/api/security/oauth.py
@@ -3,8 +3,8 @@ import json
 
 import gitlab
 from authlib.flask.client import OAuth as OAuthClient
-from flask import Blueprint, current_app, jsonify, redirect, url_for
-from flask_security import AnonymousUser, current_user
+from flask import Blueprint, redirect, url_for
+from flask_security import current_user
 from flask_security.utils import do_flash, login_user, url_for_security
 from meltano.api.models.oauth import OAuth, db
 from meltano.core.utils import compose

--- a/src/meltano/api/security/oauth.py
+++ b/src/meltano/api/security/oauth.py
@@ -6,10 +6,11 @@ from authlib.flask.client import OAuth as OAuthClient
 from flask import Blueprint, redirect, url_for
 from flask_security import current_user
 from flask_security.utils import do_flash, login_user, url_for_security
-from meltano.api.models.oauth import OAuth, db
-from meltano.core.utils import compose
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
+
+from meltano.api.models.oauth import OAuth, db
+from meltano.core.utils import compose
 
 from .identity import FreeUser, users
 

--- a/src/meltano/api/security/resource_filter.py
+++ b/src/meltano/api/security/resource_filter.py
@@ -1,4 +1,3 @@
-import logging
 from copy import copy
 from typing import Callable
 

--- a/src/meltano/api/url_converters.py
+++ b/src/meltano/api/url_converters.py
@@ -1,5 +1,6 @@
-from meltano.core.plugin import PluginRef
 from werkzeug.routing import PathConverter
+
+from meltano.core.plugin import PluginRef
 
 
 class PluginRefConverter(PathConverter):

--- a/src/meltano/api/workers/ui_available_worker.py
+++ b/src/meltano/api/workers/ui_available_worker.py
@@ -4,6 +4,7 @@ import webbrowser
 
 import click
 import requests
+
 from meltano.core.project_settings_service import ProjectSettingsService
 
 

--- a/src/meltano/api/workers/ui_available_worker.py
+++ b/src/meltano/api/workers/ui_available_worker.py
@@ -1,4 +1,3 @@
-import logging
 import threading
 import time
 import webbrowser

--- a/src/meltano/api/wsgi.py
+++ b/src/meltano/api/wsgi.py
@@ -1,8 +1,9 @@
 import importlib
 import logging
 
-import meltano
 from gunicorn.glogging import CONFIG_DEFAULTS
+
+import meltano
 from meltano.core.logging.utils import FORMAT
 from meltano.core.project import Project
 from meltano.core.project_settings_service import ProjectSettingsService

--- a/src/meltano/api/wsgi.py
+++ b/src/meltano/api/wsgi.py
@@ -1,7 +1,5 @@
 import importlib
 import logging
-import os
-import warnings
 
 import meltano
 from gunicorn.glogging import CONFIG_DEFAULTS

--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -4,7 +4,6 @@ import click
 import click.globals
 
 from meltano.core.db import project_engine
-from meltano.core.migration_service import MigrationService
 from meltano.core.project_settings_service import ProjectSettingsService
 
 from .utils import CliError
@@ -45,6 +44,8 @@ class pass_project:  # noqa: N801
             engine, _ = project_engine(project, default=True)
 
             if self.migrate:
+                from meltano.core.migration_service import MigrationService
+
                 migration_service = MigrationService(engine)
                 migration_service.upgrade(silent=True)
                 migration_service.seed(project)

--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -1,15 +1,11 @@
 import functools
-import os
-import urllib
-from pathlib import Path
 
 import click
 import click.globals
+
 from meltano.core.db import project_engine
 from meltano.core.migration_service import MigrationService
-from meltano.core.project import Project
 from meltano.core.project_settings_service import ProjectSettingsService
-from meltano.core.utils import pop_all
 
 from .utils import CliError
 

--- a/src/meltano/cli/schema.py
+++ b/src/meltano/cli/schema.py
@@ -1,4 +1,3 @@
-import logging
 
 import click
 import psycopg2
@@ -13,7 +12,6 @@ from .params import pass_project
 @cli.group(short_help="Manage system DB schema.")
 def schema():
     """Manage system DB schema."""
-    pass
 
 
 @schema.command(short_help="Create system DB schema, if not exists.")

--- a/src/meltano/cli/schema.py
+++ b/src/meltano/cli/schema.py
@@ -1,4 +1,5 @@
 import click
+
 from meltano.core.db import DB, project_engine
 
 from . import cli

--- a/src/meltano/cli/schema.py
+++ b/src/meltano/cli/schema.py
@@ -1,9 +1,5 @@
-
 import click
-import psycopg2
-import psycopg2.sql
 from meltano.core.db import DB, project_engine
-from meltano.core.project import Project
 
 from . import cli
 from .params import pass_project

--- a/src/meltano/cli/user.py
+++ b/src/meltano/cli/user.py
@@ -1,7 +1,6 @@
 """User account management CLI."""
 
 import click
-from flask_security.utils import hash_password
 
 from meltano.api.app import create_app
 
@@ -49,7 +48,9 @@ def add(ctx, username, password, role, **flags):
     """
     app = create_app()
 
-    from meltano.api.security import users
+    from flask_security.utils import hash_password
+
+    from meltano.api.security.identity import users
 
     try:
         with app.app_context():
@@ -71,6 +72,7 @@ def add(ctx, username, password, role, **flags):
             current_user = users.get_user(username) or users.create_user(
                 username=username
             )
+
             current_user.password = hash_password(password)
             current_user.roles = roles
 

--- a/src/meltano/core/behavior/visitor.py
+++ b/src/meltano/core/behavior/visitor.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from typing import Callable
 
 

--- a/src/meltano/core/block/ioblock.py
+++ b/src/meltano/core/block/ioblock.py
@@ -130,14 +130,11 @@ class IOBlock(metaclass=ABCMeta):
         Args:
             context: invocation context to use for this execution.
         """
-        pass
 
     @abstractmethod
     async def post(self) -> None:
         """Execute post-stop tasks."""
-        pass
 
     @abstractmethod
     async def close_stdin(self) -> None:
         """Close the underlying stdin if the block is a consumer."""
-        pass

--- a/src/meltano/core/connection_service.py
+++ b/src/meltano/core/connection_service.py
@@ -1,7 +1,3 @@
-import copy
-import logging
-import os
-from enum import Enum
 from pathlib import Path
 
 from .elt_context import ELTContext

--- a/src/meltano/core/connection_service.py
+++ b/src/meltano/core/connection_service.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from .elt_context import ELTContext
-from .plugin_discovery_service import PluginDiscoveryService
 
 
 class DialectNotSupportedError(Exception):

--- a/src/meltano/core/container/container_service.py
+++ b/src/meltano/core/container/container_service.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import signal
+from typing import TYPE_CHECKING
 
-import aiodocker
-from aiodocker.containers import DockerContainer
 from structlog.stdlib import get_logger
 
 from .container_spec import ContainerSpec
+
+if TYPE_CHECKING:
+    from aiodocker.containers import DockerContainer
+
 
 logger = get_logger(__name__)
 
@@ -46,6 +49,8 @@ class ContainerService:
         Returns:
             Docker container information after execution.
         """
+        import aiodocker
+
         async with aiodocker.Docker() as docker:
             if pull:
                 await docker.images.pull(spec.image)

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -86,10 +86,8 @@ class PluginInstallError(Exception):
     """Happens when a plugin fails to install."""
 
 
-
 class PluginInstallWarning(Exception):
     """Happens when a plugin optional optional step fails to install."""
-
 
 
 class PluginNotInstallable(Exception):

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -85,13 +85,11 @@ class AsyncSubprocessError(Exception):
 class PluginInstallError(Exception):
     """Happens when a plugin fails to install."""
 
-    pass
 
 
 class PluginInstallWarning(Exception):
     """Happens when a plugin optional optional step fails to install."""
 
-    pass
 
 
 class PluginNotInstallable(Exception):

--- a/src/meltano/core/extract_utils.py
+++ b/src/meltano/core/extract_utils.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Generator, Iterator
+from typing import Iterator
 
 import aiohttp
 import yaml

--- a/src/meltano/core/extract_utils.py
+++ b/src/meltano/core/extract_utils.py
@@ -55,7 +55,7 @@ def fetch_urls(
     """
     try:
         loop = asyncio.get_event_loop()
-    except RuntimeError as e:
+    except RuntimeError:
         # Fix for when asyncio runs inside a sub-thread so there is no
         #  event_loop available
         asyncio.set_event_loop(asyncio.new_event_loop())

--- a/src/meltano/core/logging/job_logging_service.py
+++ b/src/meltano/core/logging/job_logging_service.py
@@ -12,10 +12,8 @@ class MissingJobLogException(Exception):
     """Occurs when JobLoggingService can not find a requested log."""
 
 
-
 class SizeThresholdJobLogException(Exception):
     """Occurs when a Job log exceeds the MAX_FILE_SIZE."""
-
 
 
 class JobLoggingService:

--- a/src/meltano/core/logging/job_logging_service.py
+++ b/src/meltano/core/logging/job_logging_service.py
@@ -43,7 +43,7 @@ class JobLoggingService:
 
         try:
             log_file = open(log_file_name, "w")
-        except OSError as err:
+        except OSError:
             # Don't stop the Job running if you can not open the log file
             # for writting: just return /dev/null
             logging.error(

--- a/src/meltano/core/logging/job_logging_service.py
+++ b/src/meltano/core/logging/job_logging_service.py
@@ -1,11 +1,6 @@
-import datetime
-import glob
 import logging
 import os
-import shutil
 from contextlib import contextmanager
-from pathlib import Path
-from typing import Optional, Union
 
 from meltano.core.project import Project
 from meltano.core.utils import makedirs, slugify
@@ -16,13 +11,11 @@ MAX_FILE_SIZE = 2_097_152  # 2MB max
 class MissingJobLogException(Exception):
     """Occurs when JobLoggingService can not find a requested log."""
 
-    pass
 
 
 class SizeThresholdJobLogException(Exception):
     """Occurs when a Job log exceeds the MAX_FILE_SIZE."""
 
-    pass
 
 
 class JobLoggingService:

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -170,7 +170,6 @@ class SubprocessOutputWriter(Protocol):
         Args:
             lines: string to write
         """
-        pass
 
 
 async def _write_line_writer(writer, line):

--- a/src/meltano/core/plugin/config_service.py
+++ b/src/meltano/core/plugin/config_service.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-import subprocess
 from pathlib import Path
 from typing import Union
 

--- a/src/meltano/core/plugin/config_service.py
+++ b/src/meltano/core/plugin/config_service.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Union
 
 from meltano.core.plugin.project_plugin import ProjectPlugin
-from meltano.core.project import Project
 
 
 class PluginConfigService:

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -2,9 +2,8 @@
 import logging
 from pathlib import Path
 
-from meltano.core.behavior.hookable import hook
 from meltano.core.error import PluginInstallError
-from meltano.core.plugin import BasePlugin, PluginRef, PluginType
+from meltano.core.plugin import BasePlugin, PluginType
 from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_install_service import PluginInstallReason

--- a/src/meltano/core/plugin/error.py
+++ b/src/meltano/core/plugin/error.py
@@ -47,7 +47,5 @@ class PluginExecutionError(Exception):
     """Base exception for problems that stem from the execution of a plugin (sub-process)."""
 
 
-
 class PluginLacksCapabilityError(Exception):
     """Base exception when a plugin lacks a requested capability."""
-

--- a/src/meltano/core/plugin/error.py
+++ b/src/meltano/core/plugin/error.py
@@ -46,10 +46,8 @@ class PluginNotSupportedError(Exception):
 class PluginExecutionError(Exception):
     """Base exception for problems that stem from the execution of a plugin (sub-process)."""
 
-    pass
 
 
 class PluginLacksCapabilityError(Exception):
     """Base exception when a plugin lacks a requested capability."""
 
-    pass

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -1,6 +1,4 @@
-
 from meltano.core.behavior.hookable import hook
-from meltano.core.db import project_engine
 from meltano.core.plugin import BasePlugin, PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin.settings_service import PluginSettingsService

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -1,5 +1,3 @@
-import logging
-from pathlib import Path
 
 from meltano.core.behavior.hookable import hook
 from meltano.core.db import project_engine

--- a/src/meltano/core/plugin/meltano_file.py
+++ b/src/meltano/core/plugin/meltano_file.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
-import meltano.core.bundle as bundle
 import yaml
+
+import meltano.core.bundle as bundle
 
 from .file import FilePlugin
 

--- a/src/meltano/core/plugin/singer/__init__.py
+++ b/src/meltano/core/plugin/singer/__init__.py
@@ -1,4 +1,3 @@
-
 from meltano.core.plugin import PluginType
 
 from .base import *

--- a/src/meltano/core/plugin/singer/__init__.py
+++ b/src/meltano/core/plugin/singer/__init__.py
@@ -1,4 +1,3 @@
-from typing import Dict
 
 from meltano.core.plugin import PluginType
 

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from uuid import uuid4
 
 from meltano.core.behavior.hookable import hook

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -3,9 +3,7 @@ import logging
 from uuid import uuid4
 
 from meltano.core.behavior.hookable import hook
-from meltano.core.db import project_engine
 from meltano.core.plugin import BasePlugin
-from meltano.core.project import Project
 from meltano.core.utils import nest_object
 
 

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -350,11 +350,9 @@ class CatalogExecutor:
 
     def stream_node(self, node: Node, path: str):
         """Process stream node."""
-        pass
 
     def property_node(self, node: Node, path: str):
         """Process property node."""
-        pass
 
     def metadata_node(self, node: Node, path: str):
         """Process metadata node."""
@@ -365,11 +363,9 @@ class CatalogExecutor:
 
     def stream_metadata_node(self, node: Node, path: str):
         """Process stream metadata node."""
-        pass
 
     def property_metadata_node(self, node: Node, path: str):
         """Process property metadata node."""
-        pass
 
     def __call__(self, node_type, node: Node, path: str):
         """Call this instance as a function."""

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from typing import List
 
 from meltano.core.behavior.hookable import hook
-from meltano.core.db import project_engine
 from meltano.core.job import Job, Payload
 from meltano.core.plugin_invoker import PluginInvoker
 from meltano.core.setting_definition import SettingDefinition

--- a/src/meltano/core/plugin_location_remove.py
+++ b/src/meltano/core/plugin_location_remove.py
@@ -43,7 +43,6 @@ class PluginLocationRemoveManager(ABC):
     @abstractmethod
     def remove(self):
         """Abstract remove method."""
-        pass
 
     @property
     def plugin_removed(self) -> bool:

--- a/src/meltano/core/plugin_test_service.py
+++ b/src/meltano/core/plugin_test_service.py
@@ -38,7 +38,6 @@ class PluginTestService(ABC):
     @abstractmethod
     def validate(self) -> Union[bool, str]:
         """Abstract method to validate plugin configuration."""
-        pass
 
 
 class ExtractorTestService(PluginTestService):

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -5,7 +5,6 @@ import click
 
 from .cli_messages import GREETING
 from .db import project_engine
-from .migration_service import MigrationError, MigrationService
 from .plugin.meltano_file import MeltanoFilePlugin
 from .project import Project
 from .project_settings_service import ProjectSettingsService, SettingValueStore
@@ -103,6 +102,8 @@ class ProjectInitService:
 
         # register the system database connection
         engine, _ = project_engine(self.project, default=True)
+
+        from meltano.core.migration_service import MigrationError, MigrationService
 
         try:
             migration_service = MigrationService(engine)

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -136,7 +136,11 @@ class ProjectInitService:
         click.secho("  cd ", nl=False)
         click.secho(self.project_name, fg="magenta")
         click.echo("  Visit ", nl=False)
-        click.secho("https://docs.meltano.com/getting-started#create-your-meltano-project", fg="cyan", nl=False)
+        click.secho(
+            "https://docs.meltano.com/getting-started#create-your-meltano-project",
+            fg="cyan",
+            nl=False,
+        )
         click.echo(" to learn where to go from here")
 
     def join_with_project_base(self, filename):

--- a/src/meltano/core/runner/dbt.py
+++ b/src/meltano/core/runner/dbt.py
@@ -1,8 +1,5 @@
 import asyncio
-import logging
-import os
 import sys
-from io import StringIO
 
 from meltano.core.db import project_engine
 from meltano.core.elt_context import ELTContext

--- a/src/meltano/core/runner/dbt.py
+++ b/src/meltano/core/runner/dbt.py
@@ -1,13 +1,10 @@
 import asyncio
 import sys
 
-from meltano.core.db import project_engine
 from meltano.core.elt_context import ELTContext
-from meltano.core.error import SubprocessError
 from meltano.core.logging import capture_subprocess_output
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_invoker import PluginInvoker
-from meltano.core.project import Project
 
 from . import Runner, RunnerError
 

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -1,12 +1,8 @@
 import asyncio
 import logging
-import os
-import shutil
 import subprocess
 import sys
 from contextlib import suppress
-from enum import IntFlag
-from pathlib import Path
 
 from meltano.core.elt_context import ELTContext
 from meltano.core.job import Job, Payload

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -5,11 +5,10 @@ import sys
 from contextlib import suppress
 
 from meltano.core.elt_context import ELTContext
-from meltano.core.job import Job, Payload
 from meltano.core.logging import capture_subprocess_output
 from meltano.core.plugin import PluginType
-from meltano.core.plugin.singer import PluginType, SingerTap, SingerTarget
-from meltano.core.plugin_invoker import PluginInvoker, invoker_factory
+from meltano.core.plugin.singer import PluginType
+from meltano.core.plugin_invoker import PluginInvoker
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.utils import human_size
 

--- a/src/meltano/core/select_service.py
+++ b/src/meltano/core/select_service.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.base import PluginRef

--- a/src/meltano/core/select_service.py
+++ b/src/meltano/core/select_service.py
@@ -9,7 +9,6 @@ from meltano.core.plugin.singer.catalog import ListSelectedExecutor
 from meltano.core.plugin_invoker import invoker_factory
 from meltano.core.project_plugins_service import ProjectPluginsService
 
-from .db import project_engine
 from .project import Project
 
 

--- a/src/meltano/core/setting.py
+++ b/src/meltano/core/setting.py
@@ -1,5 +1,3 @@
-import logging
-import os
 
 import sqlalchemy.types as types
 from sqlalchemy import Column, UniqueConstraint

--- a/src/meltano/core/setting.py
+++ b/src/meltano/core/setting.py
@@ -1,9 +1,7 @@
-
 import sqlalchemy.types as types
-from sqlalchemy import Column, UniqueConstraint
+from sqlalchemy import Column
 
 from .models import SystemModel
-from .utils import nest
 
 
 class Setting(SystemModel):

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -109,7 +109,6 @@ class SettingsService(ABC):  # noqa: WPS214
         Returns:
             Label for the settings service.
         """
-        pass
 
     @property
     @abstractmethod
@@ -119,7 +118,6 @@ class SettingsService(ABC):  # noqa: WPS214
         Returns:
             URL for Meltano doc site.
         """
-        pass
 
     @property
     def env_prefixes(self) -> list[str]:
@@ -134,30 +132,25 @@ class SettingsService(ABC):  # noqa: WPS214
     @abstractmethod
     def db_namespace(self) -> str:
         """Return namespace for setting value records in system database."""
-        pass
 
     @property
     @abstractmethod
     def setting_definitions(self) -> list[SettingDefinition]:
         """Return definitions of supported settings."""
-        pass
 
     @property
     def inherited_settings_service(self):
         """Return settings service to inherit configuration from."""
-        pass
 
     @property
     @abstractmethod
     def meltano_yml_config(self) -> dict:
         """Return current configuration in `meltano.yml`."""
-        pass
 
     @property
     @abstractmethod
     def environment_config(self) -> dict:
         """Return current configuration in `meltano.yml`."""
-        pass
 
     @abstractmethod
     def update_meltano_yml_config(self, config):
@@ -166,7 +159,6 @@ class SettingsService(ABC):  # noqa: WPS214
         Args:
             config: updated config
         """
-        pass
 
     @abstractmethod
     def update_meltano_environment_config(self, config: dict):
@@ -175,12 +167,10 @@ class SettingsService(ABC):  # noqa: WPS214
         Args:
             config: updated config
         """
-        pass
 
     @abstractmethod
     def process_config(self):
         """Process configuration dictionary to be used downstream."""
-        pass
 
     @property
     def flat_meltano_yml_config(self):

--- a/src/meltano/core/transform_add_service.py
+++ b/src/meltano/core/transform_add_service.py
@@ -1,5 +1,3 @@
-import json
-import logging
 import os
 from pathlib import Path
 from typing import Optional

--- a/src/meltano/core/transform_add_service.py
+++ b/src/meltano/core/transform_add_service.py
@@ -4,8 +4,6 @@ from typing import Optional
 
 import yaml
 
-from .db import project_engine
-from .plugin import PluginType
 from .plugin.project_plugin import ProjectPlugin
 from .plugin.settings_service import PluginSettingsService
 from .project import Project

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -10,7 +10,6 @@ import psutil
 
 import meltano
 from meltano.cli.utils import PluginInstallReason, install_plugins
-from meltano.core.migration_service import MigrationError, MigrationService
 from meltano.core.project import Project
 from meltano.core.project_plugins_service import PluginType, ProjectPluginsService
 
@@ -109,6 +108,8 @@ class UpgradeService:
 
     def migrate_database(self):
         click.secho("Applying migrations to system database...", fg="blue")
+
+        from meltano.core.migration_service import MigrationError, MigrationService
 
         try:
             migration_service = MigrationService(self.engine)

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -9,7 +9,6 @@ import click
 import psutil
 
 import meltano
-import meltano.core.bundle as bundle
 from meltano.cli.utils import PluginInstallReason, install_plugins
 from meltano.core.migration_service import MigrationError, MigrationService
 from meltano.core.project import Project
@@ -18,7 +17,6 @@ from meltano.core.project_plugins_service import PluginType, ProjectPluginsServi
 
 class UpgradeError(Exception):
     """Occurs when the Meltano upgrade fails"""
-
 
 
 class AutomaticPackageUpgradeError(Exception):

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -1,7 +1,5 @@
-import importlib
 import logging
 import os
-import shutil
 import signal
 import subprocess
 import sys
@@ -21,7 +19,6 @@ from meltano.core.project_plugins_service import PluginType, ProjectPluginsServi
 class UpgradeError(Exception):
     """Occurs when the Meltano upgrade fails"""
 
-    pass
 
 
 class AutomaticPackageUpgradeError(Exception):

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -6,12 +6,12 @@ import logging
 import math
 import os
 import re
+import traceback
 from collections import OrderedDict
 from contextlib import suppress
 from copy import deepcopy
 from datetime import date, datetime, time
 from pathlib import Path
-import traceback
 from typing import Any, Callable, Coroutine, Dict, Iterable, Optional, TypeVar, Union
 
 import flatten_dict

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -141,7 +141,6 @@ class VenvService:
             shutil.rmtree(self.project.run_dir(self.name, make_dirs=False))
         except FileNotFoundError:
             logger.debug("No cached configuration files to remove")
-            pass
 
     def clean(self):
         """Destroy the virtual environment, if it exists."""
@@ -155,7 +154,6 @@ class VenvService:
         except FileNotFoundError:
             # If the VirtualEnv has never been created before do nothing
             logger.debug("No old virtual environment to remove")
-            pass
 
         return
 

--- a/src/meltano/migrations/versions/53e97221d99f_add_run_id_to_job.py
+++ b/src/meltano/migrations/versions/53e97221d99f_add_run_id_to_job.py
@@ -8,9 +8,8 @@ Create Date: 2019-10-10 13:12:55.147164
 import uuid
 
 import sqlalchemy as sa
-import sqlalchemy.orm
-import sqlalchemy.types as types
 from alembic import op
+
 from meltano.migrations import GUID
 
 # revision identifiers, used by Alembic.

--- a/src/meltano/migrations/versions/53e97221d99f_add_run_id_to_job.py
+++ b/src/meltano/migrations/versions/53e97221d99f_add_run_id_to_job.py
@@ -8,8 +8,9 @@ Create Date: 2019-10-10 13:12:55.147164
 import uuid
 
 import sqlalchemy as sa
+import sqlalchemy.orm
+import sqlalchemy.types as types
 from alembic import op
-
 from meltano.migrations import GUID
 
 # revision identifiers, used by Alembic.

--- a/src/meltano/oauth/app.py
+++ b/src/meltano/oauth/app.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import secrets
 
 import meltano.oauth.config

--- a/src/meltano/oauth/app.py
+++ b/src/meltano/oauth/app.py
@@ -1,10 +1,11 @@
 import logging
 import secrets
 
-import meltano.oauth.config
 from flask import Flask, render_template, url_for
-from meltano.core.project import Project
 from werkzeug.middleware.proxy_fix import ProxyFix
+
+import meltano.oauth.config
+from meltano.core.project import Project
 
 
 def create_app():

--- a/src/meltano/oauth/config.py
+++ b/src/meltano/oauth/config.py
@@ -1,4 +1,3 @@
-import os
 from secrets import token_hex
 
 from meltano.api.config import ProjectSettings as APIProjectSettings

--- a/src/meltano/oauth/providers.py
+++ b/src/meltano/oauth/providers.py
@@ -1,6 +1,5 @@
-
 from authlib.flask.client import OAuth as OAuthClient
-from flask import Blueprint, jsonify, redirect, render_template, request, url_for
+from flask import Blueprint, render_template, url_for
 
 OAuth = OAuthClient()
 

--- a/src/meltano/oauth/providers.py
+++ b/src/meltano/oauth/providers.py
@@ -1,4 +1,3 @@
-import logging
 
 from authlib.flask.client import OAuth as OAuthClient
 from flask import Blueprint, jsonify, redirect, render_template, request, url_for

--- a/tests/meltano/api/controllers/test_settings.py
+++ b/tests/meltano/api/controllers/test_settings.py
@@ -1,7 +1,8 @@
 import pytest
 from flask import url_for
+
 from meltano.api.models.security import Role, db
-from meltano.api.security import users
+from meltano.api.security.identity import users
 from meltano.core.project_settings_service import ProjectSettingsService
 
 

--- a/tests/meltano/api/test_security.py
+++ b/tests/meltano/api/test_security.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import joinedload
 
 from meltano.api.models.oauth import OAuth
 from meltano.api.models.security import User, db
-from meltano.api.security import FreeUser, users
+from meltano.api.security.identity import FreeUser, users
 from meltano.api.security.oauth import OAuthError, gitlab_token_identity
 from meltano.core.project import PROJECT_READONLY_ENV, Project
 from meltano.core.project_settings_service import ProjectSettingsService


### PR DESCRIPTION
- Unused imports (outside of `__init__.py` files) have been removed.
- Some imports that were only used for type hints were moved into an `if TYPE_CHECKING` block so that they are not imported at runtime.
- Some imports that were potentially needed at runtime inside of a function were moved into the function.

These changes have cut the time it takes to run `meltano --help` roughly in half. I'm not a fan of having imports inside of functions, but given the significant performance improvement it seems worth it for these special cases.

Later this iteration, possibly for the hack day this Friday, I'm going to try to automatically defer imports by using a `LazyModule` type that is returned by import statements in place of regular modules when the import is originating from a Meltano module.

Closes #6132