### PR TITLE
chore: Update `environment_context` 1-2-0 to work with SnowcatCloud

### DIFF
--- a/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-2-0
+++ b/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-2-0
@@ -42,9 +42,6 @@
         "notable_flag_env_vars": {
             "description": "Select environment variable flags",
             "type": "object",
-            "propertyNames": {
-                "type": "string"
-            },
             "additionalProperties": {
                 "description": "Boolean values of select env vars, or null if the truth value of the env var could not be determined",
                 "type": [


### PR DESCRIPTION
SnowcatCloud uses an older version of jsonschema that doesn't allow the `propertyNames` field.