### PR TITLE
feat: Auto-install tab-completion for Meltano when building sdist or source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,5 @@ skip_glob = ["*.md", "*.vue", "*.js"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+build-backend = "build:api"
+backend-path = ["src/meltano"]

--- a/src/meltano/build/__init__.py
+++ b/src/meltano/build/__init__.py
@@ -1,0 +1,109 @@
+"""A PEP 517 build backend for Meltano that automatically installs shell tab-completions."""
+
+import os
+from pathlib import Path
+from platform import system
+from shutil import copy
+
+from poetry.core.masonry import api  # noqa: F401
+
+
+BUILD_DIR = Path(__file__).parent
+HOME = Path.home()
+PERMISSION = 0o755
+
+
+def install_completions(src: Path, dest: Path, name: str) -> Path:
+    """Copy `src` into `dest` with the given name & create directories as needed.
+
+    Parameters:
+        src: The path to the Meltano tab-completion script for the target shell.
+        dest: The directory into which the script should be copied.
+        name: The name the script should have within `dest`.
+
+    Returns:
+        The location the Meltano completions script was installed in.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    installation_location = Path(copy(src, dest / name))
+    installation_location.chmod(PERMISSION)
+    return installation_location
+
+
+def install_bash_completions() -> Path:
+    """Install Meltano tab-completion for Bash.
+
+    Returns:
+        The location the Meltano completions script was installed in.
+    """
+    # Installs into:
+    # ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions
+    return install_completions(
+        BUILD_DIR / "meltano-complete.bash",
+        (
+            Path(
+                os.environ.get(
+                    "BASH_COMPLETION_USER_DIR",
+                    Path(os.environ.get("XDG_DATA_HOME", HOME / ".local" / "share"))
+                    / "bash-completion",
+                )
+            )
+            / "completions"
+        ),
+        "meltano",
+    )
+
+
+def install_fish_completions() -> Path:
+    """Install Meltano tab-completion for Fish.
+
+    Returns:
+        The location the Meltano completions script was installed in.
+    """
+    dest = HOME / ".config" / "fish" / "completions"
+    return install_completions(
+        BUILD_DIR / "meltano-complete.fish", dest, "meltano.fish"
+    )
+
+
+def install_zsh_completions() -> Path:
+    """Install Meltano tab-completion for Zsh.
+
+    Directories in `$FPATH` are attempted until one works, or there are none left. By default all
+    directories on `$FPATH` are owned by root, but it's common for users to add one or more user
+    directories to it.
+
+    Raises:
+        Exception: No location in `$FPATH` was suitable for installation.
+
+    Returns:
+        The location the Meltano completions script was installed in.
+    """
+    for dest in os.environ.get("FPATH", "").split(":"):
+        if dest == "":
+            continue
+        try:
+            return install_completions(
+                BUILD_DIR / "meltano-complete.zsh", Path(dest), "_meltano"
+            )
+        except OSError:
+            pass
+    raise Exception
+
+
+if system() != "Windows":
+    for shell, fn in {
+        "bash": install_bash_completions,
+        "fish": install_fish_completions,
+        "zsh": install_zsh_completions,
+    }.items():
+        try:
+            installation_location = fn()
+        except Exception:
+            print(  # noqa: WPS421
+                f"Failed to install {shell} tab-completions for Meltano"
+            )
+        else:
+            print(  # noqa: WPS421
+                f"Installed {shell} tab-completions for Meltano at {installation_location}"
+            )

--- a/src/meltano/build/meltano-complete.bash
+++ b/src/meltano/build/meltano-complete.bash
@@ -1,0 +1,21 @@
+_meltano_completion() {
+    local IFS=$'
+'
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _MELTANO_COMPLETE=complete $1 ) )
+    return 0
+}
+
+_meltano_completionetup() {
+    local COMPLETION_OPTIONS=""
+    local BASH_VERSION_ARR=(${BASH_VERSION//./ })
+    # Only BASH version 4.4 and later have the nosort option.
+    if [ ${BASH_VERSION_ARR[0]} -gt 4 ] || ([ ${BASH_VERSION_ARR[0]} -eq 4 ] && [ ${BASH_VERSION_ARR[1]} -ge 4 ]); then
+        COMPLETION_OPTIONS="-o nosort"
+    fi
+
+    complete $COMPLETION_OPTIONS -F _meltano_completion meltano
+}
+
+_meltano_completionetup;

--- a/src/meltano/build/meltano-complete.fish
+++ b/src/meltano/build/meltano-complete.fish
@@ -1,0 +1,1 @@
+complete --no-files --command meltano --arguments "(env _MELTANO_COMPLETE=complete_fish COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) meltano)";

--- a/src/meltano/build/meltano-complete.zsh
+++ b/src/meltano/build/meltano-complete.zsh
@@ -1,0 +1,32 @@
+#compdef meltano
+
+_meltano_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[meltano] )) && return 1
+
+    response=("${(@f)$( env COMP_WORDS="${words[*]}" \
+                        COMP_CWORD=$((CURRENT-1)) \
+                        _MELTANO_COMPLETE="complete_zsh" \
+                        meltano )}")
+
+    for key descr in ${(kv)response}; do
+      if [[ "$descr" == "_" ]]; then
+          completions+=("$key")
+      else
+          completions_with_descriptions+=("$key":"$descr")
+      fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+    compstate[insert]="automenu"
+}
+
+compdef _meltano_completion meltano;


### PR DESCRIPTION
[Recording of the demo on YouTube](https://youtu.be/IqaPHGRUNTA?t=3861)

This PR currently targets the `lazy-modules` branch (https://github.com/meltano/meltano/pull/6249) because tab-completion relies heavily on our CLI having a fast startup speed. Every tab-completion requires running the CLI so that Click can provide the completions to the shell.

No matter what approach we take in the end for CLI tab-completion, we probably should not use `click-completion` as it appears outdated and unmaintained: https://github.com/click-contrib/click-completion/issues/41

Closes #3401