### PR TITLE
style: Fix markdown syntax in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,7 +379,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 
-- [#6216](https://github.com/meltano/meltano/pull/6216) - Replace all <jobId> with <stateId> to fix pipeline running bug.
+- [#6216](https://github.com/meltano/meltano/pull/6216) - Replace all `jobId` with `stateId` to fix pipeline running bug.
 
 ## 2.0.3 - (2022-06-15)
 


### PR DESCRIPTION
I'm trying to import this into the new docs site and it keeps breaking on these tags. Switched to backticks so it renders appropriately. If editing this directly isn't the right way to go please let me know, thanks!