### PR TITLE
feat: `meltano install --force`

### DIFF
--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -546,9 +546,11 @@ Additionally, plugin names can be provided to only (re)install those specific pl
 
 Use `--include-related` to automatically install transforms related to installed extractor plugins.
 
-Subsequent calls to `meltano install` will upgrade a plugin to it's latest version, if any. To completely uninstall and reinstall a plugin, use `--clean`.
+Subsequent calls to `meltano install` will upgrade a plugin to its latest version, if any. To completely uninstall and reinstall a plugin, use `--clean`.
 
 Meltano installs plugins in parallel. The number of plugins to install in parallel defaults to the number of CPUs on the machine, but can be controlled with `--parallelism`. Use `--parallelism=1` to disable the feature and install them one at a time.
+
+If the plugin you are trying to install declares that it does not support the version of Python you are using, but you want to attempt to use it anyway, you can override the Python version restriction by providing the `--force` flag to `meltano install`.
 
 <div class="notification is-info">
   <p>If you're using a custom Docker image, make sure `python3-venv` is installed:</p>
@@ -582,11 +584,12 @@ meltano install extractors
 meltano install extractor tap-gitlab
 meltano install extractors tap-gitlab tap-adwords
 
-
 meltano install --include-related
 
 meltano install --parallelism=16
 meltano install --clean
