### PR TITLE
Fire exit event exactly once & include detailed exception context

### DIFF
--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from meltano.core.logging import setup_logging
 from meltano.core.project import ProjectReadonly
-from meltano.core.tracking.contexts.exception import ExceptionContext
+from meltano.core.tracking.contexts.exception import ExceptionContext  # noqa: F401
 
 from .utils import CliError
 
@@ -86,11 +86,11 @@ def main():
         global exit_code
         ex = sys.exc_info()[1]
         if ex is None:
-            exit_code = 0
+            exit_code = 0  # noqa: WPS442
         elif isinstance(ex, SystemExit):
-            exit_code = 0 if ex.code is None else ex.code
+            exit_code = 0 if ex.code is None else ex.code  # noqa: WPS442
         else:
-            exit_code = 1
+            exit_code = 1  # noqa: WPS442
         # Track the exit event now to provide more details via the exception context.
         # We assume the process will exit practically immediately after `main` returns.
         if exit_event_tracker is not None:

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -93,4 +93,5 @@ def main():
             exit_code = 1
         # Track the exit event now to provide more details via the exception context.
         # We assume the process will exit practically immediately after `main` returns.
-        exit_event_tracker.track_exit_event()
+        if exit_event_tracker is not None:
+            exit_event_tracker.track_exit_event()

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -479,4 +479,4 @@ class Tracker:  # noqa: WPS214 - too many methods 16 > 15
                 },
             )
         )
-        print(f'{self!r}.track_exit_event() -> exit_code: {cli.exit_code!r}')
+        atexit.unregister(self.track_exit_event)

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -442,17 +442,24 @@ class Tracker:  # noqa: WPS214 - too many methods 16 > 15
         )
 
     def setup_exit_event(self):
-        """If not already done, register the atexit handler to fire the exit event."""
+        """If not already done, register the atexit handler to fire the exit event.
+
+        This method also provides this tracker instance to the CLI module for
+        it to fire an exit event immediately before the CLI exits. The atexit
+        handler is used only as a fallback.
+        """
         from meltano import cli
 
-        if not cli.atexit_handler_registered:
-            cli.atexit_handler_registered = True
+        if cli.atexit_handler_registered:
+            return
 
-            # Provide `meltano.cli` with this tracker to track the exit event with more context.
-            cli.exit_event_tracker = self
+        cli.atexit_handler_registered = True
 
-            # As a fallback, use atexit to help ensure the exit event is sent.
-            atexit.register(self.track_exit_event)
+        # Provide `meltano.cli` with this tracker to track the exit event with more context.
+        cli.exit_event_tracker = self
+
+        # As a fallback, use atexit to help ensure the exit event is sent.
+        atexit.register(self.track_exit_event)
 
     def track_exit_event(self):
         """Fire exit event."""

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -442,6 +442,7 @@ class Tracker:  # noqa: WPS214 - too many methods 16 > 15
         )
 
     def setup_exit_event(self):
+        """If not already done, register the atexit handler to fire the exit event."""
         from meltano import cli
 
         if not cli.atexit_handler_registered:

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -118,7 +118,7 @@ class Tracker:  # noqa: WPS214 - too many methods 16 > 15
             self.snowplow_tracker = SnowplowTracker(emitters=emitters)
             self.snowplow_tracker.subject.set_lang(locale.getdefaultlocale()[0])
             self.snowplow_tracker.subject.set_timezone(self.timezone_name)
-            atexit.register(self.track_exit_event)
+            self.setup_exit_event()
         else:
             self.snowplow_tracker = None
 
@@ -441,9 +441,25 @@ class Tracker:  # noqa: WPS214 - too many methods 16 > 15
             )
         )
 
+    def setup_exit_event(self):
+        from meltano import cli
+
+        if not cli.atexit_handler_registered:
+            cli.atexit_handler_registered = True
+
+            # Provide `meltano.cli` with this tracker to track the exit event with more context.
+            cli.exit_event_tracker = self
+
+            # As a fallback, use atexit to help ensure the exit event is sent.
+            atexit.register(self.track_exit_event)
+
     def track_exit_event(self):
         """Fire exit event."""
-        from meltano.cli import exit_code
+        from meltano import cli
+
+        if cli.exit_code_reported:
+            return
+        cli.exit_code_reported = True
 
         start_time = datetime.utcfromtimestamp(Process().create_time())
 
@@ -455,7 +471,7 @@ class Tracker:  # noqa: WPS214 - too many methods 16 > 15
             SelfDescribingJson(
                 ExitEventSchema.url,
                 {
-                    "exit_code": exit_code,
+                    "exit_code": cli.exit_code,
                     "exit_timestamp": f"{now.isoformat()}Z",
                     "process_duration_microseconds": int(
                         (now - start_time).total_seconds() * MICROSECONDS_PER_SECOND
@@ -463,3 +479,4 @@ class Tracker:  # noqa: WPS214 - too many methods 16 > 15
                 },
             )
         )
+        print(f'{self!r}.track_exit_event() -> exit_code: {cli.exit_code!r}')


### PR DESCRIPTION
Closes #6183 

