### PR TITLE
fix: Display better errors when failing to connect with the Hub API

### DIFF
--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import Any
 
 import requests
+from requests.adapters import HTTPAdapter
 from structlog.stdlib import get_logger
+from urllib3 import Retry
 
 import meltano
 from meltano.core.plugin import (
@@ -45,8 +48,21 @@ class HubPluginTypeNotFoundError(Exception):
         """
         return "{type} is not supported in Meltano Hub. Available plugin types: {types}".format(
             type=self.plugin_type.descriptor.capitalize(),
-            types=list(PluginType),
+            types=PluginType.plurals(),
         )
+
+
+class HubConnectionError(Exception):
+    """Raised when a Hub connection error occurs."""
+
+    def __init__(self, reason: str):
+        """Create a new HubConnectionError.
+
+        Args:
+            reason: The reason for the error.
+        """
+        message = f"Could not connect to Meltano Hub: {reason}"
+        super().__init__(message)
 
 
 class HubPluginVariantNotFoundError(Exception):
@@ -83,7 +99,7 @@ class HubPluginVariantNotFoundError(Exception):
         )
 
 
-class MeltanoHubService(PluginRepository):
+class MeltanoHubService(PluginRepository):  # noqa: WPS214
     """PluginRepository implementation for the Meltano Hub."""
 
     def __init__(self, project: Project) -> None:
@@ -110,6 +126,23 @@ class MeltanoHubService(PluginRepository):
 
         if self.hub_url_auth:
             self.session.headers.update({"Authorization": self.hub_url_auth})
+
+        adapter = HTTPAdapter(
+            max_retries=Retry(
+                total=3,
+                backoff_factor=0,
+                status_forcelist=[
+                    HTTPStatus.TOO_MANY_REQUESTS,
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    HTTPStatus.BAD_GATEWAY,
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    HTTPStatus.GATEWAY_TIMEOUT,
+                ],
+                raise_on_status=False,
+            ),
+        )
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
 
     @property
     def hub_api_url(self):
@@ -184,6 +217,7 @@ class MeltanoHubService(PluginRepository):
         Raises:
             PluginNotFoundError: If the plugin definition could not be found.
             HubPluginVariantNotFoundError: If the plugin variant could not be found.
+            HubConnectionError: If the Hub API could not be reached.
         """
         plugins = self.get_plugins_of_type(plugin_type)
 
@@ -217,7 +251,7 @@ class MeltanoHubService(PluginRepository):
                 status_code=http_err.response.status_code,
                 error=http_err,
             )
-            raise PluginNotFoundError(PluginRef(plugin_type, plugin_name)) from http_err
+            raise HubConnectionError(str(http_err)) from http_err
 
         return PluginDefinition(**response.json(), plugin_type=plugin_type)
 
@@ -245,7 +279,10 @@ class MeltanoHubService(PluginRepository):
 
         return base_plugin_factory(plugin, plugin.variants[0])
 
-    def get_plugins_of_type(self, plugin_type: PluginType) -> dict[str, IndexedPlugin]:
+    def get_plugins_of_type(  # noqa: WPS210
+        self,
+        plugin_type: PluginType,
+    ) -> dict[str, IndexedPlugin]:
         """Get all plugins of a given type.
 
         Args:
@@ -256,6 +293,7 @@ class MeltanoHubService(PluginRepository):
 
         Raises:
             HubPluginTypeNotFoundError: If the plugin type is not supported.
+            HubConnectionError: If the Hub API could not be reached.
         """
         if not plugin_type.discoverable:
             return {}
@@ -271,7 +309,9 @@ class MeltanoHubService(PluginRepository):
                 status_code=err.response.status_code,
                 error=err,
             )
