### PR TITLE
fix: removed run preview references

### DIFF
--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -23,9 +23,7 @@ from .utils import InstrumentedCmd
 logger = structlog.getLogger(__name__)
 
 
-@cli.command(
-    cls=InstrumentedCmd, short_help="[preview] Run a set of plugins in series."
-)
+@cli.command(cls=InstrumentedCmd, short_help="Run a set of plugins in series.")
 @click.option(
     "--dry-run",
     help="Do not run, just parse the invocation, validate it, and explain what would be executed.",
@@ -70,7 +68,7 @@ async def run(
     `meltano run some_extractor some_loader some_plugin:some_command` and are run in the order they are specified
     from left to right. A failure in any block will cause the entire run to abort.
 
-    Multiple commmand blocks can be chained together or repeated, and tap/target pairs will automatically be linked:
+    Multiple command blocks can be chained together or repeated, and tap/target pairs will automatically be linked:
 
         `meltano run tap-gitlab target-postgres dbt:test dbt:run`\n
         `meltano run tap-gitlab target-postgres tap-salesforce target-mysql ...`\n
@@ -82,8 +80,6 @@ async def run(
         `meltano --environment=prod run tap-gitlab target-postgres tap-salesforce target-mysql`\n
 
     The above command will create two jobs with state IDs `prod:tap-gitlab-to-target-postgres` and `prod:tap-salesforce-to-target-mysql`.
-
-    This a preview feature - its functionality and cli signature is still evolving.
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#run
     """


### PR DESCRIPTION
Closes #6354

This PR:

- Removes references to `meltano run` being in 'preview' from the CLI

<img width="762" alt="Screenshot 2022-07-05 at 10 49 34" src="https://user-images.githubusercontent.com/5585874/177345173-62a09d70-b72b-49ef-b644-a6d16275394f.png">