### PR TITLE
chore: Remove deprecated Google Analytics tracking ID settings

### DIFF
--- a/docs/src/_reference/settings.md
+++ b/docs/src/_reference/settings.md
@@ -1013,49 +1013,6 @@ export OAUTH_GITLAB_CLIENT_SECRET=<gitlab-client-secret>
 export OAUTH_GITLAB_SECRET=<gitlab-client-secret>
 ```
 
-## Analytics Tracking IDs (deprecated, will be removed in a future version)
-
-Google Analytics Tracking IDs to be used if the [`send_anonymous_usage_stats` setting](#send-anonymous-usage-stats) is enabled.
-
-### `tracking_ids.cli`
-
-- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_TRACKING_IDS_CLI`
-- Default: `UA-132758957-3`
-
-Tracking ID for usage of the [`meltano` CLI](/reference/command-line-interface).
-
-```bash
-meltano config meltano set tracking_ids cli UA-123456789-1
-
-export MELTANO_TRACKING_IDS_CLI=UA-123456789-1
-```
-
-### `tracking_ids.ui`
-
-- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_TRACKING_IDS_UI`
-- Default: `UA-132758957-2`
-
-Tracking ID for usage of [Meltano UI](/reference/ui).
-
-```bash
-meltano config meltano set tracking_ids ui UA-123456789-2
-
-export MELTANO_TRACKING_IDS_UI=UA-123456789-2
-```
-
-### `tracking_ids.ui_embed`
-
-- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_TRACKING_IDS_UI_EMBED`
-- Default: `UA-132758957-6`
-
-Tracking ID for usage of [Meltano UI](/reference/ui)'s [Embed feature](/guide/analysis#share-reports-and-dashboards).
-
-```bash
-meltano config meltano set tracking_ids ui_embed UA-123456789-3
-
-export MELTANO_TRACKING_IDS_UI_EMBED=UA-123456789-3
-```
-
 ## Snowplow Tracking
 
 ### `snowplow.collector_endpoints`

--- a/src/meltano/api/app.py
+++ b/src/meltano/api/app.py
@@ -113,8 +113,6 @@ def create_app(config: dict = {}) -> Flask:  # noqa: WPS210,WPS213,B006
     else:
         logger.debug("Notifications are disabled.")
 
-    # Google Analytics setup
-
     @app.before_request
     def setup_js_context():
         # setup the appUrl
@@ -126,8 +124,6 @@ def create_app(config: dict = {}) -> Flask:  # noqa: WPS210,WPS213,B006
         setting_map = {
             "isSendAnonymousUsageStats": "send_anonymous_usage_stats",
             "projectId": "project_id",
-            "trackingID": "tracking_ids.ui",
-            "embedTrackingID": "tracking_ids.ui_embed",
             "isProjectReadonlyEnabled": "project_readonly",
             "isReadonlyEnabled": "ui.readonly",
             "isAnonymousReadonlyEnabled": "ui.anonymous_readonly",

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -173,14 +173,6 @@ settings:
   env: OAUTH_GITLAB_CLIENT_SECRET
   env_specific: true
 
-# Analytics Tracking IDs
-- name: tracking_ids.cli
-  value: UA-132758957-3
-- name: tracking_ids.ui
-  value: UA-132758957-2
-- name: tracking_ids.ui_embed
-  value: UA-132758957-6
-
 # Snowplow Tracking
 - name: snowplow.collector_endpoints
   kind: array


### PR DESCRIPTION
Came across these while addressing #6729 (PR: https://github.com/meltano/meltano/pull/6743). Since Google Analytics has already been removed (#6622), these should probably be removed too.