### PR TITLE
docs: cleanup 'Reference' section, move 'v2 migration guide' under 'guides'

### DIFF
--- a/docs/src/_guide/v2-migration.md
+++ b/docs/src/_guide/v2-migration.md
@@ -2,6 +2,8 @@
 title: Meltano 2.0 Migration Guide
 description: Migrate existing "v1" projects to the latest version of Meltano
 layout: doc
+redirect_from:
+  - /reference/v2-migration/
 weight: 20
 ---
 

--- a/docs/src/_guide/v2-migration.md
+++ b/docs/src/_guide/v2-migration.md
@@ -2,7 +2,7 @@
 title: Meltano 2.0 Migration Guide
 description: Migrate existing "v1" projects to the latest version of Meltano
 layout: doc
-weight: 4
+weight: 20
 ---
 
 _Note: This document is still a work in progress. Expect further changes, coming soon._
@@ -1070,22 +1070,23 @@ If for any reason you wish to keep sourcing or writing setting values to depreca
   </tr>
 </table>
 
-
 ## CLI and API Changes
 
 #### Use `--state-id` instead of `--job_id`
+
 In 2.0, many references to "Job ID" in our code and docs were changed to the more accurate name of "State ID".
 
 If you are explicitly providing a `--job_id` option to any scripted or otherwise automated CLI workflows, these commands should be updated to use the `--state-id` option instead.
 
-
 #### Schedule list format changes
+
 If you have custom orchestrator integrations based on the `meltano schedule list` command, you will need to make adjustments to handle a new output format.
 
 With the addition of support for scheduled jobs in 2.0, the schema output of `meltano schedule list --format=json` has changed.
 It now includes a top level field `schedules` and two nested array fields `job` and `elt` which hold and describe their respective schedules.
 
 ex:
+
 ```json
 {
   "schedules": {

--- a/docs/src/_reference/ui.md
+++ b/docs/src/_reference/ui.md
@@ -1,5 +1,5 @@
 ---
-title: GUI
+title: Meltano UI
 description: Learn how to manage and monitor your plugins and pipelines using Meltano UI
 layout: doc
 redirect_from:


### PR DESCRIPTION
- [x] Moves 'Meltano 2.0 Migration Guide' page out of 'Reference' section and into 'Guides' section.
- [x] Adds redirect from prior location to new location.
- [x] Renames 'Reference' > 'GUI' to 'Reference' > 'Meltano UI' for clarity.
- [x] Manually confirmed rendering in Netlify preview build
- [x] Manually confirmed that the old URL (`https://deploy-preview-6465--meltano.netlify.app/reference/v2-migration`) is redirecting to `https://docs.meltano.com/guide/v2-migration`. (Currently a 404 but would not be after merge.)

------------------

Pre-update:

![image](https://user-images.githubusercontent.com/18150651/180481335-0b85c41d-6020-456a-88c8-822475ecda59.png)

------------------

Post-update, the Reference Section is cleaner:

![image](https://user-images.githubusercontent.com/18150651/180483346-d65caec1-a437-4e4d-97a0-2057b82cf68d.png)

------------------

And now the migration guide is at the bottom of the "Guides" section:

![image](https://user-images.githubusercontent.com/18150651/180481670-94e4afd0-cdee-4868-9910-e812f35dcef0.png)
