### PR TITLE
test: Catch all exceptions in `snowplow_session` fixture

### DIFF
--- a/tests/fixtures/docker/snowplow.py
+++ b/tests/fixtures/docker/snowplow.py
@@ -64,17 +64,13 @@ def snowplow_session(request) -> SnowplowMicro | None:
     try:
         # Getting the `docker_services` fixture essentially causes `docker-compose up` to be run
         request.getfixturevalue("docker_services")
-    except Exception:  # pragma: no cover
-        yield None
-    else:
         args = ("docker", "port", f"pytest{os.getpid()}_snowplow_1")
         proc = subprocess.run(args, capture_output=True, text=True)
         address_and_port = proc.stdout.strip().split(" -> ")[1]
         collector_endpoint = f"http://{address_and_port}"
-        try:  # noqa: WPS505
-            yield SnowplowMicro(collector_endpoint)
-        except Exception:  # pragma: no cover
-            yield None
+        yield SnowplowMicro(collector_endpoint)
+    except Exception:  # pragma: no cover
+        yield None
 
 
 @pytest.fixture


### PR DESCRIPTION
Context: https://meltano.slack.com/archives/C013Z450LCD/p1670619321698669

This fixture is meant to return `None` if it cannot be started, since it is optional and requires additional dependencies. Previously we were only returning `None` if an exception was raised while checking for `docker-compose`, or while instantiating `SnowplowMicro` itself. This caused many errors during testing for a user for whom Snowplow Micro couldn't find Java.

I don't see why we shouldn't just catch all normal exceptions, to be on the safe side. There is little risk of this resulting in us unknowingly failing to test something, since if `None` is returned then Pytest will skip the tests, and will report that it skipped them.