### PR TITLE
ci: Do not run dependency review workflow on push events

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,8 +2,6 @@ name: Dependency Review
 
 on:
   pull_request: {}
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs: {}
 


### PR DESCRIPTION
https://github.com/meltano/meltano/runs/7416239582