### PR TITLE
fix: Re-create plugin venv if Python executable is missing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -76,6 +76,8 @@ ignore =
     WPS338
     # Allow `.` at beginning of line to accommodate Black formatting of multiline chained function calls
     WPS348
+    # Allow consecutive yield expressions
+    WPS354
     # Allow "overuse" of noqa comments.
     WPS402
     # Allow metadta variable (__all__)

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -154,8 +154,6 @@ class VenvService:  # noqa: WPS214
         self.namespace = namespace
         self.name = name
         self.venv = VirtualEnv(self.project.venvs_dir(namespace, name))
-
-        self.python_path = self.exec_path("python")
         self.plugin_fingerprint_path = self.venv.root / ".meltano_plugin_fingerprint"
 
     async def install(self, pip_install_args: list[str], clean: bool = False) -> None:
@@ -188,7 +186,7 @@ class VenvService:  # noqa: WPS214
         # A generator function is used to perform the checks lazily
         def checks():
             # The Python installation used to create this venv no longer exists
-            yield not self.python_path.exists()
+            yield not self.exec_path("python").exists()
             # The deprecated `meltano_venv.pth` feature is used by this venv
             yield self.venv.site_packages_dir.joinpath("meltano_venv.pth").exists()
             # The fingerprint of the venv does not match the pip install args
@@ -328,7 +326,7 @@ class VenvService:  # noqa: WPS214
 
         try:
             return await exec_async(
-                str(self.python_path), "-m", "pip", "install", *pip_install_args
+                str(self.exec_path("python")), "-m", "pip", "install", *pip_install_args
             )
         except AsyncSubprocessError as err:
             raise AsyncSubprocessError(

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -283,8 +283,17 @@ class VenvService:  # noqa: WPS214
         Returns:
             The venv bin directory joined to the provided executable.
         """
-        return (self.venv.bin_dir / executable).with_suffix(
-            ".exe" if platform.system() == "Windows" else ""
+        absolute_executable = self.venv.bin_dir / executable
+        if platform.system() != "Windows":
+            return absolute_executable
+
+        # On Windows, try using the '.exe' suffixed version if it exists. Use the
+        # regular executable path as a fallback (and for backwards compatibility).
+        absolute_executable_windows = absolute_executable.with_suffix(".exe")
+        return (
+            absolute_executable_windows
+            if absolute_executable_windows.exists()
+            else absolute_executable
         )
 
     async def _pip_install(

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -154,7 +154,8 @@ class VenvService:  # noqa: WPS214
         self.namespace = namespace
         self.name = name
         self.venv = VirtualEnv(self.project.venvs_dir(namespace, name))
-        self.python_path = self.venv.bin_dir / "python"
+
+        self.python_path = self.exec_path("python")
         self.plugin_fingerprint_path = self.venv.root / ".meltano_plugin_fingerprint"
 
     async def install(self, pip_install_args: list[str], clean: bool = False) -> None:
@@ -282,7 +283,9 @@ class VenvService:  # noqa: WPS214
         Returns:
             The venv bin directory joined to the provided executable.
         """
-        return self.venv.bin_dir / executable
+        return (self.venv.bin_dir / executable).with_suffix(
+            ".exe" if platform.system() == "Windows" else ""
+        )
 
     async def _pip_install(
         self, pip_install_args: list[str], clean: bool = False

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -117,7 +117,7 @@ class TestVenvService:
         # Make sure the venv exists already
         await subject.install(["example"], clean=True)
 
-        original_link_target = subject.python_path.readlink()
+        original_link_target = os.readlink(subject.python_path)
         try:
             # Simulate the deletion of the underlying Python executable by
             # making its symlink point to a file that does not exist

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -117,17 +117,18 @@ class TestVenvService:
         # Make sure the venv exists already
         await subject.install(["example"], clean=True)
 
-        original_link_target = os.readlink(subject.python_path)
-        try:
-            # Simulate the deletion of the underlying Python executable by
-            # making its symlink point to a file that does not exist
-            subject.python_path.unlink()
-            subject.python_path.symlink_to("./fake/path/to/python/executable")
-            assert subject.requires_clean_install(["example"])
-        finally:
-            # Restore the symlink to the actual Python executable
-            subject.python_path.unlink()
-            subject.python_path.symlink_to(original_link_target)
+        if platform.system() != "Windows":
+            original_link_target = os.readlink(subject.python_path)
+            try:
+                # Simulate the deletion of the underlying Python executable by
+                # making its symlink point to a file that does not exist
+                subject.python_path.unlink()
+                subject.python_path.symlink_to("./fake/path/to/python/executable")
+                assert subject.requires_clean_install(["example"])
+            finally:
+                # Restore the symlink to the actual Python executable
+                subject.python_path.unlink()
+                subject.python_path.symlink_to(original_link_target)
 
         assert not subject.requires_clean_install(["example"])
         assert subject.requires_clean_install(["example==0.1.0"])

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -117,6 +117,18 @@ class TestVenvService:
         # Make sure the venv exists already
         await subject.install(["example"], clean=True)
 
+        original_link_target = subject.python_path.readlink()
+        try:
+            # Simulate the deletion of the underlying Python executable by
+            # making its symlink point to a file that does not exist
+            subject.python_path.unlink()
+            subject.python_path.symlink_to("./fake/path/to/python/executable")
+            assert subject.requires_clean_install(["example"])
+        finally:
+            # Restore the symlink to the actual Python executable
+            subject.python_path.unlink()
+            subject.python_path.symlink_to(original_link_target)
+
         assert not subject.requires_clean_install(["example"])
         assert subject.requires_clean_install(["example==0.1.0"])
         assert subject.requires_clean_install(["example", "another-package"])

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -118,17 +118,18 @@ class TestVenvService:
         await subject.install(["example"], clean=True)
 
         if platform.system() != "Windows":
-            original_link_target = os.readlink(subject.python_path)
+            python_path = subject.exec_path("python")
+            original_link_target = os.readlink(python_path)
             try:
                 # Simulate the deletion of the underlying Python executable by
                 # making its symlink point to a file that does not exist
-                subject.python_path.unlink()
-                subject.python_path.symlink_to("./fake/path/to/python/executable")
+                python_path.unlink()
+                python_path.symlink_to("./fake/path/to/python/executable")
                 assert subject.requires_clean_install(["example"])
             finally:
                 # Restore the symlink to the actual Python executable
-                subject.python_path.unlink()
-                subject.python_path.symlink_to(original_link_target)
+                python_path.unlink()
+                python_path.symlink_to(original_link_target)
 
         assert not subject.requires_clean_install(["example"])
         assert subject.requires_clean_install(["example==0.1.0"])


### PR DESCRIPTION
These changes make it so that if the Python executable used by a Meltano-managed venv is deleted, the venv will be recreated on the next `meltano install` that affects it as if the `--clean` flag had been supplied, rather than erroring.

Closes #7008