### PR TITLE
fix: Ensure `environment_name_hash` is collected

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -66,6 +66,8 @@ ignore =
     WPS305
     # Ignore missing base class, required by pyupgrade: https://github.com/asottile/pyupgrade#rewrites-class-declaration
     WPS306
+    # Allow "incorrect multi-line parameters", since Black forces them to be "incorrect"
+    WPS317
     # Allow inconsistent returns - permitted because of too many false positives
     WPS324
     # Allow syntax-level (process when first parsed, rather than at every run) string concatenation

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -16,11 +16,7 @@ from meltano.core.project import ProjectReadonly
 # This suggests a cyclic dependency or a poorly structured interface.
 # This should be investigated and resolved to avoid implicit behavior
 # based solely on import order.
-from meltano.cli.cli import (  # isort:skip
-    activate_environment,
-    activate_explicitly_provided_environment,
-    cli,
-)
+from meltano.cli.cli import cli  # isort:skip
 from meltano.cli import (  # isort:skip # noqa: WPS235
     add,
     config,

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -17,7 +17,7 @@ from meltano.core.error import MeltanoConfigurationError
 from meltano.core.logging import LEVELS, setup_logging
 from meltano.core.project import Project, ProjectNotFound
 from meltano.core.project_settings_service import ProjectSettingsService
-from meltano.core.tracking import CliContext, Tracker
+from meltano.core.tracking import CliContext, ProjectContext, Tracker
 from meltano.core.utils import get_no_color_flag
 
 logger = logging.getLogger(__name__)
@@ -154,6 +154,14 @@ def activate_environment(
     """
     if ctx.obj["selected_environment"]:
         project.activate_environment(ctx.obj["selected_environment"])
+        # Update the project context being used for telemetry:
+        project_ctx = next(
+            ctx
+            for ctx in ctx.obj["tracker"].contexts
+            if isinstance(ctx, ProjectContext)
+        )
+        project_ctx.environment_name = ctx.obj["selected_environment"]
+
     elif required:
         raise MeltanoConfigurationError(
             reason="A Meltano environment must be specified",

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -13,11 +13,10 @@ import click
 import meltano
 from meltano.cli.utils import InstrumentedGroup
 from meltano.core.behavior.versioned import IncompatibleVersionError
-from meltano.core.error import MeltanoConfigurationError
 from meltano.core.logging import LEVELS, setup_logging
 from meltano.core.project import Project, ProjectNotFound
 from meltano.core.project_settings_service import ProjectSettingsService
-from meltano.core.tracking import CliContext, ProjectContext, Tracker
+from meltano.core.tracking import CliContext, Tracker
 from meltano.core.utils import get_no_color_flag
 
 logger = logging.getLogger(__name__)
@@ -138,57 +137,3 @@ def cli(  # noqa: WPS231
             "For more details, visit https://docs.meltano.com/guide/installation#upgrading-meltano-version"
         )
         sys.exit(3)
-
-
-def activate_environment(
-    ctx: click.Context, project: Project, required: bool = False
-) -> None:
-    """Activate the selected environment.
-
-    The selected environment is whatever was selected with the `--environment`
-    option, or the default environment (set in `meltano.yml`) otherwise.
-
-    Args:
-        ctx: The Click context, used to determine the selected environment.
-        project: The project for which the environment will be activated.
-    """
-    if ctx.obj["selected_environment"]:
-        project.activate_environment(ctx.obj["selected_environment"])
-        # Update the project context being used for telemetry:
-        project_ctx = next(
-            ctx
-            for ctx in ctx.obj["tracker"].contexts
-            if isinstance(ctx, ProjectContext)
-        )
-        project_ctx.environment_name = ctx.obj["selected_environment"]
-
-    elif required:
-        raise MeltanoConfigurationError(
-            reason="A Meltano environment must be specified",
-            instruction="Set the `default_environment` option in "
-            "`meltano.yml`, or the `--environment` CLI option",
-        )
-
-
-def activate_explicitly_provided_environment(
-    ctx: click.Context, project: Project
-) -> None:
-    """Activate the selected environment if it has been explicitly set.
-
-    Some commands (e.g. `config`, `job`, etc.) do not respect the configured
-    `default_environment`, and will only run with an environment active if it
-    has been explicitly set (e.g. with the `--environment` CLI option).
-
-    Args:
-        ctx: The Click context, used to determine the selected environment.
-        project: The project for which the environment will be activated.
-    """
-    if ctx.obj["is_default_environment"]:
-        logger.info(
-            f"The default environment {ctx.obj['selected_environment']!r} will "
-            f"be ignored for `meltano {ctx.command.name}`. To configure a specific "
-            "environment, please use the option `--environment=<environment name>`."
-        )
-        project.deactivate_environment()
-    else:
-        activate_environment(ctx, project)

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -17,7 +17,7 @@ from meltano.cli import cli
 from meltano.cli.interactive import InteractiveConfig
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
-    CliEnvironmentAction,
+    CliEnvironmentBehavior,
     CliError,
     InstrumentedGroup,
     PartialInstrumentedCmd,
@@ -117,7 +117,7 @@ def get_label(metadata) -> str:
     cls=InstrumentedGroup,
     invoke_without_command=True,
     short_help="Display Meltano or plugin configuration.",
-    environment_action=CliEnvironmentAction.activate_explicitly_provided,
+    environment_behavior=CliEnvironmentBehavior.environment_optional_ignore_default,
 )
 @click.option(
     "--plugin-type", type=click.Choice(PluginType.cli_arguments()), default=None

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -13,10 +13,15 @@ from typing import Any
 import click
 import dotenv
 
-from meltano.cli import activate_explicitly_provided_environment, cli
+from meltano.cli import cli
 from meltano.cli.interactive import InteractiveConfig
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliError, InstrumentedGroup, PartialInstrumentedCmd
+from meltano.cli.utils import (
+    CliEnvironmentAction,
+    CliError,
+    InstrumentedGroup,
+    PartialInstrumentedCmd,
+)
 from meltano.core.db import project_engine
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.error import PluginNotFoundError
@@ -112,6 +117,7 @@ def get_label(metadata) -> str:
     cls=InstrumentedGroup,
     invoke_without_command=True,
     short_help="Display Meltano or plugin configuration.",
+    environment_action=CliEnvironmentAction.activate_explicitly_provided,
 )
 @click.option(
     "--plugin-type", type=click.Choice(PluginType.cli_arguments()), default=None
@@ -139,8 +145,6 @@ def config(  # noqa: WPS231
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#config
     """
-    activate_explicitly_provided_environment(ctx, project)
-
     tracker = ctx.obj["tracker"]
     try:
         plugin_type = PluginType.from_cli_argument(plugin_type) if plugin_type else None

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -11,9 +11,9 @@ import click
 import structlog
 from structlog import stdlib as structlog_stdlib
 
-from meltano.cli import activate_environment, cli
+from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliError, PartialInstrumentedCmd
+from meltano.cli.utils import CliEnvironmentAction, CliError, PartialInstrumentedCmd
 from meltano.core.db import project_engine
 from meltano.core.elt_context import ELTContextBuilder
 from meltano.core.job import Job, JobFinder
@@ -42,6 +42,7 @@ logger = structlog_stdlib.get_logger(__name__)
 @cli.command(
     cls=PartialInstrumentedCmd,
     short_help="Run an ELT pipeline to Extract, Load, and Transform data.",
+    environment_action=CliEnvironmentAction.activate,
 )
 @click.argument("extractor")
 @click.argument("loader")
@@ -111,8 +112,6 @@ async def elt(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#elt
     """
-    activate_environment(ctx, project)
-
     if platform.system() == "Windows":
         raise CliError(
             "ELT command not supported on Windows. Please use the Run command as documented here https://docs.meltano.com/reference/command-line-interface#run"

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -13,7 +13,7 @@ from structlog import stdlib as structlog_stdlib
 
 from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliEnvironmentAction, CliError, PartialInstrumentedCmd
+from meltano.cli.utils import CliEnvironmentBehavior, CliError, PartialInstrumentedCmd
 from meltano.core.db import project_engine
 from meltano.core.elt_context import ELTContextBuilder
 from meltano.core.job import Job, JobFinder
@@ -42,7 +42,7 @@ logger = structlog_stdlib.get_logger(__name__)
 @cli.command(
     cls=PartialInstrumentedCmd,
     short_help="Run an ELT pipeline to Extract, Load, and Transform data.",
-    environment_action=CliEnvironmentAction.activate,
+    environment_behavior=CliEnvironmentBehavior.environment_optional_use_default,
 )
 @click.argument("extractor")
 @click.argument("loader")

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -9,9 +9,14 @@ import sys
 import click
 from sqlalchemy.orm import sessionmaker
 
-from meltano.cli import activate_environment, cli
+from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliError, PartialInstrumentedCmd, propagate_stop_signals
+from meltano.cli.utils import (
+    CliEnvironmentAction,
+    CliError,
+    PartialInstrumentedCmd,
+    propagate_stop_signals,
+)
 from meltano.core.db import project_engine
 from meltano.core.error import AsyncSubprocessError
 from meltano.core.plugin import PluginType
@@ -32,6 +37,7 @@ logger = logging.getLogger(__name__)
     cls=PartialInstrumentedCmd,
     context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
     short_help="Invoke a plugin.",
+    environment_action=CliEnvironmentAction.activate,
 )
 @click.option(
     "--print-var",
@@ -76,7 +82,6 @@ def invoke(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#invoke
     """
-    activate_environment(ctx, project)
     tracker: Tracker = ctx.obj["tracker"]
 
     try:

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import sessionmaker
 from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
-    CliEnvironmentAction,
+    CliEnvironmentBehavior,
     CliError,
     PartialInstrumentedCmd,
     propagate_stop_signals,
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
     cls=PartialInstrumentedCmd,
     context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
     short_help="Invoke a plugin.",
-    environment_action=CliEnvironmentAction.activate,
+    environment_behavior=CliEnvironmentBehavior.environment_optional_use_default,
 )
 @click.option(
     "--print-var",

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -10,7 +10,7 @@ import structlog
 from meltano.cli import CliError, cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
-    CliEnvironmentAction,
+    CliEnvironmentBehavior,
     InstrumentedGroup,
     PartialInstrumentedCmd,
 )
@@ -92,7 +92,7 @@ def _list_all_jobs(
 @cli.group(
     cls=InstrumentedGroup,
     short_help="Manage jobs.",
-    environment_action=CliEnvironmentAction.activate_explicitly_provided,
+    environment_behavior=CliEnvironmentBehavior.environment_optional_ignore_default,
 )
 @click.pass_context
 @pass_project(migrate=True)

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -7,9 +7,13 @@ import json
 import click
 import structlog
 
-from meltano.cli import CliError, activate_explicitly_provided_environment, cli
+from meltano.cli import CliError, cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import InstrumentedGroup, PartialInstrumentedCmd
+from meltano.cli.utils import (
+    CliEnvironmentAction,
+    InstrumentedGroup,
+    PartialInstrumentedCmd,
+)
 from meltano.core.block.parser import BlockParser, validate_block_sets
 from meltano.core.project import Project
 from meltano.core.task_sets import InvalidTasksError, TaskSets, tasks_from_yaml_str
@@ -66,10 +70,7 @@ def _list_all_jobs(
         task_sets_service: The task sets service to use.
         list_format: The format to use.
     """
-    if list_format == "text":
-        for task_set in task_sets_service.list():
-            click.echo(f"{task_set.name}: {task_set.tasks}")
-    elif list_format == "json":
+    if list_format == "json":
         click.echo(
             json.dumps(
                 {
@@ -81,11 +82,18 @@ def _list_all_jobs(
                 indent=2,
             )
         )
+    elif list_format == "text":
+        for task_set in task_sets_service.list():
+            click.echo(f"{task_set.name}: {task_set.tasks}")
     tracker: Tracker = ctx.obj["tracker"]
     tracker.track_command_event(CliEvent.completed)
 
 
-@cli.group(cls=InstrumentedGroup, short_help="Manage jobs.")
+@cli.group(
+    cls=InstrumentedGroup,
+    short_help="Manage jobs.",
+    environment_action=CliEnvironmentAction.activate_explicitly_provided,
+)
 @click.pass_context
 @pass_project(migrate=True)
 def job(project, ctx):
@@ -115,7 +123,6 @@ def job(project, ctx):
 
     \bRead more at https://docs.meltano.com/reference/command-line-interface#jobs
     """
-    activate_explicitly_provided_environment(ctx, project)
     ctx.obj["project"] = project
     ctx.obj["task_sets_service"] = TaskSetsService(project)
 

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import click
 import structlog
 
-from meltano.cli import CliError, activate_environment, cli
+from meltano.cli import CliError, cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import PartialInstrumentedCmd
+from meltano.cli.utils import CliEnvironmentAction, PartialInstrumentedCmd
 from meltano.core.block.blockset import BlockSet
 from meltano.core.block.parser import BlockParser, validate_block_sets
 from meltano.core.block.plugin_command import PluginCommandBlock
@@ -22,7 +22,11 @@ from meltano.core.utils import click_run_async
 logger = structlog.getLogger(__name__)
 
 
-@cli.command(cls=PartialInstrumentedCmd, short_help="Run a set of plugins in series.")
+@cli.command(
+    cls=PartialInstrumentedCmd,
+    short_help="Run a set of plugins in series.",
+    environment_action=CliEnvironmentAction.activate_required,
+)
 @click.option(
     "--dry-run",
     help="Do not run, just parse the invocation, validate it, and explain what would be executed.",
@@ -87,8 +91,6 @@ async def run(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#run
     """
-    activate_environment(ctx, project, required=True)
-
     if dry_run and not ProjectSettingsService.config_override.get("cli.log_level"):
         logger.info("Setting 'console' handler log level to 'debug' for dry run")
         change_console_log_level()

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -7,7 +7,7 @@ import structlog
 
 from meltano.cli import CliError, cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliEnvironmentAction, PartialInstrumentedCmd
+from meltano.cli.utils import CliEnvironmentBehavior, PartialInstrumentedCmd
 from meltano.core.block.blockset import BlockSet
 from meltano.core.block.parser import BlockParser, validate_block_sets
 from meltano.core.block.plugin_command import PluginCommandBlock
@@ -25,7 +25,7 @@ logger = structlog.getLogger(__name__)
 @cli.command(
     cls=PartialInstrumentedCmd,
     short_help="Run a set of plugins in series.",
-    environment_action=CliEnvironmentAction.activate_required,
+    environment_behavior=CliEnvironmentBehavior.environment_required,
 )
 @click.option(
     "--dry-run",

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
-    CliEnvironmentAction,
+    CliEnvironmentBehavior,
     InstrumentedDefaultGroup,
     PartialInstrumentedCmd,
 )
@@ -29,7 +29,7 @@ from meltano.core.utils import coerce_datetime
     cls=InstrumentedDefaultGroup,
     default="add",
     short_help="Manage pipeline schedules.",
-    environment_action=CliEnvironmentAction.activate_explicitly_provided,
+    environment_behavior=CliEnvironmentBehavior.environment_optional_ignore_default,
 )
 @click.pass_context
 @pass_project(migrate=True)

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -8,9 +8,13 @@ import sys
 import click
 from sqlalchemy.orm import Session
 
-from meltano.cli import activate_explicitly_provided_environment, cli
+from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import InstrumentedDefaultGroup, PartialInstrumentedCmd
+from meltano.cli.utils import (
+    CliEnvironmentAction,
+    InstrumentedDefaultGroup,
+    PartialInstrumentedCmd,
+)
 from meltano.core.db import project_engine
 from meltano.core.job.stale_job_failer import fail_stale_jobs
 from meltano.core.project import Project
@@ -22,7 +26,10 @@ from meltano.core.utils import coerce_datetime
 
 
 @cli.group(
-    cls=InstrumentedDefaultGroup, default="add", short_help="Manage pipeline schedules."
+    cls=InstrumentedDefaultGroup,
+    default="add",
+    short_help="Manage pipeline schedules.",
+    environment_action=CliEnvironmentAction.activate_explicitly_provided,
 )
 @click.pass_context
 @pass_project(migrate=True)
@@ -32,7 +39,6 @@ def schedule(project, ctx):
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#schedule
     """
-    activate_explicitly_provided_environment(ctx, project)
     ctx.obj["project"] = project
     ctx.obj["schedule_service"] = ScheduleService(project)
     ctx.obj["task_sets_service"] = TaskSetsService(project)

--- a/src/meltano/cli/select.py
+++ b/src/meltano/cli/select.py
@@ -5,9 +5,9 @@ from contextlib import closing
 
 import click
 
-from meltano.cli import activate_explicitly_provided_environment, cli
+from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliError, InstrumentedCmd
+from meltano.cli.utils import CliEnvironmentAction, CliError, InstrumentedCmd
 from meltano.core.db import project_engine
 from meltano.core.plugin.error import PluginExecutionError
 from meltano.core.plugin.singer.catalog import SelectionType, SelectPattern
@@ -39,7 +39,11 @@ def selection_mark(selection):
     return f"[{selection:<{colwidth}}]"
 
 
-@cli.command(cls=InstrumentedCmd, short_help="Manage extractor selection patterns.")
+@cli.command(
+    cls=InstrumentedCmd,
+    short_help="Manage extractor selection patterns.",
+    environment_action=CliEnvironmentAction.activate_explicitly_provided,
+)
 @click.argument("extractor")
 @click.argument("entities_filter", default="*")
 @click.argument("attributes_filter", default="*")
@@ -77,7 +81,6 @@ async def select(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#select
     """
-    activate_explicitly_provided_environment(ctx, project)
     try:
         if flags["list"]:
             await show(project, extractor, show_all=flags["all"])

--- a/src/meltano/cli/select.py
+++ b/src/meltano/cli/select.py
@@ -7,7 +7,7 @@ import click
 
 from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliEnvironmentAction, CliError, InstrumentedCmd
+from meltano.cli.utils import CliEnvironmentBehavior, CliError, InstrumentedCmd
 from meltano.core.db import project_engine
 from meltano.core.plugin.error import PluginExecutionError
 from meltano.core.plugin.singer.catalog import SelectionType, SelectPattern
@@ -42,7 +42,7 @@ def selection_mark(selection):
 @cli.command(
     cls=InstrumentedCmd,
     short_help="Manage extractor selection patterns.",
-    environment_action=CliEnvironmentAction.activate_explicitly_provided,
+    environment_behavior=CliEnvironmentBehavior.environment_optional_ignore_default,
 )
 @click.argument("extractor")
 @click.argument("entities_filter", default="*")

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -12,7 +12,7 @@ import structlog
 
 from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliEnvironmentAction, InstrumentedCmd, InstrumentedGroup
+from meltano.cli.utils import CliEnvironmentBehavior, InstrumentedCmd, InstrumentedGroup
 from meltano.core.block.parser import BlockParser
 from meltano.core.db import project_engine
 from meltano.core.job import Payload
@@ -105,7 +105,7 @@ def state_service_from_state_id(project: Project, state_id: str) -> StateService
     cls=InstrumentedGroup,
     name="state",
     short_help="Manage Singer state.",
-    environment_action=CliEnvironmentAction.activate_explicitly_provided,
+    environment_behavior=CliEnvironmentBehavior.environment_optional_ignore_default,
 )
 @click.pass_context
 @pass_project(migrate=True)

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -10,9 +10,9 @@ from operator import xor
 import click
 import structlog
 
-from meltano.cli import activate_explicitly_provided_environment, cli
+from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import InstrumentedCmd, InstrumentedGroup
+from meltano.cli.utils import CliEnvironmentAction, InstrumentedCmd, InstrumentedGroup
 from meltano.core.block.parser import BlockParser
 from meltano.core.db import project_engine
 from meltano.core.job import Payload
@@ -80,14 +80,18 @@ def state_service_from_state_id(project: Project, state_id: str) -> StateService
         try:
             if not project.active_environment:
                 logger.warn(
-                    f"Running state operation for environment '{match.group('env')}' outside of an environment"
+                    "Running state operation for environment "
+                    f"'{match['env']}' outside of an environment"
                 )
-            elif project.active_environment.name != match.group("env"):
+
+            elif project.active_environment.name != match["env"]:
                 logger.warn(
-                    f"Environment '{match.group('env')}' used in state operation does not match current environment '{project.active_environment.name}'."
+                    f"Environment '{match['env']}' used in state operation does "
+                    f"not match current environment '{project.active_environment.name}'."
                 )
-            project.activate_environment(match.group("env"))
-            blocks = [match.group("tap"), match.group("target")]
+
+            project.activate_environment(match["env"])
+            blocks = [match["tap"], match["target"]]
             parser = BlockParser(logger, project, blocks)
             return next(parser.find_blocks()).state_service
         except Exception:
@@ -97,7 +101,12 @@ def state_service_from_state_id(project: Project, state_id: str) -> StateService
     return None
 
 
-@cli.group(cls=InstrumentedGroup, name="state", short_help="Manage Singer state.")
+@cli.group(
+    cls=InstrumentedGroup,
+    name="state",
+    short_help="Manage Singer state.",
+    environment_action=CliEnvironmentAction.activate_explicitly_provided,
+)
 @click.pass_context
 @pass_project(migrate=True)
 def meltano_state(project: Project, ctx: click.Context):
@@ -106,7 +115,6 @@ def meltano_state(project: Project, ctx: click.Context):
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#state
     """
-    activate_explicitly_provided_environment(ctx, project)
     _, sessionmaker = project_engine(project)
     session = sessionmaker()
     ctx.obj[STATE_SERVICE_KEY] = StateService(project, session)  # noqa: WPS204

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -6,10 +6,12 @@ import logging
 import os
 import signal
 from contextlib import contextmanager
+from enum import Enum, auto
 
 import click
 from click_default_group import DefaultGroup
 
+from meltano.core.error import MeltanoConfigurationError
 from meltano.core.logging import setup_logging
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.base import PluginRef
@@ -29,7 +31,7 @@ from meltano.core.project_add_service import (
 )
 from meltano.core.project_plugins_service import ProjectPluginsService
 from meltano.core.setting_definition import SettingKind
-from meltano.core.tracking import CliContext, CliEvent
+from meltano.core.tracking import CliContext, CliEvent, ProjectContext
 
 setup_logging()
 
@@ -528,44 +530,141 @@ def check_dependencies_met(
     return passed, message
 
 
-class InstrumentedDefaultGroup(DefaultGroup):
-    """A variation of a DefaultGroup that instruments its invocation by updating the telemetry context."""
+def activate_environment(
+    ctx: click.Context, project: Project, required: bool = False
+) -> None:
+    """Activate the selected environment.
 
-    def invoke(self, ctx):
+    The selected environment is whatever was selected with the `--environment`
+    option, or the default environment (set in `meltano.yml`) otherwise.
+
+    Args:
+        ctx: The Click context, used to determine the selected environment.
+        project: The project for which the environment will be activated.
+    """
+    if ctx.obj["selected_environment"]:
+        project.activate_environment(ctx.obj["selected_environment"])
+        # Update the project context being used for telemetry:
+        project_ctx = next(
+            ctx
+            for ctx in ctx.obj["tracker"].contexts
+            if isinstance(ctx, ProjectContext)
+        )
+        project_ctx.environment_name = ctx.obj["selected_environment"]
+
+    elif required:
+        raise MeltanoConfigurationError(
+            reason="A Meltano environment must be specified",
+            instruction="Set the `default_environment` option in "
+            "`meltano.yml`, or the `--environment` CLI option",
+        )
+
+
+def activate_explicitly_provided_environment(
+    ctx: click.Context, project: Project
+) -> None:
+    """Activate the selected environment if it has been explicitly set.
+
+    Some commands (e.g. `config`, `job`, etc.) do not respect the configured
+    `default_environment`, and will only run with an environment active if it
+    has been explicitly set (e.g. with the `--environment` CLI option).
+
+    Args:
+        ctx: The Click context, used to determine the selected environment.
+        project: The project for which the environment will be activated.
+    """
+    if ctx.obj["is_default_environment"]:
+        logger.info(
+            f"The default environment {ctx.obj['selected_environment']!r} will "
+            f"be ignored for `meltano {ctx.command.name}`. To configure a specific "
+            "environment, please use the option `--environment=<environment name>`."
+        )
+        project.deactivate_environment()
+    else:
+        activate_environment(ctx, project)
+
+
+class CliEnvironmentAction(Enum):
+    """Enum of the different ways in which a Meltano environment can be activated."""
+
+    activate = auto()
+    activate_required = auto()
+    activate_explicitly_provided = auto()
+
+
+def enact_environment_action(
+    action: CliEnvironmentAction | None,
+    ctx: click.Context,
+) -> None:
+    """Activate the environment in the specified way."""
+    if action is None:
+        return
+    if action is CliEnvironmentAction.activate:
+        activate_environment(ctx, ctx.obj["project"], required=False)
+    elif action is CliEnvironmentAction.activate_required:
+        activate_environment(ctx, ctx.obj["project"], required=True)
+    elif action is CliEnvironmentAction.activate_explicitly_provided:
+        activate_explicitly_provided_environment(ctx, ctx.obj["project"])
+
+
+class InstrumentedCmdMixin:
+    """Shared functionality for all instrumented commands."""
+
+    def __init__(
+        self,
+        *args,
+        environment_action: CliEnvironmentAction | None = None,
+        **kwargs,
+    ):
+        """Initialize the `InstrumentedCmdMixin`.
+
+        Args:
+            args: Arguments to pass to the parent class.
+            environment_action: The action to take regarding the activation of
+                the Meltano environment for this command.
+            kwargs: Keyword arguments to pass to the parent class.
+        """
+        self.environment_action = environment_action
+        super().__init__(*args, **kwargs)
+
+
+class InstrumentedGroupMixin(InstrumentedCmdMixin):
+    """Shared functionality for all instrumented groups."""
+
+    def invoke(self, ctx: click.Context):
         """Update the telemetry context and invoke the group."""
         ctx.ensure_object(dict)
+        enact_environment_action(self.environment_action, ctx)
         if ctx.obj.get("tracker"):
             ctx.obj["tracker"].add_contexts(CliContext.from_click_context(ctx))
-        super().invoke(ctx)  # noqa: WPS608
+        super().invoke(ctx)
 
 
-class InstrumentedGroup(click.Group):
-    """A click.Group that instruments its invocation by updating the telemetry context."""
-
-    def invoke(self, ctx):
-        """Update the telemetry context and invoke the group."""
-        ctx.ensure_object(dict)
-        if ctx.obj.get("tracker"):
-            ctx.obj["tracker"].add_contexts(CliContext.from_click_context(ctx))
-        super().invoke(ctx)  # noqa: WPS608
+class InstrumentedDefaultGroup(InstrumentedGroupMixin, DefaultGroup):
+    """A variation of a `DefaultGroup` that instruments its invocation by updating the telemetry context."""
 
 
-class InstrumentedCmd(click.Command):
-    """A click.Command that automatically fires telemetry events when invoked.
+class InstrumentedGroup(InstrumentedGroupMixin, click.Group):
+    """A `click.Group` that instruments its invocation by updating the telemetry context."""
+
+
+class InstrumentedCmd(InstrumentedCmdMixin, click.Command):
+    """A `click.Command` that automatically fires telemetry events when invoked.
 
     Both starting and ending events are fired. The ending event fired is dependent on whether invocation of the command
     resulted in an Exception.
     """
 
-    def invoke(self, ctx):
+    def invoke(self, ctx: click.Context):
         """Invoke the requested command firing start and events accordingly."""
         ctx.ensure_object(dict)
+        enact_environment_action(self.environment_action, ctx)
         if ctx.obj.get("tracker"):
             tracker = ctx.obj["tracker"]
             tracker.add_contexts(CliContext.from_click_context(ctx))
             tracker.track_command_event(CliEvent.started)
             try:
-                super().invoke(ctx)  # noqa: WPS608
+                super().invoke(ctx)
             except Exception:
                 tracker.track_command_event(CliEvent.failed)
                 raise
@@ -574,13 +673,14 @@ class InstrumentedCmd(click.Command):
             super().invoke(ctx)
 
 
-class PartialInstrumentedCmd(click.Command):
-    """A click.Command that automatically fires an instrumentation 'start' event, if a tracker is available."""
+class PartialInstrumentedCmd(InstrumentedCmdMixin, click.Command):
+    """A `click.Command` that automatically fires an instrumentation 'start' event, if a tracker is available."""
 
     def invoke(self, ctx):
         """Invoke the requested command firing only a start event."""
         ctx.ensure_object(dict)
+        enact_environment_action(self.environment_action, ctx)
         if ctx.obj.get("tracker"):
             ctx.obj["tracker"].add_contexts(CliContext.from_click_context(ctx))
             ctx.obj["tracker"].track_command_event(CliEvent.started)
-        super().invoke(ctx)  # noqa: WPS608
+        super().invoke(ctx)

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm.session import sessionmaker
 from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
-    CliEnvironmentAction,
+    CliEnvironmentBehavior,
     InstrumentedCmd,
     propagate_stop_signals,
 )
@@ -66,7 +66,7 @@ class CommandLineRunner(ValidationsRunner):
 @cli.command(
     cls=InstrumentedCmd,
     short_help="Run validations using plugins' tests.",
-    environment_action=CliEnvironmentAction.activate,
+    environment_behavior=CliEnvironmentBehavior.environment_optional_use_default,
 )
 @click.option(
     "--all",

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -11,9 +11,13 @@ import click
 import structlog
 from sqlalchemy.orm.session import sessionmaker
 
-from meltano.cli import activate_environment, cli
+from meltano.cli import cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import InstrumentedCmd, propagate_stop_signals
+from meltano.cli.utils import (
+    CliEnvironmentAction,
+    InstrumentedCmd,
+    propagate_stop_signals,
+)
 from meltano.core.db import project_engine
 from meltano.core.project import Project
 from meltano.core.validation_service import ValidationOutcome, ValidationsRunner
@@ -59,7 +63,11 @@ class CommandLineRunner(ValidationsRunner):
         return exit_code
 
 
-@cli.command(cls=InstrumentedCmd, short_help="Run validations using plugins' tests.")
+@cli.command(
+    cls=InstrumentedCmd,
+    short_help="Run validations using plugins' tests.",
+    environment_action=CliEnvironmentAction.activate,
+)
 @click.option(
     "--all",
     "all_tests",
@@ -85,7 +93,6 @@ def test(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#test
     """
-    activate_environment(ctx, project)
     _, session_maker = project_engine(project)
     session = session_maker()
 

--- a/src/meltano/core/plugin/factory.py
+++ b/src/meltano/core/plugin/factory.py
@@ -25,7 +25,7 @@ def lazy_import(module: str, classname: str):
     return lazy
 
 
-base_plugin_classes = {  # noqa: WPS317
+base_plugin_classes = {
     PluginType.EXTRACTORS: lazy_import(".singer", "SingerTap"),
     PluginType.LOADERS: lazy_import(".singer", "SingerTarget"),
     PluginType.TRANSFORMS: lazy_import(".dbt", "DbtTransformPlugin"),
@@ -50,7 +50,7 @@ def base_plugin_factory(
     Returns:
         The created plugin.
     """
-    plugin_cls = base_plugin_classes.get(  # noqa: WPS317
+    plugin_cls = base_plugin_classes.get(
         (plugin_def.type, plugin_def.name),
         base_plugin_classes.get(plugin_def.type, lambda: BasePlugin),
     )()

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -1,5 +1,6 @@
 """Meltano Projects."""
 
+
 from __future__ import annotations
 
 import errno
@@ -7,7 +8,7 @@ import logging
 import os
 import sys
 import threading
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -244,10 +245,8 @@ class Project(Versioned):  # noqa: WPS214
         modified in-place, but not updated on-disk, and you need the on-disk
         version.
         """
-        try:
+        with suppress(KeyError):
             del self.__dict__["project_files"]
-        except KeyError:
-            pass
 
     @property
     def meltano(self) -> MeltanoFileTypeHint:

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -1,6 +1,8 @@
 """New Project Initialization Service."""
+
 from __future__ import annotations
 
+import contextlib
 import os
 import uuid
 from pathlib import Path
@@ -29,10 +31,8 @@ class ProjectInitService:
         """
         self.project_directory = Path(project_directory)
 
-        try:
+        with contextlib.suppress(ValueError):
             self.project_directory = self.project_directory.relative_to(Path.cwd())
-        except ValueError:
-            pass
 
     def init(self, activate: bool = True, add_discovery: bool = False) -> Project:
         """Initialise Meltano Project.

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -95,13 +95,9 @@ class SettingsService(ABC):  # noqa: WPS214
             config_override:  Optional override configuration values.
         """
         self.project = project
-
         self.show_hidden = show_hidden
-
         self.env_override = env_override or {}
-
         self.config_override = config_override or {}
-
         self._setting_defs = None
 
     @property

--- a/src/meltano/core/tracking/contexts/project.py
+++ b/src/meltano/core/tracking/contexts/project.py
@@ -54,17 +54,33 @@ class ProjectContext(SelfDescribingJson):
                 "project_uuid": str(self.project_uuid),
                 "project_uuid_source": self.project_uuid_source.name,
                 "client_uuid": str(client_id),
-                "environment_name_hash": (
-                    hash_sha256(self.project.active_environment.name)
-                    if self.project.active_environment
-                    else None
-                ),
                 "send_anonymous_usage_stats": send_anonymous_usage_stats,
                 "send_anonymous_usage_stats_source": (
                     send_anonymous_usage_stats_metadata["source"].value
                 ),
             },
         )
+
+        self.environment_name = getattr(self.project.active_environment, "name", None)
+
+    @property
+    def environment_name(self) -> str | None:
+        """Get the name of the active environment, or `None` if there is no active environment.
+
+        Only the hash of this value is reported to Snowplow.
+
+        Returns:
+            The name of the active environment, or `None` if there is no active environment.
+        """
+        return self._environment_name
+
+    @environment_name.setter
+    def environment_name(self, value: str | None) -> None:
+        self._environment_name = value
+        if value is None:
+            self.data["environment_name_hash"] = None
+        else:
+            self.data["environment_name_hash"] = hash_sha256(value)
 
     @property
     def project_uuid_source(self) -> ProjectUUIDSource:

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -191,12 +191,12 @@ class Tracker:  # noqa: WPS214 - too many methods
         Examples:
             The timezone name as an IANA timezone database name:
 
-                >>> SnowplowTracker(project).timezone_name
+                >>> Tracker(project).timezone_name
                 'Europe/Berlin'
 
             The timezone name as an IANA timezone abbreviation because the full name was not found:
 
-                >>> SnowplowTracker(project).timezone_name
+                >>> Tracker(project).timezone_name
                 'CET'
 
         Returns:

--- a/tests/asserts.py
+++ b/tests/asserts.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from click.testing import Result
 
-def assert_cli_runner(runner, message=None):
-    assertion_message = str(message or runner.output)
 
-    assert runner.exit_code == 0, assertion_message
+def assert_cli_runner(results: Result, message=None):
+    assertion_message = str(message or results.output)
+
+    assert results.exit_code == 0, assertion_message

--- a/tests/fixtures/cli.py
+++ b/tests/fixtures/cli.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
+from click import Command
 from click.testing import CliRunner
 
 from fixtures.utils import tmp_project
 from meltano.core.project_files import ProjectFiles
 
 if TYPE_CHECKING:
+    from click.testing import Result
+
     from fixtures.docker import SnowplowMicro
 
 
@@ -24,8 +27,8 @@ class MeltanoCliRunner(CliRunner):
         self.snowplow = snowplow
         super().__init__(*args, **kwargs)
 
-    def invoke(self, *args, **kwargs) -> Any:
-        results = super().invoke(*args, **kwargs)
+    def invoke(self, cli: Command, *args, **kwargs) -> Result:
+        results = super().invoke(cli, *args, **kwargs)
         if self.snowplow:  # pragma: no cover
             assert self.snowplow.all()["bad"] == 0  # pragma: no cover
             assert not self.snowplow.bad()  # pragma: no cover

--- a/tests/meltano/core/test_project_add_service.py
+++ b/tests/meltano/core/test_project_add_service.py
@@ -27,7 +27,7 @@ class TestProjectAddService:
         assert len(hub_request_counter) == 1
 
     @pytest.mark.order(0)
-    @pytest.mark.parametrize(  # noqa: WPS317
+    @pytest.mark.parametrize(
         ("plugin_type", "plugin_name", "variant", "default_variant"),
         [
             (PluginType.EXTRACTORS, "tap-mock", "meltano", "meltano"),

--- a/tests/meltano/core/tracking/test_project_context.py
+++ b/tests/meltano/core/tracking/test_project_context.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from asserts import assert_cli_runner
+from meltano.cli import cli
+from meltano.core.utils import hash_sha256
+
+if TYPE_CHECKING:
+    from fixtures.cli import MeltanoCliRunner
+    from fixtures.docker import SnowplowMicro
+    from meltano.core.project import Project
+
+
+@pytest.mark.parametrize(
+    ("cmd", "expected"),
+    (
+        ("test", hash_sha256("dev")),
+        ("--no-environment test", None),
+        ("schedule list", None),
+        ("--environment=dev schedule list", hash_sha256("dev")),
+        ("--environment=prod schedule list", hash_sha256("prod")),
+    ),
+    ids=(
+        "default-dev",
+        "explicit-no-env",
+        "default-no-env",
+        "explicit-dev",
+        "explicit-prod",
+    ),
+)
+def test_environment_name_hash(
+    cmd: str,
+    expected: str,
+    snowplow: SnowplowMicro,
+    cli_runner: MeltanoCliRunner,
+    project: Project,
+):
+    results = cli_runner.invoke(cli, cmd.split())
+    assert_cli_runner(results)
+    for event in snowplow.good():
+        project_context = next(
+            ctx
+            for ctx in event["event"]["contexts"]["data"]
+            if "project_context" in ctx["schema"]
+        )
+        assert project_context["data"]["environment_name_hash"] == expected

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -328,7 +328,7 @@ class TestTracker:
         )
         assert passed
 
-    @pytest.mark.parametrize(  # noqa: WPS317
+    @pytest.mark.parametrize(
         ("sleep_duration", "timeout_should_occur"),
         ((1.0, False), (5.0, True)),
         ids=("no_timeout", "timeout"),


### PR DESCRIPTION
In https://github.com/meltano/meltano/pull/6862 we defered the activate of environments. The `Tracker` was implicitly relying on the environment being activated before it was instantiated, or no environment being activated at all.

Unfortunately fixing that implicit dependency would be more effort than I'm willing to commit to this at this time. Instead, I have made it so that activating an environment will update `environment_name_hash` in the `ProjectContext` in the `Tracker`.

New `ProjectContext` objects created past that point will, as before, get the active environment information from the `Project` object.

I have verified that this works using Snowplow Micro locally. Before this change `environment_name_hash` was always `null`. After this change, `environment_name_hash` is set to the expected hashed string when an environment is active, and `null` when no environment is active. I would encourage at least one reviewer to double check this.

Closes https://github.com/meltano/internal-data/issues/51