### PR TITLE
feat(core): Optionally ignore missing env vars during expansion

### DIFF
--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -7,11 +7,10 @@ import functools
 import click
 from click.globals import get_current_context as get_current_click_context
 
+from meltano.cli.utils import CliError
 from meltano.core.db import project_engine
 from meltano.core.migration_service import MigrationError
 from meltano.core.project_settings_service import ProjectSettingsService
-
-from .utils import CliError
 
 
 def database_uri_option(func):

--- a/src/meltano/core/environment_service.py
+++ b/src/meltano/core/environment_service.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from meltano.core.environment import Environment
 from meltano.core.project import Project
-
-from .utils import find_named
+from meltano.core.utils import find_named
 
 
 class EnvironmentAlreadyExistsError(Exception):

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -10,7 +10,7 @@ from meltano.core.project_plugins_service import ProjectPluginsService
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.setting_definition import SettingDefinition
 from meltano.core.settings_service import FeatureFlags, SettingsService
-from meltano.core.utils import expand_env_vars
+from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars
 
 
 class PluginSettingsService(SettingsService):  # noqa: WPS214
@@ -67,7 +67,7 @@ class PluginSettingsService(SettingsService):  # noqa: WPS214
                     var: expand_env_vars(
                         value,
                         self.env_override,
-                        raise_if_missing=strict_env_var_mode,
+                        if_missing=EnvVarMissingBehavior(strict_env_var_mode),
                     )
                     for var, value in self.project.active_environment.env.items()
                 }
@@ -78,7 +78,7 @@ class PluginSettingsService(SettingsService):  # noqa: WPS214
                         **self.project.dotenv_env,
                         **self.env_override,
                     },
-                    raise_if_missing=strict_env_var_mode,
+                    if_missing=EnvVarMissingBehavior(strict_env_var_mode),
                 )
 
             self.env_override.update(

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -25,7 +25,7 @@ from meltano.core.project_plugins_service import ProjectPluginsService
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.settings_service import FeatureFlags
 from meltano.core.tracking import Tracker
-from meltano.core.utils import expand_env_vars
+from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars
 from meltano.core.venv_service import VenvService, VirtualEnv
 
 logger = get_logger(__name__)
@@ -335,12 +335,14 @@ class PluginInvoker:  # noqa: WPS214, WPS230
                 **expand_env_vars(
                     project_settings_service.env,
                     os.environ,
-                    raise_if_missing=strict_env_var_mode,
+                    if_missing=EnvVarMissingBehavior(  # noqa: WPS204
+                        strict_env_var_mode
+                    ),
                 ),
                 **expand_env_vars(
                     self.settings_service.project.dotenv_env,
                     os.environ,
-                    raise_if_missing=strict_env_var_mode,
+                    if_missing=EnvVarMissingBehavior(strict_env_var_mode),
                 ),
             }
             # Expand active env w/ expanded root env
@@ -348,7 +350,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
                 expand_env_vars(
                     self.settings_service.project.active_environment.env,
                     expanded_project_env,
-                    raise_if_missing=strict_env_var_mode,
+                    if_missing=EnvVarMissingBehavior(strict_env_var_mode),
                 )
                 if self.settings_service.project.active_environment
                 else {}
@@ -358,7 +360,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
             expanded_root_plugin_env = expand_env_vars(
                 self.settings_service.plugin.env,
                 expanded_active_env,
-                raise_if_missing=strict_env_var_mode,
+                if_missing=EnvVarMissingBehavior(strict_env_var_mode),
             )
 
             # Expand active env plugin env w/ expanded root plugin env
@@ -366,7 +368,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
                 expand_env_vars(
                     self.settings_service.environment_plugin_config.env,
                     expanded_root_plugin_env,
-                    raise_if_missing=strict_env_var_mode,
+                    if_missing=EnvVarMissingBehavior(strict_env_var_mode),
                 )
                 if self.settings_service.environment_plugin_config
                 else {}

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -10,6 +10,7 @@ from enum import Enum
 from typing import Generator, Iterable
 
 from meltano.core.project import Project
+from meltano.core.utils import EnvVarMissingBehavior
 from meltano.core.utils import expand_env_vars as do_expand_env_vars
 from meltano.core.utils import flatten
 
@@ -349,13 +350,15 @@ class SettingsService(ABC):  # noqa: WPS214
 
         # Can't do conventional SettingsService.feature_flag call to check;
         # it would result in circular dependency
