### PR TITLE
docs: change ref

### DIFF
--- a/docs/src/_reference/glossary.md
+++ b/docs/src/_reference/glossary.md
@@ -7,7 +7,7 @@ weight: 5
 
 {% for item in site.data.glossary %}
 
-<h2 id="#{{ item.shorthand }}">{{ item.term }}</h2>
+<h2 id="{{ item.shorthand }}">{{ item.term }}</h2>
 
 <p>{{ item.definition }}
 {% if item.link %}

--- a/docs/src/_reference/glossary.md
+++ b/docs/src/_reference/glossary.md
@@ -7,7 +7,7 @@ weight: 5
 
 {% for item in site.data.glossary %}
 
-<h2 id=#{{ item.shorthand }}>{{ item.term }}</h2>
+<h2 id="#{{ item.shorthand }}">{{ item.term }}</h2>
 
 <p>{{ item.definition }}
 {% if item.link %}

--- a/docs/src/_reference/glossary.md
+++ b/docs/src/_reference/glossary.md
@@ -7,7 +7,7 @@ weight: 5
 
 {% for item in site.data.glossary %}
 
-<h2>{{ item.term }} <a href="https://docs.meltano.com/reference/glossary#{{ item.shorthand }}">#</a></h2>
+<h2 id=#{{ item.shorthand }}>{{ item.term }}</h2>
 
 <p>{{ item.definition }}
 {% if item.link %}


### PR DESCRIPTION
I messed up parts of the links in  #7274, this fixes it, now completely IMHO.

(The ToC on the RHS displays weird links in the current docs thanks to  #7274).