### PR TITLE
fix: Pin `setuptools==57.5.0` in plugin venvs

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -57,7 +57,7 @@ def venv_platform_specs():
         raise Exception(f"Platform {system!r} not supported.") from ex
 
 
-PIP_PACKAGES = ("pip", "setuptools", "wheel")
+PIP_PACKAGES = ("pip", "setuptools==57.5.0", "wheel")
 
 
 class VirtualEnv:


### PR DESCRIPTION
This reverts a change made in #6975

Discussion in Slack: https://meltano.slack.com/archives/C03GKHWS0HM/p1669242572838429

Closes #7020