### PR TITLE
fix(ui): When feature flag `enable_uvicorn` is true require write lock when accessing Project.meltano attribute 

### DIFF
--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -231,9 +231,23 @@ class Project(Versioned):  # noqa: WPS214
             the current meltano config
         """
         from .meltano_file import MeltanoFile
+        from .settings_service import FEATURE_FLAG_PREFIX, FeatureFlags
+        from .yaml import configure_yaml
 
-        with self._meltano_rw_lock.read_lock():
-            return MeltanoFile.parse(self.project_files.load())
+        with open(self.meltanofile) as melt_ff:
+            meltano_ff: dict = configure_yaml().load(melt_ff)
+
+        uvicron_enabled = (
+            meltano_ff.get(f"{FEATURE_FLAG_PREFIX}.{FeatureFlags.ENABLE_UVICORN}")
+            or False
+        )
+
+        if uvicron_enabled:
+            with self._meltano_rw_lock.write_lock():
+                return MeltanoFile.parse(self.project_files.load())
+        else:
+            with self._meltano_rw_lock.read_lock():
+                return MeltanoFile.parse(self.project_files.load())
 
     @contextmanager
     def meltano_update(self):

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -237,12 +237,12 @@ class Project(Versioned):  # noqa: WPS214
         with open(self.meltanofile) as melt_ff:
             meltano_ff: dict = configure_yaml().load(melt_ff)
 
-        uvicron_enabled = (
+        uvicorn_enabled = (
             meltano_ff.get(f"{FEATURE_FLAG_PREFIX}.{FeatureFlags.ENABLE_UVICORN}")
             or False
         )
 
-        if uvicron_enabled:
+        if uvicorn_enabled:
             with self._meltano_rw_lock.write_lock():
                 return MeltanoFile.parse(self.project_files.load())
         else:


### PR DESCRIPTION
This is an attempt at option 3 proposed in PR #6297 that asked to put the `write_lock()` behind the `enable_uvicorn` feature flag.