### PR TITLE
fix: Add missing description to environment context schema

### DIFF
--- a/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-1-0
+++ b/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-1-0
@@ -131,7 +131,7 @@
             "description": "An array of objects detailing each process in the hierarchy from the current one to the init process",
             "type": "array",
             "items": {
-                "description": "",
+                "description": "Details about a process within the process hierarchy",
                 "type": "object",
                 "properties": {
                     "process_name_hash": {


### PR DESCRIPTION
SnowcatCloud has a bug where empty descriptions are replaced by `null` when the schema is saved, which makes it invalid. To work around that, I've added a description.