### PR TITLE
docs: Remove references to deprecated `MELTANO_CLI_*` aliases

### DIFF
--- a/docs/src/_guide/v2-migration.md
+++ b/docs/src/_guide/v2-migration.md
@@ -133,10 +133,21 @@ If for any reason you wish to keep sourcing or writing setting values to depreca
    </td>
   </tr>
   <tr>
-   <td rowspan="16" >meltano
+   <td rowspan="18" >meltano
    </td>
-   <td rowspan="16" >
+   <td rowspan="18" >
    </td>
+   <td>MELTANO_LOG_LEVEL
+   </td>
+   <td>MELTANO_CLI_LOG_LEVEL
+   </td>
+  </tr>
+   <td>MELTANO_LOG_CONFIG
+   </td>
+   <td>MELTANO_CLI_LOG_CONFIG
+   </td>
+  </tr>
+  <tr>
    <td>MELTANO_API_HOSTNAME
    </td>
    <td>MELTANO_UI_BIND_HOST

--- a/docs/src/_reference/settings.md
+++ b/docs/src/_reference/settings.md
@@ -336,7 +336,7 @@ These settings can be used to modify the behavior of the [`meltano` CLI](/refere
 
 ### <a name="cli-log-level"></a>`cli.log_level`
 
-- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_CLI_LOG_LEVEL`, alias: `MELTANO_LOG_LEVEL`
+- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_CLI_LOG_LEVEL`.
 - `meltano` CLI option: `--log-level`
 - Options: `debug`, `info`, `warning`, `error`, `critical`
 - Default: `info`
@@ -349,14 +349,13 @@ The granularity of CLI logging. Ignored if a local logging config is found.
 meltano config meltano set cli log_level debug
 
 export MELTANO_CLI_LOG_LEVEL=debug
-export MELTANO_LOG_LEVEL=debug
 
 meltano --log-level=debug ...
 ```
 
 ### `cli.log_config`
 
-- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_CLI_LOG_CONFIG`, alias: `MELTANO_LOG_CONFIG`
+- [Environment variable](/guide/configuration#configuring-settings): `MELTANO_CLI_LOG_CONFIG`.
 - `meltano` CLI option: `--log-config`
 - Default: `logging.yaml`
 
@@ -368,7 +367,6 @@ The path of a valid yaml formatted [python logging dict config file](https://doc
 meltano config meltano set cli log_config /path/to/logging.yaml
 
 export MELTANO_CLI_LOG_CONFIG=/path/to/logging.yaml
-export MELTANO_LOG_CONFIG=/path/to/logging.yaml
 
 meltano --log-config=/path/to/logging.yaml ...
 ```


### PR DESCRIPTION
Closes #3085 