+
+meltano install --force
 ```
 
 ### Using `install` with Environments

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -30,6 +30,12 @@ from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
     default=None,
     help="Limit the number of plugins to install in parallel. Defaults to the number of cores.",
 )
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Ignore the required Python version declared by the plugins.",
+)
 @click.pass_context
 @pass_project(migrate=True)
 def install(
@@ -39,6 +45,7 @@ def install(
     plugin_name: str,
     clean: bool,
     parallelism: int,
+    force: bool,
 ):
     """
     Install all the dependencies of your project based on the meltano.yml file.
@@ -67,7 +74,13 @@ def install(
     )
     tracker.track_command_event(CliEvent.inflight)
 
-    success = install_plugins(project, plugins, parallelism=parallelism, clean=clean)
+    success = install_plugins(
+        project,
+        plugins,
+        parallelism=parallelism,
+        clean=clean,
+        force=force,
+    )
     if not success:
         tracker.track_command_event(CliEvent.failed)
         raise CliError("Failed to install plugin(s)")

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -435,11 +435,20 @@ def install_status_update(install_state):
 
 
 def install_plugins(
-    project, plugins, reason=PluginInstallReason.INSTALL, parallelism=None, clean=False
+    project,
+    plugins,
+    reason=PluginInstallReason.INSTALL,
+    parallelism=None,
+    clean=False,
+    force=False,
 ):
     """Install the provided plugins and report results to the console."""
     install_service = PluginInstallService(
-        project, status_cb=install_status_update, parallelism=parallelism, clean=clean
+        project,
+        status_cb=install_status_update,
+        parallelism=parallelism,
+        clean=clean,
+        force=force,
     )
     install_results = install_service.install_plugins(plugins, reason=reason)
     num_successful = len([status for status in install_results if status.successful])

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -663,7 +663,7 @@ class BasePlugin(HookObject):  # noqa: WPS214
         """Return whether the plugin is invokable.
 
         Returns:
-            True if the plugin is invokable, False otherwise.
+            Whether the plugin is invokable.
         """
         return self.is_installable() or self.executable is not None
 

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -10,6 +10,7 @@ from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_install_service import PluginInstallReason
 from meltano.core.plugin_invoker import PluginInvoker
+from meltano.core.project import Project
 from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.transform_add_service import TransformAddService
 
@@ -17,26 +18,55 @@ logger = logging.getLogger(__name__)
 
 
 class DbtInvoker(PluginInvoker):
+    """dbt plugin invoker."""
+
     def Popen_options(self):  # noqa: N802
+        """Get options for `subprocess.Popen`.
+
+        Returns:
+            Mapping of keyword arguments for `subprocess.Popen`.
+        """
         return {**super().Popen_options(), "cwd": self.plugin_config["project_dir"]}
 
 
 class DbtPlugin(BasePlugin):
+    """dbt plugin."""
+
     __plugin_type__ = PluginType.TRANSFORMERS
 
     invoker_class = DbtInvoker
 
 
 class DbtTransformPluginInstaller:
-    def __init__(self, project, plugin: ProjectPlugin):
+    """Plugin installer for dbt transforms."""
+
+    def __init__(self, project: Project, plugin: ProjectPlugin):
+        """Initialize the `DbtTransformPluginInstaller`.
+
+        Args:
+            project: The Meltano project.
+            plugin: The plugin to install into the specified project.
+        """
         self.project = project
         self.plugin = plugin
 
-    async def install(self, reason, clean):
-        """Install the transform into the project."""
+    async def install(
+        self, reason: PluginInstallReason, clean: bool = False, force: bool = False
+    ) -> None:
+        """Install the transform into the project.
+
+        Args:
+            reason: Install reason.
+            clean: Ignored. Present for conformity with `PipPluginInstaller`.
+            force: Ignored. Present for conformity with `PipPluginInstaller`.
+
+        Raises:
+            PluginInstallError: The plugin failed to install.
+        """
         if reason not in {PluginInstallReason.ADD, PluginInstallReason.UPGRADE}:
             logger.info(
-                f"Run `meltano add transform {self.plugin.name}` to re-add this transform to your dbt project."
+                f"Run `meltano add transform {self.plugin.name}` "
+                "to re-add this transform to your dbt project."
             )
             return
 
@@ -58,18 +88,22 @@ class DbtTransformPluginInstaller:
             )
             logger.info(f"Adding dbt model to '{dbt_project_path}'...")
             transform_add_service.update_dbt_project(self.plugin)
-        except PluginNotFoundError:
+        except PluginNotFoundError as ex:
             raise PluginInstallError(
-                "Transformer 'dbt' is not installed. Run `meltano add transformer dbt` to add it to your project."
-            )
-        except FileNotFoundError as err:
-            relative_path = Path(err.filename).relative_to(self.project.root)
+                "Transformer 'dbt' is not installed. "
+                "Run `meltano add transformer dbt` to add it to your project."
+            ) from ex
+        except FileNotFoundError as ex:
+            relative_path = Path(ex.filename).relative_to(self.project.root)
             raise PluginInstallError(
-                f"File {relative_path}' could not be found. Run `meltano add files files-dbt` to set up a dbt project."
-            )
+                f"File '{relative_path}' could not be found. "
+                "Run `meltano add files files-dbt` to set up a dbt project."
+            ) from ex
 
 
 class DbtTransformPlugin(BasePlugin):
+    """Plugin type for dbt transforms."""
+
     __plugin_type__ = PluginType.TRANSFORMS
 
     installer_class = DbtTransformPluginInstaller
@@ -79,5 +113,10 @@ class DbtTransformPlugin(BasePlugin):
         SettingDefinition(name="_vars", kind=SettingKind.OBJECT, value={}),
     ]
 
-    def is_invokable(self):
+    def is_invokable(self) -> bool:
+        """Return whether the plugin is invokable.
+
+        Returns:
+            Whether the plugin is invokable.
+        """
         return False

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 logger = structlog.getLogger(__name__)
 
 
-class FilePlugin(BasePlugin):
+class FilePlugin(BasePlugin):  # noqa: WPS214
     """Meltano file plugin type."""
 
     __plugin_type__ = PluginType.FILES
@@ -42,7 +42,7 @@ class FilePlugin(BasePlugin):
         """Return whether the plugin is invokable.
 
         Returns:
-            True if the plugin is invokable, False otherwise.
+            Whether the plugin is invokable.
         """
         return False
 
@@ -272,33 +272,27 @@ class FilePlugin(BasePlugin):
             plugin: The installed plugin.
             reason: The reason for the installation.
         """
-        project = installer.project
-        plugins_service = installer.plugins_service
-
-        plugin_settings_service = PluginSettingsService(
-            project, plugin, plugins_service=plugins_service
-        )
-        update_config = plugin_settings_service.get("_update")
+        update_config = PluginSettingsService(
+            installer.project, plugin, plugins_service=installer.plugins_service
+        ).get("_update")
         paths_to_update = [
             path for path, to_update in update_config.items() if to_update
         ]
 
         if reason is PluginInstallReason.ADD:
             logger.info(f"Adding '{plugin.name}' files to project...")
-
-            for path in self.create_files(project, paths_to_update):
+            for path in self.create_files(installer.project, paths_to_update):
                 logger.info(f"Created {path}")
         elif reason is PluginInstallReason.UPGRADE:
             logger.info(f"Updating '{plugin.name}' files in project...")
-
-            updated_paths = self.update_files(project, paths_to_update)
+            updated_paths = self.update_files(installer.project, paths_to_update)
             if not updated_paths:
                 logger.info("Nothing to update")
                 return
-
             for path in updated_paths:
                 logger.info(f"Updated {path}")
         else:
             logger.info(
-                f"Run `meltano upgrade files` to update your project's '{plugin.name}' files."
+                "Run `meltano upgrade files` to update your project's "
+                f"{plugin.name!r} files."
             )

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -645,3 +645,31 @@ def get_no_color_flag() -> bool:
         True if the NO_COLOR environment variable is set to a truthy value, False otherwise.
     """
     return get_boolean_env_var("NO_COLOR")
+
+
+# TODO: Replace with `str.removeprefix` once Meltano drops Python 3.8 support
+def remove_prefix(string: str, prefix: str) -> str:
+    """Remove the specified prefix if it is present.
+
+    Args:
+        string: The string from which the prefix will be removed if present.
+        prefix: The prefix to remove from the string.
+
+    Returns:
+        The given string, with the prefix removed if it was present.
+    """
+    return string[len(prefix) :] if string.startswith(prefix) else string
+
+
+# TODO: Replace with `str.removesuffix` once Meltano drops Python 3.8 support
+def remove_suffix(string: str, suffix: str) -> str:
+    """Remove the specified suffix if it is present.
+
+    Args:
+        string: The string from which the suffix will be removed if present.
+        suffix: The suffix to remove from the string.
+
+    Returns:
+        The given string, with the suffix removed if it was present.
+    """
+    return string[: -len(suffix)] if string.endswith(suffix) else string

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -645,31 +645,3 @@ def get_no_color_flag() -> bool:
         True if the NO_COLOR environment variable is set to a truthy value, False otherwise.
     """
     return get_boolean_env_var("NO_COLOR")
-
-
-# TODO: Replace with `str.removeprefix` once Meltano drops Python 3.8 support
-def remove_prefix(string: str, prefix: str) -> str:
-    """Remove the specified prefix if it is present.
-
-    Args:
-        string: The string from which the prefix will be removed if present.
-        prefix: The prefix to remove from the string.
-
-    Returns:
-        The given string, with the prefix removed if it was present.
-    """
-    return string[len(prefix) :] if string.startswith(prefix) else string
-
-
-# TODO: Replace with `str.removesuffix` once Meltano drops Python 3.8 support
-def remove_suffix(string: str, suffix: str) -> str:
-    """Remove the specified suffix if it is present.
-
-    Args:
-        string: The string from which the suffix will be removed if present.
-        suffix: The suffix to remove from the string.
-
-    Returns:
-        The given string, with the suffix removed if it was present.
-    """
-    return string[: -len(suffix)] if string.endswith(suffix) else string

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -12,10 +12,11 @@ import subprocess
 import sys
 from asyncio.subprocess import Process
 from collections import namedtuple
+from collections.abc import Iterable
 from pathlib import Path
 
-from .error import AsyncSubprocessError
-from .project import Project
+from meltano.core.error import AsyncSubprocessError
+from meltano.core.project import Project
 
 logger = logging.getLogger(__name__)
 
@@ -37,37 +38,75 @@ NT = VenvSpecs(
     site_packages_dir=os.path.join("Lib", "site-packages"),
 )
 
-PIP_PACKAGES = ("pip", "setuptools==57.5.0", "wheel")
+PLATFORM_SPECS = {"Linux": POSIX, "Darwin": POSIX, "Windows": NT}
+
+
+def venv_platform_specs():
+    """Get virtual environment sub-path info for the current platform.
+
+    Raises:
+        Exception: This platform is not supported.
+
+    Returns:
+        Virtual environment sub-path info for the current platform.
+    """
+    system = platform.system()
+    try:
+        return PLATFORM_SPECS[system]
+    except KeyError as ex:
+        raise Exception(f"Platform {system!r} not supported.") from ex
+
+
+PIP_PACKAGES = ("pip", "setuptools", "wheel")
 
 
 class VirtualEnv:
-    PLATFORM_SPECS = {"Linux": POSIX, "Darwin": POSIX, "Windows": NT}
+    """Info about a single virtual environment."""
 
     def __init__(self, root: Path):
-        self.root = root
-        self._specs = self.__class__.platform_specs()
+        """Initialize the `VirtualEnv` instance.
 
-    @classmethod
-    def platform_specs(cls):
-        system = platform.system()
-        try:
-            return cls.PLATFORM_SPECS[system]
-        except KeyError:
-            raise Exception(f"Platform {system} not supported.")
+        Args:
+            root: The root directory of the virtual environment.
+        """
+        self.root = root.resolve()
+        self.specs = venv_platform_specs()
 
-    def __getattr__(self, attr):
-        spec = getattr(self._specs, attr)
-        return self.root.joinpath(spec)
+    def __getattr__(self, key: str):
+        """Get a specific attribute from this instance.
+
+        Used to provide `VenvSpecs` attributes for this specific virtual environment.
+
+        Args:
+            key: The attribute name. Must be one of the `VenvSpecs` attributes.
+
+        Returns:
+            The root directory of this virtual environment joined to the requested
+            platform-specific path using this platform's `VenvSpecs` instance.
+        """
+        return self.root / getattr(self.specs, key)
 
     def __str__(self):
+        """_summary_.
+
+        Returns:
+            _description_.
+        """
         return str(self.root)
 
 
 async def exec_async(*args, **kwargs) -> Process:
-    """
-    Run an executable asyncronously.
+    """Run an executable asyncronously in a subprocess.
 
-    :raises AsyncSubprocessError: if the command fails
+    Args:
+        args: Positional arguments for `asyncio.create_subprocess_exec`.
+        kwargs: Keyword arguments for `asyncio.create_subprocess_exec`.
+
+    Raises:
+        AsyncSubprocessError: The command failed.
+
+    Returns:
+        The subprocess.
     """
     run = await asyncio.create_subprocess_exec(
         *args,
@@ -83,70 +122,86 @@ async def exec_async(*args, **kwargs) -> Process:
     return run
 
 
-def fingerprint(pip_urls: list[str]):
-    """Return a unique string for the given pip urls."""
-    key = " ".join(sorted(pip_urls))
-    return hashlib.sha256(bytes(key, "utf-8")).hexdigest()
+def fingerprint(pip_install_args: Iterable[str]) -> str:
+    """Generate a hash identifying pip install args.
+
+    Arguments are sorted and deduplicated before the hash is generated.
+
+    Args:
+        pip_install_args: Arguments for `pip install`.
+
+    Returns:
+        The SHA256 hash hex digest of the sorted set of pip install args.
+    """
+    return hashlib.sha256(" ".join(sorted(set(pip_install_args))).encode()).hexdigest()
 
 
-class VenvService:
+class VenvService:  # noqa: WPS214
+    """Manages virtual environments.
+
+    The methods in this class are not threadsafe.
+    """
+
     def __init__(self, project: Project, namespace: str = "", name: str = ""):
-        """
-        Manage isolated virtual environments.
+        """Initialize the `VenvService`.
 
-        The methods in this class are not threadsafe.
+        Args:
+            project: The Meltano project.
+            namespace: The namespace for the venv, e.g. a Plugin type.
+            name: The name of the venv, e.g. a Plugin name.
         """
         self.project = project
         self.namespace = namespace
         self.name = name
         self.venv = VirtualEnv(self.project.venvs_dir(namespace, name))
-        self.python_path = self.venv.bin_dir.joinpath("python")
-        self.plugin_fingerprint_path = self.venv.root.joinpath(
-            ".meltano_plugin_fingerprint"
-        )
+        self.python_path = self.venv.bin_dir / "python"
+        self.plugin_fingerprint_path = self.venv.root / ".meltano_plugin_fingerprint"
 
-    async def install(self, *pip_urls: str, clean: bool = False):
+    async def install(self, pip_install_args: list[str], clean: bool = False) -> None:
+        """Configure a virtual environment, then run pip install with the given args.
+
+        Args:
+            pip_install_args: Arguments passed to `pip install`.
+            clean: Whether to not attempt to use an existing virtual environment.
         """
-        Configure a virtual environment and install the given `pip_urls` packages in it.
-
-        This will try to use an existing virtual environment if one exists unless commanded
-        to `clean`.
-        """
-        pip_urls = [pip_url for arg in pip_urls for pip_url in arg.split(" ")]
-
-        if not clean and self.requires_clean_install(pip_urls):
+        if not clean and self.requires_clean_install(pip_install_args):
             logger.debug(
                 f"Packages for '{self.namespace}/{self.name}' have changed so performing a clean install."
             )
             clean = True
 
         self.clean_run_files()
+        await self._pip_install(pip_install_args=pip_install_args, clean=clean)
+        self.write_fingerprint(pip_install_args)
 
-        if clean:
-            await self._clean_install(pip_urls)
-        else:
-            await self._upgrade_install(pip_urls)
-        self.write_fingerprint(pip_urls)
+    def requires_clean_install(self, pip_install_args: list[str]) -> bool:
+        """Determine whether a clean install is needed.
 
-    def requires_clean_install(self, pip_urls: list[str]) -> bool:
-        """Return `True` if the virtual environment doesn't exist or can't be reused."""
-        meltano_pth_path = self.venv.site_packages_dir.joinpath("meltano_venv.pth")
-        if meltano_pth_path.exists():
+        Args:
+            pip_install_args: The arguments being passed to `pip install`, used
+                for fingerprinting the installation.
+
+        Returns:
+            Whether virtual environment doesn't exist or can't be reused.
+        """
+        if self.venv.site_packages_dir.joinpath("meltano_venv.pth").exists():
             # clean up deprecated feature
             return True
         existing_fingerprint = self.read_fingerprint()
-        if not existing_fingerprint:
-            return True
-        return existing_fingerprint != fingerprint(pip_urls)
+        return (
+            existing_fingerprint != fingerprint(pip_install_args)
+            if existing_fingerprint
+            else True
+        )
 
-    def clean_run_files(self):
+    def clean_run_files(self) -> None:
         """Destroy cached configuration files, if they exist."""
         try:
             shutil.rmtree(self.project.run_dir(self.name, make_dirs=False))
         except FileNotFoundError:
             logger.debug("No cached configuration files to remove")
 
-    def clean(self):
+    def clean(self) -> None:
         """Destroy the virtual environment, if it exists."""
         try:
             shutil.rmtree(self.venv.root)
@@ -159,85 +214,108 @@ class VenvService:
             # If the VirtualEnv has never been created before do nothing
             logger.debug("No old virtual environment to remove")
 
-    async def create(self):
-        """Create a new virtual environment."""
+    async def create(self) -> Process:
+        """Create a new virtual environment.
+
+        Raises:
+            AsyncSubprocessError: The virtual environment could not be created.
+
+        Returns:
+            The Python process creating the virtual environment.
+        """
         logger.debug(f"Creating virtual environment for '{self.namespace}/{self.name}'")
         try:
-            return await exec_async(
-                sys.executable,
-                "-m",
-                "venv",
-                str(self.venv),
-            )
+            return await exec_async(sys.executable, "-m", "venv", str(self.venv))
         except AsyncSubprocessError as err:
             raise AsyncSubprocessError(
                 f"Could not create the virtualenv for '{self.namespace}/{self.name}'",
                 err.process,
-            )
+            ) from err
 
-    async def upgrade_pip(self):
-        """Upgrade the `pip` package to the latest version in the virtual environment."""
+    async def upgrade_pip(self) -> Process:
+        """Upgrade the `pip` package to the latest version in the virtual environment.
+
+        Raises:
+            AsyncSubprocessError: Failed to upgrade pip to the latest version.
+
+        Returns:
+            The process running `pip install --upgrade ...`.
+        """
         logger.debug(f"Upgrading pip for '{self.namespace}/{self.name}'")
-
         try:
-            return await self._pip_install(*PIP_PACKAGES, upgrade=True)
-
+            return await self._pip_install(["--upgrade", *PIP_PACKAGES])
         except AsyncSubprocessError as err:
             raise AsyncSubprocessError(
                 "Failed to upgrade pip to the latest version.", err.process
-            )
+            ) from err
 
     def read_fingerprint(self) -> str | None:
-        """Return the fingerprint of the existing virtual environment, if any."""
+        """Get the fingerprint of the existing virtual environment.
+
+        Returns:
+            The fingerprint of the existing virtual environment if it exists.
+            `None` otherwise.
+        """
         if not self.plugin_fingerprint_path.exists():
             return None
         with open(self.plugin_fingerprint_path) as fingerprint_file:
             return fingerprint_file.read()
 
-    def write_fingerprint(self, pip_urls: list[str]):
-        """Save the fingerprint for this installation."""
+    def write_fingerprint(self, pip_install_args: list[str]) -> None:
+        """Save the fingerprint for this installation.
+
+        Args:
+            pip_install_args: The arguments being passed to `pip install`.
+        """
         with open(self.plugin_fingerprint_path, "wt") as fingerprint_file:
-            fingerprint_file.write(fingerprint(pip_urls))
+            fingerprint_file.write(fingerprint(pip_install_args))
 
     def exec_path(self, executable: str) -> Path:
-        """Return the absolute path for the given binary in the virtual environment."""
-        return self.venv.bin_dir.joinpath(executable)
+        """Return the absolute path for the given executable in the virtual environment.
 
-    async def _clean_install(self, pip_urls: list[str]):
-        self.clean()
-        await self.create()
-        await self.upgrade_pip()
+        Args:
+            executable: The path to the executable relative to the venv bin directory.
 
-        logger.debug(
-            f"Installing '{' '.join(pip_urls)}' into virtual environment for '{self.namespace}/{self.name}'"  # noqa: WPS221
-        )
-        await self._pip_install(*pip_urls)
-
-    async def _upgrade_install(self, pip_urls: list[str]):
-        logger.debug(
-            f"Upgrading '{' '.join(pip_urls)}' in existing virtual environment for '{self.namespace}/{self.name}'"  # noqa: WPS221
-        )
-        await self._pip_install(*PIP_PACKAGES, *pip_urls, upgrade=True)
-
-    async def _pip_install(self, *pip_urls: str, upgrade: bool = False):
+        Returns:
+            The venv bin directory joined to the provided executable.
         """
-        Install a package using `pip` in the proper virtual environment.
+        return self.venv.bin_dir / executable
 
-        :raises: AsyncSubprocessError: if the command fails.
+    async def _pip_install(
+        self, pip_install_args: list[str], clean: bool = False
+    ) -> Process:
+        """Install a package using `pip` in the proper virtual environment.
+
+        Args:
+            pip_install_args: The arguments to pass to `pip install`.
+            clean: Whether the installation should be done in a clean venv.
+
+        Raises:
+            AsyncSubprocessError: The command failed.
+
+        Returns:
+            The process running `pip install` with the provided args.
         """
-        args = [
-            str(self.python_path),
-            "-m",
-            "pip",
-            "install",
-        ]
-        if upgrade:
-            args += ["--upgrade"]
-        args += pip_urls
+        if clean:
+            self.clean()
+            await self.create()
+            await self.upgrade_pip()
+
+        pip_install_args_str = " ".join(pip_install_args)
+        log_msg_prefix = (
+            f"Upgrading with args {pip_install_args_str!r} in existing"
+            if "--upgrade" in pip_install_args
+            else f"Installing with args {pip_install_args_str!r} into"
+        )
+        logger.debug(
+            f"{log_msg_prefix} virtual environment for '{self.namespace}/{self.name}'"
+        )
 
         try:
-            return await exec_async(*args)
+            return await exec_async(
+                str(self.python_path), "-m", "pip", "install", *pip_install_args
+            )
         except AsyncSubprocessError as err:
             raise AsyncSubprocessError(
                 f"Failed to install plugin '{self.name}'.", err.process
-            )
+            ) from err

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -34,7 +34,11 @@ class TestCliInstall:
             assert_cli_runner(result)
 
             install_plugin_mock.assert_called_once_with(
-                project, [tap, tap_gitlab, target, dbt], parallelism=None, clean=False
+                project,
+                [tap, tap_gitlab, target, dbt],
+                parallelism=None,
+                clean=False,
+                force=False,
             )
 
     def test_install_type(
@@ -58,7 +62,7 @@ class TestCliInstall:
             assert_cli_runner(result)
 
             install_plugin_mock_e.assert_called_once_with(
-                project, [tap, tap_gitlab], parallelism=None, clean=False
+                project, [tap, tap_gitlab], parallelism=None, clean=False, force=False
             )
 
         with mock.patch(
@@ -71,7 +75,7 @@ class TestCliInstall:
             assert_cli_runner(result)
 
             install_plugin_mock_l.assert_called_once_with(
-                project, [target], parallelism=None, clean=False
+                project, [target], parallelism=None, clean=False, force=False
             )
 
         with mock.patch(
@@ -115,7 +119,7 @@ class TestCliInstall:
             assert_cli_runner(result)
 
             install_plugin_mock_e.assert_called_once_with(
-                project, [tap], parallelism=None, clean=False
+                project, [tap], parallelism=None, clean=False, force=False
             )
 
         with mock.patch(
@@ -128,7 +132,7 @@ class TestCliInstall:
             assert_cli_runner(result)
 
             install_plugin_mock_l.assert_called_once_with(
-                project, [target], parallelism=None, clean=False
+                project, [target], parallelism=None, clean=False, force=False
             )
 
         with mock.patch(
@@ -166,7 +170,7 @@ class TestCliInstall:
             assert_cli_runner(result)
 
             install_plugin_mock.assert_called_once_with(
-                project, [tap, tap_gitlab], parallelism=None, clean=False
+                project, [tap, tap_gitlab], parallelism=None, clean=False, force=False
             )
 
     def test_install_parallel(

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -9,7 +9,7 @@ import mock
 import pytest
 
 from meltano.core.project import Project
-from meltano.core.venv_service import VenvService, VirtualEnv
+from meltano.core.venv_service import PLATFORM_SPECS, VenvService, VirtualEnv
 
 
 class TestVenvService:
@@ -32,7 +32,7 @@ class TestVenvService:
                 "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
             )
 
-        await subject.install("example", clean=True)
+        await subject.install(["example"], clean=True)
         venv_dir = subject.project.venvs_dir("namespace", "name")
 
         # ensure the venv is created
@@ -85,7 +85,7 @@ class TestVenvService:
             )
 
         # Make sure the venv exists already
-        await subject.install("example", clean=True)
+        await subject.install(["example"], clean=True)
         venv_dir = subject.project.venvs_dir("namespace", "name")
 
         # remove the package, then check that after a regular install the package exists
@@ -102,7 +102,7 @@ class TestVenvService:
             capture_output=True,
         )
 
-        await subject.install("example")
+        await subject.install(["example"])
 
         # ensure that the package is installed
         run = subprocess.run(
@@ -115,7 +115,7 @@ class TestVenvService:
     @pytest.mark.asyncio
     async def test_requires_clean_install(self, project, subject: VenvService):
         # Make sure the venv exists already
-        await subject.install("example", clean=True)
+        await subject.install(["example"], clean=True)
 
         assert not subject.requires_clean_install(["example"])
         assert subject.requires_clean_install(["example==0.1.0"])
@@ -127,10 +127,10 @@ class TestVirtualEnv:
     def test_cross_platform(self, system, project):
         with mock.patch("platform.system", return_value=system):
             subject = VirtualEnv(project.venvs_dir("pytest", "pytest"))
-            assert subject._specs == VirtualEnv.PLATFORM_SPECS[system]
+            assert subject.specs == PLATFORM_SPECS[system]
 
     def test_unknown_platform(self, project):
         with mock.patch("platform.system", return_value="commodore64"), pytest.raises(
-            Exception, match="(?i)Platform commodore64.*?not supported."
+            Exception, match="(?i)Platform 'commodore64'.*?not supported."
         ):
             VirtualEnv(project.venvs_dir("pytest", "pytest"))


### PR DESCRIPTION
The new `--force` flag for `meltano install` allows one to  ignore the Python version constraints imposed by plugins.

It does this by passing the `--ignore-requires-python` argument to `pip install`.

Due to updating some long-unchanged files, many updates had to be done to appease the linters.

Example using Python 3.10 with `tap-google-analytics` at commit `87fc834ba32218700d99d4b626dafc45bb2fdc00`, which is before it supported Python 3.10.

Before:

```
$ meltano install extractor tap-google-analytics
Installing 1 plugins...
Installing extractor 'tap-google-analytics'...
Extractor 'tap-google-analytics' could not be installed: failed to install plugin 'tap-google-analytics'.
  Running command git clone --filter=blob:none --quiet https://github.com/MeltanoLabs/tap-google-analytics.git /tmp/pip-req-build-0i1baqdk
  Running command git rev-parse -q --verify 'sha^87fc834ba32218700d99d4b626dafc45bb2fdc00'
  Running command git fetch -q https://github.com/MeltanoLabs/tap-google-analytics.git 87fc834ba32218700d99d4b626dafc45bb2fdc00
  Running command git checkout -q 87fc834ba32218700d99d4b626dafc45bb2fdc00
ERROR: Package 'tap-google-analytics' requires a different Python: 3.10.5 not in '<3.10,>=3.7.1'

Need help fixing this problem? Visit http://melta.no/ for troubleshooting steps, or to
join our friendly Slack community.

Failed to install plugin(s)
```

After:

```
$ meltano install --force extractor tap-google-analytics
Installing 1 plugins...
Installing extractor 'tap-google-analytics'...
Installed extractor 'tap-google-analytics'
```

Closes #6975