### PR TITLE
feat: Place `project_id` before `environments` in initial `meltano.yml`

### DIFF
--- a/src/meltano/core/bundle/initialize.yml
+++ b/src/meltano/core/bundle/initialize.yml
@@ -1,6 +1,7 @@
 meltano.yml: |
   version: 1
   default_environment: dev
+  project_id: 00000000-0000-0000-0000-000000000000
   env: {}
   environments:
   - name: dev

--- a/src/meltano/core/discovery_file.py
+++ b/src/meltano/core/discovery_file.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from .behavior.canonical import Canonical
-from .plugin import PluginDefinition, PluginType
+from meltano.core.behavior.canonical import Canonical
+from meltano.core.plugin import PluginDefinition, PluginType
 
 
 class DiscoveryFile(Canonical):

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -273,7 +273,7 @@ class Project(Versioned):  # noqa: WPS214
             yield meltano_config
 
             try:
-                meltano_config = self.project_files.update(meltano_config.canonical())
+                self.project_files.update(meltano_config.canonical())
             except Exception as err:
                 logger.critical("Could not update meltano.yml: %s", err)  # noqa: WPS323
                 raise

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -9,10 +9,10 @@ from typing import Any
 
 from ruamel.yaml import Representer
 
-from . import utils
-from .behavior import NameEq
-from .behavior.canonical import Canonical
-from .error import Error
+from meltano.core import utils
+from meltano.core.behavior import NameEq
+from meltano.core.behavior.canonical import Canonical
+from meltano.core.error import Error
 
 VALUE_PROCESSORS = {
     "nest_object": utils.nest_object,

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -1,4 +1,5 @@
 """Storage Managers for Meltano Configuration."""
+
 from __future__ import annotations
 
 import logging
@@ -14,15 +15,15 @@ import dotenv
 import sqlalchemy
 from sqlalchemy.orm import Session
 
-from .environment import NoActiveEnvironment
-from .error import Error
-from .project import ProjectReadonly
-from .setting import Setting
-from .setting_definition import SettingDefinition, SettingMissingError
-from .utils import flatten, pop_at_path, set_at_path
+from meltano.core.environment import NoActiveEnvironment
+from meltano.core.error import Error
+from meltano.core.project import ProjectReadonly
+from meltano.core.setting import Setting
+from meltano.core.setting_definition import SettingDefinition, SettingMissingError
+from meltano.core.utils import flatten, pop_at_path, set_at_path
 
 if TYPE_CHECKING:
-    from .settings_service import SettingsService
+    from meltano.core.settings_service import SettingsService
 
 
 logger = logging.getLogger(__name__)
@@ -588,10 +589,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         Raises:
             ConflictingSettingValueException: if multiple conflicting values for the same setting are provided.
         """
-        keys = [name]
-        if setting_def:
-            keys = [setting_def.name, *setting_def.aliases]
-
+        keys = [setting_def.name, *setting_def.aliases] if setting_def else [name]
         flat_config = self.flat_config
         vals_with_metadata = []
         for key in keys:
@@ -609,6 +607,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
             raise ConflictingSettingValueException(
                 metadata["key"] for _, metadata in vals_with_metadata
             )
+
         return vals_with_metadata[0] if vals_with_metadata else (None, {})
 
     def set(
@@ -629,19 +628,16 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         Returns:
             An empty dictionary.
         """
-        keys_to_unset = [name]
-        if setting_def:
-            keys_to_unset = [setting_def.name, *setting_def.aliases]
-
+        keys_to_unset = (
+            [setting_def.name, *setting_def.aliases] if setting_def else [name]
+        )
         paths_to_unset = [key for key in keys_to_unset if "." in key]
 
         if len(path) == 1:
-            # No need to unset `name`,
-            # since it will be overridden anyway
+            # No need to unset `name`, since it will be overridden anyway
             keys_to_unset.remove(name)
         elif name.split(".") == path:
-            # No need to unset `name` as path,
-            # since it will be overridden anyway
+            # No need to unset `name` as path, since it will be overridden anyway
             paths_to_unset.remove(name)
 
         with self.update_config() as config:


### PR DESCRIPTION
The only functional change is the addition of `project_id: 00000000-0000-0000-0000-000000000000` to `src/meltano/core/bundle/initialize.yml`. The rest is just style/formatting changes I made while trying other approaches to solving this.

`src/meltano/core/bundle/initialize.yml` is only used during `meltano init`, and `meltano init` replaces the `project_id` with a randomly generated UUID. The reason I have a default one there is because `ProjectFiles.update` calls `ProjectFiles._split_config_dict`, which in turn calls `ProjectFiles._restore_file_key_order`, which re-orders keys based on how they were initially. The initial order comes from `initialize.yml`

I had originally tried re-ordering the `CommentedMap` produced by `Canonical.as_canonical` based on a default order in `MeltanoFile`, but that order was being undone by `ProjectFiles._restore_file_key_order`, hence the current approach.

Closes #6734