### PR TITLE
fix: Respect `requests`/`curl` custom Certificate Authorities env vars

### DIFF
--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -229,8 +229,17 @@ class MeltanoHubService(PluginRepository):  # noqa: WPS214
         Raises:
             HubConnectionError: If the Hub API could not be reached.
         """
+        prep = self._build_request("GET", url)
+        settings = self.session.merge_environment_settings(
+            prep.url,
+            None,
+            None,
+            None,
+            None,
+        )
+
         try:
-            return self.session.send(self._build_request("GET", url))
+            return self.session.send(prep, **settings)
         except requests.exceptions.ConnectionError as connection_err:
             raise HubConnectionError("Could not reach Meltano Hub.") from connection_err
 

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -6,6 +6,7 @@ import click
 import mock
 import pytest
 from requests import HTTPError, Response
+from requests.adapters import BaseAdapter
 
 from meltano.cli import cli
 from meltano.cli.discovery import discover
@@ -136,3 +137,24 @@ class TestMeltanoHubService:
             get_context.return_value = None
             request = subject._build_request("GET", "https://example.com")
             assert "X-Meltano-Command" not in request.headers
+
+    def test_custom_ca(self, project, monkeypatch):
+        send_kwargs = {}
+
+        class _Adapter(BaseAdapter):
+            def send(self, request, **kwargs):
+                nonlocal send_kwargs
+                send_kwargs = kwargs
+
+                response = Response()
+                response._content = b'{"name": "tap-mock", "namespace": "tap_mock"}'
+                response.status_code = 200
+                return response
+
+        mock_url = "hub://meltano"
+        hub = MeltanoHubService(project)
+        hub.session.mount(mock_url, _Adapter())
+
+        monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/path/to/ca.pem")
+        hub._get(mock_url)
+        assert send_kwargs["verify"] == "/path/to/ca.pem"


### PR DESCRIPTION
Related:

- Closes https://github.com/meltano/meltano/issues/7298
- Fixes a regression introduced in https://github.com/meltano/meltano/pull/7188
