### PR TITLE
fix: Use `$MELTANO_ENVIRONMENT` set in `.env`

### DIFF
--- a/docs/src/_getting-started/index.md
+++ b/docs/src/_getting-started/index.md
@@ -127,7 +127,7 @@ This will allow you to use [`git diff`](https://git-scm.com/docs/git-diff) to ea
 
 ## View and Activate Your Environments
 
-As part of creating your Meltano project, we automatically added your first [environments](/concepts/environments) called `dev`, `staging` and `prod`. This allows you to define configurations specific to the environment in which you're running your project. Theres also a [`default_environment`](https://docs.meltano.com/concepts/environments#default-environments) setting in the `meltano.yml` that get automatically set to `dev`, you can list and change the active environment using:
+As part of creating your Meltano project, we automatically added your first [environments](/concepts/environments) called `dev`, `staging` and `prod`. This allows you to define configurations specific to the environment in which you're running your project. There's also a [`default_environment`](https://docs.meltano.com/concepts/environments#default-environments) setting in the `meltano.yml` that get automatically set to `dev`, you can list and change the active environment using:
 
 1. List your available environments:
 
@@ -147,7 +147,7 @@ As part of creating your Meltano project, we automatically added your first [env
    $env:MELTANO_ENVIRONMENT="dev"
    ```
 
-   Alternatively you can include the `--environment=dev` argument to each meltano command. You should now see a log message that says `Environment 'dev' is active` each time you run a meltano command.
+   Alternatively you can include the `--environment=dev` argument to each `meltano` command. You should now see a log message that says `Environment 'dev' is active` each time you run a `meltano` command.
 
 1. [optional] Add a new environment:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,7 @@ pyflakes = [
   "-WPS407",
   "-WPS410", # Allow metadata variable (__all__)
   "-WPS412",
+  "-WPS414", # Allow unpacking assignments
   "-WPS420", # Allow `pass` keywords in `except` bodies to prevent falling through to another `except`
   "-WPS429",
   "-WPS430",

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -154,9 +154,9 @@ def detect_selected_environment(
     Returns:
         The selected environment, and whether it is the default environment.
     """
-    environment = cli_environment or os.environ.get(
+    environment = os.environ.get(
         PROJECT_ENVIRONMENT_ENV,
-        project.dotenv_env.get(PROJECT_ENVIRONMENT_ENV, None),
+        project.dotenv_env.get(PROJECT_ENVIRONMENT_ENV, cli_environment),
     )
     if cli_no_environment or (environment and environment.lower() == "null"):
         logger.info("No Meltano environment was selected")

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -15,7 +15,7 @@ from meltano.cli.utils import InstrumentedGroup
 from meltano.core.behavior.versioned import IncompatibleVersionError
 from meltano.core.error import EmptyMeltanoFileException
 from meltano.core.logging import LEVELS, setup_logging
-from meltano.core.project import Project, ProjectNotFound
+from meltano.core.project import PROJECT_ENVIRONMENT_ENV, Project, ProjectNotFound
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.tracking import Tracker
 from meltano.core.tracking.contexts import CliContext
@@ -51,11 +51,7 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
     "--log-config", type=str, help="Path to a python logging yaml config file."
 )
 @click.option("-v", "--verbose", count=True, help="Not used.")
-@click.option(
-    "--environment",
-    envvar="MELTANO_ENVIRONMENT",
-    help="Meltano environment name.",
-)
+@click.option("--environment", help="Meltano environment name.")
 @click.option(
     "--no-environment", is_flag=True, default=False, help="Don't use any environment."
 )
@@ -111,23 +107,18 @@ def cli(  # noqa: C901,WPS231
         if project.readonly:
             logger.debug("Project is read-only.")
 
-        # detect active environment
-        selected_environment = None
-        is_default_environment = False
-        if no_environment or (environment and environment.lower() == "null"):
-            logger.info("No environment is active")
-        elif environment:
-            selected_environment = environment
-        elif project_setting_service.get("default_environment"):
-            selected_environment = project_setting_service.get("default_environment")
-            is_default_environment = True
-        ctx.obj["selected_environment"] = selected_environment
-        ctx.obj["is_default_environment"] = is_default_environment
+        (
+            ctx.obj["selected_environment"],
+            ctx.obj["is_default_environment"],
+        ) = detect_selected_environment(
+            cli_environment=environment,
+            cli_no_environment=no_environment,
+            project=project,
+            project_settings_service=project_setting_service,
+        )
         ctx.obj["project"] = project
         ctx.obj["tracker"] = Tracker(project)
-        ctx.obj["tracker"].add_contexts(
-            CliContext.from_click_context(ctx)
-        )  # backfill the `cli` CliContext
+        ctx.obj["tracker"].add_contexts(CliContext.from_click_context(ctx))
     except ProjectNotFound:
         ctx.obj["project"] = None
     except EmptyMeltanoFileException:
@@ -143,3 +134,34 @@ def cli(  # noqa: C901,WPS231
             "For more details, visit https://docs.meltano.com/guide/installation#upgrading-meltano-version"
         )
         sys.exit(3)
+
+
+def detect_selected_environment(
+    *,
+    cli_environment: str | None,
+    cli_no_environment: bool,
+    project: Project,
+    project_settings_service: ProjectSettingsService,
+) -> tuple[str | None, bool]:
+    """Detect the Meltano environment selected (but not yet activated).
+
+    Args:
+        cli_environment: The `--environment` option value from the CLI.
+        no_environment: The `--no-environment` option value from the CLI.
+        project: The Meltano project.
+        project_setting_service: A project settings service for the project.
+
+    Returns:
+        The selected environment, and whether it is the default environment.
+    """
+    environment = cli_environment or os.environ.get(
+        PROJECT_ENVIRONMENT_ENV,
+        project.dotenv_env.get(PROJECT_ENVIRONMENT_ENV, None),
+    )
+    if cli_no_environment or (environment and environment.lower() == "null"):
+        logger.info("No Meltano environment was selected")
+    elif environment:
+        return environment, False
+    elif project_settings_service.get("default_environment"):
+        return project_settings_service.get("default_environment"), True
+    return None, False

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -145,6 +145,13 @@ def detect_selected_environment(
 ) -> tuple[str | None, bool]:
     """Detect the Meltano environment selected (but not yet activated).
 
+    Precedence is:
+    1. The `--environment` CLI option
+    2. Env var from the shell
+    3. Env var from `.env`
+    4. Default environment from `meltano.yml`
+    5. `None`
+
     Args:
         cli_environment: The `--environment` option value from the CLI.
         no_environment: The `--no-environment` option value from the CLI.
@@ -154,9 +161,9 @@ def detect_selected_environment(
     Returns:
         The selected environment, and whether it is the default environment.
     """
-    environment = os.environ.get(
+    environment = cli_environment or os.environ.get(
         PROJECT_ENVIRONMENT_ENV,
-        project.dotenv_env.get(PROJECT_ENVIRONMENT_ENV, cli_environment),
+        project.dotenv_env.get(PROJECT_ENVIRONMENT_ENV, None),
     )
     if cli_no_environment or (environment and environment.lower() == "null"):
         logger.info("No Meltano environment was selected")

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -602,7 +602,7 @@ def enact_environment_behavior(
     ctx: click.Context,
 ) -> None:
     """Activate the environment in the specified way."""
-    if behavior is None:
+    if behavior is None or "selected_environment" not in ctx.obj:
         return
     if behavior is CliEnvironmentBehavior.environment_optional_use_default:
         activate_environment(ctx, ctx.obj["project"], required=False)


### PR DESCRIPTION
Context on Slack: https://meltano.slack.com/archives/C03GKHWS0HM/p1675776097120869

I decided to add some special handling for `MELTANO_ENVIRONMENT` to fix this, rather than try for some kind of generic solution for respecting env vars early on in the CLI. This was partially because we already rely on special handling for this env var and its related options/settings, so any sort of generic solution would have to content with the special handling that already exists.

I pulled out the existing logic for detecting which Meltano environment was selected into a function `detect_selected_environment`, and updated it to check `project.dotenv_env` for `MELTANO_ENVIRONMENT` as a fallback if it wasn't set terminal environment. The order of precedence is:
1. `$MELTANO_ENVIRONMENT` set in the terminal
2. `$MELTANO_ENVIRONMENT` set in `.env`
3. The `--environment` CLI option.

@tayloramurphy Please let me know if that precedence is correct.

Closes #7280 