### PR TITLE
chore: Remove unncessary `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-CHANGELOG.md merge=union


### PR DESCRIPTION
The file `CHANGELOG.md` is updated almost exclusively by Commitizen, so this `.gitattributes` file really isn't necessary.