### PR TITLE
chore: Update misleading module docstring in `src/meltano/core/bundle`

### DIFF
--- a/src/meltano/core/bundle/__init__.py
+++ b/src/meltano/core/bundle/__init__.py
@@ -1,15 +1,5 @@
-"""
-This module files should be created via
-`make bundle` at the project root.
-"""
+"""Bundled yaml files."""
 
-import os
 from pathlib import Path
 
-
-def root() -> Path:
-    return Path(os.path.dirname(__file__))
-
-
-def find(file_path: Path) -> Path:
-    return root().joinpath(file_path)
+root = Path(__file__).parent

--- a/src/meltano/core/config_service.py
+++ b/src/meltano/core/config_service.py
@@ -37,7 +37,7 @@ class ConfigService:
             The project settings.
         """
         if self._settings is None:
-            with bundle.find("settings.yml").open() as settings_yaml:
+            with open(bundle.root / "settings.yml") as settings_yaml:
                 settings = yaml.safe_load(settings_yaml)
             self._settings = list(map(SettingDefinition.parse, settings["settings"]))
 

--- a/src/meltano/core/meltano_invoker.py
+++ b/src/meltano/core/meltano_invoker.py
@@ -18,7 +18,7 @@ class MeltanoInvoker:
 
         Parameters:
             project: Project class
-            settings_service: ProjectSettingService Class blank
+            settings_service: ProjectSettingsService Class blank
         """
         self.project = project
         self.settings_service = settings_service or ProjectSettingsService(project)

--- a/src/meltano/core/plugin/meltano_file.py
+++ b/src/meltano/core/plugin/meltano_file.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import yaml
 
-import meltano.core.bundle as bundle
+from meltano.core import bundle
 
 from .file import FilePlugin
 
@@ -13,13 +13,13 @@ class MeltanoFilePlugin(FilePlugin):
         self._discovery = discovery
 
     def file_contents(self, project):
-        initialize_file = bundle.find("initialize.yml")
+        initialize_file = bundle.root / "initialize.yml"
         file_contents = {
             Path(relative_path): content
             for relative_path, content in yaml.safe_load(initialize_file.open()).items()
         }
         if self._discovery:
-            file_contents["discovery.yml"] = bundle.find("discovery.yml").read_text()
+            file_contents["discovery.yml"] = (bundle.root / "discovery.yml").read_text()
         return file_contents
 
     def update_config(self, project):

--- a/src/meltano/core/plugin_discovery_service.py
+++ b/src/meltano/core/plugin_discovery_service.py
@@ -327,7 +327,7 @@ class PluginDiscoveryService(  # noqa: WPS214 (too many public methods)
         Returns:
             The discovery file.
         """
-        with bundle.find("discovery.yml").open() as bundled_discovery:
+        with open(bundle.root / "discovery.yml") as bundled_discovery:
             discovery = self.load_discovery(bundled_discovery, cache=True)
 
         return discovery

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -44,7 +44,7 @@ PROJECT_NAME = "a_meltano_project"
 
 @pytest.fixture(scope="class")
 def discovery():  # noqa: WPS213
-    with bundle.find("discovery.yml").open() as base:
+    with open(bundle.root / "discovery.yml") as base:
         discovery = yaml.safe_load(base)
 
     discovery[PluginType.EXTRACTORS].append(

--- a/tests/meltano/core/test_plugin_discovery_service.py
+++ b/tests/meltano/core/test_plugin_discovery_service.py
@@ -283,7 +283,7 @@ class TestPluginDiscoveryServiceDiscoveryManifest:
 
     @pytest.fixture
     def bundled_discovery(self):
-        with open(bundle / "discovery.yml") as bundled_discovery:
+        with open(bundle.root / "discovery.yml") as bundled_discovery:
             return yaml.safe_load(bundled_discovery)
 
     def test_local_discovery(self, subject, local_discovery):

--- a/tests/meltano/core/test_plugin_discovery_service.py
+++ b/tests/meltano/core/test_plugin_discovery_service.py
@@ -283,7 +283,7 @@ class TestPluginDiscoveryServiceDiscoveryManifest:
 
     @pytest.fixture
     def bundled_discovery(self):
-        with bundle.find("discovery.yml").open() as bundled_discovery:
+        with open(bundle / "discovery.yml") as bundled_discovery:
             return yaml.safe_load(bundled_discovery)
 
     def test_local_discovery(self, subject, local_discovery):


### PR DESCRIPTION
The docstring previously stated:

```python
"""
This module files should be created via
`make bundle` at the project root.
"""
```

As best I can tell, this was never true. I've also gone ahead and simplified the module to just contain its path as `root`, and updated the sites where it was being used to reflect this change.

Also a typo fix in `src/meltano/core/meltano_invoker.py`