### PR TITLE
docs: Update for Windows and for using pipx --python version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,9 +48,11 @@ You will need to be running Linux, macOS, or Windows, and have [Python](https://
 
     ```bash
     pipx install meltano
+    ```
+    If you have multiple versions of Python installed, you can use a specific one with the `--python` arugment:
     
-    #If you have multiple versions of Python installed, you can use a specific one with the --python arugment
-    #  pipx install meltano --python [path to desired Python exe]
+    ```bash
+    pipx install meltano --python [path to desired Python exe]
     ```
 
 1. Optionally, verify that the [`meltano` CLI](/reference/command-line-interface) is now available by viewing the version:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,9 +48,11 @@ You will need to be running Linux, macOS, or Windows, and have [Python](https://
 
     ```bash
     pipx install meltano
+    ```
+    If you have multiple versions of Python installed, you can use a specific one with the --python arugment
     
-    #If you have multiple versions of Python installed, you can use a specific one with the --python arugment
-    #  pipx install meltano --python [path to desired Python exe]
+    ```bash
+    pipx install meltano --python [path to desired Python exe]
     ```
 
 1. Optionally, verify that the [`meltano` CLI](/reference/command-line-interface) is now available by viewing the version:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,10 +139,14 @@ As part of creating your Meltano project, we automatically added your first [env
 1. Activate your environment for your shell session:
 
     ```bash
-    #For Windows (PowerShell): $env:MELTANO_ENVIRONMENT="dev"
-    export MELTANO_ENVIRONMENT=dev
+        export MELTANO_ENVIRONMENT=dev
     ```
-
+    or for Windows PowerShell:
+    
+    ```powershell
+        $env:MELTANO_ENVIRONMENT="dev"
+    ```
+    
     Alternatively you can include the `--environment=dev` argument to each meltano command. You should now see a log message that says `Environment 'dev' is active` each time you run a meltano command.
 
 1. [optional] Add a new environment:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,7 +144,7 @@ As part of creating your Meltano project, we automatically added your first [env
     or for Windows PowerShell:
     
     ```powershell
-        $env:MELTANO_ENVIRONMENT="dev"
+    $env:MELTANO_ENVIRONMENT="dev"
     ```
     
     Alternatively you can include the `--environment=dev` argument to each meltano command. You should now see a log message that says `Environment 'dev' is active` each time you run a meltano command.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ You will need to be running Linux, macOS, or Windows, and have [Python](https://
     If you have multiple versions of Python installed, you can use a specific one with the `--python` arugment:
     
     ```bash
-    pipx install meltano --python [path to desired Python exe]
+    pipx install meltano --python <path to desired Python executable>
     ```
 
 1. Optionally, verify that the [`meltano` CLI](/reference/command-line-interface) is now available by viewing the version:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,9 @@ You will need to be running Linux, macOS, or Windows, and have [Python](https://
 
     ```bash
     pipx install meltano
+    
+    #If you have multiple versions of Python installed, you can use a specific one with the --python arugment
+    #  pipx install meltano --python [path to desired Python exe]
     ```
 
 1. Optionally, verify that the [`meltano` CLI](/reference/command-line-interface) is now available by viewing the version:
@@ -133,6 +136,7 @@ As part of creating your Meltano project, we automatically added your first [env
 1. Activate your environment for your shell session:
 
     ```bash
+    #For Windows (PowerShell): $env:MELTANO_ENVIRONMENT="dev"
     export MELTANO_ENVIRONMENT=dev
     ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,7 +139,7 @@ As part of creating your Meltano project, we automatically added your first [env
 1. Activate your environment for your shell session:
 
     ```bash
-        export MELTANO_ENVIRONMENT=dev
+    export MELTANO_ENVIRONMENT=dev
     ```
     or for Windows PowerShell:
     


### PR DESCRIPTION
1. Setting env variable in Windows PowerShell. Added:
#For Windows (PowerShell):
$env:MELTANO_ENVIRONMENT="dev"

2. Python version - 
I learned that Meltano must be pipx installed using a version of Python that is compatible with all of the extractors and loaders (see https://meltano.slack.com/x-p526315946325-3801798270198-3808513868754/archives/C01TCRBBJD7/p1657981158809849). I've added instructions for performing a pipx install with a specified version of Python, but I think this issue could use a bit more documentation to help the reader understand when they may need to use that command, especially because line 24 indicates everything _should_ work with Python 3.10, but tap-rest-api-msdk requires Meltano to be installed with 3.9.7 or earlier.
