### PR TITLE
fix: Misc `meltano.yml` schema fixes

### DIFF
--- a/schema/meltano.schema.json
+++ b/schema/meltano.schema.json
@@ -713,6 +713,7 @@
               "inherit_from": {},
               "pip_url": {},
               "repo": {},
+              "variant": {},
               "namespace": {},
               "label": {},
               "description": {},
@@ -1002,6 +1003,7 @@
                         "properties": {
                           "name": {},
                           "config": {},
+                          "env": {},
                           "select": {},
                           "select_filter": {},
                           "catalog": {},
@@ -1064,8 +1066,7 @@
           }
         },
         "env": {
-          "type": "object",
-          "description": "An object of environment specific variables."
+          "$ref": "#/definitions/env"
         }
       },
       "$defs": {


### PR DESCRIPTION
- Mappers now support the `variant` field.
- Extractors may now have an `env` field within the `environments` field.

Tested with the following JSON at https://jsonschemalint.com/#!/version/draft-07/markup/json:

```json
{
  "plugins": {
    "mappers": [
      {
        "name": "mapper",
        "variant": "mapper-variant"
      }
    ]
  },
  "environments": [
    {
      "name": "dev",
      "config": {
        "plugins": {
          "extractors": [
            {
              "name": "example",
              "env": {}
            }
          ]
        }
      }
    }
  ]
}
```

Before the changes to the schema:
![image](https://user-images.githubusercontent.com/11428666/206739014-22cb366d-75da-4b68-bcac-1ed796dd7cbf.png)

After the changes to the schema (plus removing the ID in the validator to prevent a conflict):
![image](https://user-images.githubusercontent.com/11428666/206739095-bb238600-eb3b-405f-89cf-3a85fc01c1a3.png)

Closes #7037