### PR TITLE
fix: update schedule schema entry to support job ref and add a jobs entry

### DIFF
--- a/schema/meltano.schema.json
+++ b/schema/meltano.schema.json
@@ -103,6 +103,13 @@
         "$ref": "#/definitions/schedules"
       },
       "description": "Scheduled ELT jobs, added using 'meltano schedule'"
+    },
+    "jobs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/jobs"
+      },
+      "description": "Jobs, added using 'meltano job'"
     }
   },
   "definitions": {
@@ -717,13 +724,15 @@
     },
     "schedules": {
       "type": "object",
-      "required": [
-        "name",
-        "extractor",
-        "loader",
-        "transform",
-        "interval",
-        "start_date"
+      "oneOf": [
+        {"required": ["name", "job", "interval"]},
+        {"required": [
+          "name",
+          "extractor",
+          "loader",
+          "transform",
+          "interval",
+          "start_date"]}
       ],
       "description": "https://www.meltano.com/docs/orchestration.html#orchestration",
       "additionalProperties": false,
@@ -732,6 +741,11 @@
           "type": "string",
           "description": "The schedule's unique name",
           "examples": ["gitlab-to-jsonl"]
+        },
+        "job": {
+          "type": "string",
+          "description": "The name of a meltano job",
+          "examples": ["some-custom-job"]
         },
         "extractor": {
           "type": "string",
@@ -759,6 +773,45 @@
           "type": "string",
           "description": "The date when the schedule should first execute",
           "examples": ["2020-08-06 00:00:00"]
+        }
+      }
+    },
+    "jobs": {
+      "type": "object",
+      "required": [
+        "name",
+        "tasks"
+      ],
+      "description": "https://docs.meltano.com/reference/command-line-interface#job",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "This jobs unique name",
+          "examples": ["gitlab-to-jsonl"]
+        },
+        "tasks": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
Update's the schedule schema to support jobs and adds a shiny new jobs entry.

Should address:

-  https://github.com/meltano/meltano/issues/6170