### PR TITLE
feat: Allow setting the working directory for plugin invocation

### DIFF
--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -243,6 +243,7 @@ class Variant(NameEq, Canonical):
         settings: list | None = None,
         commands: dict | None = None,
         requires: dict[PluginType, list] | None = None,
+        cwd: str | None = None,
         env: dict[str, str] | None = None,
         **extras,
     ):
@@ -261,6 +262,7 @@ class Variant(NameEq, Canonical):
             settings: The settings of the variant.
             commands: The commands of the variant.
             requires: Other plugins this plugin depends on.
+            cwd: The working directory to use for invocation.
             env: Environment variables to inject into plugins runtime context.
             extras: Additional keyword arguments.
         """
@@ -277,6 +279,7 @@ class Variant(NameEq, Canonical):
             settings=list(map(SettingDefinition.parse, settings or [])),
             commands=Command.parse_all(commands),
             requires=PluginRequirement.parse_all(requires),
+            cwd=cwd,
             env=env or {},
             extras=extras,
         )
@@ -721,6 +724,7 @@ class StandalonePlugin(Canonical):
         settings: list | None = None,
         commands: dict | None = None,
         requires: dict[PluginType, list] | None = None,
+        cwd: str | None = None,
         env: dict[str, str] | None = None,
         **extras,
     ):
@@ -741,6 +745,7 @@ class StandalonePlugin(Canonical):
             settings: The settings of the plugin.
             commands: The commands of the plugin.
             requires: Other plugins this plugin depends on.
+            cwd: The working directory to use for invocation.
             env: Environment variables to inject into plugins runtime context.
             extras: Additional attributes to set on the plugin.
         """
@@ -759,6 +764,7 @@ class StandalonePlugin(Canonical):
             settings=list(map(SettingDefinition.parse, settings or [])),
             commands=Command.parse_all(commands),
             requires=PluginRequirement.parse_all(requires),
+            cwd=cwd,
             env=env or {},
             extras=extras,
         )

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -243,7 +243,7 @@ class Variant(NameEq, Canonical):
         settings: list | None = None,
         commands: dict | None = None,
         requires: dict[PluginType, list] | None = None,
-        cwd: str | None = None,
+        workdir: str | None = None,
         env: dict[str, str] | None = None,
         **extras,
     ):
@@ -262,7 +262,7 @@ class Variant(NameEq, Canonical):
             settings: The settings of the variant.
             commands: The commands of the variant.
             requires: Other plugins this plugin depends on.
-            cwd: The working directory to use for invocation.
+            workdir: The working directory to use for invocation.
             env: Environment variables to inject into plugins runtime context.
             extras: Additional keyword arguments.
         """
@@ -279,7 +279,7 @@ class Variant(NameEq, Canonical):
             settings=list(map(SettingDefinition.parse, settings or [])),
             commands=Command.parse_all(commands),
             requires=PluginRequirement.parse_all(requires),
-            cwd=cwd,
+            workdir=workdir,
             env=env or {},
             extras=extras,
         )
@@ -724,7 +724,7 @@ class StandalonePlugin(Canonical):
         settings: list | None = None,
         commands: dict | None = None,
         requires: dict[PluginType, list] | None = None,
-        cwd: str | None = None,
+        workdir: str | None = None,
         env: dict[str, str] | None = None,
         **extras,
     ):
@@ -745,7 +745,7 @@ class StandalonePlugin(Canonical):
             settings: The settings of the plugin.
             commands: The commands of the plugin.
             requires: Other plugins this plugin depends on.
-            cwd: The working directory to use for invocation.
+            workdir: The working directory to use for invocation.
             env: Environment variables to inject into plugins runtime context.
             extras: Additional attributes to set on the plugin.
         """
@@ -764,7 +764,7 @@ class StandalonePlugin(Canonical):
             settings=list(map(SettingDefinition.parse, settings or [])),
             commands=Command.parse_all(commands),
             requires=PluginRequirement.parse_all(requires),
-            cwd=cwd,
+            workdir=workdir,
             env=env or {},
             extras=extras,
         )

--- a/src/meltano/core/plugin/command.py
+++ b/src/meltano/core/plugin/command.py
@@ -35,7 +35,7 @@ class Command(Canonical):
         description: Optional[str] = None,
         executable: Optional[str] = None,
         container_spec: Optional[dict] = None,
