### PR TITLE
refactor: Replace `StaleJobFailer` class with `fail_stale_jobs` function

### DIFF
--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -13,7 +13,7 @@ from structlog import stdlib as structlog_stdlib
 from meltano.core.db import project_engine
 from meltano.core.elt_context import ELTContextBuilder
 from meltano.core.job import Job, JobFinder
-from meltano.core.job.stale_job_failer import StaleJobFailer
+from meltano.core.job.stale_job_failer import fail_stale_jobs
 from meltano.core.logging import JobLoggingService, OutputLogger
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.error import PluginNotFoundError
@@ -221,7 +221,7 @@ async def dump_file(context_builder, dumpable):
 
 
 async def _run_job(tracker, project, job, session, context_builder, force=False):
-    StaleJobFailer(job.job_name).fail_stale_jobs(session)
+    fail_stale_jobs(session, job.job_name)
 
     if not force:
         existing = JobFinder(job.job_name).latest_running(session)

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -8,7 +8,7 @@ import click
 from sqlalchemy.orm import Session
 
 from meltano.core.db import project_engine
-from meltano.core.job.stale_job_failer import StaleJobFailer
+from meltano.core.job.stale_job_failer import fail_stale_jobs
 from meltano.core.legacy_tracking import LegacyTracker
 from meltano.core.schedule import Schedule
 from meltano.core.schedule_service import ScheduleAlreadyExistsError, ScheduleService
@@ -186,7 +186,7 @@ def list(ctx, format):  # noqa: WPS125
     _, sessionMaker = project_engine(project)  # noqa: N806
     session = sessionMaker()
     try:
-        StaleJobFailer().fail_stale_jobs(session)
+        fail_stale_jobs(session)
 
         if format == "text":
             transform_elt_markers = {

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from meltano.core.db import project_engine
 from meltano.core.elt_context import PluginContext
 from meltano.core.job import Job, JobFinder
-from meltano.core.job.stale_job_failer import StaleJobFailer
+from meltano.core.job.stale_job_failer import fail_stale_jobs
 from meltano.core.logging import JobLoggingService, OutputLogger
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
@@ -450,7 +450,7 @@ class ExtractLoadBlocks(BlockSet):  # noqa: WPS214
             RunnerError: if failures are encountered during execution or if the underlying pipeline/job is already running.
         """
         job = self.context.job
-        StaleJobFailer(job.job_name).fail_stale_jobs(self.context.session)
+        fail_stale_jobs(self.context.session, job.job_name)
         if not self.context.force:
             existing = JobFinder(job.job_name).latest_running(self.context.session)
             if existing:

--- a/tests/meltano/core/job/test_stale_job_failer.py
+++ b/tests/meltano/core/job/test_stale_job_failer.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from meltano.core.job import Job
-from meltano.core.job.stale_job_failer import StaleJobFailer
+from meltano.core.job.stale_job_failer import fail_stale_jobs
 
 
 class TestStaleJobFailer:
@@ -50,8 +50,7 @@ class TestStaleJobFailer:
         assert stale_job.is_stale()
         assert other_stale_job.is_stale()
 
-        failer = StaleJobFailer()
-        failer.fail_stale_jobs(session)
+        fail_stale_jobs(session)
 
         session.refresh(live_job)
         session.refresh(stale_job)
@@ -75,8 +74,7 @@ class TestStaleJobFailer:
         assert stale_job.is_stale()
         assert other_stale_job.is_stale()
 
-        failer = StaleJobFailer(state_id=stale_job.job_name)
-        failer.fail_stale_jobs(session)
+        fail_stale_jobs(session, state_id=stale_job.job_name)
 
         session.refresh(live_job)
         session.refresh(stale_job)


### PR DESCRIPTION
Just a small simplification I made while working on #3437 that I figured should be pull out as a separate PR.