### PR TITLE
feat: meltano now surfaces full stderr output for catalog discovery failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 - [#3419](https://github.com/meltano/meltano/issues/3419) Change default `meltano config` behavior to --no-environment.
+- [#6150](https://github.com/meltano/meltano/issues/6150) Print full stderr for catalog discovery failures.
 
 ### Fixes
 

--- a/docs/example-library/meltano-run/ending-meltano.yml
+++ b/docs/example-library/meltano-run/ending-meltano.yml
@@ -14,7 +14,7 @@ plugins:
   transformers:
   - name: dbt-postgres
     variant: dbt-labs
-    pip_url: dbt-core~=1.0.0 dbt-postgres~=1.0.0
+    pip_url: dbt-core~=1.1.0 dbt-postgres~=1.1.0
 environments:
 - name: dev
   config:

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -70,7 +70,9 @@ def _debug_logging_handler(
     """
     if not plugin_invoker.context or not plugin_invoker.context.base_output_logger:
         return asyncio.ensure_future(
-            _stream_redirect(stderr, *(sys.stderr, *other_dsts), write_str=True)
+            _stream_redirect(
+                stderr, *(sys.stderr, *other_dsts), write_str=True  # noqa: WPS517
+            )
         )
 
     out = plugin_invoker.context.base_output_logger.out(
@@ -78,7 +80,9 @@ def _debug_logging_handler(
     )
     with out.line_writer() as outerr:
         return asyncio.ensure_future(
-            _stream_redirect(stderr, *(outerr, *other_dsts), write_str=True)
+            _stream_redirect(
+                stderr, *(outerr, *other_dsts), write_str=True  # noqa: WPS517
+            )
         )
 
 

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -423,7 +423,9 @@ class SingerTap(SingerPlugin):
                     else:
                         invoke_futures.append(
                             asyncio.ensure_future(
-                                _stream_redirect(handle.stderr, stderr_buff)
+                                _stream_redirect(
+                                    handle.stderr, stderr_buff, write_str=True
+                                )
                             )
                         )
                     done, _ = await asyncio.wait(

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -404,14 +404,18 @@ class SingerTap(SingerPlugin):
                     )
                     invoke_futures = [
                         asyncio.ensure_future(_stream_redirect(handle.stdout, catalog)),
-                        asyncio.ensure_future(_stream_redirect(handle.stderr, stderr_buff)),
-                        asyncio.ensure_future(handle.wait())
+                        asyncio.ensure_future(
+                            _stream_redirect(handle.stderr, stderr_buff)
+                        ),
+                        asyncio.ensure_future(handle.wait()),
                     ]
                     done, _ = await asyncio.wait(
                         invoke_futures,
                         return_when=asyncio.ALL_COMPLETED,
                     )
-                    failed = [future for future in done if future.exception() is not None]
+                    failed = [
+                        future for future in done if future.exception() is not None
+                    ]
                     if failed:
                         failed_future = failed.pop()
                         raise failed_future.exception()

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -783,7 +783,7 @@ class TestSingerTap:
         ), mock.patch("meltano.core.plugin.singer.tap._stream_redirect") as stream_mock:
             await subject.run_discovery(invoker, catalog_path)
 
-            assert stream_mock.call_count == 1
+            assert stream_mock.call_count == 2
 
         with mock.patch(
             "meltano.core.plugin.singer.tap.logger.isEnabledFor", return_value=True
@@ -869,11 +869,6 @@ class TestSingerTap:
 
         assert sys.getdefaultencoding() == "utf-8"
 
-        with mock.patch(
-            "meltano.core.plugin.singer.tap.logger.isEnabledFor", return_value=True
-        ), mock.patch("sys.getdefaultencoding", return_value="ascii"):
-            with pytest.raises(UnicodeDecodeError):
-                await subject.run_discovery(invoker, catalog_path)
 
         with mock.patch(
             "meltano.core.plugin.singer.tap.logger.isEnabledFor", return_value=True

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -869,7 +869,6 @@ class TestSingerTap:
 
         assert sys.getdefaultencoding() == "utf-8"
 
-
         with mock.patch(
             "meltano.core.plugin.singer.tap.logger.isEnabledFor", return_value=True
         ):

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -782,7 +782,6 @@ class TestSingerTap:
             "meltano.core.plugin.singer.tap.logger.isEnabledFor", return_value=False
         ), mock.patch("meltano.core.plugin.singer.tap._stream_redirect") as stream_mock:
             await subject.run_discovery(invoker, catalog_path)
-
             assert stream_mock.call_count == 2
 
         with mock.patch(
@@ -791,9 +790,7 @@ class TestSingerTap:
             "meltano.core.plugin.singer.tap._stream_redirect"
         ) as stream_mock2:
             await subject.run_discovery(invoker, catalog_path)
-
             assert stream_mock2.call_count == 2
-            assert stream_mock2.call_args[1]["write_str"] is True
 
         # ensure stderr is redirected to devnull if we don't need it
         discovery_logger = logging.getLogger("meltano.core.plugin.singer.tap")
@@ -807,10 +804,8 @@ class TestSingerTap:
             await subject.run_discovery(invoker, catalog_path)
 
             assert stream_mock3.call_count == 2
-            assert stream_mock3.call_args[1]["write_str"] is True
-
             call_kwargs = invoker.invoke_async.call_args_list[0][1]
-            assert call_kwargs.get("stderr") is subprocess.DEVNULL
+            assert call_kwargs.get("stderr") is subprocess.PIPE
 
         discovery_logger.setLevel(original_level)
 


### PR DESCRIPTION
When invoking discovery for Singer taps, we previously redirected stderr to `asyncio.subprocess.DEVNULL` _unless_ debug logging was enabled. With this PR, we instead redirect that stderr stream into a `BytesIO` and then that buffer is tacked on to the error message. So anywhere that a catalog discovery error is surfaced, it will now include the specific stderr output from the underlying plugin invocation. 

We had explicit tests around the existing stream redirection logic, so those tests have been changed and assertions removed to reflect he new logic.

Closes #6150 