### PR TITLE
Revert "ci: update commitizen"

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Bump version
       id: cz-bump
-      uses: commitizen-tools/commitizen-action@0.16.2
+      uses: commitizen-tools/commitizen-action@0.16.0
       with:
         increment: ${{ github.event.inputs.bump != 'auto' && github.event.inputs.bump || '' }}
         prerelease: ${{ github.event.inputs.prerelease != 'none' && github.event.inputs.prerelease || '' }}


### PR DESCRIPTION
Reverts meltano/meltano#7275

Context on Slack: https://meltano.slack.com/archives/C03GKHWS0HM/p1675702118509419

In summary: this version bump introduced the following 2 changes:
- https://github.com/commitizen-tools/commitizen-action/commit/3d7526e3d2b2f7ab12c0086da95ae9e2a1be856d
- https://github.com/commitizen-tools/commitizen-action/commit/364839d55ead4e32d7a1fe0e00cc3d5cabdc2ed9

This changes the base image running `commitizen` to Alpine Linux, which cannot build `cffi` without additional dependencies.

Long-term we may need to create a fork of `commitizen-action`, or submit a PR that provides the dependencies required to build `cffi`.

Short-term, to fix the version bump workflow, we should revert these changes.