### PR TITLE
fix: Make fully missing env var settings `None`

### DIFF
--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -360,6 +360,9 @@ class SettingsService(ABC):  # noqa: WPS214
                 env=expandable_env,
                 if_missing=EnvVarMissingBehavior(strict_env_var_mode),
             )
+            # https://github.com/meltano/meltano/issues/7189#issuecomment-1396112167
+            if value and not expanded_value:  # The whole string was missing env vars
+                expanded_value = None
 
             if expanded_value != value:
                 metadata["expanded"] = True

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -538,7 +538,7 @@ class TestPluginSettingsService:
 
         assert config["var"] == "hello world!"
         assert config["foo"] == "42"
-        assert config["missing"] == ""
+        assert config["missing"] is None
         assert config["multiple"] == "rock paper scissors"
         assert config["info"] == "tap-mock"
 
@@ -939,4 +939,4 @@ class TestPluginSettingsService:
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], False
         )
         subject.set("stacked_env_var", "${NONEXISTENT_ENV_VAR}")
-        assert subject.get("stacked_env_var") == ""
+        assert subject.get("stacked_env_var") is None

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -188,3 +188,11 @@ class TestProjectSettingsService:
         value, source = subject.get_with_source("database_max_retries")
         assert source == SettingValueStore.MELTANO_YML
         assert value == 10000
+
+    def test_fully_missing_env_var_setting_is_none(
+        self, subject: ProjectSettingsService
+    ):
+        # https://github.com/meltano/meltano/issues/7189#issuecomment-1396112167
+        with pytest.warns(RuntimeWarning, match="Unknown setting 'port'"):
+            subject.set("port", "${UNSET_PORT_ENV_VAR}")
+        assert subject.get("port") is None

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -192,6 +192,7 @@ class TestProjectSettingsService:
     def test_fully_missing_env_var_setting_is_none(
         self, subject: ProjectSettingsService
     ):
+        subject.set([FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], False)
         # https://github.com/meltano/meltano/issues/7189#issuecomment-1396112167
         with pytest.warns(RuntimeWarning, match="Unknown setting 'port'"):
             subject.set("port", "${UNSET_PORT_ENV_VAR}")


### PR DESCRIPTION
Previously string settings which were env vars (e.g. `"${DB_PORT}"`) would be replaced by `None` if the env var was missing during expansion. This was unintentionally changed in #7123 when the function which expanded env vars was changed.

This PR restores the old behaviour in `src/meltano/core/settings_service.py::SettingsService.get_with_metadata` where it was being relied on.

This PR does not re-implement the old behaviour in the function which expands env vars, since the old behaviour there seems incorrect/surprising.

Closes #7189