### PR TITLE
docs: reindent code block

### DIFF
--- a/docs/src/_getting-started/index.md
+++ b/docs/src/_getting-started/index.md
@@ -167,9 +167,9 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
 1.  Find out if an extractor for your data source is [supported out of the box](/concepts/plugins#discoverable-plugins)
     by checking the [Extractors list](https://hub.meltano.com/extractors/) or using [`meltano discover`](/reference/command-line-interface#discover):
 
-        ```bash
-        meltano discover extractors
-        ```
+    ```bash
+    meltano discover extractors
+    ```
 
 1.  Depending on the result, pick your next step:
 


### PR DESCRIPTION
- `Complete Tutorial` Section, bash words are shown in code block
  - [https://docs.meltano.com/getting-started/#add-an-extractor-to-pull-data-from-a-source](https://docs.meltano.com/getting-started/#add-an-extractor-to-pull-data-from-a-source)
- fix it (remove blank)