### PR TITLE
chore: Disable `meltano compile` command

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -37,7 +37,8 @@ jobs:
         - { integration_test: "meltano-state-s3", needs_postgres: false}
         - { integration_test: "meltano-state-local", needs_postgres: false}
         - { integration_test: "meltano-config", needs_postgres: false}
-        - { integration_test: "meltano-manifest", needs_postgres: false}
+        # Disabled temporarily: https://github.com/meltano/meltano/issues/7306#issuecomment-1432086410
+        # - { integration_test: "meltano-manifest", needs_postgres: false}
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -18,7 +18,6 @@ from meltano.core.logging import setup_logging
 from meltano.cli.cli import cli  # isort:skip
 from meltano.cli import (  # isort:skip # noqa: WPS235
     add,
-    compile,
     config,
     discovery,
     dragon,

--- a/tests/meltano/cli/test_compile.py
+++ b/tests/meltano/cli/test_compile.py
@@ -28,6 +28,7 @@ def check_indent(json_path: Path, indent: int):
     assert json.dumps(json.loads(text), indent=indent if indent > 0 else None) == text
 
 
+@pytest.mark.skip(reason="Compile command temporarily disabled")
 class TestCompile:
     @pytest.fixture
     def manifest_dir(self, project: Project) -> Path:


### PR DESCRIPTION
Context:
- https://github.com/meltano/meltano/issues/7306#issuecomment-1432086410

To avoid anyone depending on the manifest feature before we are confident that we can avoid making breaking changes to it, this PR disables the `meltano compile` command. Manifests can continue to be used internally, but once we allow users to generate them via the CLI, and depend on the data they contain, we will have to be careful about what we change.