### PR TITLE
fix: Wrong Feature Flag Reference During UI Startup on Windows

### DIFF
--- a/src/meltano/api/workers/api_worker.py
+++ b/src/meltano/api/workers/api_worker.py
@@ -44,7 +44,7 @@ class APIWorker(threading.Thread):
                         "Windows OS detected auto setting ff.enable_uvicorn"
                     )
                     logging.warning(
-                        "Add ff.start_uvicorn: True to your meltano.yml to supress this waring"
+                        "Add ff.enable_uvicorn: True to your meltano.yml to supress this waring"
                     )
                     enable_uvicorn = True
 


### PR DESCRIPTION
Fixed the warning logger to state the correct feature flag `ff.enable_uvicorn` message during the start of `meltano ui` on windows machines.

Closes #6332 