### PR TITLE
fix: Avoid casting settings before env var expansion

### DIFF
--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -351,7 +351,8 @@ class SettingsService(ABC):  # noqa: WPS214
         # Can't do conventional SettingsService.feature_flag call to check;
         # it would result in circular dependency
         strict_env_var_mode, _ = source.manager(self.project_settings_service).get(
-            f"{FEATURE_FLAG_PREFIX}.{FeatureFlags.STRICT_ENV_VAR_MODE}"
+            f"{FEATURE_FLAG_PREFIX}.{FeatureFlags.STRICT_ENV_VAR_MODE}",
+            cast_value=True,
         )
         if expand_env_vars and metadata.get("expandable", False):
             metadata["expandable"] = False
@@ -378,10 +379,7 @@ class SettingsService(ABC):  # noqa: WPS214
             ):
                 object_value = {}
                 object_source = metadata["source"]
-                for setting_key in [  # noqa: WPS335
-                    setting_def.name,
-                    *setting_def.aliases,
-                ]:
+                for setting_key in (setting_def.name, *setting_def.aliases):
                     flat_config_metadata = self.config_with_metadata(
                         prefix=f"{setting_key}.",
                         redacted=redacted,

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -210,6 +210,8 @@ class TestProjectSettingsService:
         SettingValueStore.MELTANO_YML.manager(subject).set(
             name, [name], "$DB_MAX_RETRIES_TEST", setting_def=setting_def
         )
+
+        subject.set([FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], False)
         assert subject.get(name) is None
 
         subject.env_override["DB_MAX_RETRIES_TEST"] = "7"


### PR DESCRIPTION
This fixes a regression in #7232. In that PR logic was added to cast settings within the setting store. This was needed because some settings were not retrieved through a settings service in order to avoid infinite regression (i.e. the `get` method in a setting service cannot generally call itself).

A consequence of those changes was that now we are casting setting values before env var expansion has occurred. To address the regression, this PR makes the casting logic from #7232 disabled by default, and it is only enabled when accessing settings from within the `get` methods of a setting service (where we cannot rely on the regular setting casting).

A cleaner approach would be preferable, but this should be sufficient to address the regression while preserving the bug fix that #7232 implemented.

Closes #7293