### PR TITLE
chore: Add `libpq-dev` to Meltano Docker image

### DIFF
--- a/docker/meltano/Dockerfile
+++ b/docker/meltano/Dockerfile
@@ -11,7 +11,7 @@ ENV PIP_NO_CACHE_DIR=1
 
 RUN mkdir "${WORKDIR}" && \
     apt-get update && \
-    apt-get install -y build-essential git && \
+    apt-get install -y build-essential git libpq-dev && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 WORKDIR "${WORKDIR}"


### PR DESCRIPTION
Successful Docker publish workflow targetting the GitHub registry: https://github.com/meltano/meltano/actions/runs/2847838317

This increases the image size a negligible amount, and pulls in few libraries that we didn't already have.

It introduces 2 new security vulnerabilities, but I'm not sure which ones. GitHub doesn't seem to provide a way to diff the alerts between 2 branches.