### PR TITLE
docs: add list of video tuts and demos

### DIFF
--- a/docs/src/_tutorials/video-tutorials.md
+++ b/docs/src/_tutorials/video-tutorials.md
@@ -1,0 +1,30 @@
+---
+title: Video Tutorials & Demos
+description: Learn advanced Meltano projects taught in an Office Hour or Demo Day session via YouTube.
+layout: doc
+---
+Below is a list video tutorials & demos on specific Meltano-related topics. Most lessons are part of a longer YouTube video. If that is the case, the link below will guide you to the correct time period.
+
+
+- **[DemoDay - Combining Meltano & Lightdash](https://youtu.be/NZZyBnEOGOI?list=PLO0YrxtDbWAuLRElrtwFI5PwlAEMUi0AD&t=937)** - Using Meltano as EL and T tool together with Lightdash, a leightweight BI tool that integrates well with dbt.
+- **[DemoDay - Meltano Mappers](https://www.youtube.com/watch?v=41RGHQ49U_M&t=99s)** - An introduction to mappers and in particular to both, the two default mappers transferwise and meltano-map-transformer.
+- **[Tap a thon - tap-trello](https://youtu.be/41RGHQ49U_M?t=704)** - Intro to the tap for trello.
+- **[DemoDay - Meltano Slack Notifications](https://youtu.be/41RGHQ49U_M?t=1151)** - How to get job notifications from Meltano into Slack.
+- **[Tap a thon - tap-auth0](https://youtu.be/41RGHQ49U_M?t=1614)** - Intro to the tap for Auth0.
+- **[Tap a thon - tap-shopify](https://youtu.be/41RGHQ49U_M?t=2210)** - Intro to the tap for Shopify.
+- **[ReleaseParty - Meltano default environments](https://www.youtube.com/watch?v=p_uBJjxDfxA&t=139s)** - Putting in default environments into the meltano project YAML.
+- **[DemoDay - Meltano Incremental Runs](https://www.youtube.com/watch?v=RXo-lIQtwB8&t=98s)** - Introduction to the incremental runs feature in the meltano run command and it's differences to the meltano elt command.
+- **[DemoDay - Meltano UI Cron Intervals](https://youtu.be/RXo-lIQtwB8?t=719)** - Using the UI to define custom cron schedules.
+- **[DemoDay - Superset import datasources](https://www.youtube.com/watch?v=RXo-lIQtwB8&t=944s)** - Introduction to automatic import of dbt database connections and sources into superset via meltano.
+- **[DemoDay - Meltano, AD and dbt audit tables](https://youtu.be/RXo-lIQtwB8?t=1789)** - Using Meltano to update AD accounts
+- **[DemoDay - Meltano Plugin Inheritance Optimization](https://youtu.be/BmubPgBkjG8?t=71)** - How to optimize plugin inheritance, sharing and unsharing venvs.
+- **[DemoDay - Meltano, Lock Files](https://youtu.be/5GA8xXPP2_k?t=162)** - How lock files on plugins work.
+- **[DemoDay - Meltano Jobs & Tasks](https://youtu.be/kpOu4lOHY_Q?t=83)** - The meltano job command introduced.
+- **[DemoDay - Meltano Kedro plugin](https://youtu.be/w6uGN9sY8VY?t=71)** - How the Meltano Kedro plugin works.
+- **[DemoDay - Meltano dbt-osmosis](https://youtu.be/33jVAUR8-RY?t=1468)** - How dbt-osmosis works together with Meltano.
+- **[DemoDay - Meltano Interactive Mode](https://youtu.be/JzYfq31lawY?t=128)** - The Meltano interactive mode explained.
+- **[DemoDay - Meltano Container Spec](https://youtu.be/udCPX0EawtM?t=144)** - How to use the container spec to run commands in containers.
+- **[DemoDay - Meltano Great Expectations](https://youtu.be/udCPX0EawtM?t=882)** - Meltano Great Expectations introduced.
+- **[DemoDay - Meltano Mapper Plugins](https://youtu.be/udCPX0EawtM?t=1321)** - How Meltano mapper plugins, in particular the default transferwise plugin works.
+
+

--- a/docs/src/_tutorials/video-tutorials.md
+++ b/docs/src/_tutorials/video-tutorials.md
@@ -26,5 +26,3 @@ Below is a list video tutorials & demos on specific Meltano-related topics. Most
 - **[DemoDay - Meltano Container Spec](https://youtu.be/udCPX0EawtM?t=144)** - How to use the container spec to run commands in containers.
 - **[DemoDay - Meltano Great Expectations](https://youtu.be/udCPX0EawtM?t=882)** - Meltano Great Expectations introduced.
 - **[DemoDay - Meltano Mapper Plugins](https://youtu.be/udCPX0EawtM?t=1321)** - How Meltano mapper plugins, in particular the default transferwise plugin works.
-
-


### PR DESCRIPTION
Thanks to @pnadolny13 for creating & maintaining this list in the first place, but I definitely think this should be inside the docs. There are multiple features that don't have written documentation that are just inside the videos. Having this list inside the docs will enable people to search for them.