### PR TITLE
fix: Allow `meltano run` to run without providing subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 - [#3419](https://github.com/meltano/meltano/issues/3419) Change default `meltano config` behavior to --no-environment.
 
+- [#6188](https://github.com/meltano/meltano/issues/6188) Allow `meltano run` to run without provided subcommand
+
 ### Fixes
 
 ### Breaks

--- a/docs/example-library/meltano-run/ending-meltano.yml
+++ b/docs/example-library/meltano-run/ending-meltano.yml
@@ -14,7 +14,7 @@ plugins:
   transformers:
   - name: dbt-postgres
     variant: dbt-labs
-    pip_url: dbt-core~=1.0.0 dbt-postgres~=1.0.0
+    pip_url: dbt-core~=1.1.0 dbt-postgres~=1.1.0
 environments:
 - name: dev
   config:

--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -821,7 +821,7 @@ jobs:
     tasks:
       - tap-gitlab hide-gitlab-secrets target-postgres
       - dbt-postgres:run
-	  - custom-utility-plugin
+      - custom-utility-plugin
 ```
 
 While `tap-gitlab-to-target-postgres-processed` and `tap-gitlab-to-target-postgres-processed-multiple-tasks` will run the

--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -771,7 +771,7 @@ Note that such a sequence is only valid if it is one of:
 
 1. An extractor followed directly by a loader. E.g. `tap-gitlab target-postgres`
 1. An extractor followed by one or more mappers and then a loader. E.g. `tap-gitlab hide-gitlab-secrets target-postgres`
-1. A plugin command invocation. E.g. `dbt-postgres:run`
+1. A plugin invocation, with optional command. E.g. `dbt-postgres:run` or `custom_utility_plugin`
 1. Any sequence of the above. E.g. `tap-gitlab hide-gitlab-secrets target-postgres dbt-postgres:run tap-zendesk target-csv`
 
 If a job has only one task, that task can be supplied as a single quoted argument:
@@ -781,7 +781,7 @@ If a job has only one task, that task can be supplied as a single quoted argumen
 meltano job add tap-gitlab-to-target-postgres --tasks "tap-gitlab target-postgres"
 
 # A more complex task
-meltano job add tap-gitlab-to-target-postgres-processed --tasks "tap-gitlab hide-gitlab-secrets target-postgres dbt-postgres:run"
+meltano job add tap-gitlab-to-target-postgres-processed --tasks "tap-gitlab hide-gitlab-secrets target-postgres dbt-postgres:run custom-utility-plugin"
 ```
 
 This would add the following to your `meltano.yml`:
@@ -793,7 +793,7 @@ jobs:
       - tap-gitlab target-postgres
   - name: tap-gitlab-to-target-postgres-processed
     tasks:
-      - tap-gitlab hide-gitlab-secrets target-postgres dbt-postgres:run
+      - tap-gitlab hide-gitlab-secrets target-postgres dbt-postgres:run custom-utility-plugin
 ```
 
 When an Airflow DAG is generated for a job, each task in the job definition will become a single task in the generated DAG.
@@ -810,7 +810,7 @@ supplied to the `meltano job add` command as an array in YAML format.
 For instance the `tap-gitlab-to-target-postgres-processed` job in the above example could also be created as:
 
 ```bash
-meltano job add tap-gitlab-to-target-postgres-processed --tasks "[tap-gitlab hide-gitlab-secrets target-postgres, dbt-postgres:run]"
+meltano job add tap-gitlab-to-target-postgres-processed-multiple-tasks --tasks "[tap-gitlab hide-gitlab-secrets target-postgres, dbt-postgres:run, custom-utility-plugin]"
 ```
 
 This would add the following to your `meltano.yml`:
@@ -821,15 +821,17 @@ jobs:
     tasks:
       - tap-gitlab hide-gitlab-secrets target-postgres
       - dbt-postgres:run
+	  - custom-utility-plugin
 ```
 
 While `tap-gitlab-to-target-postgres-processed` and `tap-gitlab-to-target-postgres-processed-multiple-tasks` will run the
 same steps of the pipeline in the same order, [scheduling](#schedule) the former will result in a generated DAG consisting
-of a single task while scheduling the latter will result in a generated DAG consisting of two tasks:
+of a single task while scheduling the latter will result in a generated DAG consisting of three tasks:
 
 ```
 task 1: "meltano run tap-gitlab hide-gitlab-secrets target-postgres"
 task 2: "meltano run dbt-postgres:run" , depends on task 1
+task 3: "meltano run custom-utility-plugin", depends on task 2
 ```
 
 ### Examples

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -65,7 +65,7 @@ async def run(
     Run a set of command blocks in series.
 
     Blocks are specified as a list of plugin names, e.g.
-    `meltano run some_extractor some_loader some_plugin:some_command` and are run in the order they are specified
+    `meltano run some_extractor some_loader some_plugin:some_optional_command` and are run in the order they are specified
     from left to right. A failure in any block will cause the entire run to abort.
 
     Multiple command blocks can be chained together or repeated, and tap/target pairs will automatically be linked:

--- a/src/meltano/core/block/singer.py
+++ b/src/meltano/core/block/singer.py
@@ -94,9 +94,6 @@ class InvokerBase:  # noqa: WPS230, WPS214
         Raises:
             RunnerError: If the plugin process can not start.
         """
-        if self.command is None:
-            raise RunnerError("No command to run")
-
         try:
             self.process_handle = await self.invoker.invoke_async(
                 *args,


### PR DESCRIPTION
Closes #6188