### PR TITLE
feat: Lazy install plugins on invocation

### DIFF
--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -173,29 +173,9 @@ async def _invoke(
                     *plugin_args,
                 )
             else:
-                try:
-                    handle = await invoker.invoke_async(*plugin_args, command=command_name)
-                    with propagate_stop_signals(handle):
-                        exit_code = await handle.wait()
-                except ExecutableNotFoundError:
-                    # If the plugin is not installed, try to install it
-                    logging.info(f"Installing plugin '{invoker.plugin.name}'...")
-
-                    # Try to install the plugin
-                    install_service = PluginInstallService(
-                        project=project,
-                        plugins_service=invoker.plugins_service,
-                        clean=True
-                    )
-                    await install_service.install_plugin_async(invoker.plugin)
-
-                    # Log that the plugin is installed
-                    logging.info(f"Plugin '{invoker.plugin.name}' installed. Retrying invocation...")
-
-                    # Try to invoke the plugin again
-                    handle = await invoker.invoke_async(*plugin_args, command=command_name)
-                    with propagate_stop_signals(handle):
-                        exit_code = await handle.wait()
+                handle = await invoker.invoke_async(*plugin_args, command=command_name)
+                with propagate_stop_signals(handle):
+                    exit_code = await handle.wait()
 
     except UnknownCommandError as err:
         raise click.BadArgumentUsage(err) from err

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -21,7 +21,9 @@ from meltano.core.db import project_engine
 from meltano.core.error import AsyncSubprocessError
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.error import PluginNotFoundError
+from meltano.core.plugin_install_service import PluginInstallService
 from meltano.core.plugin_invoker import (
+    ExecutableNotFoundError,
     PluginInvoker,
     UnknownCommandError,
     invoker_factory,
@@ -171,9 +173,29 @@ async def _invoke(
                     *plugin_args,
                 )
             else:
-                handle = await invoker.invoke_async(*plugin_args, command=command_name)
-                with propagate_stop_signals(handle):
-                    exit_code = await handle.wait()
+                try:
+                    handle = await invoker.invoke_async(*plugin_args, command=command_name)
+                    with propagate_stop_signals(handle):
+                        exit_code = await handle.wait()
+                except ExecutableNotFoundError:
+                    # If the plugin is not installed, try to install it
+                    logging.info(f"Installing plugin '{invoker.plugin.name}'...")
+
+                    # Try to install the plugin
+                    install_service = PluginInstallService(
+                        project=project,
+                        plugins_service=invoker.plugins_service,
+                        clean=True
+                    )
+                    await install_service.install_plugin_async(invoker.plugin)
+
+                    # Log that the plugin is installed
+                    logging.info(f"Plugin '{invoker.plugin.name}' installed. Retrying invocation...")
+
+                    # Try to invoke the plugin again
+                    handle = await invoker.invoke_async(*plugin_args, command=command_name)
+                    with propagate_stop_signals(handle):
+                        exit_code = await handle.wait()
 
     except UnknownCommandError as err:
         raise click.BadArgumentUsage(err) from err

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -46,7 +46,7 @@ class SingerPlugin(BasePlugin):
     async def before_cleanup(self, invoker):
         """Delete configuration file."""
         config_path = invoker.files["config"]
-        config_path.unlink()
+        config_path.unlink(missing_ok=True)
         logging.debug(f"Deleted configuration at {config_path}")
 
     @property

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -353,10 +353,7 @@ class SingerTap(SingerPlugin):  # noqa: WPS 214
             logging.debug("Cached catalog is outdated, running discovery...")
 
         # We're gonna generate a new catalog, so delete the cache key.
-        try:
-            catalog_cache_key_path.unlink()
-        except FileNotFoundError:
-            pass
+        catalog_cache_key_path.unlink(missing_ok=True)
 
         custom_catalog_filename = plugin_invoker.plugin_config_extras["_catalog"]
         if custom_catalog_filename:
@@ -380,7 +377,7 @@ class SingerTap(SingerPlugin):  # noqa: WPS 214
                 catalog = json.load(catalog_file)
                 Draft4Validator.check_schema(catalog)
         except Exception as err:
-            catalog_path.unlink()
+            catalog_path.unlink(missing_ok=True)
             raise PluginExecutionError(
                 f"Catalog discovery failed: invalid catalog: {err}"
             ) from err

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -10,6 +10,7 @@ import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Generator
+
 from structlog.stdlib import get_logger
 
 from meltano.core.container.container_service import ContainerService
@@ -461,14 +462,14 @@ class PluginInvoker:  # noqa: WPS214, WPS230
 
             # Try to install the plugin
             install_service = PluginInstallService(
-                project=self.project,
-                plugins_service=self.plugins_service,
-                clean=True
+                project=self.project, plugins_service=self.plugins_service, clean=True
             )
             await install_service.install_plugin_async(self.plugin)
 
             # Log that the plugin is installed
-            logging.info(f"Plugin '{self.plugin.name}' installed. Retrying invocation...")
+            logging.info(
+                f"Plugin '{self.plugin.name}' installed. Retrying invocation..."
+            )
 
             # Try to invoke the plugin again
             async with self._invoke(*args, **kwargs) as (
@@ -481,7 +482,6 @@ class PluginInvoker:  # noqa: WPS214, WPS230
                     **popen_options,
                     env=popen_env,
                 )
-
 
     async def invoke_docker(  # noqa: WPS210
         self, plugin_command: str, *args, **kwargs


### PR DESCRIPTION
# Lazy install
I was playing around with the idea of lazy installing plugins if there are present in your Meltano project, but the executable is missing. Instead of displaying the missing "Missing plugin run meltano install xyz to install it", Meltano would install the plugin for you and re-invoke it instantly. 

This would remove the necassity of always running Meltano install on a new project. It would also make the use of Meltano in ephemeral environments easier, as you no longer need to have all plugin pre-installed. 

When running the following command `rm -rf .meltano && meltano invoke dagster` it looks like this:
![image](https://user-images.githubusercontent.com/26525996/217274271-91401cb7-353b-4fe5-a94e-7dbc49e38b40.png)


# Catalog file issue
I am running into an issue however, when running the following command: `rm -rf .meltano && meltano --log-level=debug run tap-carbon-intensity target-jsonl` the code reaches the discovery command and tries to install the tap. However, here some weird bugs occur which I can't quite figure out. 

```
Cannot start plugin tap-carbon-intensity: Catalog discovery failed: invalid catalog: [Errno 2] No such file or directory: '/home/jules/projects/temp/project/.meltano/run/tap-carbon-intensity/tap.properties.json'
```
It probably has to do something with the fact it tries to write the catalog here: https://github.com/meltano/meltano/blob/af049cc941884c1f19356b92697056e20bd2b2ef/src/meltano/core/plugin/singer/tap.py#L376, while the file is open here: https://github.com/meltano/meltano/blob/af049cc941884c1f19356b92697056e20bd2b2ef/src/meltano/core/plugin/singer/tap.py#L405

Do you think the lazy install is feasable, or is it too much of a hassle?