### PR TITLE
docs: make clear you can override `executable` in `commands`

### DIFF
--- a/docs/src/_reference/plugin-definition-syntax.md
+++ b/docs/src/_reference/plugin-definition-syntax.md
@@ -246,7 +246,7 @@ Friendly description of the command.
 
 ### `commands.<command_name>.executable`
 
-Optionally, override the default `executable` of the plugin.
+Optionally, override the plugin's default `executable` when running this command.
 
 ### `commands.<command_name>.container_spec`
 

--- a/docs/src/_reference/plugin-definition-syntax.md
+++ b/docs/src/_reference/plugin-definition-syntax.md
@@ -244,6 +244,10 @@ Command line arguments for the command.
 
 Friendly description of the command.
 
+### `commands.<command_name>.executable`
+
+Optionally, override the default `executable` of the plugin.
+
 ### `commands.<command_name>.container_spec`
 
 The container specification to use for the command.


### PR DESCRIPTION
Realized this was missing when replying in this slack convo:

- https://meltano.slack.com/archives/C013Z450LCD/p1666329193831789?thread_ts=1665674957.357919&cid=C013Z450LCD