### PR TITLE
docs: fix outdated plugin names in `meltano add files` references

### DIFF
--- a/docs/src/_guide/containerization.md
+++ b/docs/src/_guide/containerization.md
@@ -87,7 +87,7 @@ you can add the appropriate `docker-compose.prod.yml` file to your project by ad
 docker-compose --version
 
 # Add Docker Compose files to your project
-meltano add files docker-compose
+meltano add files files-docker-compose
 
 # Start the `meltano-ui` and `meltano-system-db` services in the background
 docker-compose -f docker-compose.prod.yml up -d
@@ -113,7 +113,7 @@ files to your project by adding the
 # GitLab CI/CD and Container Registry enabled
 
 # Add GitLab CI/CD files to your project
-meltano add files gitlab-ci
+meltano add files files-gitlab-ci
 
 # Initialize Git repository, if you haven't already
 git init

--- a/docs/src/_guide/orchestration.md
+++ b/docs/src/_guide/orchestration.md
@@ -52,7 +52,7 @@ and invoke the `airflow` executable with the provided arguments.
 You can add the Meltano DAG generator to your project without also installing the Airflow orchestrator plugin by adding the [`airflow` file bundle](https://github.com/meltano/files-airflow/):
 
 ```bash
-meltano add files airflow
+meltano add files files-airflow
 ```
 
 Now, you'll want to copy the DAG generator in to your Airflow installation's `dags_folder`,

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -63,7 +63,7 @@ class DbtTransformPluginInstaller:
         except FileNotFoundError as err:
             relative_path = Path(err.filename).relative_to(self.project.root)
             raise PluginInstallError(
-                f"File {relative_path}' could not be found. Run `meltano add files dbt` to set up a dbt project."
+                f"File {relative_path}' could not be found. Run `meltano add files files-dbt` to set up a dbt project."
             )
 
 


### PR DESCRIPTION
Resolves #6197

Method:

- Searched for all references to `meltano add files`.
- If the named plugin was not prefixed with `files-`, I added a `files-` prefix.