### PR TITLE
Revert "docs: add giffy to title"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@
 
 Welcome to your CLI for ELT+. It's ppen source, flexible, scales to your needs. Confidently move, transform, and test your data using tools you know with a data engineering workflow you’ll love.
 
-![Meltano Speedrun](meltano_superstart.gif)
 
 Integrations
 ------------


### PR DESCRIPTION
@WillDaSilva Ok, valid points. Sounds like I need to do a round 2. 

FWIW, we're focusing in on the ELT part of Meltano, and the chip is a representation of the DataOps infrastructure.

With a positioning that moves more towards the "Your CLI for ELT+", I think its almost mandatory for us to also show this "CLI". 

But you're right, the way I've done it might be too confusing. I'll take another shot at it next week maybe akin to https://fly.io/ (without gif just a static CLI). 