-        cwd: Optional[str] = None,
+        workdir: Optional[str] = None,
     ):
         """Initialize a Command.
 
@@ -44,13 +44,13 @@ class Command(Canonical):
             description: Command description.
             executable: Optional command executable.
             container_spec: Container specification for this command.
-            cwd: Change the working directory for execution.
+            workdir: Change the working directory for execution.
         """
         super().__init__(
             args=args,
             description=description,
             executable=executable,
-            cwd=cwd,
+            workdir=workdir,
         )
         if container_spec is not None:
             self.container_spec = ContainerSpec(**container_spec)

--- a/src/meltano/core/plugin/command.py
+++ b/src/meltano/core/plugin/command.py
@@ -1,6 +1,5 @@
 """Stored command arguments for plugins."""
 import shlex
-from pathlib import Path
 from typing import Dict, Optional, Type, TypeVar
 
 from meltano.core.behavior.canonical import Canonical
@@ -80,26 +79,6 @@ class Command(Canonical):
             expanded.append(value)
 
         return expanded
-
-    def expand_cwd(self, env: dict, root_dir: Optional[Path] = None) -> Optional[Path]:
-        """Resolve the working directory to execute the command.
-
-        Expands environment variables, and returns an absolute path relative to
-        the provided root.
-
-        Args:
-            env: Mapping of environment variables to expand the working directory.
-            root_dir: The path that relative directories should be resolved to.
-
-        Returns:
-            A Path to use for the working directory, if cwd is defined.
-        """
-        if not self.cwd:
-            return None
-        path = Path(expand_env_vars(self.cwd, env))
-        if root_dir:
-            path = root_dir / path
-        return path.resolve()
 
     def canonical(self):
         """Serialize the command.

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class DbtInvoker(PluginInvoker):
-    def Popen_options(self):
-        return {**super().Popen_options(), "cwd": self.plugin_config["project_dir"]}
+    def popen_options(self):
+        return {**super().popen_options(), "cwd": self.plugin_config["project_dir"]}
 
 
 class DbtPlugin(BasePlugin):

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -20,7 +20,8 @@ class DbtInvoker(PluginInvoker):
         self, command: Optional[str] = None, env: Optional[dict] = None
     ) -> Optional[Path]:
         return (
-            super().workdir(command=command, env=env) or self.plugin_config["project_dir"]
+            super().workdir(command=command, env=env)
+            or self.plugin_config["project_dir"]
         )
 
 

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -7,22 +7,18 @@ from meltano.core.plugin import BasePlugin, PluginType
 from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_install_service import PluginInstallReason
-from meltano.core.plugin_invoker import PluginInvoker
 from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.transform_add_service import TransformAddService
 
 logger = logging.getLogger(__name__)
 
 
-class DbtInvoker(PluginInvoker):
-    def popen_options(self):
-        return {**super().popen_options(), "cwd": self.plugin_config["project_dir"]}
-
-
 class DbtPlugin(BasePlugin):
     __plugin_type__ = PluginType.TRANSFORMERS
 
-    invoker_class = DbtInvoker
+    @property
+    def cwd(self) -> str:
+        return self.plugin_config["project_dir"]
 
 
 class DbtTransformPluginInstaller:

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -1,24 +1,33 @@
 """Defines DBT-specific plugins."""
 import logging
 from pathlib import Path
+from typing import Optional
 
 from meltano.core.error import PluginInstallError
 from meltano.core.plugin import BasePlugin, PluginType
 from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_install_service import PluginInstallReason
+from meltano.core.plugin_invoker import PluginInvoker
 from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.transform_add_service import TransformAddService
 
 logger = logging.getLogger(__name__)
 
 
+class DbtInvoker(PluginInvoker):
+    def cwd(
+        self, command: Optional[str] = None, env: Optional[dict] = None
+    ) -> Optional[Path]:
+        return (
+            super().cwd(command=command, env=env) or self.plugin_config["project_dir"]
+        )
+
+
 class DbtPlugin(BasePlugin):
     __plugin_type__ = PluginType.TRANSFORMERS
 
-    @property
-    def cwd(self) -> str:
-        return self.plugin_config["project_dir"]
+    invoker_class = DbtInvoker
 
 
 class DbtTransformPluginInstaller:

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 class DbtInvoker(PluginInvoker):
-    def cwd(
+    def workdir(
         self, command: Optional[str] = None, env: Optional[dict] = None
     ) -> Optional[Path]:
         return (
-            super().cwd(command=command, env=env) or self.plugin_config["project_dir"]
+            super().workdir(command=command, env=env) or self.plugin_config["project_dir"]
         )
 
 

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -342,7 +342,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
 
         return env
 
-    def cwd(
+    def workdir(
         self, command: Optional[str] = None, env: Optional[dict] = None
     ) -> Optional[Path]:
         """Resolve the working directory for invocation.
