### PR TITLE
fix: Make default `default_environment` null

### DIFF
--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -1,7 +1,7 @@
 settings:
 # Project
 - name: default_environment
-  value: dev
+  value: null
 - name: send_anonymous_usage_stats
   kind: boolean
   value: true


### PR DESCRIPTION
Previously if `default_environment` was not set in `meltano.yml` (and the `--environment` CLI option was not used) Meltano would try to use the `dev` environment. Now it is set to null in `settings.yml`, which results in no default environment being used when there isn't one set in `meltano.yml`.

Closes #6833

Related to #6677