### PR TITLE
fix: Avoid adding `LICENSE` file directly in `site-packages`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ packages = [
 ]
 # Explicitly include non-Python files and gitignored files:
 include = [
-  "LICENSE",
   "src/meltano/api/static/css/*",
   "src/meltano/api/static/js/*",
   "src/meltano/api/templates/embed.html",


### PR DESCRIPTION
You can verify that the wheel file still contains our license by running `pip wheel --no-deps .`, then opening the wheel file as if it were a zip file. Likewise, the sdist can be verified by running `poetry build -f sdist`, and opening the gzipped tar file.

Closes #7234