-            raise HubPluginTypeNotFoundError(plugin_type) from err
+            if err.response.status_code < HTTPStatus.TOO_MANY_REQUESTS:
+                raise HubPluginTypeNotFoundError(plugin_type) from err
+            raise HubConnectionError(err.response.reason) from err
 
         plugins: dict[str, dict[str, Any]] = response.json()
         return {

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -61,7 +61,7 @@ class HubConnectionError(Exception):
         Args:
             reason: The reason for the error.
         """
-        message = f"Could not connect to Meltano Hub: {reason}"
+        message = f"Could not connect to Meltano Hub. {reason}"
         super().__init__(message)
 
 
@@ -145,7 +145,7 @@ class MeltanoHubService(PluginRepository):  # noqa: WPS214
         self.session.mount("https://", adapter)
 
     @property
-    def hub_api_url(self):
+    def hub_api_url(self) -> str:
         """Return the URL of the Hub API.
 
         Returns:

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -178,6 +178,15 @@ class PluginType(YAMLEnum):  # noqa: WPS214
 
         raise ValueError(f"{value} is not a valid {cls.__name__}")
 
+    @classmethod
+    def plurals(cls) -> list[str]:
+        """Return the list of plugin plural names.
+
+        Returns:
+            The list of plugin plurals.
+        """
+        return [plugin_type.value for plugin_type in cls]
+
 
 class PluginRef(Canonical):
     """A reference to a plugin."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,10 @@ def concurrency():
 
 
 class MockAdapter(BaseAdapter):
+    RETURN_500 = {
+        "/extractors/this-returns-500--original": {"error": "Server error"},
+    }
+
     def _process_discovery(self, api_url: str, discovery: dict) -> dict:
         hub = {}
         for plugin_type in PluginType:
@@ -137,6 +141,17 @@ class MockAdapter(BaseAdapter):
         self.count = Counter()
         self._mapping = self._process_discovery(api_url, deepcopy(discovery))
 
+        # Special cases
+        self._mapping["/extractors/index"]["this-returns-500"] = {
+            "default_variant": "original",
+            "logo_url": "https://mock.meltano.com/this-returns-500.png",
+            "variants": {
+                "original": {
+                    "ref": f"{api_url}/plugins/extractors/this-returns-500--original"
+                }
+            },
+        }
+
     def send(
         self,
         request: requests.PreparedRequest,
@@ -147,8 +162,17 @@ class MockAdapter(BaseAdapter):
         proxies: Mapping[str, str] | None = None,
     ):
         _, endpoint = request.path_url.split("/meltano/api/v1/plugins")
+
         response = requests.Response()
         response.request = request
+        response.url = request.url
+
+        response_500 = self.RETURN_500.get(endpoint)
+        if response_500:
+            response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+            response.reason = "Internal Server Error"
+            response._content = json.dumps(response_500).encode()
+            return response
 
         try:
             data = self._mapping[endpoint]

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from collections import Counter
 
 import pytest
+from requests import HTTPError, Response
 
 from meltano.core.hub import MeltanoHubService
-from meltano.core.hub.client import HubPluginVariantNotFoundError
+from meltano.core.hub.client import HubConnectionError, HubPluginVariantNotFoundError
 from meltano.core.plugin.base import PluginType, Variant
 from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.project_settings_service import ProjectSettingsService
@@ -88,7 +89,7 @@ class TestMeltanoHubService:
         hub_request_counter: Counter,
     ):
         extractors = subject.get_plugins_of_type(PluginType.EXTRACTORS)
-        assert len(extractors) == 34  # noqa: WPS432
+        assert len(extractors) == 35  # noqa: WPS432
         assert len(extractors["tap-mock"].variants) == 2
         assert extractors["tap-mock"].variant_labels == [
             "meltano (default)",
@@ -100,3 +101,19 @@ class TestMeltanoHubService:
         ProjectSettingsService(project).set("hub_url_auth", "Bearer s3cr3t")
         hub = MeltanoHubService(project)
         assert hub.session.headers["Authorization"] == "Bearer s3cr3t"
+
+    def test_server_error(self, subject: MeltanoHubService):
+        with pytest.raises(
+            HubConnectionError,
+            match="Could not connect to Meltano Hub. 500 Server Error",
+        ) as exc_info:
+            subject.find_definition(PluginType.EXTRACTORS, "this-returns-500")
+
+        assert isinstance(exc_info.value.__cause__, HTTPError)
+        assert isinstance(exc_info.value.__cause__.response, Response)
+        assert exc_info.value.__cause__.response.status_code == 500
+        assert exc_info.value.__cause__.response.json() == {"error": "Server error"}
+        assert exc_info.value.__cause__.response.url == (
+            "https://hub.meltano.com/meltano/api/v1/plugins/extractors"
+            "/this-returns-500--original"
+        )


### PR DESCRIPTION
- Avoids new dependencies by using [`urllib3.Retry`](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry) to handle retries

Closes https://github.com/meltano/meltano/issues/7079
