### PR TITLE
docs: Shrink contrib. docs in sidebar to 1p

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ docker_images: base_image prod_image ## Build the Meltano Docker images
 
 docs: ## Serve docs
 	cd docs &&\
-	 bundle exec jekyll serve 
+	 bundle exec jekyll serve
 
 # Docker Image Related
 # ====================

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ clean: ## Delete build artifacts
 
 docker_images: base_image prod_image ## Build the Meltano Docker images
 
+docs: ## Serve docs
+	cd docs &&\
+	 bundle exec jekyll serve 
+
 # Docker Image Related
 # ====================
 #
@@ -65,7 +69,7 @@ docker_images: base_image prod_image ## Build the Meltano Docker images
 # - `make prod_image` builds meltano/meltano which is an all-in-one production
 #   image that includes the static ui artifacts in the image.
 
-.PHONY: base_image prod_image
+.PHONY: base_image prod_image docs
 
 base_image: ## Build the Meltano base image
 	docker build \

--- a/docs/src/_contribute/api.md
+++ b/docs/src/_contribute/api.md
@@ -3,6 +3,7 @@ title: API Development
 description: Contribute to the Meltano API.
 layout: doc
 weight: 10
+hidden: true
 ---
 
 This section of the guide provides guidance on how to work with the Meltano API, which serves as the backend of Meltano and is built with the [Python framework: Flask](https://github.com/pallets/flask).

--- a/docs/src/_contribute/cli.md
+++ b/docs/src/_contribute/cli.md
@@ -3,6 +3,7 @@ title: CLI Development
 description: Contribute to the Meltano CLI.
 layout: doc
 weight: 10
+hidden: true
 ---
 
 This section of the guide provides guidance on how to work with the Meltano CLI, which serves as the primary UI of Meltano

--- a/docs/src/_contribute/docs.md
+++ b/docs/src/_contribute/docs.md
@@ -3,6 +3,7 @@ title: Documentation Development
 description: Meltano is open source software built by a growing team and a community of contributors.
 layout: doc
 weight: 10
+hidden: true
 ---
 
 ## Documentation Structure

--- a/docs/src/_contribute/merge.md
+++ b/docs/src/_contribute/merge.md
@@ -3,6 +3,7 @@ title: Pull Request Process
 description: Meltano is open source software built by a growing team and a community of contributors.
 layout: doc
 weight: 3
+hidden: true
 ---
 
 Meltano uses an approval workflow for all pull requests.

--- a/docs/src/_contribute/plugins.md
+++ b/docs/src/_contribute/plugins.md
@@ -3,6 +3,7 @@ title: Plugins
 description: Meltano is open source software built by a growing team and a community of contributors.
 layout: doc
 weight: 10
+hidden: true
 ---
 
 ## Discoverable plugins

--- a/docs/src/_contribute/prerequisites.md
+++ b/docs/src/_contribute/prerequisites.md
@@ -3,6 +3,7 @@ title: Prerequisites
 description: Meltano is open source software built by a growing team and a community of contributors.
 layout: doc
 weight: 2
+hidden: true
 ---
 
 ## Prerequisites

--- a/docs/src/_contribute/responsible-disclosure.md
+++ b/docs/src/_contribute/responsible-disclosure.md
@@ -8,4 +8,6 @@ weight: 11
 hidden: true
 ---
 
-Please email `security@meltano.com` to report any security vulnerabilities. We will acknowledge receipt of your vulnerability report the next business day and strive to send you regular updates about our progress. If you're curious about the status of your disclosure please feel free to email us again.
+Please email `security@meltano.com` to report any security vulnerabilities. 
+We will acknowledge receipt of your vulnerability report the next business day and strive to send you regular updates about our progress. 
+If you're curious about the status of your disclosure please feel free to email us again.

--- a/docs/src/_contribute/responsible-disclosure.md
+++ b/docs/src/_contribute/responsible-disclosure.md
@@ -5,6 +5,7 @@ layout: doc
 redirect_from:
   - /the-project/responsible-disclosure/
 weight: 11
+hidden: true
 ---
 
 Please email `security@meltano.com` to report any security vulnerabilities. We will acknowledge receipt of your vulnerability report the next business day and strive to send you regular updates about our progress. If you're curious about the status of your disclosure please feel free to email us again.

--- a/docs/src/_contribute/style.md
+++ b/docs/src/_contribute/style.md
@@ -3,6 +3,7 @@ title: Code Style Guide
 description: Meltano is open source software built by a growing team and a community of contributors.
 layout: doc
 weight: 10
+hidden: true
 ---
 
 ## Code style

--- a/docs/src/_contribute/telemetry.md
+++ b/docs/src/_contribute/telemetry.md
@@ -3,6 +3,7 @@ title: Telemetry
 description: Meltano is open source software built by a growing team and a community of contributors.
 layout: doc
 weight: 10
+hidden: true
 ---
 
 To update how [Meltano telemetry](/reference/settings#send_anonymous_usage_stats) works, or update the schemas we use for Snowplow events and contexts, refer to [the `README.md` file in the tracking module](https://github.com/meltano/meltano/blob/main/src/meltano/core/tracking/README.md).

--- a/docs/src/_contribute/tests.md
+++ b/docs/src/_contribute/tests.md
@@ -3,6 +3,7 @@ title: Tests
 description: Meltano is open source software built by a growing team and a community of contributors.
 layout: doc
 weight: 10
+hidden: true
 ---
 
 ## Unit Tests

--- a/docs/src/_contribute/ui.md
+++ b/docs/src/_contribute/ui.md
@@ -3,6 +3,7 @@ title: UI Development
 description: Meltano is open source software built by a growing team and a community of contributors.
 layout: doc
 weight: 10
+hidden: true
 ---
 
 ## UI Development


### PR DESCRIPTION
The documentation sidebar/ nav space should display the most important parts of Meltano. While contributing is an essential part, I feel style guides & UI contributions shouldn't be as important as other "level 2" items as all tutorials & how tos. So I propose to hide all but one Contribution page (which links to the rest).

However we might need to add more how tos and tutorials related to the extension of Meltano.

related to discussion: https://github.com/meltano/meltano/discussions/6738