### PR TITLE
fix: Handle case where setting metadata is `None`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -41,6 +41,8 @@ ignore =
     # pycodestyle
     # Allow for line breaks where Black decides are valid
     W503
+    # Let Black put whitespace before :
+    E203
     # Allow for long lines since we delegate to Black for enforcement
     E501
     # Allow custom exceptions whose name ends with "Exception"

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -211,9 +211,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
 
     @staticmethod
     def _value_prompt(config_metadata):
-        if (not config_metadata["setting"]) or config_metadata[
-            "setting"
-        ].kind != SettingKind.OPTIONS:
+        if config_metadata["setting"].kind != SettingKind.OPTIONS:
             return (
                 click.prompt(
                     "New value",
@@ -222,7 +220,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
                     hide_input=True,
                     confirmation_prompt=True,
                 )
-                if config_metadata["setting"] and config_metadata["setting"].is_redacted
+                if config_metadata["setting"].is_redacted
                 else click.prompt("New value", default="", show_default=False)
             )
 
@@ -390,7 +388,8 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
 
         name = metadata["name"]
         store = metadata["store"]
-        if metadata["setting"] and metadata["setting"].is_redacted:
+        is_redacted = metadata["setting"] and metadata["setting"].is_redacted
+        if is_redacted:
             value = REDACTED_VALUE
         click.secho(
             f"{settings.label.capitalize()} setting '{name}' was set in {store.label}: {value!r}",
@@ -399,7 +398,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
 
         current_value, source = settings.get_with_source(name, session=self.session)
         if source != store:
-            if metadata["setting"] and metadata["setting"].is_redacted:
+            if is_redacted:
                 current_value = REDACTED_VALUE
             click.secho(
                 f"Current value is still: {current_value!r} (from {source.label})",

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -142,6 +142,7 @@ class SettingsService(ABC):  # noqa: WPS214
         """Return definitions of supported settings."""
 
     @property
+    @abstractmethod
     def inherited_settings_service(self):
         """Return settings service to inherit configuration from."""
 

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -231,11 +231,10 @@ class SettingsService(ABC):  # noqa: WPS214
                 **kwargs,
             )
 
-            name = setting_def.name
-            if prefix:
-                name = name[len(prefix) :]  # noqa: E203
-
-            config[name] = {**metadata, "value": value}
+            config[setting_def.name[len(prefix) :] if prefix else setting_def.name] = {
+                **metadata,
+                "value": value,
+            }
 
         return config
 
@@ -275,10 +274,8 @@ class SettingsService(ABC):  # noqa: WPS214
         Returns:
             settings as environment variables
         """
-        full_config = self.config_with_metadata(*args, **kwargs)
-
         env = {}
-        for _, config in full_config.items():
+        for _, config in self.config_with_metadata(*args, **kwargs).items():
             value = config["value"]
             if value is None:
                 continue
@@ -442,8 +439,8 @@ class SettingsService(ABC):  # noqa: WPS214
         value, _ = self.get_with_source(*args, **kwargs)
         return value
 
-    def set_with_metadata(  # noqa: WPS615
-        self, path: list[str], value, store=SettingValueStore.AUTO, **kwargs
+    def set_with_metadata(  # noqa: WPS615, WPS210
+        self, path: str | list[str], value, store=SettingValueStore.AUTO, **kwargs
     ):
         """Set the value and metadata for a setting.
 
@@ -466,6 +463,7 @@ class SettingsService(ABC):  # noqa: WPS214
         try:
             setting_def = self.find_setting(name)
         except SettingMissingError:
+            warnings.warn(f"Unknown setting {name!r}", RuntimeWarning)
             setting_def = None
 
         metadata = {"name": name, "path": path, "store": store, "setting": setting_def}
@@ -480,11 +478,13 @@ class SettingsService(ABC):  # noqa: WPS214
                 metadata["uncast_value"] = value
                 value = cast_value
 
-        manager = store.manager(self, **kwargs)
-        set_metadata = manager.set(name, path, value, setting_def=setting_def)
-        metadata.update(set_metadata)
+        metadata.update(
+            store.manager(self, **kwargs).set(
+                name, path, value, setting_def=setting_def
+            )
+        )
 
-        self.log(f"Set setting '{name}' with metadata: {metadata}")
+        self.log(f"Set setting {name!r} with metadata: {metadata}")
         return value, metadata
 
     def set(self, *args, **kwargs):
@@ -523,13 +523,15 @@ class SettingsService(ABC):  # noqa: WPS214
         except SettingMissingError:
             setting_def = None
 
-        metadata = {"name": name, "path": path, "store": store, "setting": setting_def}
+        metadata = {
+            "name": name,
+            "path": path,
+            "store": store,
+            "setting": setting_def,
+            **store.manager(self, **kwargs).unset(name, path, setting_def=setting_def),
+        }
 
-        manager = store.manager(self, **kwargs)
-        unset_metadata = manager.unset(name, path, setting_def=setting_def)
-        metadata.update(unset_metadata)
-
-        self.log(f"Unset setting '{name}' with metadata: {metadata}")
+        self.log(f"Unset setting {name!r} with metadata: {metadata}")
         return metadata
 
     def reset(self, store=SettingValueStore.AUTO, **kwargs):

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -141,8 +141,7 @@ class SettingsService(ABC):  # noqa: WPS214
     def setting_definitions(self) -> list[SettingDefinition]:
         """Return definitions of supported settings."""
 
-    @property
-    @abstractmethod
+    @property  # noqa: B027
     def inherited_settings_service(self):
         """Return settings service to inherit configuration from."""
 


### PR DESCRIPTION
Before:
```
$ meltano config meltano set state_backend.uri file:///${MELTANO_ROOT_DIR}/.meltano/state
Need help fixing this problem? Visit http://melta.no/ for troubleshooting steps, or to
join our friendly Slack community.

'NoneType' object has no attribute 'is_redacted'
```

After:
```
$ meltano config meltano set state_backend.uri file:///${MELTANO_ROOT_DIR}/.meltano/state
Meltano setting 'state_backend.uri' was set in `meltano.yml`: 'file:////.meltano/state'
```

Instead of setting the non-existent setting, would we rather it error cleanly?


Closes #6937