### PR TITLE
ci: Fix Docker scan action

### DIFF
--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -74,7 +74,8 @@ runs:
         sleep 10 # Give GitHub some time to process the uploaded report
         NUM_ISSUES="$(curl --no-progress-meter -H "Authorization: token ${{ inputs.token }}" \
             "https://api.github.com/repos/meltano/meltano/code-scanning/alerts?tool_name=Grype&state=open&ref=${{ github.ref }}")"
-        [ $NUM_ISSUES = '0' ] # Error if there are any alerts that are neither fixed nor dismissed
+        echo "At least $NUM_ISSUES issues have been detected."
+        [ "$NUM_ISSUES" = '0' ] # Error if there are any alerts that are neither fixed nor dismissed
 
     - name: Login to the registry
       uses: docker/login-action@v2

--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -70,7 +70,7 @@ runs:
       continue-on-error: true
       run: |
         echo "View scan results at:"
-        echo "https://github.com/meltano/meltano/security/code-scanning?query=ref:${{ github.ref }}"
+        echo "https://github.com/meltano/meltano/security/code-scanning?query=ref:${{ github.ref }}+tool:Grype"
         sleep 10 # Give GitHub some time to process the uploaded report
         NUM_ISSUES="$(curl --no-progress-meter -H "Authorization: token ${{ inputs.token }}" \
             "https://api.github.com/repos/meltano/meltano/code-scanning/alerts?tool_name=Grype&state=open&ref=${{ github.ref }}")"

--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -73,8 +73,8 @@ runs:
         echo "https://github.com/meltano/meltano/security/code-scanning?query=ref:${{ github.ref }}+tool:Grype"
         sleep 10 # Give GitHub some time to process the uploaded report
         NUM_ISSUES="$(curl --no-progress-meter -H "Authorization: token ${{ inputs.token }}" \
-            "https://api.github.com/repos/meltano/meltano/code-scanning/alerts?tool_name=Grype&state=open&ref=${{ github.ref }}")"
-        echo "At least $NUM_ISSUES issues have been detected."
+            "https://api.github.com/repos/meltano/meltano/code-scanning/alerts?tool_name=Grype&state=open&ref=${{ github.ref }}" \
+            | jq length)"
         [ "$NUM_ISSUES" = '0' ] # Error if there are any alerts that are neither fixed nor dismissed
 
     - name: Login to the registry


### PR DESCRIPTION
This should've been done originally as part of https://github.com/meltano/meltano/pull/6562. The lines I ran locally to test it included the `jq` step, but I mistakenly didn't update the action with it.