### PR TITLE
fix: Fix documentation for adding docker files

### DIFF
--- a/docs/src/_guide/containerization.md
+++ b/docs/src/_guide/containerization.md
@@ -43,7 +43,7 @@ appropriate `Dockerfile` and `.dockerignore` files to your project by adding the
 docker --version
 
 # Add Docker files to your project
-meltano add files docker
+meltano add files files-docker
 
 # Build Docker image containing
 # Meltano, your project, and all of its plugins

--- a/docs/src/_reference/ui.md
+++ b/docs/src/_reference/ui.md
@@ -48,7 +48,7 @@ you can add the appropriate `docker-compose.yml` file to your project by adding 
 docker-compose --version
 
 # Add Docker Compose files to your project
-meltano add files docker-compose
+meltano add files files-docker-compose
 
 # Start the `meltano-ui` service in the background
 docker-compose up -d


### PR DESCRIPTION
The names for the docker files and docker-compose files repos have changed, but the documentation wasn't updated accordingly. This PR fixes that.