### PR TITLE
docs: Expand UI deprecation description

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ You can add `.md` and `.html` files to this project to be rendered. Most pages a
 
 #### Front Matter
 
-All pages require [fromt matter](https://jekyllrb.com/docs/front-matter/) to render properly. At a minimum you will need to specify:
+All pages require [front matter](https://jekyllrb.com/docs/front-matter/) to render properly. At a minimum you will need to specify:
 
 - `layout:` The template file to use when rendering the content. For most pages use `doc`. Custom templates can be created and placed in `_layouts`.
 - `title:` The title of the page.

--- a/docs/src/_guide/troubleshooting.md
+++ b/docs/src/_guide/troubleshooting.md
@@ -131,7 +131,7 @@ The UI **does** work with:
 - Schedules based on [the `elt` command](https://docs.meltano.com/reference/command-line-interface#elt) (`meltano schedule add <schedule_name> --extractor <tap> --loader <target> --transform ...`)
 
 The UI does **not** work with:
-- Schedules based on jobs (`meltano schedule add <schedule_name> --job <job>`)
+- Schedules based on [jobs](https://docs.meltano.com/reference/command-line-interface#job) (`meltano schedule add <schedule_name> --job <job>`)
 - Environments
 
 ### Replacing UI functionality

--- a/docs/src/_guide/troubleshooting.md
+++ b/docs/src/_guide/troubleshooting.md
@@ -136,6 +136,6 @@ The UI does **not** work with:
 
 ### Replacing UI functionality
 
-If you're using [Airflow](https://hub.meltano.com/utilities/airflow) or [Dagster](https://hub.meltano.com/utilities/dagster) as your orchestrator, the Airflow or Dagster webserver UI should be able to serve as a replacement for many Meltano UI use cases. 
+If you're using [Airflow](https://hub.meltano.com/utilities/airflow) or [Dagster](https://hub.meltano.com/utilities/dagster) as your orchestrator, the Airflow or Dagster webserver UI should be able to serve as a replacement for many Meltano UI use cases.
 
 If using Airflow as orchestrator, see the ["Airflow orchestrator" section of the "Deployment in Production" guide](/guide/production#airflow-orchestrator) for more details on how to get the webserver running. From the webserver, you can [view all DAGs](https://airflow.apache.org/docs/apache-airflow/1.10.14/ui.html#dags-view). You can also access the Meltano logs for a specific task instance by going to the [task instance context menu](https://airflow.apache.org/docs/apache-airflow/1.10.14/ui.html#task-instance-context-menu) and clicking "Log" or "View logs".

--- a/docs/src/_guide/troubleshooting.md
+++ b/docs/src/_guide/troubleshooting.md
@@ -128,7 +128,7 @@ To view the previous documentation on the UI, review [this pull request](https:/
 If you are still using the UI, please note that it is not compatible with many newer Meltano features.
 
 The UI **does** work with:
-- Schedules based on ELT (`meltano schedule add <schedule_name> --extractor <tap> --loader <target> --transform ...`)
+- Schedules based on [the `elt` command](https://docs.meltano.com/reference/command-line-interface#elt) (`meltano schedule add <schedule_name> --extractor <tap> --loader <target> --transform ...`)
 
 The UI does **not** work with:
 - Schedules based on jobs (`meltano schedule add <schedule_name> --job <job>`)

--- a/docs/src/_guide/troubleshooting.md
+++ b/docs/src/_guide/troubleshooting.md
@@ -132,7 +132,7 @@ The UI **does** work with:
 
 The UI does **not** work with:
 - Schedules based on [jobs](https://docs.meltano.com/reference/command-line-interface#job) (`meltano schedule add <schedule_name> --job <job>`)
-- Environments
+- [Environments](https://docs.meltano.com/concepts/environments)
 
 ### Replacing UI functionality
 

--- a/docs/src/_guide/troubleshooting.md
+++ b/docs/src/_guide/troubleshooting.md
@@ -122,3 +122,18 @@ Early versions of Meltano promoted a simple UI feature that was used for setting
 Meltano will eventually have a UI again as the company and community grows. Please let us know your thoughts on what you would like to see in a future Meltano UI in [this GitHub discussion](https://github.com/meltano/meltano/discussions/6957).
 
 To view the previous documentation on the UI, review [this pull request](https://github.com/meltano/meltano/pull/6955) where they were removed.
+
+### Limitations & Capabilities of the Deprecated UI
+
+If you are still using the UI, please note that it is not compatible with many newer Meltano features.
+
+The UI **does** work with:
+- Schedules based on ELT (`meltano schedule add <schedule_name> --extractor <tap> --loader <target> --transform ...`)
+
+The UI does **not** work with:
+- Schedules based on jobs (`meltano schedule add <schedule_name> --job <job>`)
+- Environments
+
+### Replacing UI functionality
+
+If you're using Airflow as your orchestrator, the Airflow webserver UI should be able to serve as a replacement for many Meltano UI use cases. See the ["Airflow orchestrator" section of the "Deployment in Production" guide](/guide/production#airflow-orchestrator) for more details on how to get the webserver running. From the webserver, you can [view all DAGs](https://airflow.apache.org/docs/apache-airflow/1.10.14/ui.html#dags-view). You can also access the Meltano logs for a specific task instance by going to the [task instance context menu](https://airflow.apache.org/docs/apache-airflow/1.10.14/ui.html#task-instance-context-menu) and clicking "Log" or "View logs".

--- a/docs/src/_guide/troubleshooting.md
+++ b/docs/src/_guide/troubleshooting.md
@@ -136,4 +136,6 @@ The UI does **not** work with:
 
 ### Replacing UI functionality
 
-If you're using Airflow as your orchestrator, the Airflow webserver UI should be able to serve as a replacement for many Meltano UI use cases. See the ["Airflow orchestrator" section of the "Deployment in Production" guide](/guide/production#airflow-orchestrator) for more details on how to get the webserver running. From the webserver, you can [view all DAGs](https://airflow.apache.org/docs/apache-airflow/1.10.14/ui.html#dags-view). You can also access the Meltano logs for a specific task instance by going to the [task instance context menu](https://airflow.apache.org/docs/apache-airflow/1.10.14/ui.html#task-instance-context-menu) and clicking "Log" or "View logs".
+If you're using [Airflow](https://hub.meltano.com/utilities/airflow) or [Dagster](https://hub.meltano.com/utilities/dagster) as your orchestrator, the Airflow or Dagster webserver UI should be able to serve as a replacement for many Meltano UI use cases. 
+
+If using Airflow as orchestrator, see the ["Airflow orchestrator" section of the "Deployment in Production" guide](/guide/production#airflow-orchestrator) for more details on how to get the webserver running. From the webserver, you can [view all DAGs](https://airflow.apache.org/docs/apache-airflow/1.10.14/ui.html#dags-view). You can also access the Meltano logs for a specific task instance by going to the [task instance context menu](https://airflow.apache.org/docs/apache-airflow/1.10.14/ui.html#task-instance-context-menu) and clicking "Log" or "View logs".


### PR DESCRIPTION
Small docs PR to resolve issue #7038, per convo in office hours on 11/30. Thanks to @Sburwash for pointing out that the Airflow webserver can replace nearly all Meltano UI functionality.

Maintainers please do add or edit, I wasn't sure what other features are/aren't supported by UI, nor do I know the details of how the UI/environments interact, just think I remember someone saying they dont play nice together. Thanks!