### PR TITLE
ci: Tag Docker images with Meltano major and minor versions

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -65,11 +65,20 @@ jobs:
     - name: Assemble image tags
       id: assemble-tags
       run: |
+        MELTANO_VERSION="${{ steps.get-meltano-version.outputs.release-version }}"
+        MELTANO_VERSION_ARRAY=(${MELTANO_VERSION//./ })
+        MELTANO_VERSION_MAJOR="${MELTANO_VERSION_ARRAY[0]}"
+        MELTANO_VERSION_MAJOR_MINOR="${MELTANO_VERSION_ARRAY[0]}.${MELTANO_VERSION_ARRAY[1]}"
+        MELTANO_VERSION_MAJOR_MINOR_PATCH="${MELTANO_VERSION_ARRAY[0]}.${MELTANO_VERSION_ARRAY[1]}.${MELTANO_VERSION_ARRAY[2]}"
         # To save space, only publish the `latest` tag for each images to the GitHub registry
         if [[ "${{ env.registry }}" != "ghcr.io" ]]; then
-          echo "v${{ steps.get-meltano-version.outputs.release-version }}-python${{ matrix.python-version }}" >> tags
+          echo "v${MELTANO_VERSION_MAJOR}-python${{ matrix.python-version }}" >> tags
+          echo "v${MELTANO_VERSION_MAJOR_MINOR}-python${{ matrix.python-version }}" >> tags
+          echo "v${MELTANO_VERSION_MAJOR_MINOR_PATCH}-python${{ matrix.python-version }}" >> tags
           [[ "${{ matrix.is-default-python }}" == "true" ]] && echo "SHA-${{ github.sha }}" >> tags
-          [[ "${{ matrix.is-default-python }}" == "true" ]] && echo "v${{ steps.get-meltano-version.outputs.release-version }}" >> tags
+          [[ "${{ matrix.is-default-python }}" == "true" ]] && echo "v${MELTANO_VERSION_MAJOR}" >> tags
+          [[ "${{ matrix.is-default-python }}" == "true" ]] && echo "v${MELTANO_VERSION_MAJOR_MINOR}" >> tags
+          [[ "${{ matrix.is-default-python }}" == "true" ]] && echo "v${MELTANO_VERSION_MAJOR_MINOR_PATCH}" >> tags
         fi
         echo "latest-python${{ matrix.python-version }}" >> tags
         [[ "${{ matrix.is-default-python }}" == "true" ]] && echo "latest" >> tags


### PR DESCRIPTION
Successful push to the GitHub registry: https://github.com/meltano/meltano/runs/8077855019

Success dry-run targeting Docker Hub: https://github.com/meltano/meltano/actions/runs/2951254717

Tags to be pushed for Python 3.9:

![image](https://user-images.githubusercontent.com/11428666/187284246-243167d7-a40e-479f-bcb5-8eae2068ca3c.png)

Tags to be pushed for other versions of Python (in this case, Python 3.8):

![image](https://user-images.githubusercontent.com/11428666/187284369-b1dec093-bbab-4471-88f5-65c2303639ce.png)

Closes #6589