### PR TITLE
feat: Add `--force` option to ignore existing files/directories in an non-empty project directory with `meltano init`

### DIFF
--- a/src/meltano/cli/initialize.py
+++ b/src/meltano/cli/initialize.py
@@ -26,10 +26,16 @@ path_type = click.Path(file_okay=False, path_type=Path)
 @click.pass_context
 @click.argument("project_directory", required=False, type=path_type)
 @click.option(
+    "-f",
+    "--force",
+    help="Ignore existing files/directories within the project directory, if it exists.",
+    is_flag=True,
+)
+@click.option(
     "--no_usage_stats", help="Do not send anonymous usage stats.", is_flag=True
 )
 @database_uri_option
-def init(ctx, project_directory: Path, no_usage_stats):
+def init(ctx, project_directory: Path, force: bool, no_usage_stats):
     """
     Create a new Meltano project.
 
@@ -52,7 +58,7 @@ def init(ctx, project_directory: Path, no_usage_stats):
 
     init_service = ProjectInitService(project_directory)
 
-    project = init_service.init()
+    project = init_service.init(force=force)
     init_service.echo_instructions(project)
 
     # since the project didn't exist, tracking was not initialized in cli.py

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -34,12 +34,15 @@ class ProjectInitService:
         except ValueError:
             pass
 
-    def init(self, activate: bool = True, add_discovery: bool = False) -> Project:
+    def init(
+        self, activate: bool = True, add_discovery: bool = False, force: bool = False
+    ) -> Project:
         """Initialise Meltano Project.
 
         Args:
             activate: Activate newly created project
             add_discovery: Add discovery.yml file to created project
+            force: Ignore existing files/directories within the project directory, if it exists
 
         Returns:
             A new Project instance
@@ -50,7 +53,7 @@ class ProjectInitService:
         try:
             self.project_directory.mkdir()
         except FileExistsError as ex:
-            if any(self.project_directory.iterdir()):
+            if not force and any(self.project_directory.iterdir()):
                 raise ProjectInitServiceError(
                     f"Directory '{self.project_directory}' not empty."
                 ) from ex

--- a/tests/meltano/core/test_project_init_service.py
+++ b/tests/meltano/core/test_project_init_service.py
@@ -61,6 +61,19 @@ def test_project_init_non_empty_directory(tmp_path: Path, pushd):
         ProjectInitService(project_dir).init(activate=False, add_discovery=False)
 
 
+def test_project_init_non_empty_directory_force(tmp_path: Path, pushd):
+    projects_dir = tmp_path.joinpath("exists")
+    projects_dir.mkdir()
+    pushd(projects_dir)
+
+    project_dir = projects_dir.joinpath("test_project")
+    project_dir.joinpath("test").mkdir(parents=True)
+
+    ProjectInitService(project_dir).init(
+        activate=False, add_discovery=False, force=True
+    )
+
+
 def test_project_init_no_write_permission(tmp_path: Path, pushd):
     if platform.system() == "Windows":
         pytest.xfail(


### PR DESCRIPTION
One of the primary use-cases addressed by #6806 was to be able to create an empty repository in GitHub, clone into a directory and immediately `meltano init` into it. I completely forgot about this when implementing #6814, so this is the follow-up PR! :sweat_smile: 

See [this Slack thread](https://meltano.slack.com/archives/C013Z450LCD/p1666396209017099) for more information.