### PR TITLE
Docs: Add feedback widget

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -18,4 +18,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-KS47SNT');</script>
 <!-- End Google Tag Manager -->
+
+<!-- Freddy Feedback Widget -->
+<script>
+    var ffWidgetId = '21957808-3a88-445b-88f8-4530d7c60cef';
+    var ffWidgetScript  = document.createElement('script');
+    ffWidgetScript.type = 'text/javascript';
+    ffWidgetScript.src = 'https://freddyfeedback.com/widget/freddyfeedback.js';
+    document.head.appendChild(ffWidgetScript);
+</script>
+
 </head>


### PR DESCRIPTION
Adds a widget to the docs that allows us to collect feedback:
<img width="376" alt="Screen Shot 2022-07-15 at 12 36 48 PM" src="https://user-images.githubusercontent.com/2797769/179268322-fad44d21-028d-4ed1-adc2-9494521d7288.png">

This appears on every page:


<img width="273" alt="Screen Shot 2022-07-15 at 12 37 34 PM" src="https://user-images.githubusercontent.com/2797769/179268409-54838902-0912-4a35-89a5-6818e1d6cc66.png">

