### PR TITLE
Resolve intermittent errors when calling `meltano config airflow` 

### DIFF
--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -102,7 +102,6 @@ def config(  # noqa: WPS231
                 plugins_service=plugins_service,
             )
             invoker = PluginInvoker(project, plugin)
-            run_async(invoker.prepare(session))
         else:
             settings = ProjectSettingsService(
                 project, config_service=plugins_service.config_service
@@ -320,8 +319,8 @@ def test(ctx):
     session = ctx.obj["session"]
 
     async def _validate():  # noqa: WPS430
-        async with invoker.prepared(session):
-            plugin_test_service = PluginTestServiceFactory(invoker).get_test_service()
+        plugin_test_service = PluginTestServiceFactory(invoker).get_test_service()
+        async with plugin_test_service.plugin_invoker.prepared(session):
             return await plugin_test_service.validate()
 
     try:


### PR DESCRIPTION
Don't proactively prepare invoker in top level click group AND only prepare invoker for `meltano config <plugin> test` calls once we've obtained a test service, and thus know that the plugin is actually even testable.

```
(melty-3.8) ➜  meltano config airflow set webserver web_server_port 8081
Orchestrator 'airflow' setting 'webserver.web_server_port' was set in `meltano.yml`: 8081
(melty-3.8) ➜  meltano config tap-gitlab test
Plugin configuration is valid
(melty-3.8) ➜  meltano config airflow test
Operation not supported for orchestrator 'airflow'
```

closes #6119 