### PR TITLE
fix: Persist `description` and `logo_url` to plugin lock files

### DIFF
--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -259,6 +259,8 @@ class Variant(NameEq, Canonical):
         repo: str | None = None,
         pip_url: str | None = None,
         executable: str | None = None,
+        description: str | None = None,
+        logo_url: str | None = None,
         capabilities: list | None = None,
         settings_group_validation: list | None = None,
         settings: list | None = None,
@@ -277,6 +279,8 @@ class Variant(NameEq, Canonical):
             repo: The repository URL.
             pip_url: The pip URL.
             executable: The executable name.
+            description: The description of the plugin.
+            logo_url: The logo URL of the plugin.
             capabilities: The capabilities of the variant.
             settings_group_validation: The settings group validation.
             settings: The settings of the variant.
@@ -293,6 +297,8 @@ class Variant(NameEq, Canonical):
             repo=repo,
             pip_url=pip_url,
             executable=executable,
+            description=description,
+            logo_url=logo_url,
             capabilities=list(capabilities or []),
             settings_group_validation=list(settings_group_validation or []),
             settings=list(map(SettingDefinition.parse, settings or [])),
@@ -465,6 +471,8 @@ class PluginDefinition(PluginRef):
             repo=plugin.repo,
             pip_url=plugin.pip_url,
             executable=plugin.executable,
+            description=plugin.description,
+            logo_url=plugin.logo_url,
             capabilities=plugin.capabilities,
             settings_group_validation=plugin.settings_group_validation,
             settings=plugin.settings,
@@ -737,6 +745,8 @@ class StandalonePlugin(Canonical):
         repo: str | None = None,
         pip_url: str | None = None,
         executable: str | None = None,
+        description: str | None = None,
+        logo_url: str | None = None,
         capabilities: list | None = None,
         settings_group_validation: list | None = None,
         settings: list | None = None,
@@ -757,6 +767,8 @@ class StandalonePlugin(Canonical):
             repo: The repository URL of the plugin.
             pip_url: The pip URL of the plugin.
             executable: The executable of the plugin.
+            description: The description of the plugin.
+            logo_url: The logo URL of the plugin.
             capabilities: The capabilities of the plugin.
             settings_group_validation: The settings group validation of the plugin.
             settings: The settings of the plugin.
@@ -775,6 +787,8 @@ class StandalonePlugin(Canonical):
             repo=repo,
             pip_url=pip_url,
             executable=executable,
+            description=description,
+            logo_url=logo_url,
             capabilities=capabilities or [],
             settings_group_validation=settings_group_validation or [],
             settings=list(map(SettingDefinition.parse, settings or [])),
@@ -809,6 +823,8 @@ class StandalonePlugin(Canonical):
             repo=variant.repo,
             pip_url=variant.pip_url,
             executable=variant.executable,
+            description=variant.description,
+            logo_url=variant.logo_url,
             capabilities=variant.capabilities,
             settings_group_validation=variant.settings_group_validation,
             settings=variant.settings,

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -64,7 +64,7 @@ class PluginRefNameContainsStateIdDelimiterError(Exception):
 yaml.add_multi_representer(YAMLEnum, YAMLEnum.yaml_representer)
 
 
-class PluginType(YAMLEnum):
+class PluginType(YAMLEnum):  # noqa: WPS214
     """The type of a plugin."""
 
     EXTRACTORS = "extractors"
@@ -603,7 +603,7 @@ class BasePlugin(HookObject):  # noqa: WPS214
         return self._variant.settings
 
     @property
-    def extra_settings(self):
+    def extra_settings(self):  # noqa: WPS210
         """Return the extra settings for this plugin.
 
         Returns:

--- a/tests/meltano/core/plugin/test_plugin.py
+++ b/tests/meltano/core/plugin/test_plugin.py
@@ -22,6 +22,8 @@ class TestPluginDefinition:
             "repo": "https://gitlab.com/meltano/tap-example",
             "foo": "bar",
             "baz": "qux",
+            "description": "tap-example description",
+            "logo_url": "path/to/tap_example_logo.jpg",
             "requires": {
                 "files": [
                     {


### PR DESCRIPTION
This PR resolves #6914. Also despite me not changing methods or local variables the pre-commit hooks failed with:
```
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check for added large files..............................................Passed
check for merge conflicts................................................Passed
check toml...........................................(no files to check)Skipped
debug statements (python)................................................Passed
eslint...............................................(no files to check)Skipped
black....................................................................Passed
isort....................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

src/meltano/core/plugin/base.py:67:1: WPS214 Found too many methods: 8 > 7
class PluginType(YAMLEnum):
^
src/meltano/core/plugin/base.py:606:5: WPS210 Found too many local variables: 6 > 5
    def extra_settings(self):
    ^

```