### PR TITLE
chore: allow `deps` scope for dependabot style sem titles

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -30,3 +30,4 @@ scopes:
   - ui
   - core
   - cli
+  - deps


### PR DESCRIPTION
e.g.: `chore(deps): bump virtualenv from 20.15.0 to 20.15.1 in /.github/workflows` - https://github.com/meltano/meltano/pull/6328

...seems like a useful scope anyway for when deps give us grief.