### PR TITLE
chore: Set environment context UUID for subprocesses

### DIFF
--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -20,7 +20,8 @@ from meltano.core.plugin_install_service import PluginInstallReason
 from meltano.core.project import Project
 from meltano.core.project_add_service import ProjectAddService
 from meltano.core.project_plugins_service import ProjectPluginsService
-from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
+from meltano.core.tracking import Tracker
+from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 
 @cli.command(  # noqa: WPS238
@@ -61,7 +62,7 @@ from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
 )
 @pass_project()
 @click.pass_context
-def add(
+def add(  # noqa: WPS238
     ctx,
     project: Project,
     plugin_type: str,

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -17,7 +17,8 @@ from meltano.core.error import MeltanoConfigurationError
 from meltano.core.logging import LEVELS, setup_logging
 from meltano.core.project import Project, ProjectNotFound
 from meltano.core.project_settings_service import ProjectSettingsService
-from meltano.core.tracking import CliContext, Tracker
+from meltano.core.tracking import Tracker
+from meltano.core.tracking.contexts import CliContext
 from meltano.core.utils import get_no_color_flag
 
 logger = logging.getLogger(__name__)

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -28,7 +28,7 @@ from meltano.core.project_plugins_service import ProjectPluginsService
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.settings_service import SettingValueStore
 from meltano.core.settings_store import StoreNotSupportedError
-from meltano.core.tracking import CliEvent, PluginsTrackingContext
+from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 logger = logging.getLogger(__name__)
 

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -26,7 +26,8 @@ from meltano.core.project_plugins_service import ProjectPluginsService
 from meltano.core.runner import RunnerError
 from meltano.core.runner.dbt import DbtRunner
 from meltano.core.runner.singer import SingerRunner
-from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
+from meltano.core.tracking import Tracker
+from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 from meltano.core.utils import click_run_async
 
 DUMPABLES = {

--- a/src/meltano/cli/environment.py
+++ b/src/meltano/cli/environment.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import click
 
+from meltano.cli import cli
 from meltano.cli.params import pass_project
+from meltano.cli.utils import InstrumentedGroup, PartialInstrumentedCmd
 from meltano.core.environment_service import EnvironmentService
 from meltano.core.project import Project
-from meltano.core.tracking import CliEvent
-
-from . import cli
-from .utils import InstrumentedGroup, PartialInstrumentedCmd
+from meltano.core.tracking.contexts import CliEvent
 
 ENVIRONMENT_SERVICE_KEY = "environment_service"
 

--- a/src/meltano/cli/initialize.py
+++ b/src/meltano/cli/initialize.py
@@ -1,4 +1,5 @@
 """New Project Initialization CLI."""
+
 from __future__ import annotations
 
 import logging
@@ -6,13 +7,13 @@ from pathlib import Path
 
 import click
 
+from meltano.cli import cli
+from meltano.cli.params import database_uri_option
+from meltano.cli.utils import CliError, InstrumentedCmd
 from meltano.core.project_init_service import ProjectInitService
 from meltano.core.project_settings_service import ProjectSettingsService
-from meltano.core.tracking import CliContext, CliEvent, Tracker
-
-from . import cli
-from .params import database_uri_option
-from .utils import CliError, InstrumentedCmd
+from meltano.core.tracking import Tracker
+from meltano.core.tracking.contexts import CliContext, CliEvent
 
 EXTRACTORS = "extractors"
 LOADERS = "loaders"

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -10,7 +10,8 @@ from meltano.cli.utils import CliError, PartialInstrumentedCmd, install_plugins
 from meltano.core.plugin import PluginType
 from meltano.core.project import Project
 from meltano.core.project_plugins_service import ProjectPluginsService
-from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
+from meltano.core.tracking import Tracker
+from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 
 @cli.command(cls=PartialInstrumentedCmd, short_help="Install project dependencies.")

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -24,7 +24,7 @@ from meltano.core.settings_service import (
     SettingValueStore,
 )
 from meltano.core.settings_store import StoreNotSupportedError
-from meltano.core.tracking import CliEvent
+from meltano.core.tracking.contexts import CliEvent
 
 PLUGIN_COLOR = "magenta"
 ENVIRONMENT_COLOR = "orange1"

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -23,7 +23,8 @@ from meltano.core.plugin_invoker import (
 )
 from meltano.core.project import Project
 from meltano.core.project_plugins_service import ProjectPluginsService
-from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
+from meltano.core.tracking import Tracker
+from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 logger = logging.getLogger(__name__)
 

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -18,7 +18,8 @@ from meltano.core.task_sets_service import (
     JobNotFoundError,
     TaskSetsService,
 )
-from meltano.core.tracking import CliEvent, PluginsTrackingContext, Tracker
+from meltano.core.tracking import Tracker
+from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 logger = structlog.getLogger(__name__)
 

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -7,17 +7,16 @@ from typing import TYPE_CHECKING
 import click
 import structlog
 
+from meltano.cli import CliError, cli
+from meltano.cli.params import pass_project
+from meltano.cli.utils import PartialInstrumentedCmd
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_lock_service import (
     LockfileAlreadyExistsError,
     PluginLockService,
 )
 from meltano.core.project_plugins_service import DefinitionSource, ProjectPluginsService
-from meltano.core.tracking import CliEvent, PluginsTrackingContext
-
-from . import CliError, cli
-from .params import pass_project
-from .utils import PartialInstrumentedCmd
+from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 if TYPE_CHECKING:
     from meltano.core.project import Project

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -15,7 +15,8 @@ from meltano.core.logging.utils import change_console_log_level
 from meltano.core.project import Project
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.runner import RunnerError
-from meltano.core.tracking import BlockEvents, CliEvent, Tracker
+from meltano.core.tracking import BlockEvents, Tracker
+from meltano.core.tracking.contexts import CliEvent
 from meltano.core.tracking.contexts.plugins import PluginsTrackingContext
 from meltano.core.utils import click_run_async
 

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -29,7 +29,7 @@ from meltano.core.project_add_service import (
 )
 from meltano.core.project_plugins_service import ProjectPluginsService
 from meltano.core.setting_definition import SettingKind
-from meltano.core.tracking import CliContext, CliEvent
+from meltano.core.tracking.contexts import CliContext, CliEvent
 
 setup_logging()
 

--- a/src/meltano/core/meltano_invoker.py
+++ b/src/meltano/core/meltano_invoker.py
@@ -1,12 +1,20 @@
 """Defines MeltanoInvoker."""
+
 from __future__ import annotations
 
 import os
+import platform
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
-from .project_settings_service import ProjectSettingsService, SettingValueStore
+from meltano.core.project import Project
+from meltano.core.project_settings_service import (
+    ProjectSettingsService,
+    SettingValueStore,
+)
+from meltano.core.tracking import Tracker
 
 MELTANO_COMMAND = "meltano"
 
@@ -14,7 +22,9 @@ MELTANO_COMMAND = "meltano"
 class MeltanoInvoker:
     """Class used to find and invoke all commands passed to it."""
 
-    def __init__(self, project, settings_service: ProjectSettingsService | None = None):
+    def __init__(
+        self, project: Project, settings_service: ProjectSettingsService | None = None
+    ):
         """
         Load the class with the project and service settings.
 
@@ -23,6 +33,7 @@ class MeltanoInvoker:
             settings_service: ProjectSettingsService Class blank
         """
         self.project = project
+        self.tracker = Tracker(project)
         self.settings_service = settings_service or ProjectSettingsService(project)
 
     def invoke(self, args, command=MELTANO_COMMAND, env=None, **kwargs):
@@ -51,31 +62,24 @@ class MeltanoInvoker:
             if executable_symlink.exists():
                 return str(executable_symlink)
 
-        if os.name == "nt":
-            command_exe = f"{command}.exe"
-            executable = Path(os.path.dirname(sys.executable), command_exe)
-        else:
-            executable = Path(os.path.dirname(sys.executable), command)
-
-        if executable.exists():
-            return str(executable)
-
-        # Fall back on expecting command to be in the PATH
-        return command
-
-    def _executable_env(self, env=None):
-        exec_env = {}
-
-        # Include env that project settings are evaluated in
-        exec_env.update(self.settings_service.env)
-
-        # Include env for settings explicitly overridden using CLI flags
-        exec_env.update(
-            self.settings_service.as_env(source=SettingValueStore.CONFIG_OVERRIDE)
+        executable = Path(
+            os.path.dirname(sys.executable),
+            f"{command}.exe" if platform.system() == "Windows" else command,
         )
 
-        # Include explicitly provided env
-        if env:
-            exec_env.update(env)
+        # Fall back on expecting command to be in the PATH
+        return str(executable) if executable.exists() else command
 
-        return exec_env
+    def _executable_env(self, env: Mapping[str, str] | None = None) -> dict[str, str]:
+        if env is None:
+            env = {}
+        return {
+            # Include env that project settings are evaluated in
+            **self.settings_service.env,
+            # Include env for settings explicitly overridden using CLI flags
+            **self.settings_service.as_env(source=SettingValueStore.CONFIG_OVERRIDE),
+            # Include explicitly provided env
+            **env,
+            # Include telemetry env vars
+            **self.tracker.env,
+        }

--- a/src/meltano/core/tracking/__init__.py
+++ b/src/meltano/core/tracking/__init__.py
@@ -2,12 +2,4 @@
 
 from __future__ import annotations
 
-from .contexts import (
-    CliContext,
-    CliEvent,
-    ExceptionContext,
-    PluginsTrackingContext,
-    ProjectContext,
-    environment_context,
-)
-from .tracker import BlockEvents, Tracker
+from meltano.core.tracking.tracker import BlockEvents, Tracker

--- a/src/meltano/core/tracking/contexts/__init__.py
+++ b/src/meltano/core/tracking/contexts/__init__.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from .cli import CliContext, CliEvent
-from .environment import environment_context
-from .exception import ExceptionContext
-from .plugins import PluginsTrackingContext
-from .project import ProjectContext
+from meltano.core.tracking.contexts.cli import CliContext, CliEvent
+from meltano.core.tracking.contexts.environment import (
+    EnvironmentContext,
+    environment_context,
+)
+from meltano.core.tracking.contexts.exception import ExceptionContext
+from meltano.core.tracking.contexts.plugins import PluginsTrackingContext
+from meltano.core.tracking.contexts.project import ProjectContext

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -35,7 +35,8 @@ def _get_environment_context_uuid() -> uuid.UUID:
         except ValueError:
             warn(
                 f"Invalid telemetry environment context UUID {uuid_str!r} "
-                "from $MELTANO_CONTEXT_UUID - a random UUID will be used"
+                "from $MELTANO_CONTEXT_UUID - a random UUID will be used",
+                RuntimeWarning,
             )
     return uuid.uuid4()
 

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -41,11 +41,11 @@ def _get_environment_context_uuid() -> uuid.UUID:
     return uuid.uuid4()
 
 
-def _get_parent_context_uuid() -> uuid.UUID | None:
+def _get_parent_context_uuid_str() -> str | None:
     with suppress(KeyError):
         uuid_str = os.environ["MELTANO_PARENT_CONTEXT_UUID"]
         try:
-            return uuid.UUID(uuid_str)
+            return str(uuid.UUID(uuid_str))
         except ValueError:
             warn(
                 f"Invalid telemetry parent environment context UUID {uuid_str!r} "
@@ -65,7 +65,7 @@ class EnvironmentContext(SelfDescribingJson):
             EnvironmentContextSchema.url,
             {
                 "context_uuid": str(_get_environment_context_uuid()),
-                "parent_context_uuid": str(_get_parent_context_uuid()),
+                "parent_context_uuid": _get_parent_context_uuid_str(),
                 "meltano_version": meltano.__version__,
                 "is_dev_build": not release_marker_path.exists(),
                 "is_ci_environment": any(

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -27,20 +27,6 @@ logger = get_logger(__name__)
 release_marker_path = Path(__file__).parent / ".release_marker"
 
 
-def _get_environment_context_uuid() -> uuid.UUID:
-    with suppress(KeyError):
-        uuid_str = os.environ["MELTANO_CONTEXT_UUID"]
-        try:
-            return uuid.UUID(uuid_str)
-        except ValueError:
-            warn(
-                f"Invalid telemetry environment context UUID {uuid_str!r} "
-                "from $MELTANO_CONTEXT_UUID - a random UUID will be used",
-                RuntimeWarning,
-            )
-    return uuid.uuid4()
-
-
 def _get_parent_context_uuid_str() -> str | None:
     with suppress(KeyError):
         uuid_str = os.environ["MELTANO_PARENT_CONTEXT_UUID"]
@@ -64,7 +50,7 @@ class EnvironmentContext(SelfDescribingJson):
         super().__init__(
             EnvironmentContextSchema.url,
             {
-                "context_uuid": str(_get_environment_context_uuid()),
+                "context_uuid": str(uuid.uuid4()),
                 "parent_context_uuid": _get_parent_context_uuid_str(),
                 "meltano_version": meltano.__version__,
                 "is_dev_build": not release_marker_path.exists(),

--- a/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-1-0
+++ b/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-1-0
@@ -1,9 +1,9 @@
 {
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-    "description": "Schema for a Snowplow context describing the environment in which a Meltano project is running",
+    "description": "Schema for a Snowplow context describing the environment in which the Meltano process is executing",
     "self": {
         "vendor": "com.meltano",
-        "name": "project_context",
+        "name": "environment_context",
         "format": "jsonschema",
         "version": "1-1-0"
     },
@@ -26,45 +26,155 @@
             "minLength": 36,
             "maxLength": 36
         },
-        "project_uuid": {
-            "description": "A UUID that uniquely identifies the Meltano project",
+        "meltano_version": {
+            "description": "The version of Meltano in use",
             "type": "string",
-            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-            "minLength": 36,
-            "maxLength": 36
+            "maxLength": 256
         },
-        "project_uuid_source": {
-            "description": "How the 'project_id' was obtained/derived - either explicitly set, derived by hashing a non-UUID project ID, or randomly generated",
+        "is_dev_build": {
+            "description": "Whether the installed version of Meltano is a dev build",
+            "type": "boolean"
+        },
+        "is_ci_environment": {
+            "description": "Whether Meltano is running in a CI environment",
+            "type": "boolean"
+        },
+        "python_version": {
+            "description": "The version of Python in use",
             "type": "string",
-            "enum": [
-                "explicit",
-                "derived",
-                "random"
-            ]
+            "maxLength": 256
         },
-        "client_uuid": {
-            "description": "A UUID that uniquely identifies the client",
+        "python_implementation": {
+            "description": "The Python implementation in use",
             "type": "string",
-            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-            "minLength": 36,
-            "maxLength": 36
+            "maxLength": 256
         },
-        "environment_name_hash": {
-            "description": "The hash of the active environment for the Meltano project",
+        "system_name": {
+            "description": "The system/OS name, e.g. 'Linux', 'Darwin', 'Java', 'Windows', etc.",
             "type": [
                 "string",
                 "null"
             ],
             "maxLength": 256
+        },
+        "system_release": {
+            "description": "The system's release, e.g. '2.2.0', 'NT', etc.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "system_version": {
+            "description": "The system's release version, e.g. '#124-Ubuntu SMP Thu Apr 14 19:46:19 UTC 2022'",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "machine": {
+            "description": "The machine type, e.g. 'x86_64', 'i386', 'arm64', etc.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "windows_edition": {
+            "description": "The Windows edition, e.g. 'Enterprise', 'IoTUAP', 'ServerStandard', 'nanoserver', etc.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "freedesktop_id": {
+            "description": "The 'ID' field of the Freedesktop os-release standard, e.g. 'linuxmint'",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "freedesktop_id_like": {
+            "description": "The 'ID_LIKE' field of the Freedesktop os-release standard, e.g. 'ubuntu'",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "freedesktop_version_id": {
+            "description": "The 'VERSION_ID' field of the Freedesktop os-release standard, e.g. '20.3'",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "num_cpu_cores": {
+            "description": "The total number of logical CPU cores",
+            "type": "integer",
+            "multipleOf": 1,
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "num_cpu_cores_available": {
+            "description": "The number of logical CPU cores available to the process",
+            "type": "integer",
+            "multipleOf": 1,
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "process_hierarchy": {
+            "description": "An array of objects detailing each process in the hierarchy from the current one to the init process",
+            "type": "array",
+            "items": {
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "process_name_hash": {
+                        "description": "The hashed name of the process",
+                        "type": "string",
+                        "pattern": "^[a-fA-F0-9]{64}$",
+                        "maxLength": 64,
+                        "minLength": 64
+                    },
+                    "process_creation_timestamp": {
+                        "description": "The date and time the process was created in the ISO 8601 format",
+                        "type": "string",
+                        "pattern": "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?(?:Z|[+-][01]\\d:[0-5]\\d)$",
+                        "maxLength": 64
+                    }
+                },
+                "required": [
+                    "process_name_hash",
+                    "process_creation_timestamp"
+                ],
+                "additionalProperties": false
+            }
         }
     },
     "required": [
         "context_uuid",
         "parent_context_uuid",
-        "project_uuid",
-        "project_uuid_source",
-        "client_uuid",
-        "environment_name_hash"
+        "meltano_version",
+        "is_dev_build",
+        "is_ci_environment",
+        "python_version",
+        "python_implementation",
+        "system_name",
+        "system_release",
+        "system_version",
+        "machine",
+        "windows_edition",
+        "freedesktop_id",
+        "freedesktop_id_like",
+        "freedesktop_version_id",
+        "num_cpu_cores",
+        "num_cpu_cores_available",
+        "process_hierarchy"
     ],
     "additionalProperties": false
 }

--- a/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-1-0
+++ b/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-1-0
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Schema for a Snowplow context describing the environment in which a Meltano project is running",
+    "self": {
+        "vendor": "com.meltano",
+        "name": "project_context",
+        "format": "jsonschema",
+        "version": "1-1-0"
+    },
+    "type": "object",
+    "properties": {
+        "context_uuid": {
+            "description": "A UUID that uniquely identifies an instance of this context",
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "parent_context_uuid": {
+            "description": "The environment context UUID of the closest Meltano process above this one in the process tree",
+            "type": [
+                "string",
+                "null"
+            ],
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "project_uuid": {
+            "description": "A UUID that uniquely identifies the Meltano project",
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "project_uuid_source": {
+            "description": "How the 'project_id' was obtained/derived - either explicitly set, derived by hashing a non-UUID project ID, or randomly generated",
+            "type": "string",
+            "enum": [
+                "explicit",
+                "derived",
+                "random"
+            ]
+        },
+        "client_uuid": {
+            "description": "A UUID that uniquely identifies the client",
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "environment_name_hash": {
+            "description": "The hash of the active environment for the Meltano project",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        }
+    },
+    "required": [
+        "context_uuid",
+        "parent_context_uuid",
+        "project_uuid",
+        "project_uuid_source",
+        "client_uuid",
+        "environment_name_hash"
+    ],
+    "additionalProperties": false
+}

--- a/src/meltano/core/tracking/schemas.py
+++ b/src/meltano/core/tracking/schemas.py
@@ -28,7 +28,7 @@ class IgluSchema:
 CliContextSchema = IgluSchema("cli_context", "1-1-0")
 CliEventSchema = IgluSchema("cli_event", "1-0-1")
 BlockEventSchema = IgluSchema("block_event", "1-0-0")
-EnvironmentContextSchema = IgluSchema("environment_context", "1-0-0")
+EnvironmentContextSchema = IgluSchema("environment_context", "1-1-0")
 ExceptionContextSchema = IgluSchema("exception_context", "1-0-0")
 ExitEventSchema = IgluSchema("exit_event", "1-0-1")
 PluginsContextSchema = IgluSchema("plugins_context", "1-0-0")

--- a/tests/meltano/core/test_meltano_invoker.py
+++ b/tests/meltano/core/test_meltano_invoker.py
@@ -8,9 +8,12 @@ from pathlib import Path
 
 import mock
 import pytest
+from pytest import MonkeyPatch
 
 import meltano
 from meltano.core.meltano_invoker import MELTANO_COMMAND, MeltanoInvoker
+from meltano.core.project import Project
+from meltano.core.tracking.contexts import environment_context
 
 
 class TestMeltanoInvoker:
@@ -18,7 +21,7 @@ class TestMeltanoInvoker:
     def subject(self, project):
         return MeltanoInvoker(project)
 
-    def test_invoke(self, subject):
+    def test_invoke(self, subject: MeltanoInvoker):
         if platform.system() == "Windows":
             pytest.xfail(
                 "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
@@ -27,7 +30,22 @@ class TestMeltanoInvoker:
         assert process.returncode == 0
         assert meltano.__version__ in str(process.stdout)  # noqa: WPS609
 
-    def test_invoke_executable(self, subject, project):
+    def test_env(self, subject: MeltanoInvoker, monkeypatch: MonkeyPatch):
+        # Process env vars are injected
+        monkeypatch.setenv("ENV_VAR_KEY", "ENV_VAR_VALUE_1")
+        assert subject._executable_env()["ENV_VAR_KEY"] == "ENV_VAR_VALUE_1"
+
+        # Provided env vars overrides process env vars
+        env = subject._executable_env({"ENV_VAR_KEY": "ENV_VAR_VALUE_2"})
+        assert env["ENV_VAR_KEY"] == "ENV_VAR_VALUE_2"
+
+        # Environment context UUID from parent process is injected
+        assert (
+            env["MELTANO_PARENT_CONTEXT_UUID"]
+            == environment_context.data["context_uuid"]
+        )
+
+    def test_invoke_executable(self, subject: MeltanoInvoker, project: Project):
         if platform.system() == "Windows":
             pytest.xfail(
                 "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -7,6 +7,7 @@ import pytest
 
 from meltano.core.plugin.command import UndefinedEnvVarError
 from meltano.core.plugin_invoker import UnknownCommandError
+from meltano.core.tracking.contexts import environment_context
 from meltano.core.venv_service import VirtualEnv
 
 
@@ -55,6 +56,11 @@ class TestPluginInvoker:
         assert env["VIRTUAL_ENV"] == str(venv.root)
         assert env["PATH"].startswith(str(venv.bin_dir))
         assert "PYTHONPATH" not in env
+
+        assert (
+            env["MELTANO_PARENT_CONTEXT_UUID"]
+            == environment_context.data["context_uuid"]
+        )
 
     @pytest.mark.asyncio
     async def test_environment_env(

--- a/tests/meltano/core/tracking/test_exception.py
+++ b/tests/meltano/core/tracking/test_exception.py
@@ -12,8 +12,8 @@ from typing import Any
 import pytest
 from jsonschema import ValidationError, validate
 
-from meltano.core.tracking import ExceptionContext
 from meltano.core.tracking import __file__ as tracking_module_path
+from meltano.core.tracking.contexts import ExceptionContext
 from meltano.core.utils import hash_sha256
 
 THIS_FILE_BASENAME = Path(__file__).name

--- a/tests/meltano/core/tracking/test_plugins.py
+++ b/tests/meltano/core/tracking/test_plugins.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from meltano.core.block.plugin_command import plugin_command_invoker
 from meltano.core.plugin.project_plugin import ProjectPlugin
-from meltano.core.tracking import PluginsTrackingContext
+from meltano.core.tracking.contexts import PluginsTrackingContext
 from meltano.core.tracking.schemas import PluginsContextSchema
 from meltano.core.utils import hash_sha256
 


### PR DESCRIPTION
This PR extends https://github.com/meltano/meltano/pull/7007, and should not be merged before it. With https://github.com/meltano/meltano/pull/7007, we can set the environment context UUID using an env var. With this PR, we that env var is automatically set by Meltano when invoking Meltano or a plugin, and is reported using the new `parent_context_uuid` field within version 1-1-0 of the environment context.

Once this PR has been approved, but before it is merged, I will publish the new environment context schema version to Snowcat Cloud.

Meltano can invoke a plugin, which then calls into Meltano (e.g. to list schedules). Now telemetry from the child Meltano process can more easily be related to telemetry from the parent process. This was previously possible using the data from the process tree, but it was difficult.

Most of the changes in this PR were done to make it so that importing the `Tracker` class doesn't import much else. The need to import the tracker in a couple new spots was causing circular imports.

Relates to https://github.com/meltano/cloud-planning/issues/85