### PR TITLE
Run isort & clean-up `tox.ini`

### DIFF
--- a/tests/meltano/api/conftest.py
+++ b/tests/meltano/api/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from meltano.api.models import db as _db
 
 

--- a/tests/meltano/api/controllers/test_orchestration.py
+++ b/tests/meltano/api/controllers/test_orchestration.py
@@ -5,6 +5,7 @@ from asynctest import CoroutineMock, mock
 from flask import Flask, url_for
 from flask.testing import FlaskClient
 from flask.wrappers import Response
+
 from meltano.core.plugin.settings_service import REDACTED_VALUE, SettingValueStore
 
 

--- a/tests/meltano/api/test_workers.py
+++ b/tests/meltano/api/test_workers.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+
 from meltano.api.workers import UIAvailableWorker
 
 

--- a/tests/meltano/cli/test_auto_install.py
+++ b/tests/meltano/cli/test_auto_install.py
@@ -1,4 +1,5 @@
 import pytest
+
 from asserts import assert_cli_runner
 from meltano.cli import cli
 

--- a/tests/meltano/cli/test_remove.py
+++ b/tests/meltano/cli/test_remove.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+
 from asserts import assert_cli_runner
 from meltano.cli import cli
 from meltano.core.plugin import PluginType

--- a/tests/meltano/cli/test_select.py
+++ b/tests/meltano/cli/test_select.py
@@ -1,7 +1,8 @@
 import json
 
-from asserts import assert_cli_runner
 from asynctest import mock
+
+from asserts import assert_cli_runner
 from meltano.cli import cli
 
 

--- a/tests/meltano/core/behavior/test_canonical.py
+++ b/tests/meltano/core/behavior/test_canonical.py
@@ -1,5 +1,6 @@
 import pytest
 import yaml
+
 from meltano.core.behavior.canonical import Canonical
 
 definition = {

--- a/tests/meltano/core/behavior/test_hookable.py
+++ b/tests/meltano/core/behavior/test_hookable.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+
 from meltano.core.behavior.hookable import HookObject, hook
 
 

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 import psutil
 import pytest
+
 from meltano.core.job.job import (
     HEARTBEAT_VALID_MINUTES,
     HEARTBEATLESS_JOB_VALID_HOURS,

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -6,8 +6,9 @@ from unittest import mock
 
 import pytest
 import structlog
-from meltano.core.logging.output_logger import Out, OutputLogger
 from structlog.testing import LogCapture
+
+from meltano.core.logging.output_logger import Out, OutputLogger
 
 
 def assert_lines(output, *lines):

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+
 from meltano.core.plugin.singer.catalog import (
     CatalogRule,
     ListExecutor,

--- a/tests/meltano/core/plugin/singer/test_target.py
+++ b/tests/meltano/core/plugin/singer/test_target.py
@@ -1,4 +1,5 @@
 import pytest
+
 from meltano.core.job import Job, Payload
 from meltano.core.plugin import PluginType
 from meltano.core.project_plugins_service import PluginAlreadyAddedException

--- a/tests/meltano/core/plugin/test_airflow.py
+++ b/tests/meltano/core/plugin/test_airflow.py
@@ -2,6 +2,7 @@ from configparser import ConfigParser
 
 import pytest
 from asynctest import CoroutineMock, mock
+
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.airflow import AirflowInvoker
 from meltano.core.plugin_install_service import PluginInstallService

--- a/tests/meltano/core/plugin/test_command.py
+++ b/tests/meltano/core/plugin/test_command.py
@@ -1,4 +1,5 @@
 import pytest
+
 from meltano.core.behavior.canonical import Canonical
 from meltano.core.plugin.command import Command, UndefinedEnvVarError
 

--- a/tests/meltano/core/test_db_reconnection.py
+++ b/tests/meltano/core/test_db_reconnection.py
@@ -1,8 +1,9 @@
 from unittest.mock import Mock
 
 import pytest
-from meltano.core.db import check_db_connection
 from sqlalchemy.exc import OperationalError
+
+from meltano.core.db import check_db_connection
 
 
 class TestConnectionRetries:

--- a/tests/meltano/core/test_meltano_invoker.py
+++ b/tests/meltano/core/test_meltano_invoker.py
@@ -4,8 +4,9 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import meltano
 import pytest
+
+import meltano
 from meltano.core.meltano_invoker import MELTANO_COMMAND, MeltanoInvoker
 
 

--- a/tests/meltano/core/test_plugins_test_service.py
+++ b/tests/meltano/core/test_plugins_test_service.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from asynctest import CoroutineMock, Mock, patch
+
 from meltano.core.plugin.error import PluginNotSupportedError
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_test_service import (

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -5,6 +5,7 @@ import sys
 from unittest import mock
 
 import pytest
+
 from meltano.core.project import Project
 from meltano.core.venv_service import VenvService, VirtualEnv
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,6 @@ envlist = fix,lint
 skipsdist = true
 isolated_build = true
 
-[build-system]
-requires = ["poetry_core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-
 [testenv]
 whitelist_externals = poetry
 


### PR DESCRIPTION
I ran `tox`, and it ran `isort` on `src/` and `tests/`. Might as well commit the results.

As for the removal of the `[build-system]` section from `tox.ini`, it is no longer required. Tox will source it from `pyproject.toml`