### PR TITLE
fix: Use random UUID as default `project_id`

### DIFF
--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -66,7 +66,7 @@ class ProjectInitService:
         self.settings_service = ProjectSettingsService(self.project)
         self.settings_service.set(
             "project_id",
-            f"{self.project_name}-{uuid.uuid4()}",
+            str(uuid.uuid4()),
             store=SettingValueStore.MELTANO_YML,
         )
         self.set_send_anonymous_usage_stats()


### PR DESCRIPTION
Closes #6733