### PR TITLE
chore: Fix banner image link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ---
 
-![Meltano Logo](https://lh4.googleusercontent.com/WHoN-WpacMaVicq-jRuIvCQjCIdPZwYOwBgd38k9JjMpX1Z7THUqowY-oRsTzGUbAvb8F4tcb9BJYyfX9MeA2ECirsWZ7XBHteDZ_y59REMwHjq1AX05U2k8H6mdI4G_olF27gadCfp1Wx7cVQ)
+![Meltano Logo](https://user-images.githubusercontent.com/11428666/215905636-073eee14-b368-4e62-89c9-9d3d41bda7fd.png)
 
 <div align="center">
 <a href="https://docs.meltano.com/">


### PR DESCRIPTION
I found what I thought would be the original image in a Meltano shared Google Drive, but it was smaller than the one from The Internet Archive. I could've just re-exported from the SVG, but I see no harm in using the archived copy. The link now points to GitHub's servers, which stored it when I pasted it into their editor.

Closes #7259