### PR TITLE
ci: add config and docs for semantic-prs

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -4,7 +4,7 @@
 titleOnly: true
 
 # Provides a custom URL for the "Details" link, which appears next to the success/failure message from the app:
-targetUrl: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#semantic-pull-requests
+targetUrl: https://docs.meltano.com/contribute/merge#semantic-prs
 
 # The values allowed for the "type" part of the PR title/commit message.
 # e.g. for a PR title/commit message of "feat: add some stuff", the type would be "feat"

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -25,6 +25,6 @@ types:
 # e.g. for a PR title/commit message of "feat(awesome-feature): add some stuff",
 #      the scope would be "awesome-feature"
 scopes:
-  - ui      # target SDK only
-  - core    # mappers only
-  - cli     # cookiecutters
+  - ui
+  - core
+  - cli

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,30 @@
+# Config ref: https://github.com/Ezard/semantic-prs
+
+# Validate the PR title, and ignore all commit messages
+titleOnly: true
+
+# Provides a custom URL for the "Details" link, which appears next to the success/failure message from the app:
+targetUrl: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#semantic-pull-requests
+
+# The values allowed for the "type" part of the PR title/commit message.
+# e.g. for a PR title/commit message of "feat: add some stuff", the type would be "feat"
+types:
+  - ci
+  - chore
+  - build
+  - docs
+  - feat
+  - fix
+  - perf
+  - refactor
+  - revert
+  - style
+  - test
+
+# The values allowed for the "scope" part of the PR title/commit message.
+# e.g. for a PR title/commit message of "feat(awesome-feature): add some stuff",
+#      the scope would be "awesome-feature"
+scopes:
+  - ui      # target SDK only
+  - core    # mappers only
+  - cli     # cookiecutters

--- a/docs/src/_contribute/index.md
+++ b/docs/src/_contribute/index.md
@@ -56,31 +56,3 @@ The following guides have information to help get you up and running and ready t
     <li><a href="{{ doc.url }}">{{ doc.title }}</a></li>
   {% endfor %}
 </ul>
-
-## Semantic Pull Requests
-
-The `meltano` repo uses the [semantic-prs](https://github.com/Ezard/semantic-prs) GitHub app to check all PRs againts the conventional commit syntax.
-
-Pull requests should be named according to the conventional commit syntax to streamline changelog and release notes management. We encourage (but do not require) the use of conventional commits in commit messages as well.
-
-In general, PR titles should follow the format "<type>: <desc>", where type is any one of these:
-
-- `ci`
-- `chore`
-- `build`
-- `docs`
-- `feat`
-- `fix`
-- `perf`
-- `refactor`
-- `revert`
-- `style`
-- `test`
-
-Optionally, you may use the expanded syntax to specify a scope in the form `<type>(<scope>): <desc>`. Currently scopes are:
-
-- `ui`
-- `core`
-- `cli`
-
-The latest rules and settings can be found within the file [`.github/semantic.yml`](https://github.com/meltano/meltano/blob/main/.github/semantic.yml).

--- a/docs/src/_contribute/index.md
+++ b/docs/src/_contribute/index.md
@@ -56,3 +56,31 @@ The following guides have information to help get you up and running and ready t
     <li><a href="{{ doc.url }}">{{ doc.title }}</a></li>
   {% endfor %}
 </ul>
+
+## Semantic Pull Requests
+
+The `meltano` repo uses the [semantic-prs](https://github.com/Ezard/semantic-prs) GitHub app to check all PRs againts the conventional commit syntax.
+
+Pull requests should be named according to the conventional commit syntax to streamline changelog and release notes management. We encourage (but do not require) the use of conventional commits in commit messages as well.
+
+In general, PR titles should follow the format "<type>: <desc>", where type is any one of these:
+
+- `ci`
+- `chore`
+- `build`
+- `docs`
+- `feat`
+- `fix`
+- `perf`
+- `refactor`
+- `revert`
+- `style`
+- `test`
+
+Optionally, you may use the expanded syntax to specify a scope in the form `<type>(<scope>): <desc>`. Currently scopes are:
+
+- `ui`
+- `core`
+- `cli`
+
+The latest rules and settings can be found within the file [`.github/semantic.yml`](https://github.com/meltano/meltano/blob/main/.github/semantic.yml).

--- a/docs/src/_contribute/merge.md
+++ b/docs/src/_contribute/merge.md
@@ -12,13 +12,41 @@ Meltano uses an approval workflow for all pull requests.
 1. Once the review is done the reviewer may approve the pull request or send it back for further iteration.
 1. Once approved, the pull request will be merged by any Meltano maintainer.
 
-### Reviews
+## Reviews
 
 A contributor can ask for a review on any pull request, without this pull request being done and/or ready to merge.
 
 Asking for a review is asking for feedback on the implementation, not approval of the pull request. It is also the perfect time to familiarize yourself with the code base. If you don’t understand why a certain code path would solve a particular problem, that should be sent as feedback: it most probably means the code is cryptic/complex or that the problem is bigger than anticipated.
 
 Merge conflicts, failing tests and/or missing checkboxes should not be used as ground for sending back a pull request without feedback, unless specified by the reviewer.
+
+## Semantic PRs
+
+The `meltano` repo uses the [semantic-prs](https://github.com/Ezard/semantic-prs) GitHub app to check all PRs againts the conventional commit syntax.
+
+Pull requests should be named according to the conventional commit syntax to streamline changelog and release notes management. We encourage (but do not require) the use of conventional commits in commit messages as well.
+
+In general, PR titles should follow the format "<type>: <desc>", where type is any one of these:
+
+- `ci`
+- `chore`
+- `build`
+- `docs`
+- `feat`
+- `fix`
+- `perf`
+- `refactor`
+- `revert`
+- `style`
+- `test`
+
+Optionally, you may use the expanded syntax to specify a scope in the form `<type>(<scope>): <desc>`. Currently scopes are:
+
+- `ui`
+- `core`
+- `cli`
+
+The latest rules and settings are found within the file [`.github/semantic.yml`](https://github.com/meltano/meltano/blob/main/.github/semantic.yml).
 
 ## Architectural Decision Records
 

--- a/docs/src/_contribute/merge.md
+++ b/docs/src/_contribute/merge.md
@@ -22,7 +22,7 @@ Merge conflicts, failing tests and/or missing checkboxes should not be used as g
 
 ## Semantic PRs
 
-The `meltano` repo uses the [semantic-prs](https://github.com/Ezard/semantic-prs) GitHub app to check all PRs againts the conventional commit syntax.
+The `meltano` repo uses the [semantic-prs](https://github.com/Ezard/semantic-prs) GitHub app to check all PRs againts the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
 
 Pull requests should be named according to the conventional commit syntax to streamline changelog and release notes management. We encourage (but do not require) the use of conventional commits in commit messages as well.
 


### PR DESCRIPTION
This PR preps us to turn on Semantic PRs checks, which would significantly streamline release notes generation.

Modeled after the same in the SDK, and as discussed in our gitops discussion:

- https://github.com/meltano/gitops/issues/6

Attn: @tayloramurphy, @afolson, @edgarrmondragon, @pandemicsyn, @meltano/engineering 

Turning on the App integration just takes 5 minutes. I'll do that at the same time as merging this.


