### PR TITLE
fix: Ignore default environment for some commands

### DIFF
--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -101,6 +101,10 @@ meltano add extractor tap-spotify --no-install
 
 - `--no-install`: Do not install the plugin after adding it to the project.
 
+### Using `add` with Environments
+
+The `add` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
+
 ## `config`
 
 Enables you to manage the [configuration](/guide/configuration) of Meltano itself or any of its plugins, as well as [plugin extras](#how-to-use-plugin-extras).
@@ -217,11 +221,7 @@ meltano config <plugin> set <property>.<deep>.<nesting> <value>
 
 ### Using `config` with Environments
 
-If you have multiple [Meltano Environments](/concepts/environments) you can specify the environment name:
-
-```bash
-meltano --environment=<ENVIRONMENT> config <plugin>
-```
+The `config` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). However, the [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored.
 
 <br>
 > Note: Unlike other commands like [`meltano run`](#run) and [`meltano invoke`](#invoke), the `meltano config` command ignores any configured [default environment](/concepts/environments#default-environment).
@@ -291,6 +291,11 @@ meltano discover extractors
 meltano discover loaders
 
 ```
+
+### Using `discover` with Environments
+
+The `discover` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
+
 
 ## `elt`
 
@@ -372,11 +377,7 @@ meltano elt tap-gitlab target-postgres --state-id=gitlab-to-postgres --dump=stat
 
 ### Using `elt` with Environments
 
-The `--environment` option can be passed to specify a [Meltano Environment](/concepts/environments) context for running.
-
-```bash
-meltano --environment=prod elt tap-gitlab target-postgres --transform=run --state-id=gitlab-to-postgres
-```
+The `elt` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). The [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be applied if `--environment` is not provided explicitly.
 
 ### Debugging
 
@@ -449,6 +450,10 @@ Once an Environment is configured, the `--environment` option or `MELTANO_ENVIRO
 If there is a value provided for `default_environment` in your `meltano.yml`, then these commands, with the exception of [`config`](#using-config-with-environments), will be run using that Environment if no `--environment` option or `MELTANO_ENVIRONMENT` environment variable is provided.
 If you have `default_environment` set this way but would prefer to use no environment use the option `--environment=null` (or its equivalent using a space instead of an `=`: `--environment null`) or use the `--no-environment` flag.
 
+### Using `discover` with Environments
+
+The `discover` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
+
 ### Examples
 
 ```bash
@@ -511,6 +516,10 @@ echo "export MELTANO_SEND_ANONYMOUS_USAGE_STATS=0" >> $SHELLRC
 meltano init demo-project # --no_usage_stats is implied
 ```
 
+### Using `init` with Environments
+
+The `init` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag will be ignored if set.
+
 ## `install`
 
 Installs dependencies of your project based on the **meltano.yml** file.
@@ -563,6 +572,11 @@ meltano install --parallelism=16
 meltano install --clean
 ```
 
+### Using `install` with Environments
+
+The `install` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
+
+
 ## `invoke`
 
 Invoke the plugin's executable with specified arguments.
@@ -590,11 +604,7 @@ Like any standard output, the dumped content can be [redirected](<https://en.wik
 
 ### Using `invoke` with Environments
 
-If you have multiple [Meltano Environments](/concepts/environments) you can specify the environment name:
-
-```bash
-meltano --environment=<ENVIRONMENT> invoke <plugin> [PLUGIN]_ARGS...]
-```
+The `invoke` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). The [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be applied if `--environment` is not provided explicitly.
 
 ### Commands
 
@@ -664,6 +674,10 @@ meltano lock <name> <name_two> --plugin-type=<type>
 meltano lock --all --update
 ```
 
+### Using `lock` with Environments
+
+The `lock` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
+
 ## `remove`
 
 `meltano remove` removes one or more [plugins](/concepts/plugins#project-plugins) of the same [type](/concepts/plugins#types) from your Meltano [project](/concepts/project).
@@ -681,6 +695,10 @@ Specifically, [plugins](/concepts/plugins#project-plugins) will be removed from 
 meltano remove <type> <name>
 meltano remove <type> <name> <name_two>
 ```
+
+### Using `remove` with Environments
+
+The `remove` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
 
 ### Examples
 
@@ -725,8 +743,7 @@ meltano run --state-id-suffix=<STATE_ID_SUFFIX> tap-gitlab target-postgres
 
 #### Parameters
 
-When an active environment is present, `run` will attempt to run incrementally and save state by default.
-However, four top level flags are provided to alter behavior:
+`run` will attempt to run incrementally and save state by default. Four top level flags are provided to alter behavior:
 
 - `--dry-run` just parse the invocation, validate it, and explain what would be executed. Does not execute anything.
   (implicitly enables --log-level=debug for 'console' named handlers).
@@ -756,13 +773,9 @@ meltano --environment=dev --state-id-suffix pipeline-alias run tap-gitlab hide-s
 
 ### Using `run` with Environments
 
-If you have multiple Meltano Environments you can specify the environment name:
 
-```bash
-meltano --environment=<ENVIRONMENT> run ...
-```
+The `run` command always requires a [Meltano Environment](https://docs.meltano.com/concepts/environments) to be set. The environment name can be provided using the `--environment` flag or with the [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file.
 
-Note that if no environment is active, `meltano run` _does not_ generate a state ID and it does not track state.
 
 ## `job`
 
@@ -871,6 +884,10 @@ task 2: "meltano run dbt-postgres:run" , depends on task 1
 task 3: "meltano run custom-utility-plugin", depends on task 2
 ```
 
+### Using `job` with Environments
+
+The `job` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). However, the [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored.
+
 ### Examples
 
 ```bash
@@ -932,6 +949,10 @@ meltano schedule set <schedule_name> --extractor <new-tap> --interval <new-inter
 meltano schedule run <schedule_name>
 ```
 
+### Using `schedule` with Environments
+
+The `schedule` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). However, the [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored.
+
 ### Examples
 
 ```bash
@@ -984,11 +1005,7 @@ Use `--rm` or `--remove` to remove previously added select patterns.
 
 ### Using `select` with Environments
 
-If you have multiple [Meltano Environments](/concepts/environments) you can specify the environment name:
-
-```bash
-meltano --environment=<ENVIRONMENT> select <tap_name>
-```
+The `select` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). However, the [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored.
 
 ### Examples
 
@@ -1279,6 +1296,10 @@ echo '{"singer_state": {"project_123456_issues": "2020-01-01"}}' > gitlab_state.
 meltano state set --force dev:tap-gitlab-to-target-jsonl --input-file gitlab_state.json
 ```
 
+### Using `state` with Environments
+
+The `state` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). However, the [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored.
+
 ## `test`
 
 Run tests for one or more plugins. A test is any [command](/reference/command-line-interface#commands) with a name starting with `test`.
@@ -1298,6 +1319,10 @@ meltano test <plugin>:<test-name>
 # Run a named test for one or more plugins
 meltano test <plugin1>:<test-name1> <plugin2>:<test-name2>
 ```
+
+### Using `test` with Environments
+
+The `test` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). The [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be applied if `--environment` is not provided explicitly.
 
 ## `ui`
 
@@ -1342,6 +1367,10 @@ meltano ui setup [--bits=256] <server_name>
 meltano ui setup meltano.example.com
 ```
 
+### Using `ui` with Environments
+
+The `ui` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
+
 ## `user`
 
 <div class="notification is-info">
@@ -1366,6 +1395,10 @@ Add the user to the role. Meltano ships with two built-in roles: `admin` and `re
 meltano user add admin securepassword --role admin
 ```
 
+### Using `user` with Environments
+
+The `user` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
+
 ## `upgrade`
 
 Upgrade Meltano and your Meltano project to the latest version.
@@ -1386,6 +1419,11 @@ meltano upgrade package # Only upgrade Meltano package
 meltano upgrade files # Only update files managed by file bundles
 meltano upgrade database # Only apply migrations to system database
 ```
+
+### Using `upgrade` with Environments
+
+The `upgrade` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.
+
 
 ## `version`
 

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -1,26 +1,27 @@
 """Main entry point for the meltano CLI."""
+
 from __future__ import annotations
 
 import logging
 import os
 import sys
-from textwrap import dedent
 from typing import TYPE_CHECKING, NoReturn
 
+from meltano.cli.utils import CliError
 from meltano.core.error import MeltanoError
 from meltano.core.logging import setup_logging
 from meltano.core.project import ProjectReadonly
-from meltano.core.tracking.contexts.exception import ExceptionContext  # noqa: F401
-
-from .interactive import InteractionStatus, InteractiveConfig  # noqa: F401
-from .utils import CliError
 
 # TODO: Importing the cli.cli module breaks other cli module imports
 # This suggests a cyclic dependency or a poorly structured interface.
 # This should be investigated and resolved to avoid implicit behavior
 # based solely on import order.
-from .cli import cli  # isort:skip
-from . import (  # isort:skip # noqa: F401, WPS235
+from meltano.cli.cli import (  # isort:skip
+    activate_environment,
+    activate_explicitly_provided_environment,
+    cli,
+)
+from meltano.cli import (  # isort:skip # noqa: WPS235
     add,
     config,
     discovery,

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -11,6 +11,7 @@ import click
 import meltano
 from meltano.cli.utils import InstrumentedGroup
 from meltano.core.behavior.versioned import IncompatibleVersionError
+from meltano.core.error import MeltanoConfigurationError
 from meltano.core.logging import LEVELS, setup_logging
 from meltano.core.project import Project, ProjectNotFound
 from meltano.core.project_settings_service import ProjectSettingsService
@@ -120,7 +121,9 @@ def cli(  # noqa: WPS231
         sys.exit(3)
 
 
-def activate_environment(ctx: click.Context, project: Project) -> None:
+def activate_environment(
+    ctx: click.Context, project: Project, required: bool = False
+) -> None:
     """Activate the selected environment.
 
     The selected environment is whatever was selected with the `--environment`
@@ -132,6 +135,12 @@ def activate_environment(ctx: click.Context, project: Project) -> None:
     """
     if ctx.obj["selected_environment"]:
         project.activate_environment(ctx.obj["selected_environment"])
+    elif required:
+        raise MeltanoConfigurationError(
+            reason="A Meltano environment must be specified",
+            instruction="Set the `default_environment` option in "
+            "`meltano.yml`, or the `--environment` CLI option",
+        )
 
 
 def activate_explicitly_provided_environment(

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -123,6 +123,9 @@ def cli(  # noqa: WPS231
 def activate_environment(ctx: click.Context, project: Project) -> None:
     """Activate the selected environment.
 
+    The selected environment is whatever was selected with the `--environment`
+    option, or the default environment (set in `meltano.yml`) otherwise.
+
     Args:
         ctx: The Click context, used to determine the selected environment.
         project: The project for which the environment will be activated.

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -1,4 +1,5 @@
 """Defines `meltano elt` command."""
+
 from __future__ import annotations
 
 import datetime
@@ -10,6 +11,9 @@ import click
 import structlog
 from structlog import stdlib as structlog_stdlib
 
+from meltano.cli import activate_environment, cli
+from meltano.cli.params import pass_project
+from meltano.cli.utils import CliError, PartialInstrumentedCmd
 from meltano.core.db import project_engine
 from meltano.core.elt_context import ELTContextBuilder
 from meltano.core.job import Job, JobFinder
@@ -24,10 +28,6 @@ from meltano.core.runner.dbt import DbtRunner
 from meltano.core.runner.singer import SingerRunner
 from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
 from meltano.core.utils import click_run_async
-
-from . import cli
-from .params import pass_project
-from .utils import CliError, PartialInstrumentedCmd
 
 DUMPABLES = {
     "catalog": (PluginType.EXTRACTORS, "catalog"),
@@ -111,6 +111,8 @@ async def elt(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#elt
     """
+    activate_environment(ctx, project)
+
     if platform.system() == "Windows":
         raise CliError(
             "ELT command not supported on Windows. Please use the Run command as documented here https://docs.meltano.com/reference/command-line-interface#run"

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -9,7 +9,7 @@ import sys
 import click
 from sqlalchemy.orm import sessionmaker
 
-from meltano.cli import cli
+from meltano.cli import activate_environment, cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import CliError, PartialInstrumentedCmd, propagate_stop_signals
 from meltano.core.db import project_engine
@@ -76,6 +76,7 @@ def invoke(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#invoke
     """
+    activate_environment(ctx, project)
     tracker: Tracker = ctx.obj["tracker"]
 
     try:

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -1,4 +1,5 @@
 """Job management CLI."""
+
 from __future__ import annotations
 
 import json
@@ -6,6 +7,9 @@ import json
 import click
 import structlog
 
+from meltano.cli import CliError, activate_explicitly_provided_environment, cli
+from meltano.cli.params import pass_project
+from meltano.cli.utils import InstrumentedGroup, PartialInstrumentedCmd
 from meltano.core.block.parser import BlockParser, validate_block_sets
 from meltano.core.project import Project
 from meltano.core.task_sets import InvalidTasksError, TaskSets, tasks_from_yaml_str
@@ -15,10 +19,6 @@ from meltano.core.task_sets_service import (
     TaskSetsService,
 )
 from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
-
-from . import CliError, cli
-from .params import pass_project
-from .utils import InstrumentedGroup, PartialInstrumentedCmd
 
 logger = structlog.getLogger(__name__)
 
@@ -115,6 +115,7 @@ def job(project, ctx):
 
     \bRead more at https://docs.meltano.com/reference/command-line-interface#jobs
     """
+    activate_explicitly_provided_environment(ctx, project)
     ctx.obj["project"] = project
     ctx.obj["task_sets_service"] = TaskSetsService(project)
 

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -1,9 +1,13 @@
-"""meltano run command and supporting functions."""
+"""Meltano run command and supporting functions."""
+
 from __future__ import annotations
 
 import click
 import structlog
 
+from meltano.cli import CliError, activate_environment, cli
+from meltano.cli.params import pass_project
+from meltano.cli.utils import PartialInstrumentedCmd
 from meltano.core.block.blockset import BlockSet
 from meltano.core.block.parser import BlockParser, validate_block_sets
 from meltano.core.block.plugin_command import PluginCommandBlock
@@ -14,10 +18,6 @@ from meltano.core.runner import RunnerError
 from meltano.core.tracking import BlockEvents, CliEvent, Tracker
 from meltano.core.tracking.contexts.plugins import PluginsTrackingContext
 from meltano.core.utils import click_run_async
-
-from . import CliError, cli
-from .params import pass_project
-from .utils import PartialInstrumentedCmd
 
 logger = structlog.getLogger(__name__)
 
@@ -87,10 +87,11 @@ async def run(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#run
     """
-    if dry_run:
-        if not ProjectSettingsService.config_override.get("cli.log_level"):
-            logger.info("Setting 'console' handler log level to 'debug' for dry run")
-            change_console_log_level()
+    activate_environment(ctx, project)
+
+    if dry_run and not ProjectSettingsService.config_override.get("cli.log_level"):
+        logger.info("Setting 'console' handler log level to 'debug' for dry run")
+        change_console_log_level()
 
     tracker: Tracker = ctx.obj["tracker"]
 

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -87,7 +87,7 @@ async def run(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#run
     """
-    activate_environment(ctx, project)
+    activate_environment(ctx, project, required=True)
 
     if dry_run and not ProjectSettingsService.config_override.get("cli.log_level"):
         logger.info("Setting 'console' handler log level to 'debug' for dry run")

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -8,7 +8,7 @@ import sys
 import click
 from sqlalchemy.orm import Session
 
-from meltano.cli import cli
+from meltano.cli import activate_explicitly_provided_environment, cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import InstrumentedDefaultGroup, PartialInstrumentedCmd
 from meltano.core.db import project_engine
@@ -32,6 +32,7 @@ def schedule(project, ctx):
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#schedule
     """
+    activate_explicitly_provided_environment(ctx, project)
     ctx.obj["project"] = project
     ctx.obj["schedule_service"] = ScheduleService(project)
     ctx.obj["task_sets_service"] = TaskSetsService(project)

--- a/src/meltano/cli/select.py
+++ b/src/meltano/cli/select.py
@@ -5,16 +5,15 @@ from contextlib import closing
 
 import click
 
+from meltano.cli import activate_explicitly_provided_environment, cli
+from meltano.cli.params import pass_project
+from meltano.cli.utils import CliError, InstrumentedCmd
 from meltano.core.db import project_engine
 from meltano.core.plugin.error import PluginExecutionError
 from meltano.core.plugin.singer.catalog import SelectionType, SelectPattern
 from meltano.core.project import Project
 from meltano.core.select_service import SelectService
 from meltano.core.utils import click_run_async
-
-from . import cli
-from .params import pass_project
-from .utils import CliError, InstrumentedCmd
 
 
 def selection_color(selection):
@@ -78,6 +77,7 @@ async def select(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#select
     """
+    activate_explicitly_provided_environment(ctx, project)
     try:
         if flags["list"]:
             await show(project, extractor, show_all=flags["all"])

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -10,15 +10,14 @@ from operator import xor
 import click
 import structlog
 
+from meltano.cli import activate_explicitly_provided_environment, cli
 from meltano.cli.params import pass_project
+from meltano.cli.utils import InstrumentedCmd, InstrumentedGroup
 from meltano.core.block.parser import BlockParser
 from meltano.core.db import project_engine
 from meltano.core.job import Payload
 from meltano.core.project import Project
 from meltano.core.state_service import InvalidJobStateError, StateService
-
-from . import cli
-from .utils import InstrumentedCmd, InstrumentedGroup
 
 STATE_SERVICE_KEY = "state_service"
 
@@ -107,6 +106,7 @@ def meltano_state(project: Project, ctx: click.Context):
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#state
     """
+    activate_explicitly_provided_environment(ctx, project)
     _, sessionmaker = project_engine(project)
     session = sessionmaker()
     ctx.obj[STATE_SERVICE_KEY] = StateService(session)  # noqa: WPS204

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -11,13 +11,12 @@ import click
 import structlog
 from sqlalchemy.orm.session import sessionmaker
 
+from meltano.cli import activate_environment, cli
+from meltano.cli.params import pass_project
 from meltano.cli.utils import InstrumentedCmd, propagate_stop_signals
 from meltano.core.db import project_engine
 from meltano.core.project import Project
 from meltano.core.validation_service import ValidationOutcome, ValidationsRunner
-
-from . import cli
-from .params import pass_project
 
 logger = structlog.getLogger(__name__)
 
@@ -74,7 +73,9 @@ class CommandLineRunner(ValidationsRunner):
     nargs=-1,
 )
 @pass_project(migrate=True)
+@click.pass_context
 def test(
+    ctx: click.Context,
     project: Project,
     all_tests: bool,
     plugin_tests: tuple[str] = (),
@@ -84,6 +85,7 @@ def test(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#test
     """
+    activate_environment(ctx, project)
     _, session_maker = project_engine(project)
     session = session_maker()
 

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -87,3 +87,7 @@ class PluginInstallWarning(Exception):
 
 class EmptyMeltanoFileException(Exception):
     """Exception for empty meltano.yml file."""
+
+
+class MeltanoConfigurationError(MeltanoError):
+    """Exception for when Meltano is inproperly configured."""

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -340,6 +340,7 @@ class Project(Versioned):  # noqa: WPS214
             name: Name of the environment.
         """
         self.active_environment = Environment.find(self.meltano.environments, name)
+        logger.info(f"Environment {name!r} is active")
 
     def deactivate_environment(self) -> None:
         """Deactivate the currently active environment."""

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -94,7 +94,7 @@ class TestCli:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
-            ["discover"],
+            ["test"],
         )
         assert Project._default.active_environment.name == "test-meltano-environment"
 
@@ -104,7 +104,7 @@ class TestCli:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
-            ["--environment", "test-subconfig-2-yml", "discover"],
+            ["--environment", "test-subconfig-2-yml", "test"],
         )
 
         assert Project._default.active_environment.name == "test-subconfig-2-yml"
@@ -117,7 +117,7 @@ class TestCli:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
-            ["discover"],
+            ["test"],
         )
         assert Project._default.active_environment.name == "test-subconfig-2-yml"
 


### PR DESCRIPTION
Given the urgency of #6677, and the relative ease of #6834, I decided to quickly put together an implementation.

In this implementation, commands which require an environment call `activate_environment`, and those which will only use an environment if it is explicitly provided (e.g. via `--environment`) call `activate_explicitly_provided_environment`. By default no environment is required nor used, which comes with the side benefit of avoiding the "default environment activated" log message for most commands.

Closes #6834