### PR TITLE
fix: failing Meltano UI schedule execution due to stateID jobID renames

### DIFF
--- a/src/webapp/src/api/orchestrations.js
+++ b/src/webapp/src/api/orchestrations.js
@@ -19,16 +19,16 @@ export default {
     return axios.delete(utils.apiUrl('orchestrations', `subscriptions/${id}`))
   },
 
-  downloadJobLog({ jobId }) {
-    return axios.get(utils.apiUrl('orchestrations', `jobs/${jobId}/download`))
+  downloadJobLog({ stateId }) {
+    return axios.get(utils.apiUrl('orchestrations', `jobs/${stateId}/download`))
   },
 
   extract(extractor) {
     return axios.post(utils.apiUrl('orchestrations', `extract/${extractor}`))
   },
 
-  getJobLog({ jobId }) {
-    return axios.get(utils.apiUrl('orchestrations', `jobs/${jobId}/log`))
+  getJobLog({ stateId }) {
+    return axios.get(utils.apiUrl('orchestrations', `jobs/${stateId}/log`))
   },
 
   getPipelineSchedules() {

--- a/src/webapp/src/components/pipelines/CronJobModal.vue
+++ b/src/webapp/src/components/pipelines/CronJobModal.vue
@@ -21,11 +21,11 @@ export default {
     ...mapState('orchestration', ['pipelines']),
     ...mapGetters('plugins', ['getInstalledPlugin', 'getPluginLabel']),
     relatedPipeline() {
-      return this.pipelines.find(pipeline => pipeline.name === this.jobId)
+      return this.pipelines.find(pipeline => pipeline.name === this.stateId)
     }
   },
   created() {
-    this.jobId = this.$route.params.jobId
+    this.stateId = this.$route.params.stateId
     if (
       this.$route.params.cronInterval &&
       this.$route.params.cronInterval.includes('*')

--- a/src/webapp/src/components/pipelines/LogModal.vue
+++ b/src/webapp/src/components/pipelines/LogModal.vue
@@ -27,7 +27,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('orchestration', ['getRunningPipelineJobIds']),
+    ...mapGetters('orchestration', ['getRunningPipelinestateIds']),
     ...mapState('orchestration', ['pipelines']),
     ...mapGetters('plugins', ['getPluginLabel']),
     getDownloadPromise() {
@@ -71,7 +71,7 @@ export default {
       return !!this.$flask['isAnalysisEnabled']
     },
     relatedPipeline() {
-      return this.pipelines.find(pipeline => pipeline.name === this.jobId)
+      return this.pipelines.find(pipeline => pipeline.name === this.stateId)
     },
     dataSourceLabel() {
       return this.relatedPipeline
@@ -80,7 +80,7 @@ export default {
     }
   },
   created() {
-    this.jobId = this.$route.params.jobId
+    this.stateId = this.$route.params.stateId
     this.initJobPoller()
   },
   beforeDestroy() {
@@ -96,7 +96,7 @@ export default {
     },
     initJobPoller() {
       const pollFn = () => {
-        this.getJobLog(this.jobId)
+        this.getJobLog(this.stateId)
           .then(response => {
             this.jobStatus = response.data
             this.hasError = this.jobStatus.hasError
@@ -107,7 +107,7 @@ export default {
             this.jobLog = error.response.data.code
           })
           .finally(() => {
-            if (this.getRunningPipelineJobIds.indexOf(this.jobId) === -1) {
+            if (this.getRunningPipelinestateIds.indexOf(this.stateId) === -1) {
               this.isPolling = false
               this.jobPoller.dispose()
             }
@@ -177,7 +177,7 @@ export default {
               <SubscribeButton
                 event-type="pipeline_manual_run"
                 source-type="pipeline"
-                :source-id="jobId"
+                :source-id="stateId"
               >
                 <label
                   slot="label"
@@ -213,9 +213,9 @@ export default {
         <DownloadButton
           v-if="hasLogExceededMaxSize || !isPolling"
           label="Download Log"
-          :file-name="`${jobId}-job-log.txt`"
+          :file-name="`${stateId}-job-log.txt`"
           :trigger-promise="getDownloadPromise"
-          :trigger-payload="{ jobId }"
+          :trigger-payload="{ stateId }"
         ></DownloadButton>
         <label v-else class="checkbox is-unselectable">
           <input v-model="shouldAutoScroll" type="checkbox" />

--- a/src/webapp/src/components/pipelines/Pipeline.vue
+++ b/src/webapp/src/components/pipelines/Pipeline.vue
@@ -62,8 +62,8 @@ export default {
       'updatePipelineSchedule',
       'getPipelineSchedules'
     ]),
-    goToLog(jobId) {
-      this.$router.push({ name: 'runLog', params: { jobId } })
+    goToLog(stateId) {
+      this.$router.push({ name: 'runLog', params: { stateId } })
     },
     onChangeItem(option, pipeline, item) {
       const newPipelineValue = option.srcElement.selectedOptions[0].value
@@ -73,11 +73,11 @@ export default {
           pipeline.extractor
         ).namespace
         if (newPipelineValue === '@other') {
-          const jobId = pipeline.jobId
+          const stateId = pipeline.stateId
           const cronDefault = this.defaultCronInterval
           this.$router.push({
             name: 'cronJobSettings',
-            params: { jobId, cronDefault }
+            params: { stateId, cronDefault }
           })
         } else {
           if (item === 'interval' && newPipelineValue != '@other') {
@@ -97,10 +97,10 @@ export default {
         }
       }
     },
-    setCRONInterval(jobId, cronInterval) {
+    setCRONInterval(stateId, cronInterval) {
       this.$router.push({
         name: 'cronJobSettings',
-        params: { jobId, cronInterval }
+        params: { stateId, cronInterval }
       })
     },
     removePipeline(pipeline) {
@@ -232,7 +232,7 @@ export default {
                 : 'View the last run of this ELT pipeline.'
             }`
           "
-          @click="goToLog(pipeline.jobId)"
+          @click="goToLog(pipeline.stateId)"
         >
           <span>
             {{ getLastRunLabel(pipeline) }}
@@ -274,7 +274,7 @@ export default {
             data-tooltip="Set the CRON interval you'd like"
             :class="{ 'is-loading': pipeline.isRunning }"
             :disabled="getIsDisabled(pipeline)"
-            @click="setCRONInterval(pipeline.jobId, pipeline.cronExpression)"
+            @click="setCRONInterval(pipeline.stateId, pipeline.cronExpression)"
           >
             <span>Interval Details</span>
             <span class="icon is-small">

--- a/src/webapp/src/router/app.js
+++ b/src/webapp/src/router/app.js
@@ -84,7 +84,7 @@ const router = new Router({
           }
         },
         {
-          path: ':jobId',
+          path: ':stateId',
           name: 'runLog',
           components: {
             default: Pipelines,
@@ -96,7 +96,7 @@ const router = new Router({
           }
         },
         {
-          path: '/cron-job-settings/:jobId',
+          path: '/cron-job-settings/:stateId',
           name: 'cronJobSettings',
           components: {
             default: Pipelines,


### PR DESCRIPTION
Fix an issue where the UI hangs because of an incompatibility between 2.0.x and anything 1.x.x due to stateId vs jobId.