### PR TITLE
fix: add missing `disable_tracking` setting entry

### DIFF
--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -8,7 +8,6 @@ settings:
 - name: disable_tracking
   kind: boolean
   # Replaces negated env_alias from `send_anonymous_usage_stats`
-  # env_aliases: ["!MELTANO_DISABLE_TRACKING"]
 - name: project_id
 - name: database_uri
   value: sqlite:///$MELTANO_PROJECT_ROOT/.meltano/meltano.db

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -3,7 +3,12 @@ settings:
 - name: send_anonymous_usage_stats
   kind: boolean
   value: true
-  env_aliases: ["!MELTANO_DISABLE_TRACKING"]
+  # Previously:
+  # env_aliases: ["!MELTANO_DISABLE_TRACKING"]
+- name: disable_tracking
+  kind: boolean
+  # Replaces negated env_alias from `send_anonymous_usage_stats`
+  # env_aliases: ["!MELTANO_DISABLE_TRACKING"]
 - name: project_id
 - name: database_uri
   value: sqlite:///$MELTANO_PROJECT_ROOT/.meltano/meltano.db


### PR DESCRIPTION
We discovered in https://github.com/meltano/meltano/pull/6199