### PR TITLE
chore: Add `git` and `build-essential` to the Meltano Docker image

### DIFF
--- a/docker/meltano/Dockerfile
+++ b/docker/meltano/Dockerfile
@@ -11,7 +11,7 @@ ENV PIP_NO_CACHE_DIR=1
 
 RUN mkdir "${WORKDIR}" && \
     apt-get update && \
-    apt-get install -y git && \
+    apt-get install -y build-essential git && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 WORKDIR "${WORKDIR}"

--- a/docker/meltano/Dockerfile
+++ b/docker/meltano/Dockerfile
@@ -9,7 +9,10 @@ ARG WORKDIR="/project"
 
 ENV PIP_NO_CACHE_DIR=1
 
-RUN mkdir "${WORKDIR}"
+RUN mkdir "${WORKDIR}" && \
+    apt-get update && \
+    apt-get install -y git && \
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 WORKDIR "${WORKDIR}"
 


### PR DESCRIPTION
Context: https://meltano.slack.com/archives/CKHP6G5V4/p1660060697122949?thread_ts=1659552634.170039&cid=CKHP6G5V4

Successful build & publish to the GitHub registry: https://github.com/meltano/meltano/actions/runs/2827386004

We can pursue more complex/time-consuming solutions to reduce our dependencies and image size later. For now we should ensure the image is useful by adding these packages.