### PR TITLE
refactor(core): Make `ProjectInitService.init` generate/set a `project_id`

### DIFF
--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import uuid
 
 import click
 
@@ -54,6 +55,11 @@ class ProjectInitService:
         self.create_files(add_discovery=add_discovery)
 
         self.settings_service = ProjectSettingsService(self.project)
+        self.settings_service.set(
+            "project_id",
+            f"{self.project_name}-{uuid.uuid4()}",
+            store=SettingValueStore.MELTANO_YML,
+        )
         self.set_send_anonymous_usage_stats()
         if activate:
             Project.activate(self.project)

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -84,10 +84,7 @@ class ProjectSettingsService(SettingsService):
                     "Unable to restore 'project_id' from 'analytics.json'", err=err
                 )
             else:
-                self.update_meltano_yml_config(
-                    {"project_id": project_id, **self.meltano_yml_config}
-                )
-                self.set("project_id", project_id)
+                self.set("project_id", project_id, store=SettingValueStore.MELTANO_YML)
                 logger.debug("Restored 'project_id' from 'analytics.json'")
 
     @property

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -39,10 +39,14 @@ class TestProjectSettingsService:
         return Environment("testing", {})
 
     def test_get_with_source(self, subject, monkeypatch):
+        # A warning is raised because the setting does not exist.
+        with pytest.warns(RuntimeWarning):
+            assert subject.get_with_source(
+                "and_now_for_something_completely_different"
+            ) == (None, SettingValueStore.DEFAULT)
+
         def assert_value_source(value, source):
             assert subject.get_with_source("project_id") == (value, source)
-
-        assert_value_source(None, SettingValueStore.DEFAULT)
 
         subject.set(
             "project_id", "from_meltano_yml", store=SettingValueStore.MELTANO_YML

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -117,7 +117,11 @@ class TestTracker:
         # Create a new `ProjectSettingsService` because it is what restores the project ID
         restored_project_id = ProjectSettingsService(project).get("project_id")
 
-        assert original_project_id == restored_project_id
+        # Apply the same transformation that gets applied to the project ID
+        # when it is originally stored in `analytics.json`.
+        assert (
+            str(uuid.UUID(hash_sha256(original_project_id)[::2])) == restored_project_id
+        )
 
     @pytest.mark.xfail(
         platform.system() == "Windows",


### PR DESCRIPTION
While addressing #6620 I realized that without the legacy tracker, nothing generates a project ID during initialization. The fact that that responsibility falls on it seems like an oversight.

This PR makes it so that new projects get a default project ID in the form `<project name>-<random UUID>`.