### PR TITLE
fix: `meltano state list` change pattern from argument to option

### DIFF
--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -111,7 +111,7 @@ def meltano_state(project: Project, ctx: click.Context):
 
 
 @meltano_state.command(cls=InstrumentedCmd, name="list")
-@click.argument("pattern", required=False)
+@click.option("--pattern", type=str, help="Filter state IDs by pattern.")
 @click.pass_context
 @pass_project()
 def list_state(

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -87,7 +87,7 @@ class TestCliState:
     ):
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for (pattern, expected_result) in patterns_with_expected_results:
-                result = cli_runner.invoke(cli, ["state", "list", pattern])
+                result = cli_runner.invoke(cli, ["state", "list", "--pattern", pattern])
                 assert_cli_runner(result)
                 assert self.get_result_set(result) == expected_result
 


### PR DESCRIPTION
Closes #6477

- #6477