@@ -355,16 +355,16 @@ class PluginInvoker:  # noqa: WPS214, WPS230
             env: Environment variables to use for expansion.
 
         Returns:
-            A Path to use for the working directory, if cwd is defined.
+            A Path to use for the working directory, if workdir is defined.
         """
         env = env or self.env()
-        base_cwd = self.plugin.cwd
+        base_workdir = self.plugin.workdir
         if command:
-            base_cwd = self.find_command(command).cwd or base_cwd
-        if not base_cwd:
+            base_workdir = self.find_command(command).workdir or base_workdir
+        if not base_workdir:
             return None
 
-        path = self.project.root_dir() / Path(expand_env_vars(base_cwd, env))
+        path = self.project.root_dir() / Path(expand_env_vars(base_workdir, env))
         return path.resolve()
 
     def popen_options(self) -> dict[str, Any]:  # noqa: N802
@@ -391,7 +391,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
 
         async with self.plugin.trigger_hooks("invoke", self, args):
             popen_env = {**self.env(), **env}
-            cwd = self.cwd(command=command, env=popen_env)
+            cwd = self.workdir(command=command, env=popen_env)
             popen_options = {
                 "cwd": cwd,
                 **self.popen_options(),
@@ -401,7 +401,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
             logging.debug(f"Invoking: {popen_args}")
             logging.debug(f"Env: {popen_env}")
             if cwd:
-                logging.debug(f"CWD: {cwd}")
+                logging.debug(f"Working directory: {cwd}")
 
             try:
                 yield (popen_args, popen_options, popen_env)

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -356,7 +356,9 @@ class PluginInvoker:  # noqa: WPS214, WPS230
             A Path to use for the working directory, if cwd is defined.
         """
         env = env or self.env()
-        base_cwd = self.find_command(command).cwd if command else self.plugin.cwd
+        base_cwd = self.plugin.cwd
+        if command:
+            base_cwd = self.find_command(command).cwd or base_cwd
         if not base_cwd:
             return None
 
@@ -390,7 +392,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
             cwd = self.cwd(command=command, env=popen_env)
             popen_options = {
                 "cwd": cwd,
-                **self.popen_options(command=command, env=popen_env),
+                **self.popen_options(),
                 **kwargs,
             }
             popen_args = self.exec_args(*args, command=command, env=popen_env)

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -9,7 +9,7 @@ import os
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Generator, Optional
 
 from structlog.stdlib import get_logger
 
@@ -342,7 +342,9 @@ class PluginInvoker:  # noqa: WPS214, WPS230
 
         return env
 
