### PR TITLE
docs: fix another few typos

### DIFF
--- a/docs/src/_getting-started/part2.md
+++ b/docs/src/_getting-started/part2.md
@@ -43,22 +43,23 @@ The container will need a few seconds to initialize. You can test the connection
 - password: password
 
 ## Add the postgres loader
-Add the postgres loader using the `meltano add loader target-postgres` command.
+Add the postgres loader using the `meltano add loader target-postgres --variant=meltanolabs` command.
 
 <div class="termy">
 
 ```console
 $ meltano add loader target-postgres --variant=meltanolabs
 Added loader 'target-postgres' to your Meltano project
-Variant:        transferwise (default)
-Repository:     https://github.com/transferwise/pipelinewise-target-postgres
-Documentation:  https://hub.meltano.com/loaders/target-postgres
+Variant:        meltanolabs (default)
+Repository:     https://github.com/MeltanoLabs/target-postgres
+Documentation:  https://hub.meltano.com/loaders/target-postgres--meltanolabs
 
 Installing loader 'target-postgres'...
 ---> 100%
+
 Installed loader 'target-postgres'
 
-To learn more about loader 'target-postgres', visit https://hub.meltano.com/loaders/target-postgres
+To learn more about loader 'target-postgres', visit https://hub.meltano.com/loaders/target-postgres--meltanolabs
 ```
 </div>
 <br />

--- a/docs/src/_getting-started/part3.md
+++ b/docs/src/_getting-started/part3.md
@@ -32,6 +32,7 @@ This will add the following line to your project file:
         select:
         - commits.url # <== technically not necessary anymore, but no need to delete
         - commits.sha # <== technically not necessary anymore, but no need to delete
+        - commits.commit_timestamp # <== technically not necessary anymore, but no need to delete
         - commits.* # <== new data.
 ```
 


### PR DESCRIPTION
Found three more typos related to the exchange of the variants to the meltanolabs variants.