### PR TITLE
fix: Do not attempt to lock inherited plugins when using `meltano lock`

### DIFF
--- a/docs/src/_concepts/plugins.md
+++ b/docs/src/_concepts/plugins.md
@@ -106,6 +106,12 @@ When you add a plugin to your project using `meltano add`, the [discoverable plu
 
 Later invocations of the plugin will use this file to determine the settings, installation source, etc.
 
+<div class="notification is-info">
+  <p>Note that <a href="#custom-plugins">custom</a> and <a href="#plugin-inheritance">inherited</a> plugins
+  do not get a lock file.
+  </p>
+</div>
+
 ## Types
 
 Meltano supports the following types of plugins:

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -93,12 +93,12 @@ class TestLock:
         cli_runner: CliRunner,
         project: Project,
         tap: ProjectPlugin,
-        alternative_tap: ProjectPlugin,
+        inherited_tap: ProjectPlugin,
         hub_endpoints: MeltanoHubService,
     ):
         lockfiles = list(project.root_plugins_dir().glob("./*/*.lock"))
-        # 2 taps, 1 target
-        assert len(lockfiles) == 3
+        # 1 tap, 1 target
+        assert len(lockfiles) == 2
 
         result = cli_runner.invoke(
             cli,
@@ -107,4 +107,4 @@ class TestLock:
         assert result.exit_code == 0
         assert "Lockfile exists" not in result.output
         assert "Locked definition for extractor tap-mock" in result.output
-        assert "Locked definition for extractor tap-mock--singer-io" in result.output
+        assert "Extractor tap-mock-inherited is an inherited plugin" in result.output


### PR DESCRIPTION
Closes #6359 