### PR TITLE
fix: Swap add_related for add_required in api v1 plugins

### DIFF
--- a/src/meltano/api/controllers/plugins.py
+++ b/src/meltano/api/controllers/plugins.py
@@ -147,7 +147,7 @@ def install_batch():  # noqa: WPS210
     )
 
     add_service = ProjectAddService(project, plugins_service=plugins_service)
-    related_plugins = add_service.add_related(plugin)
+    related_plugins = add_service.add_required(plugin)
 
     # We will install the plugins in reverse order, since dependencies
     # are listed after their dependents in `related_plugins`, but should

--- a/src/meltano/api/controllers/plugins.py
+++ b/src/meltano/api/controllers/plugins.py
@@ -58,8 +58,8 @@ def _handle(ex):
     return (jsonify({"error": True, "code": str(ex)}), 502)
 
 
-@pluginsBP.route("/all", methods=["GET"])  # noqa: WPS125
-def all():
+@pluginsBP.route("/all", methods=["GET"])
+def all():  # noqa: WPS125
     """Plugins found by the PluginDiscoveryService.
 
     Returns:

--- a/src/meltano/api/controllers/plugins.py
+++ b/src/meltano/api/controllers/plugins.py
@@ -147,12 +147,12 @@ def install_batch():  # noqa: WPS210
     )
 
     add_service = ProjectAddService(project, plugins_service=plugins_service)
-    related_plugins = add_service.add_required(plugin)
+    required_plugins = add_service.add_required(plugin)
 
     # We will install the plugins in reverse order, since dependencies
-    # are listed after their dependents in `related_plugins`, but should
+    # are listed after their dependents in `required_plugins`, but should
     # be installed first.
-    related_plugins.reverse()
+    required_plugins.reverse()
 
     # This was added to assist api_worker threads
     try:
@@ -163,14 +163,14 @@ def install_batch():  # noqa: WPS210
 
     install_service = PluginInstallService(project, plugins_service=plugins_service)
     install_results = install_service.install_plugins(
-        related_plugins, reason=PluginInstallReason.ADD
+        required_plugins, reason=PluginInstallReason.ADD
     )
 
     for result in install_results:
         if not result.successful:
             raise PluginInstallError(result.message)
 
-    return jsonify([plugin.canonical() for plugin in related_plugins])
+    return jsonify([plugin.canonical() for plugin in required_plugins])
 
 
 @pluginsBP.route("/install", methods=["POST"])

--- a/src/meltano/api/controllers/plugins.py
+++ b/src/meltano/api/controllers/plugins.py
@@ -149,11 +149,6 @@ def install_batch():  # noqa: WPS210
     add_service = ProjectAddService(project, plugins_service=plugins_service)
     required_plugins = add_service.add_required(plugin)
 
-    # We will install the plugins in reverse order, since dependencies
-    # are listed after their dependents in `required_plugins`, but should
-    # be installed first.
-    required_plugins.reverse()
-
     # This was added to assist api_worker threads
     try:
         asyncio.get_event_loop()


### PR DESCRIPTION
This PR swaps the call of `.add_related()`, which was recently removed, to its replacement function `.add_required()` .  The variables `related_plugin` variables used were changed to be `required_plugins` to match the function swap. 

Closes #6301 