### PR TITLE
docs: fix config name for poetry

### DIFF
--- a/docs/src/_contribute/merge.md
+++ b/docs/src/_contribute/merge.md
@@ -27,7 +27,7 @@ The `meltano` repo uses the [semantic-prs](https://github.com/Ezard/semantic-prs
 
 Pull requests should be named according to the conventional commit syntax to streamline changelog and release notes management. We encourage (but do not require) the use of conventional commits in commit messages as well.
 
-In general, PR titles should follow the format "<type>: <desc>", where type is any one of these:
+In general, PR titles should follow the format `<type>: <desc>`, where type is any one of these:
 
 - `ci`
 - `chore`

--- a/docs/src/_tutorials/custom-extractor.md
+++ b/docs/src/_tutorials/custom-extractor.md
@@ -131,7 +131,7 @@ Change directory into the json-placeholder tap directory, and install the python
 cd tap-jsonplaceholder
 
 # [Optional] but useful if you need to debug your custom extractor
-poetry config virtualenv.in-project true
+poetry config virtualenvs.in-project true
 
 poetry install
 ```


### PR DESCRIPTION
Running the command as specified yields
```text
Setting virtualenv.in-project does not exist
```

Also, some text that looks like tags were being swallowed on the PR doc page
![image](https://user-images.githubusercontent.com/2873968/207691414-90e0b9c4-ecb9-4b88-9e71-20c884c62374.png)
