### PR TITLE
feat: add `ui.update_check` configuration to disable PyPi-based version check in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ ENV/
 env.bak/
 venv.bak/
 .env.dev
+.nvmrc
 
 # Spyder project settings
 .spyderproject

--- a/docs/src/_reference/settings.md
+++ b/docs/src/_reference/settings.md
@@ -464,14 +464,20 @@ The host to bind to.
 Together with the [`ui.bind_port` setting](#ui-bind-port), this setting corresponds to
 [Gunicorn's `bind` setting](https://docs.gunicorn.org/en/stable/settings.html#bind).
 
+### <a name="ui-update-check"></a>`ui.update_check`
+
+- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_UI_UPDATE_CHECK`
+- Type: `boolean`
+- Default: `true`
+
+Whether to check for newer Meltano versions and display update notifications in the UI.
+
 #### How to use
 
 ```bash
-meltano config meltano set ui bind_host 127.0.0.1
+meltano config meltano set ui update_check false
 
-export MELTANO_UI_BIND_HOST=127.0.0.1
-
-meltano ui --bind=127.0.0.1
+export MELTANO_UI_UPDATE_CHECK=false
 ```
 
 ### <a name="ui-bind-port"></a>`ui.bind_port`
@@ -492,7 +498,6 @@ meltano config meltano set ui bind_port 80
 
 export MELTANO_UI_BIND_PORT=80
 
-meltano ui --bind-port=80
 ```
 
 ### <a name="ui-server-name"></a>`ui.server_name`

--- a/src/meltano/api/app.py
+++ b/src/meltano/api/app.py
@@ -129,6 +129,7 @@ def create_app(config: dict = {}) -> Flask:  # noqa: WPS210,WPS213,B006
             "isAnonymousReadonlyEnabled": "ui.anonymous_readonly",
             "isNotificationEnabled": "ui.notification",
             "isAnalysisEnabled": "ui.analysis",
+            "isUpdateCheckEnabled": "ui.update_check",
             "logoUrl": "ui.logo_url",
             "oauthServiceUrl": "oauth_service.url",
         }

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -104,6 +104,9 @@ settings:
 - name: ui.analysis
   kind: boolean
   value: false
+- name: ui.update_check
+  kind: boolean
+  value: true
 
 # UI customization
 - name: ui.logo_url

--- a/src/webapp/src/App.vue
+++ b/src/webapp/src/App.vue
@@ -13,7 +13,11 @@ export default {
     }
   },
   created() {
-    this.$store.dispatch('system/check')
+    const isUpdateCheckEnabled = this.$flask.isUpdateCheckEnabled
+    this.$store.dispatch('system/check', {
+      include_latest: isUpdateCheckEnabled
+    })
+
     this.$store.dispatch('system/fetchIdentity')
     this.tryAcknowledgeAnalyticsTracking()
   },

--- a/src/webapp/src/store/modules/system.js
+++ b/src/webapp/src/store/modules/system.js
@@ -23,11 +23,17 @@ const getters = {
 }
 
 const actions = {
-  check({ commit }) {
-    return systemApi.version({ include_latest: true }).then(response => {
-      commit('setVersion', response.data.version)
-      commit('setLatestVersion', response.data.latestVersion)
-    })
+  check(context, args) {
+    return systemApi
+      .version({ include_latest: args.include_latest })
+      .then(response => {
+        context.commit('setVersion', response.data.version)
+        if (response.data.hasOwnProperty('latestVersion')) {
+          context.commit('setLatestVersion', response.data.latestVersion)
+        } else {
+          context.commit('setLatestVersion', null)
+        }
+      })
   },
 
   upgrade({ state, commit }) {

--- a/src/webapp/src/utils/flask.js
+++ b/src/webapp/src/utils/flask.js
@@ -13,6 +13,7 @@ export default function() {
         .split(',')
         .filter(Boolean),
       isAnalysisEnabled: true,
+      isUpdateCheckEnabled: false,
       isNotificationEnabled: false,
       isProjectReadonlyEnabled: false,
       isReadonlyEnabled: false,


### PR DESCRIPTION
Took a stab at solving this [https://github.com/meltano/meltano/issues/6750#issuecomment-1247116799 .](https://github.com/meltano/meltano/issues/6760).

First time messing with Vue.js so bear with me here :pray:

I guess the UI doesn't have a solidly defined concept of an update check in the first place, so the implementation here feels a bit hacky. Basically, the switch just stops the UI from requesting the latest version from the backend when the flag is set to false, and sets the latest version to `null`. The consequence of this is already handled in the `NavBar` component with a null check.

I've tested it manually and it seems to work, however I wonder how to test this with the proper flask-based context manager?

**I'm missing the docs here** but figured it's best to get a review on the implementation first.