### PR TITLE
style: Remove extra whitespace from `getting-started.md`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ You will need to be running Linux, macOS, or Windows, and have [Python](https://
     ```
 
     If you have multiple versions of Python installed, you can use a specific one with the `--python` arugment:
-    
+
     ```bash
     pipx install meltano --python <path to desired Python executable>
     ```
@@ -142,11 +142,11 @@ As part of creating your Meltano project, we automatically added your first [env
     export MELTANO_ENVIRONMENT=dev
     ```
     or for Windows PowerShell:
-    
+
     ```powershell
     $env:MELTANO_ENVIRONMENT="dev"
     ```
-    
+
     Alternatively you can include the `--environment=dev` argument to each meltano command. You should now see a log message that says `Environment 'dev' is active` each time you run a meltano command.
 
 1. [optional] Add a new environment:


### PR DESCRIPTION
This was causing a failure in our pre-commit checks for anyone who had modified the file. It could've been fixed in the PR that introduced it, but we didn't have permission to edit that branch ourselves, and bugging a helpful community member to fix their whitespace is not worth it.