### PR TITLE
Add telemetry page to contributing docs

### DIFF
--- a/docs/src/_contribute/telemetry.md
+++ b/docs/src/_contribute/telemetry.md
@@ -1,0 +1,8 @@
+---
+title: Telemetry
+description: Meltano is open source software built by a growing team and a community of contributors.
+layout: doc
+weight: 10
+---
+
+To update how Meltano telemetry works, or update the schemas we use for Snowplow events and contexts, refer to [the `README.md` file in the tracking module](https://github.com/meltano/meltano/blob/main/src/meltano/core/tracking/README.md).

--- a/docs/src/_contribute/telemetry.md
+++ b/docs/src/_contribute/telemetry.md
@@ -5,4 +5,4 @@ layout: doc
 weight: 10
 ---
 
-To update how Meltano telemetry works, or update the schemas we use for Snowplow events and contexts, refer to [the `README.md` file in the tracking module](https://github.com/meltano/meltano/blob/main/src/meltano/core/tracking/README.md).
+To update how [Meltano telemetry](/reference/settings#send_anonymous_usage_stats) works, or update the schemas we use for Snowplow events and contexts, refer to [the `README.md` file in the tracking module](https://github.com/meltano/meltano/blob/main/src/meltano/core/tracking/README.md).


### PR DESCRIPTION
Added per @aaronsteers' request. This way if someone goes looking for info on how to update our telemetry, they'll be pointed to the telemetry `README.md` file in the `tracking` module.