### PR TITLE
test: Suppress misleading warnings for unknown setting `ff.strict_env_var_mode`

### DIFF
--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -666,8 +666,9 @@ class SettingsService(ABC):  # noqa: WPS214
             # other feature flags are nested under feature flag
             else:
                 allowed = self.get(f"{FEATURE_FLAG_PREFIX}.{feature}") or False
-            try:
-                yield allowed
-            finally:
-                if raise_error and not allowed:
-                    raise FeatureNotAllowedException(feature)
+
+        try:
+            yield allowed
+        finally:
+            if raise_error and not allowed:
+                raise FeatureNotAllowedException(feature)


### PR DESCRIPTION
Closes #6366