-        env_var_strict_mode, _ = source.manager(self.project_settings_service).get(
+        strict_env_var_mode, _ = source.manager(self.project_settings_service).get(
             f"{FEATURE_FLAG_PREFIX}.{FeatureFlags.STRICT_ENV_VAR_MODE}"
         )
         if expand_env_vars and metadata.get("expandable", False):
             metadata["expandable"] = False
             expanded_value = do_expand_env_vars(
-                value, env=expandable_env, raise_if_missing=env_var_strict_mode
+                value,
+                env=expandable_env,
+                if_missing=EnvVarMissingBehavior(strict_env_var_mode),
             )
 
             if expanded_value != value:

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -14,6 +14,7 @@ import traceback
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import date, datetime, time
+from enum import IntEnum
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence, TypeVar, overload
 
@@ -480,12 +481,19 @@ ENV_VAR_PATTERN = re.compile(
 Expandable = TypeVar("Expandable", str, Mapping[str, "Expandable"])
 
 
+class EnvVarMissingBehavior(IntEnum):
+    """The behavior that should be employed when expanding a missing env var."""
+
+    use_empty_str = 0
+    raise_exception = 1
+    ignore = 2
+
+
 def expand_env_vars(
     raw_value: Expandable,
     env: Mapping[str, str],
     *,
-    raise_if_missing: bool = False,
-    ignore_if_missing: bool = False,
+    if_missing: EnvVarMissingBehavior = EnvVarMissingBehavior.use_empty_str,
     flat: bool = False,
 ) -> Expandable:
     """Expand/interpolate provided env vars into a string or env mapping.
@@ -496,14 +504,8 @@ def expand_env_vars(
     Args:
         raw_value: A string or env mapping in which env vars will be expanded.
         env: The env vars to use for the expansion of `raw_value`.
-        raise_if_missing: Raise `EnvironmentVariableNotSetError` if an env var
-            in `raw_value` is not found in the provided env dict. The
-            `raise_if_missing` and `ignore_if_missing` parameters cannot both
-            be `True`.
-        ignore_if_missing: Leave an env var unexpanded if an env var in
-            `raw_value` is not found in the provided env dict. The
-            `raise_if_missing` and `ignore_if_missing` parameters cannot both
-            be `True`.
+        if_missing: The behavior to employ if an env var in `raw_value` is not
+            set in `env`.
         flat: Whether the `raw_value` has a flat structure. Ignored if
             `raw_value` is not a mapping. Otherwise it controls whether this
             function will process nested levels within `raw_value`. Defaults to
@@ -511,20 +513,16 @@ def expand_env_vars(
             for performance, safety, and cleanliness reasons.
 
     Raises:
-        ValueError: Both `raise_if_missing` and `ignore_if_missing` are `True`.
         EnvironmentVariableNotSetError: Attempted to expand an env var that was not
-            defined in the provided env dict, and `raise_if_missing` was `True`.
+            defined in the provided env dict, and `if_missing` was
+            `EnvVarMissingBehavior.raise_exception`.
 
     Returns:
         The string or env dict with env vars expanded. For backwards
         compatibility, if anything other than an `str` or mapping is provided
         as the `raw_value`, it is returned unchanged.
     """  # noqa: DAR402
-    if raise_if_missing and ignore_if_missing:
-        raise ValueError(
-            "The `raise_if_missing` and `ignore_if_missing` parameters cannot "
-            "both be `True`"
-        )
+    if_missing = EnvVarMissingBehavior(if_missing)
 
     if not isinstance(raw_value, (str, Mapping)):
         return raw_value
@@ -538,9 +536,9 @@ def expand_env_vars(
             logger.debug(
                 f"Variable '${var}' is not set in the provided env dictionary."
             )
-            if raise_if_missing:
+            if if_missing == EnvVarMissingBehavior.raise_exception:
                 raise EnvironmentVariableNotSetError(var) from ex
-            elif ignore_if_missing:
+            elif if_missing == EnvVarMissingBehavior.ignore:
                 return f"${{{var}}}"
             return ""
         if not val:

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -538,7 +538,7 @@ class TestPluginSettingsService:
 
         assert config["var"] == "hello world!"
         assert config["foo"] == "42"
-        assert config["missing"] is None
+        assert config["missing"] == ""
         assert config["multiple"] == "rock paper scissors"
         assert config["info"] == "tap-mock"
 
@@ -939,4 +939,4 @@ class TestPluginSettingsService:
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], False
         )
         subject.set("stacked_env_var", "${NONEXISTENT_ENV_VAR}")
-        assert subject.get("stacked_env_var") is None
+        assert subject.get("stacked_env_var") == ""

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -91,6 +91,17 @@ def test_expand_env_vars():
     assert expand_env_vars("${ENV_VAR}", env) == "substituted"
     assert expand_env_vars("$ENV_VAR", env) == "substituted"
 
+    with pytest.raises(ValueError):
+        expand_env_vars("", {}, raise_if_missing=True, ignore_if_missing=True)
+
+    assert expand_env_vars("$ENV_VAR", {}) == ""
+    assert expand_env_vars("$ENV_VAR", {}, ignore_if_missing=True) == "${ENV_VAR}"
+    assert expand_env_vars("${ENV_VAR}", {}, ignore_if_missing=True) == "${ENV_VAR}"
+    assert (
+        expand_env_vars("prefix-${ENV_VAR}-suffix", {}, ignore_if_missing=True)
+        == "prefix-${ENV_VAR}-suffix"
+    )
+
 
 def test_expand_env_vars_nested():
     input_dict = {

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import pytest  # noqa: F401
 
-from meltano.core.utils import expand_env_vars, flatten, nest, pop_at_path, set_at_path
+from meltano.core.utils import (
+    EnvVarMissingBehavior,
+    expand_env_vars,
+    flatten,
+    nest,
+    pop_at_path,
+    set_at_path,
+)
 
 
 def test_nest():
@@ -91,14 +98,19 @@ def test_expand_env_vars():
     assert expand_env_vars("${ENV_VAR}", env) == "substituted"
     assert expand_env_vars("$ENV_VAR", env) == "substituted"
 
-    with pytest.raises(ValueError):
-        expand_env_vars("", {}, raise_if_missing=True, ignore_if_missing=True)
-
     assert expand_env_vars("$ENV_VAR", {}) == ""
-    assert expand_env_vars("$ENV_VAR", {}, ignore_if_missing=True) == "${ENV_VAR}"
-    assert expand_env_vars("${ENV_VAR}", {}, ignore_if_missing=True) == "${ENV_VAR}"
     assert (
-        expand_env_vars("prefix-${ENV_VAR}-suffix", {}, ignore_if_missing=True)
+        expand_env_vars("$ENV_VAR", {}, if_missing=EnvVarMissingBehavior.ignore)
+        == "${ENV_VAR}"
+    )
+    assert (
+        expand_env_vars("${ENV_VAR}", {}, if_missing=EnvVarMissingBehavior.ignore)
+        == "${ENV_VAR}"
+    )
+    assert (
+        expand_env_vars(
+            "prefix-${ENV_VAR}-suffix", {}, if_missing=EnvVarMissingBehavior.ignore
+        )
         == "prefix-${ENV_VAR}-suffix"
     )
 

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -82,10 +82,14 @@ def test_flatten():
 
 
 def test_expand_env_vars():
+    env = {"ENV_VAR": "substituted"}
+    assert expand_env_vars("${ENV_VAR}_suffix", env) == "substituted_suffix"
+    assert expand_env_vars("prefix_${ENV_VAR}", env) == "prefix_substituted"
     assert (
-        expand_env_vars("${ENV_VAR}_suffix", {"ENV_VAR": "substituted"})
-        == "substituted_suffix"
+        expand_env_vars("prefix_${ENV_VAR}_suffix", env) == "prefix_substituted_suffix"
     )
+    assert expand_env_vars("${ENV_VAR}", env) == "substituted"
+    assert expand_env_vars("$ENV_VAR", env) == "substituted"
 
 
 def test_expand_env_vars_nested():


### PR DESCRIPTION
In addition to addressing #7122, this also includes some performance improvements that have a significant effect when using `expand_env_vars` on many large env dictionaries, as will be done by the implementation for [Meltano manifest](https://github.com/meltano/meltano/issues/6876).

Some work to wrangle the complexity of `expand_env_vars` was made, but it's widely used by legacy code, which makes it difficult to improve significantly.

For instance, `expand_env_var` could previous be called on any type, and it would return it. This is now disallowed by the type hint, but still supported in the code itself. Hopefully this will discourage these bad practices.

Another questionable aspect of `expand_env_vars` that had to be preserved is that it will perform a recursive tree-traversal on any mapping structure it is provided as `raw_value`. This dangerous/slow/complex behaviour can now be opted out of by setting the `flat` paramter to `True`, which asserts that the `raw_value` being provided has a flat structure (i.e. no nested dicts).

Closes #7122