### PR TITLE
ci: Fixed expected dbt version in integration test

### DIFF
--- a/docs/example-library/meltano-run/ending-meltano.yml
+++ b/docs/example-library/meltano-run/ending-meltano.yml
@@ -14,7 +14,7 @@ plugins:
   transformers:
   - name: dbt-postgres
     variant: dbt-labs
-    pip_url: dbt-core~=1.0.0 dbt-postgres~=1.0.0
+    pip_url: dbt-core~=1.1.0 dbt-postgres~=1.1.0
 environments:
 - name: dev
   config:


### PR DESCRIPTION
Fixes #6437

This was hard to replicate locally, although the fix is obvious

1. You have to run  poetry run bash integration/validate.sh meltano-run from the root of meltano
1. container must be running
1. You must have a fresh postgres instance up
1. meltano.yml file in docs/example-library/meltano-run changes as a part of the run
1. Lock file already exists due to meltano project being created in the same directory (Idempotentency is violated locally)

Created an issue about these steps here https://github.com/meltano/meltano/issues/6439