### PR TITLE
ci: Run FOSSA scan nightly & when lock files are updated

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,11 @@
 name: Dependency Review
 
 on:
-  pull_request_target: {}
+  schedule:
+    - cron: '12 12 * * *'
+  pull_request_target:
+    paths:
+      - '**.lock'
   workflow_dispatch:
     inputs: {}
 
@@ -10,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FOSSA_CLI_VERSION: '3.3.11'
+  FOSSA_CLI_VERSION: '3.6.7'
 
 permissions:
   contents: read


### PR DESCRIPTION
I also updated the version of the FOSSA CLI we're using.

Closes #7036