### PR TITLE
chore: Do not run Nox coverage session after tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -54,16 +54,12 @@ def tests(session: Session) -> None:
         "requests-mock",
     )
 
-    try:
-        session.run(
-            "pytest",
-            f"--randomly-seed={randint(0, 2**32-1)}",  # noqa: S311, WPS432
-            *session.posargs,
-            env={"NOX_CURRENT_SESSION": "tests"},
-        )
-    finally:
-        if session.interactive:
-            session.notify("coverage", posargs=[])
+    session.run(
+        "pytest",
+        f"--randomly-seed={randint(0, 2**32-1)}",  # noqa: S311, WPS432
+        *session.posargs,
+        env={"NOX_CURRENT_SESSION": "tests"},
+    )
 
 
 @nox_session(python=main_python_version)


### PR DESCRIPTION
When we run `pytest` with Nox, it uses `pytest-cov`, which automatically (and uncontrollably) prints a coverage report. Nox then runs its coverage session, which prints the coverage report a second time. The coverage job is still useful (it's used in CI, among other things), but I don't think it should be run automatically after the tests when running in interactive mode.

Note that this change has no effect on CI, since the coverage session was only being called in interactive mode.