### PR TITLE
fix(core): Extras of kind `object` not honored in inherited plugins

### DIFF
--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -374,12 +374,14 @@ class SettingsService(ABC):  # noqa: WPS214
                 value = expanded_value
 
         if setting_def:
+            # Expand flattened config values if the root value is the default
+            # or inherited empty object.
             if setting_def.kind == SettingKind.OBJECT and (
                 metadata["source"]
                 in {SettingValueStore.DEFAULT, SettingValueStore.INHERITED}
             ):
                 object_value = {}
-                object_source = SettingValueStore.DEFAULT
+                object_source = metadata["source"]
                 for setting_key in [  # noqa: WPS335
                     setting_def.name,
                     *setting_def.aliases,

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -374,9 +374,9 @@ class SettingsService(ABC):  # noqa: WPS214
                 value = expanded_value
 
         if setting_def:
-            if (
-                setting_def.kind == SettingKind.OBJECT
-                and metadata["source"] is SettingValueStore.DEFAULT
+            if setting_def.kind == SettingKind.OBJECT and (
+                metadata["source"]
+                in {SettingValueStore.DEFAULT, SettingValueStore.INHERITED}
             ):
                 object_value = {}
                 object_source = SettingValueStore.DEFAULT

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -876,6 +876,27 @@ class TestPluginSettingsService:
             SettingValueStore.MELTANO_ENV,
         )
 
+        subject.project.active_environment = None
+
+        try:
+            inherited = project_add_service.add(
+                PluginType.TRANSFORMS,
+                "tap-mock-transform--inherited",
+                inherit_from=transform.name,
+            )
+        except PluginAlreadyAddedException as err:
+            inherited = err.plugin
+
+        inherited_subject = plugin_settings_service_factory(inherited)
+        inherited_subject.set("_vars", {"new": "from_inheriting"})
+
+        assert inherited_subject.get_with_source("_vars") == (
+            {
+                "new": "from_inheriting",
+            },
+            SettingValueStore.MELTANO_YML,
+        )
+
     def test_find_setting_raises_with_conflicting(
         self, tap, plugin_settings_service_factory, monkeypatch
     ):

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -878,15 +878,11 @@ class TestPluginSettingsService:
 
         subject.project.active_environment = None
 
-        try:
-            inherited = project_add_service.add(
-                PluginType.TRANSFORMS,
-                "tap-mock-transform--inherited",
-                inherit_from=transform.name,
-            )
-        except PluginAlreadyAddedException as err:
-            inherited = err.plugin
-
+        inherited = project_add_service.add(
+            PluginType.TRANSFORMS,
+            "tap-mock-transform--inherited",
+            inherit_from=transform.name,
+        )
         inherited_subject = plugin_settings_service_factory(inherited)
         inherited_subject.set("_vars", {"new": "from_inheriting"})
 

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -892,6 +892,7 @@ class TestPluginSettingsService:
 
         assert inherited_subject.get_with_source("_vars") == (
             {
+                "other": "from_meltano_yml",
                 "new": "from_inheriting",
             },
             SettingValueStore.MELTANO_YML,


### PR DESCRIPTION
Related:

- Closes #6380
- Similar PR for environments #6376