Previously something like `meltano invoke tap-csvx` would provide an exit event with the exit code 1, but its exception context would not include details about the exception that caused the exit because it was being fired from within the atexit handler. Now we only use the atexit handler as a fallback - most exit events are fired from the finally block within the CLI `main` function. 

Here is the exception context that comes with the exit event fired from running `meltano invoke tap-csvx`:

<details><summary>Exception Context JSON</summary>


```json
{
  "schema": "iglu:com.meltano/exceptions_context/jsonschema/1-0-0",
  "data": {
    "context_uuid": "44140fc1-fe91-4de4-be22-1e374d987260",
    "exception": {
      "type": "SystemExit",
      "str_hash": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
      "repr_hash": "13e50e71a2a40a19953717fe6b6a1847d49c2404ed37138bd73731b82eb8ed9b",
      "traceback": [
        {
          "file": "lib/python3.7/site-packages/meltano/cli/__init__.py",
          "line_number": 84
        },
        {
          "file": "lib/python3.7/site-packages/meltano/cli/__init__.py",
          "line_number": 76
        }
      ],
      "cause": null,
      "context": {
        "type": "CliError",
        "str_hash": "f949cb9cf1d464a156ea30c1f9062e977f1d0c671e44134567c07f8f068d9bb2",
        "repr_hash": "0a95982302f85cfbccf20d3c8bcbfaf484da247f497e59b26d501b328758c1ca",
        "traceback": [
          {
            "file": "lib/python3.7/site-packages/meltano/cli/__init__.py",
            "line_number": 73
          }
        ],
        "cause": {
          "type": "PluginNotFoundError",
          "str_hash": "f949cb9cf1d464a156ea30c1f9062e977f1d0c671e44134567c07f8f068d9bb2",
          "repr_hash": "6e8f8685deb32bb7e44b3b5d4fae5d7119c19aabcdfa941eb862c6c6e8822009",
          "traceback": [
            {
              "file": "lib/python3.7/site-packages/meltano/cli/__init__.py",
              "line_number": 65
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 829
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 782
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 1259
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 1066
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 610
            },
            {
              "file": "lib/python3.7/site-packages/meltano/cli/params.py",
              "line_number": 23
            },
            {
              "file": "lib/python3.7/site-packages/meltano/cli/params.py",
              "line_number": 56
            },
            {
              "file": "lib/python3.7/site-packages/meltano/cli/invoke.py",
              "line_number": 106
            },
            {
              "file": "lib/python3.7/site-packages/meltano/core/project_plugins_service.py",
              "line_number": 237
            }
          ],
          "cause": {
            "type": "StopIteration",
            "str_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "repr_hash": "b6b8bc6772e37b15ef153b96cb4e4459abd43a38af09bbc0f7c91cca7177d017",
            "traceback": [
              {
                "file": "lib/python3.7/site-packages/meltano/core/project_plugins_service.py",
                "line_number": 218
              }
            ],
            "cause": null,
            "context": null
          },
          "context": {
            "type": "StopIteration",
            "str_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "repr_hash": "b6b8bc6772e37b15ef153b96cb4e4459abd43a38af09bbc0f7c91cca7177d017",
            "traceback": [
              {
                "file": "lib/python3.7/site-packages/meltano/core/project_plugins_service.py",
                "line_number": 218
              }
            ],
            "cause": null,
            "context": null
          }
        },
        "context": {
          "type": "PluginNotFoundError",
          "str_hash": "f949cb9cf1d464a156ea30c1f9062e977f1d0c671e44134567c07f8f068d9bb2",
          "repr_hash": "6e8f8685deb32bb7e44b3b5d4fae5d7119c19aabcdfa941eb862c6c6e8822009",
          "traceback": [
            {
              "file": "lib/python3.7/site-packages/meltano/cli/__init__.py",
              "line_number": 65
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 829
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 782
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 1259
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 1066
            },
            {
              "file": "lib/python3.7/site-packages/click/core.py",
              "line_number": 610
            },
            {
              "file": "lib/python3.7/site-packages/meltano/cli/params.py",
              "line_number": 23
            },
            {
              "file": "lib/python3.7/site-packages/meltano/cli/params.py",
              "line_number": 56
            },
            {
              "file": "lib/python3.7/site-packages/meltano/cli/invoke.py",
              "line_number": 106
            },
            {
              "file": "lib/python3.7/site-packages/meltano/core/project_plugins_service.py",
              "line_number": 237
            }
          ],
          "cause": {
            "type": "StopIteration",
            "str_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "repr_hash": "b6b8bc6772e37b15ef153b96cb4e4459abd43a38af09bbc0f7c91cca7177d017",
            "traceback": [
              {
                "file": "lib/python3.7/site-packages/meltano/core/project_plugins_service.py",
                "line_number": 218
              }
            ],
            "cause": null,
            "context": null
          },
          "context": {
            "type": "StopIteration",
            "str_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
            "repr_hash": "b6b8bc6772e37b15ef153b96cb4e4459abd43a38af09bbc0f7c91cca7177d017",
            "traceback": [
              {
                "file": "lib/python3.7/site-packages/meltano/core/project_plugins_service.py",
                "line_number": 218
              }
            ],
            "cause": null,
            "context": null
          }
        }
      }
    }
  }
}
```

</details>


This PR also fixes the bug where multiple exit events could be fired by a single Meltano process.