### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/_getting-started/part1.md
+++ b/docs/src/_getting-started/part1.md
@@ -209,7 +209,8 @@ This will add the configuration to your [`meltano.yml` project file](/concepts/p
         - name: tap-github
           config:
             start_date: 2022-01-01
-            repository: sbalnojan/meltano-lightdash
+            repositories:
+              - sbalnojan/meltano-lightdash
   ```
 
 It will also add your secret auth token to the file `.env`:


### PR DESCRIPTION
Change from tap-github singer io to meltanolabs variant didn*t propagate in all examples. This one fixes hopefully the last.