### PR TITLE
fix: Do not log env vars passed to subprocesses

### DIFF
--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -426,7 +426,6 @@ class PluginInvoker:  # noqa: WPS214, WPS230
             popen_env = {**self.env(), **env}
             popen_args = self.exec_args(*args, command=command, env=popen_env)
             logging.debug(f"Invoking: {popen_args}")
-            logging.debug(f"Env: {popen_env}")
 
             try:
                 yield (popen_args, popen_options, popen_env)


### PR DESCRIPTION
It was originally added in https://github.com/meltano/meltano/commit/3603cd558613c5ae2a511f9860e0b599d12faf63