-    def cwd(self, command: str | None = None, env=None) -> Path | None:
+    def cwd(
+        self, command: Optional[str] = None, env: Optional[dict] = None
+    ) -> Optional[Path]:
         """Resolve the working directory for invocation.
 
         Expands environment variables, and resolves paths relative to

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -196,17 +196,38 @@ def discovery():  # noqa: WPS213
                         "volumes": ["$MELTANO_PROJECT_ROOT/example/:/usr/app/"],
                     },
                 },
-                "cwd-relative": {
+            },
+        }
+    )
+
+    discovery[PluginType.UTILITIES].append(
+        {
+            "name": "utility-cwd",
+            "namespace": "utility_cwd",
+            "pip_url": "utility-cwd",
+            "executable": "utility-cwd",
+            "cwd": "path",
+            "settings": [
+                {
+                    "name": "project_dir",
+                    "env": "PROJECT_DIR",
+                }
+            ],
+            "config": {
+                "project_dir": "project",
+            },
+            "commands": {
+                "relative": {
                     "args": "-v",
-                    "cwd": "transform",
+                    "cwd": "path2",
                 },
-                "cwd-absolute": {
+                "absolute": {
                     "args": "-v",
                     "cwd": "/root",
                 },
-                "cwd-expansion": {
+                "expansion": {
                     "args": "-v",
-                    "cwd": "$MELTANO_PROJECT_ROOT/transform",
+                    "cwd": "$UTILITY_CWD__CONFIG_PROJECT_DIR/test",
                 },
             },
         }
@@ -399,6 +420,14 @@ def transformer(project_add_service: ProjectAddService):
 def utility(project_add_service):
     try:
         return project_add_service.add(PluginType.UTILITIES, "utility-mock")
+    except PluginAlreadyAddedException as err:
+        return err.plugin
+
+
+@pytest.fixture(scope="class")
+def alternate_cwd_plugin(project_add_service: ProjectAddService):
+    try:
+        return project_add_service.add(PluginType.UTILITIES, "utility-cwd")
     except PluginAlreadyAddedException as err:
         return err.plugin
 

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -196,6 +196,18 @@ def discovery():  # noqa: WPS213
                         "volumes": ["$MELTANO_PROJECT_ROOT/example/:/usr/app/"],
                     },
                 },
+                "cwd-relative": {
+                    "args": "-v",
+                    "cwd": "transform",
+                },
+                "cwd-absolute": {
+                    "args": "-v",
+                    "cwd": "/root",
+                },
+                "cwd-expansion": {
+                    "args": "-v",
+                    "cwd": "$MELTANO_PROJECT_ROOT/transform",
+                },
             },
         }
     )

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -202,11 +202,11 @@ def discovery():  # noqa: WPS213
 
     discovery[PluginType.UTILITIES].append(
         {
-            "name": "utility-cwd",
-            "namespace": "utility_cwd",
-            "pip_url": "utility-cwd",
-            "executable": "utility-cwd",
-            "cwd": "path",
+            "name": "utility-workdir",
+            "namespace": "utility_workdir",
+            "pip_url": "utility-workdir",
+            "executable": "utility-workdir",
+            "workdir": "path",
             "settings": [
                 {
                     "name": "project_dir",
@@ -219,15 +219,15 @@ def discovery():  # noqa: WPS213
             "commands": {
                 "relative": {
                     "args": "-v",
-                    "cwd": "path2",
+                    "workdir": "path2",
                 },
                 "absolute": {
                     "args": "-v",
-                    "cwd": "/root",
+                    "workdir": "/root",
                 },
                 "expansion": {
                     "args": "-v",
-                    "cwd": "$UTILITY_CWD__CONFIG_PROJECT_DIR/test",
+                    "workdir": "$UTILITY_WORKDIR__CONFIG_PROJECT_DIR/test",
                 },
             },
         }
@@ -425,9 +425,9 @@ def utility(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def alternate_cwd_plugin(project_add_service: ProjectAddService):
+def alternate_workdir_plugin(project_add_service: ProjectAddService):
     try:
-        return project_add_service.add(PluginType.UTILITIES, "utility-cwd")
+        return project_add_service.add(PluginType.UTILITIES, "utility-workdir")
     except PluginAlreadyAddedException as err:
         return err.plugin
 

--- a/tests/meltano/core/plugin/test_command.py
+++ b/tests/meltano/core/plugin/test_command.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from meltano.core.behavior.canonical import Canonical
@@ -72,11 +70,3 @@ class TestCommand:
                 name="cmd",
                 env={},
             )
-
-    def test_expand_cwd(self, commands):
-        foo = Command.parse(commands["foo"])
-        bar = Command.parse(commands["bar"])
-
-        assert foo.expand_cwd(env={}) == Path.cwd() / Path("path")
-        assert foo.expand_cwd(env={}, root_dir=Path("/root")) == Path("/root/path")
-        assert bar.expand_cwd(env={}) is None

--- a/tests/meltano/core/plugin/test_command.py
+++ b/tests/meltano/core/plugin/test_command.py
@@ -12,7 +12,7 @@ class TestCommand:
                 "args": "foo",
                 "description": "foo desc",
                 "executable": "foo",
-                "cwd": "path",
+                "workdir": "path",
             },
             "bar": {"args": "bar"},
             "baz": "baz",
@@ -30,19 +30,19 @@ class TestCommand:
         assert serialized["foo"].args == "foo"
         assert serialized["foo"].description == "foo desc"
         assert serialized["foo"].executable == "foo"
-        assert serialized["foo"].cwd == "path"
+        assert serialized["foo"].workdir == "path"
         assert serialized["bar"].args == "bar"
         assert serialized["bar"].description is None
         assert serialized["bar"].executable is None
-        assert serialized["bar"].cwd is None
+        assert serialized["bar"].workdir is None
         assert serialized["baz"].args == "baz"
         assert serialized["baz"].description is None
         assert serialized["baz"].executable is None
-        assert serialized["baz"].cwd is None
+        assert serialized["baz"].workdir is None
         assert serialized["test"].args == "--test"
         assert serialized["test"].description == "Run tests"
         assert serialized["test"].executable is None
-        assert serialized["test"].cwd is None
+        assert serialized["test"].workdir is None
 
     def test_deserialize(self, commands):
         serialized = Command.parse_all(commands)

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -182,15 +182,21 @@ class TestPluginInvoker:
         sys_root = os.path.abspath(os.sep)
         proj_root = alternate_workdir_plugin_invoker.project.root
         assert alternate_workdir_plugin_invoker.workdir() == proj_root / "path"
-        assert alternate_workdir_plugin_invoker.workdir(command="relative") == proj_root / "path2"
-        assert alternate_workdir_plugin_invoker.workdir(command="absolute") == sys_root / Path("root")
+        assert (
+            alternate_workdir_plugin_invoker.workdir(command="relative")
+            == proj_root / "path2"
+        )
+        assert alternate_workdir_plugin_invoker.workdir(
+            command="absolute"
+        ) == sys_root / Path("root")
         assert (
             alternate_workdir_plugin_invoker.workdir(command="expansion")
             == proj_root / "project" / "test"
         )
         assert (
             alternate_workdir_plugin_invoker.workdir(
-                command="expansion", env={"UTILITY_WORKDIR__CONFIG_PROJECT_DIR": "project2"}
+                command="expansion",
+                env={"UTILITY_WORKDIR__CONFIG_PROJECT_DIR": "project2"},
             )
             == proj_root / "project2" / "test"
         )

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -1,3 +1,4 @@
+import os
 import platform
 from pathlib import Path
 
@@ -178,17 +179,18 @@ class TestPluginInvoker:
         assert "PYTHONPATH" not in env
 
     def test_cwd(self, alternate_cwd_plugin_invoker):
-        root = alternate_cwd_plugin_invoker.project.root
-        assert alternate_cwd_plugin_invoker.cwd() == root / "path"
-        assert alternate_cwd_plugin_invoker.cwd(command="relative") == root / "path2"
-        assert alternate_cwd_plugin_invoker.cwd(command="absolute") == Path("/root")
+        sys_root = os.path.abspath(os.sep)
+        proj_root = alternate_cwd_plugin_invoker.project.root
+        assert alternate_cwd_plugin_invoker.cwd() == proj_root / "path"
+        assert alternate_cwd_plugin_invoker.cwd(command="relative") == proj_root / "path2"
+        assert alternate_cwd_plugin_invoker.cwd(command="absolute") == sys_root / Path("root")
         assert (
             alternate_cwd_plugin_invoker.cwd(command="expansion")
-            == root / "project" / "test"
+            == proj_root / "project" / "test"
         )
         assert (
             alternate_cwd_plugin_invoker.cwd(
                 command="expansion", env={"UTILITY_CWD__CONFIG_PROJECT_DIR": "project2"}
             )
-            == root / "project2" / "test"
+            == proj_root / "project2" / "test"
         )

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -24,10 +24,10 @@ class TestPluginInvoker:
             yield subject
 
     @pytest.fixture
-    async def alternate_cwd_plugin_invoker(
-        self, alternate_cwd_plugin, session, plugin_invoker_factory
+    async def alternate_workdir_plugin_invoker(
+        self, alternate_workdir_plugin, session, plugin_invoker_factory
     ):
-        subject = plugin_invoker_factory(alternate_cwd_plugin)
+        subject = plugin_invoker_factory(alternate_workdir_plugin)
         async with subject.prepared(session):
             yield subject
 
@@ -178,19 +178,19 @@ class TestPluginInvoker:
         assert "VIRTUAL_ENV" not in env
         assert "PYTHONPATH" not in env
 
-    def test_cwd(self, alternate_cwd_plugin_invoker):
+    def test_workdir(self, alternate_workdir_plugin_invoker):
         sys_root = os.path.abspath(os.sep)
-        proj_root = alternate_cwd_plugin_invoker.project.root
-        assert alternate_cwd_plugin_invoker.cwd() == proj_root / "path"
-        assert alternate_cwd_plugin_invoker.cwd(command="relative") == proj_root / "path2"
-        assert alternate_cwd_plugin_invoker.cwd(command="absolute") == sys_root / Path("root")
+        proj_root = alternate_workdir_plugin_invoker.project.root
+        assert alternate_workdir_plugin_invoker.workdir() == proj_root / "path"
+        assert alternate_workdir_plugin_invoker.workdir(command="relative") == proj_root / "path2"
+        assert alternate_workdir_plugin_invoker.workdir(command="absolute") == sys_root / Path("root")
         assert (
-            alternate_cwd_plugin_invoker.cwd(command="expansion")
+            alternate_workdir_plugin_invoker.workdir(command="expansion")
             == proj_root / "project" / "test"
         )
         assert (
-            alternate_cwd_plugin_invoker.cwd(
-                command="expansion", env={"UTILITY_CWD__CONFIG_PROJECT_DIR": "project2"}
+            alternate_workdir_plugin_invoker.workdir(
+                command="expansion", env={"UTILITY_WORKDIR__CONFIG_PROJECT_DIR": "project2"}
             )
             == proj_root / "project2" / "test"
         )

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -1,4 +1,5 @@
 import platform
+from pathlib import Path
 
 import dotenv
 import pytest
@@ -167,3 +168,16 @@ class TestPluginInvoker:
 
         assert "VIRTUAL_ENV" not in env
         assert "PYTHONPATH" not in env
+
+    def test_popen_options(self, plugin_invoker):
+        env = plugin_invoker.env()
+        assert not plugin_invoker.popen_options(command=None, env=env)
+        assert plugin_invoker.popen_options(command="cwd-relative", env=env) == {
+            "cwd": plugin_invoker.project.root / "transform"
+        }
+        assert plugin_invoker.popen_options(command="cwd-absolute", env=env) == {
+            "cwd": Path("/root")
+        }
+        assert plugin_invoker.popen_options(command="cwd-expansion", env=env) == {
+            "cwd": plugin_invoker.project.root / "transform"
+        }


### PR DESCRIPTION
Hello folks!

I really wanted to set up Dagster with a `test` command that runs pytest on the project:

```yaml
utilities:
  - name: dagster
    namespace: dagster
    pip_url: -e orchestrate
    executable: dagster
    settings:
    - name: home
      env: DAGSTER_HOME
    config:
      home: $MELTANO_PROJECT_ROOT/orchestrate
    commands:
      scheduler:
        args: run -w $DAGSTER_HOME/workspace.yaml
        executable: dagster-daemon
      ui:
        args: -w $DAGSTER_HOME/workspace.yaml -h 0.0.0.0
        executable: dagit
      test:
        args: --rootdir=$DAGSTER_HOME
        executable: pytest
```

However, despite setting `--rootdir` in the `pytest` args, pytest insisted on picking up tests and `conftest.py` files from elsewhere in our project, like `transforms/dbt_modules`.

I figured it made sense to allow plugins and commands to define a working directory to be invoked in, instead of the current working directory:

```yml
utilities:
  - name: dagster
    namespace: dagster
    pip_url: -e orchestrate
    executable: dagster
    cwd: orchestrate # also supports variable expansion, e.g. $MELTANO_PROJECT_ROOT/orchestrate although that's redundant
    commands:
      test:
        executable: pytest
        cwd: orchestrate/tests # commands can override the plugin config
```

This simplified `DbtPlugin`, as it no longer needs a custom `PluginInvoker`, it just needs to set the cwd to the project directory. This could be further simplified if we defined it in the discovery configuration, but to avoid backward compatibility issues I explicitly implemented the method.

This could use some docs, but wanted to get y'alls thoughts first.
