### PR TITLE
ci: Use `actions/dependency-review-action` instead of fork

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,8 +24,7 @@ jobs:
 
       - name: GitHub dependency vulnerability check
         if: ${{ github.event_name == 'pull_request_target' }}
-        # Use this fork until https://github.com/actions/dependency-review-action/pull/165 is merged
-        uses: WillDaSilva/dependency-review-action@main
+        uses: actions/dependency-review-action@v2.1.0
 
       - name: FOSSA dependency license check
         run: |


### PR DESCRIPTION
We are currently using my personal fork of `actions/dependency-review-action` because it has the ability to run on `pull_request_target` events (and use custom base/head refs).

Now that those changed have been merged into the upstream repository, and released under the tag `v2.1.0`, we should use it instead of my fork.