### PR TITLE
chore: Check JSONschema using pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,17 @@ repos:
       - id: check-toml
       - id: debug-statements
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.20.0
+    hooks:
+      - id: check-metaschema
+        files: ^schemas?/.*\.json$
+      - id: check-jsonschema
+        files: .*/meltano.yml$
+        args:
+          - "--schemafile"
+          - "schema/meltano.schema.json"
+
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.31.0 # Keep this in sync with the eslint "additional_dependency" below!
     hooks:


### PR DESCRIPTION
This checks that each of the schemas in the `schema/` directory are valid against their declared metaschema, and that each `meltano.yml` file within the repository is valid against `schema/meltano.schema.json`.

Relates to #7168 