### PR TITLE
chore: Use fork with fix for `commitizen-action`

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Bump version
       id: cz-bump
-      uses: commitizen-tools/commitizen-action@0.16.2
+      uses: WillDaSilva/commitizen-action@main
       with:
         increment: ${{ github.event.inputs.bump != 'auto' && github.event.inputs.bump || '' }}
         prerelease: ${{ github.event.inputs.prerelease != 'none' && github.event.inputs.prerelease || '' }}


### PR DESCRIPTION
Diff between `commitizen-action` and my fork: https://github.com/commitizen-tools/commitizen-action/compare/master...WillDaSilva:commitizen-action:master

If this fork fixes our version bump workflow, I'll open a PR to get my changes merged upstream.

Context on Slack: https://meltano.slack.com/archives/C03GKHWS0HM/p1675702118509419

In summary: this version bump introduced the following 2 changes:
- https://github.com/commitizen-tools/commitizen-action/commit/3d7526e3d2b2f7ab12c0086da95ae9e2a1be856d
- https://github.com/commitizen-tools/commitizen-action/commit/364839d55ead4e32d7a1fe0e00cc3d5cabdc2ed9

This changes the base image running `commitizen` to Alpine Linux, which cannot build `cffi` without additional dependencies.

We'll also need to update the SDK.
