### PR TITLE
docs: State that the `meltano compile` command is in beta

### DIFF
--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -122,6 +122,10 @@ The `add` command does not run relative to a [Meltano Environment](https://docs.
 
 ## `compile`
 
+<div class="notification is-warning">
+    <p>The compile command is currently experimental, and subject to change without corresponding semantic version updates.</p>
+</div>
+
 ### How to use
 
 Generally, the `compile` command need not be executed manually, as it will be run automatically by Meltano as-needed.

--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -123,7 +123,7 @@ The `add` command does not run relative to a [Meltano Environment](https://docs.
 ## `compile`
 
 <div class="notification is-warning">
-    <p>The compile command is currently experimental, and subject to change without corresponding semantic version updates.</p>
+    <p><a href="https://github.com/meltano/meltano/discussions/7323">The compile command is currently in beta</a>, and subject to change without corresponding semantic version updates.</p>
 </div>
 
 ### How to use

--- a/src/meltano/cli/compile.py
+++ b/src/meltano/cli/compile.py
@@ -18,9 +18,7 @@ from meltano.core.tracking import Tracker
 from meltano.core.tracking.contexts import CliEvent
 
 
-@cli.command(
-    cls=InstrumentedCmd, short_help="Compile a Meltano manifest. (experimental)"
-)
+@cli.command(cls=InstrumentedCmd, short_help="Compile a Meltano manifest. (beta)")
 @click.option(
     "--directory",
     default=".meltano/manifests",
@@ -58,7 +56,7 @@ def compile(  # noqa: WPS125
     """
     Compile a Meltano project into environment-specific manifest files.
 
-    This feature is experimental, and subject to change without corresponding semantic version updates.
+    This command is in beta, and subject to change without corresponding semantic version updates.
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#compile
     """  # noqa: E501

--- a/src/meltano/cli/compile.py
+++ b/src/meltano/cli/compile.py
@@ -18,8 +18,9 @@ from meltano.core.tracking import Tracker
 from meltano.core.tracking.contexts import CliEvent
 
 
-# FIXME: Should this command be named `manifest` instead of `compile`?
-@cli.command(cls=InstrumentedCmd, short_help="Compile a Meltano manifest.")
+@cli.command(
+    cls=InstrumentedCmd, short_help="Compile a Meltano manifest. (experimental)"
+)
 @click.option(
     "--directory",
     default=".meltano/manifests",
@@ -57,8 +58,10 @@ def compile(  # noqa: WPS125
     """
     Compile a Meltano project into environment-specific manifest files.
 
+    This feature is experimental, and subject to change without corresponding semantic version updates.
+
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#compile
-    """
+    """  # noqa: E501
     tracker: Tracker = ctx.obj["tracker"]
 
     try:


### PR DESCRIPTION
Supersedes:
- https://github.com/meltano/meltano/pull/7321