### PR TITLE
style: Use `import typing as t` to minimize merge conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,5 +115,6 @@ repos:
           - flake8-quotes==3.3.1
           - flake8-rst-docstrings==0.2.7
           - flake8-string-format==0.3.0
+          - flake8-typing-as-t==0.0.3
           - pep8-naming==0.12.1
           - wemake-python-styleguide==0.16.1

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, NoReturn
+import typing as t
 
 from meltano.cli.utils import CliError
 from meltano.core.error import MeltanoError, ProjectReadonly
@@ -42,7 +42,7 @@ from meltano.cli import (  # isort:skip # noqa: WPS235
     job,
 )
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.tracking.tracker import Tracker
 
 
@@ -64,7 +64,7 @@ join our friendly Slack community.
 """
 
 
-def handle_meltano_error(error: MeltanoError) -> NoReturn:
+def handle_meltano_error(error: MeltanoError) -> t.NoReturn:
     """Handle a MeltanoError.
 
     Args:

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import typing as t
 from pathlib import Path
-from typing import NoReturn
 
 import click
 
@@ -33,7 +33,7 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
     typical Meltano commands fail, e.g. `meltano select tap-gitlab tags "*"`.
     """
 
-    def main(self, *args, **kwargs) -> NoReturn:
+    def main(self, *args, **kwargs) -> t.NoReturn:
         """Invoke the Click CLI with Windows globbing disabled.
 
         Args:

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -6,9 +6,9 @@ import asyncio
 import json
 import logging
 import tempfile
+import typing as t
 from functools import wraps
 from pathlib import Path
-from typing import Any
 
 import click
 import dotenv
@@ -36,7 +36,7 @@ from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 logger = logging.getLogger(__name__)
 
 
-def _get_ctx_arg(*args: Any) -> click.core.Context:
+def _get_ctx_arg(*args: t.Any) -> click.core.Context:
     """Get the click.core.Context arg from a set of args.
 
     Args:
@@ -341,7 +341,7 @@ def reset(ctx, store):
 def set_(
     ctx: click.core.Context,
     setting_name: tuple[str, ...],
-    value: Any,
+    value: t.Any,
     store: str,
     interactive: bool,
 ):

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import typing as t
 
 import click
 import structlog
@@ -18,7 +18,7 @@ from meltano.core.plugin_lock_service import (
 from meltano.core.project_plugins_service import DefinitionSource
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import shutil
 import sys
-from typing import Iterable
+from collections import abc
 
 import click
 import structlog
@@ -116,7 +116,7 @@ def test(
 
 async def _run_plugin_tests(
     session: sessionmaker,
-    runners: Iterable[ValidationsRunner],
+    runners: abc.Iterable[ValidationsRunner],
 ) -> dict[str, dict[str, int]]:
     return {runner.plugin_name: await runner.run_all(session) for runner in runners}
 

--- a/src/meltano/core/behavior/canonical.py
+++ b/src/meltano/core/behavior/canonical.py
@@ -4,21 +4,21 @@ from __future__ import annotations
 
 import copy
 import json
+import typing as t
 from functools import lru_cache
 from os import PathLike
-from typing import Any, NamedTuple, TypeVar
 
 import yaml
 from ruamel.yaml import Representer
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 
-T = TypeVar("T", bound="Canonical")  # noqa: WPS111 (name too short)
+T = t.TypeVar("T", bound="Canonical")  # noqa: WPS111 (name too short)
 
 
 class IdHashBox:
     """Wrapper class that makes the hash of an object its Python ID."""
 
-    def __init__(self, content: Any):
+    def __init__(self, content: t.t.Any):
         """Initialize the `IdHashBox`.
 
         Parameters:
@@ -35,7 +35,7 @@ class IdHashBox:
         """
         return id(self.content)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: t.Any) -> bool:
         """Check equality of this instance and some other object.
 
         Parameters:
@@ -50,7 +50,7 @@ class IdHashBox:
 CANONICAL_PARSE_CACHE_SIZE = 4096
 
 
-class Annotations(NamedTuple):
+class Annotations(t.NamedTuple):
     """Tuple storing the data of an annotation, and its index."""
 
     index: int
@@ -60,7 +60,7 @@ class Annotations(NamedTuple):
 class AnnotationsMeta(type):
     """Metaclass to intercept and store annotations before calling `__init__`."""
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+    def __call__(cls, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Create and return an instance of the class this metaclass is applied to.
 
         Args:
@@ -97,7 +97,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
       - All attributes that start with "_" are excluded
     """
 
-    def __init__(self, *args: Any, **attrs: Any):
+    def __init__(self, *args: t.Any, **attrs: t.Any):
         """Initialize the current instance with the given attributes.
 
         Args:
@@ -119,7 +119,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         self._defaults = {}
 
     @classmethod
-    def _canonize(cls, val: Any) -> Any:
+    def _canonize(cls, val: t.Any) -> t.Any:
         """Call `as_canonical` on `val`, respecting `Canonical` subclasses.
 
         Args:
@@ -134,8 +134,8 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
 
     @classmethod
     def as_canonical(
-        cls: type[T], target: Any
-    ) -> dict | list | CommentedMap | CommentedSeq | Any:
+        cls: type[T], target: t.Any
+    ) -> dict | list | CommentedMap | CommentedSeq | t.Any:
         """Return a canonical representation of the given instance.
 
         Args:
@@ -173,7 +173,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
 
         return copy.deepcopy(target)
 
-    def canonical(self) -> dict | list | CommentedMap | CommentedSeq | Any:
+    def canonical(self) -> dict | list | CommentedMap | CommentedSeq | t.Any:
         """Return a canonical representation of the current instance.
 
         Returns:
@@ -181,7 +181,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         """
         return type(self).as_canonical(self)
 
-    def with_attrs(self: T, *args: Any, **kwargs: Any) -> T:
+    def with_attrs(self: T, *args: t.Any, **kwargs: t.Any) -> T:
         """Return a new instance with the given attributes set.
 
         Args:
@@ -194,7 +194,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         return type(self)(**{**self.canonical(), **kwargs})
 
     @classmethod
-    def parse(cls: type[T], obj: Any) -> T:
+    def parse(cls: type[T], obj: t.Any) -> T:
         """Parse a 'Canonical' object from a dictionary or return the instance.
 
         Args:
@@ -251,7 +251,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         """
         return self._dict.get(attr) is not None
 
-    def __getattr__(self, attr: str) -> Any:
+    def __getattr__(self, attr: str) -> t.Any:  # noqa: C901
         """Return the value of the given attribute.
 
         Args:
@@ -285,7 +285,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
 
         return value
 
-    def __setattr__(self, attr: str, value: Any):
+    def __setattr__(self, attr: str, value: t.Any):
         """Set the given attribute to the given value.
 
         Args:
@@ -297,7 +297,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         else:
             self._dict[attr] = value
 
-    def __getitem__(self, attr: str) -> Any:
+    def __getitem__(self, attr: str) -> t.Any:
         """Return the value of the given attribute.
 
         Args:
@@ -308,7 +308,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         """
         return getattr(self, attr)
 
-    def __setitem__(self, attr: str, value: Any) -> None:
+    def __setitem__(self, attr: str, value: t.Any) -> None:
         """Set the given attribute to the given value.
 
         Args:
@@ -356,7 +356,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         """
         return len(self._dict)
 
-    def __contains__(self, obj: Any):
+    def __contains__(self, obj: t.Any):
         """Return whether the current instance contains the given object.
 
         Args:
@@ -367,7 +367,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         """
         return obj in self._dict
 
-    def update(self, *others: Any, **kwargs: Any) -> None:
+    def update(self, *others: t.Any, **kwargs: t.Any) -> None:
         """Update the current instance with the given others.
 
         Args:
@@ -384,7 +384,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
                 setattr(self, key, val)
 
     @classmethod
-    def yaml(cls, dumper: yaml.BaseDumper, obj: Any) -> yaml.MappingNode:
+    def yaml(cls, dumper: yaml.BaseDumper, obj: t.Any) -> yaml.MappingNode:
         """YAML serializer for Canonical objects.
 
         Args:
@@ -399,7 +399,7 @@ class Canonical(metaclass=AnnotationsMeta):  # noqa: WPS214 (too many methods)
         )
 
     @classmethod
-    def to_yaml(cls, representer: Representer, obj: Any):
+    def to_yaml(cls, representer: Representer, obj: t.Any):
         """YAML serializer for Canonical objects.
 
         Args:

--- a/src/meltano/core/behavior/canonical.py
+++ b/src/meltano/core/behavior/canonical.py
@@ -18,7 +18,7 @@ T = t.TypeVar("T", bound="Canonical")  # noqa: WPS111 (name too short)
 class IdHashBox:
     """Wrapper class that makes the hash of an object its Python ID."""
 
-    def __init__(self, content: t.t.Any):
+    def __init__(self, content: t.Any):
         """Initialize the `IdHashBox`.
 
         Parameters:

--- a/src/meltano/core/behavior/visitor.py
+++ b/src/meltano/core/behavior/visitor.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Callable
+import typing as t
 
 
 class visit_with:  # noqa: N801
-    def __init__(self, visit: Callable):
+    def __init__(self, visit: t.Callable):  # noqa: D107
         self.visit = visit
 
     def __call__(self, base_cls):

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import typing as t
 from contextlib import asynccontextmanager, closing
 from pathlib import Path
-from typing import AsyncIterator
 
 import structlog
 from sqlalchemy.orm import Session
@@ -320,10 +320,7 @@ class ExtractLoadBlocks(BlockSet):  # noqa: WPS214
         Returns:
             bool indicating whether BlockSet has 'state' capability
         """
-        for block in self.blocks:
-            if block.has_state:
-                return True
-        return False
+        return any(block.has_state for block in self.blocks)
 
     @property
     def state_service(self) -> StateService:
@@ -541,7 +538,7 @@ class ExtractLoadBlocks(BlockSet):  # noqa: WPS214
         return self.blocks[1:-1]
 
     @asynccontextmanager
-    async def _start_blocks(self) -> AsyncIterator[None]:
+    async def _start_blocks(self) -> t.AsyncIterator[None]:
         """Start the blocks in the block set.
 
         Yields:

--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Generator
+import typing as t
+from contextlib import suppress
 
 import click
 import structlog
@@ -157,7 +158,7 @@ class BlockParser:  # noqa: D101
 
     def find_blocks(
         self, offset: int = 0
-    ) -> Generator[BlockSet | PluginCommandBlock, None, None]:
+    ) -> t.Generator[BlockSet | PluginCommandBlock, None, None]:
         """
         Find all blocks in the invocation.
 
@@ -207,16 +208,13 @@ class BlockParser:  # noqa: D101
         Raises:
             ClickException: If mapping name returns multiple matches.
         """
-        try:
+        with suppress(PluginNotFoundError):
             return self.project.plugins.find_plugin(name)
-        except PluginNotFoundError:
-            pass
 
         mapper = None
-        try:
+
+        with suppress(PluginNotFoundError):
             mapper = self.project.plugins.find_plugins_by_mapping_name(name)
-        except PluginNotFoundError:
-            pass
 
         if mapper is None:
             return None

--- a/src/meltano/core/config_service.py
+++ b/src/meltano/core/config_service.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import typing as t
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
 
 import yaml
 
@@ -19,7 +19,7 @@ if sys.version_info >= (3, 8):
 else:
     from cached_property import cached_property
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 logger = logging.getLogger(__name__)

--- a/src/meltano/core/container/container_service.py
+++ b/src/meltano/core/container/container_service.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import signal
-from typing import TYPE_CHECKING
+import typing as t
 
 from structlog.stdlib import get_logger
 
 from meltano.core.container.container_spec import ContainerSpec
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from aiodocker.containers import DockerContainer
 
 

--- a/src/meltano/core/container/container_spec.py
+++ b/src/meltano/core/container/container_spec.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import shlex
+import typing as t
 from collections import defaultdict
-from typing import Any
 
 from meltano.core.behavior.canonical import Canonical
 from meltano.core.utils import expand_env_vars
 
 
-def env_mapping_to_docker(mapping: dict[str, Any]) -> list[str]:
+def env_mapping_to_docker(mapping: dict[str, t.Any]) -> list[str]:
     """Convert a dictionary of environment variables to the <ENVVAR>=<VALUE> form.
 
     Args:
@@ -36,7 +36,7 @@ class ContainerSpec(Canonical):
         entrypoint: str | None = None,
         ports: dict[str, str] | None = None,
         volumes: list[str] | None = None,
-        env: dict[str, Any] | None = None,
+        env: dict[str, t.Any] | None = None,
     ):
         """Create a new container specification.
 
@@ -76,7 +76,7 @@ class ContainerSpec(Canonical):
 
         volumes = [expand_env_vars(bind, env) for bind in self.volumes]
 
-        exposed_ports: dict[str, Any] = {}
+        exposed_ports: dict[str, t.Any] = {}
         port_bindings = defaultdict(list)
 
         for host_port, container_port in self.ports.items():

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import typing as t
 from collections import namedtuple
-from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -21,7 +21,7 @@ class PluginContext(
 ):
     """Plugin Context container."""
 
-    def __getattr__(self, attr: str) -> Any:
+    def __getattr__(self, attr: str) -> t.Any:
         """Get plugin attribute.
 
         Args:
@@ -32,7 +32,7 @@ class PluginContext(
         """
         return getattr(self.plugin, attr)
 
-    def get_config(self, name: str, **kwargs: Any) -> Any:
+    def get_config(self, name: str, **kwargs: t.Any) -> t.Any:
         """Get plugin config by name.
 
         Args:

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Iterable, TypeVar
+import typing as t
 
 from meltano.core.behavior import NameEq
 from meltano.core.behavior.canonical import Canonical
@@ -13,7 +13,7 @@ from meltano.core.plugin.base import PluginRef
 from meltano.core.setting_definition import SettingDefinition
 from meltano.core.utils import NotFound
 
-TEnv = TypeVar("TEnv", bound="Environment")
+TEnv = t.TypeVar("TEnv", bound="Environment")
 
 
 class NoActiveEnvironment(Exception):  # noqa: N818
@@ -79,7 +79,7 @@ class EnvironmentPluginConfig(PluginRef):
         return {**self.config, **self.extra_config}
 
     @config_with_extras.setter
-    def config_with_extras(self, new_config_with_extras: dict[str, Any]):
+    def config_with_extras(self, new_config_with_extras: dict[str, t.Any]):
         """Set plugin configuration values from the Meltano environment.
 
         Args:
@@ -95,7 +95,7 @@ class EnvironmentPluginConfig(PluginRef):
                 self.config[key] = value
 
     def get_orphan_settings(
-        self, existing: Iterable[SettingDefinition]
+        self, existing: t.Iterable[SettingDefinition]
     ) -> list[SettingDefinition]:
         """Get orphan settings for this plugin.
 
@@ -180,7 +180,7 @@ class Environment(NameEq, Canonical):
         self.state_id_suffix = state_id_suffix
 
     @classmethod
-    def find(cls: type[TEnv], objects: Iterable[TEnv], name: str) -> TEnv:
+    def find(cls: type[TEnv], objects: t.Iterable[TEnv], name: str) -> TEnv:
         """Lookup an environment by name from an iterable.
 
         Args:

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import typing as t
 from asyncio.streams import StreamReader
 from asyncio.subprocess import Process
 from enum import Enum
-from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 
@@ -24,8 +24,8 @@ class MeltanoError(Exception):
         self,
         reason: str,
         instruction: str | None = None,
-        *args: Any,
-        **kwargs: Any,
+        *args: t.Any,
+        **kwargs: t.Any,
     ) -> None:
         """Initialize a MeltanoError.
 

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import typing as t
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any
 
 import click
 import requests
@@ -24,7 +24,7 @@ from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.factory import base_plugin_factory
 from meltano.core.plugin_discovery_service import PluginRepository
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 logger = get_logger(__name__)
@@ -47,9 +47,9 @@ class HubPluginTypeNotFoundError(Exception):
         Returns:
             The string representation of the error.
         """
-        return "{type} is not supported in Meltano Hub. Available plugin types: {types}".format(
-            type=self.plugin_type.descriptor.capitalize(),
-            types=PluginType.plurals(),
+        return (
+            f"{self.plugin_type.descriptor.capitalize()} is not supported in "
+            f"Meltano Hub. Available plugin types: {PluginType.plurals()}"
         )
 
 
@@ -92,11 +92,10 @@ class HubPluginVariantNotFoundError(Exception):
         Returns:
             The string representation of the error.
         """
-        return "{type} '{name}' variant '{variant}' is not known to Meltano. Variants: {variant_labels}".format(
-            type=self.plugin_type.descriptor.capitalize(),
-            name=self.plugin.name,
-            variant=self.variant_name,
-            variant_labels=self.plugin.variant_labels,
+        return (
+            f"{self.plugin_type.descriptor.capitalize()} '{self.plugin.name}' "
+            f"variant '{self.variant_name}' is not known to Meltano. "
+            f"Variants: {self.plugin.variant_labels}"
         )
 
 
@@ -357,7 +356,7 @@ class MeltanoHubService(PluginRepository):  # noqa: WPS214
                 raise HubPluginTypeNotFoundError(plugin_type) from err
             raise HubConnectionError(err.response.reason) from err
 
-        plugins: dict[str, dict[str, Any]] = response.json()
+        plugins: dict[str, dict[str, t.Any]] = response.json()
         return {
             name: IndexedPlugin(
                 name,

--- a/src/meltano/core/job_state.py
+++ b/src/meltano/core/job_state.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import json
+import typing as t
 from datetime import datetime
 from io import TextIOWrapper
-from typing import Any
 
 from sqlalchemy import Column, types
 from sqlalchemy.ext.mutable import MutableDict
@@ -33,8 +33,8 @@ class JobState(SystemModel):  # noqa: WPS214
 
     updated_at = Column(types.DATETIME, onupdate=datetime.now)
 
-    partial_state: Mapped[Any] = Column(MutableDict.as_mutable(JSONEncodedDict))
-    completed_state: Mapped[Any] = Column(MutableDict.as_mutable(JSONEncodedDict))
+    partial_state: Mapped[t.Any] = Column(MutableDict.as_mutable(JSONEncodedDict))
+    completed_state: Mapped[t.Any] = Column(MutableDict.as_mutable(JSONEncodedDict))
 
     def __eq__(self, other: object) -> bool:
         """Check equality with another JobState.
@@ -67,8 +67,8 @@ class JobState(SystemModel):  # noqa: WPS214
         Returns:
             JobState built from job run history
         """
-        completed_state: dict[Any, Any] = {}
-        partial_state: dict[Any, Any] = {}
+        completed_state: dict[t.Any, t.Any] = {}
+        partial_state: dict[t.Any, t.Any] = {}
         incomplete_since = None
         finder = JobFinder(state_id)
 

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import sys
+import typing as t
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Sequence, TextIO
 
 import click
 import structlog
@@ -14,7 +14,7 @@ from structlog.types import Processor
 
 from meltano.core.utils import get_no_color_flag
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     if sys.version_info >= (3, 8):
         from typing import Literal
     else:
@@ -37,7 +37,7 @@ def rich_exception_formatter_factory(
     color_system: Literal["auto", "standard", "256", "truecolor", "windows"] = "auto",
     no_color: bool | None = None,
     show_locals: bool = False,
-) -> Callable[[TextIO, structlog.types.ExcInfo], None]:
+) -> t.Callable[[t.TextIO, structlog.types.ExcInfo], None]:
     """Create an exception formatter for logging using the rich package.
 
     Examples:
@@ -55,7 +55,7 @@ def rich_exception_formatter_factory(
 
     def _traceback(
         sio,
-        exc_info: tuple[type[Any], BaseException, TracebackType | None],
+        exc_info: tuple[type[t.Any], BaseException, TracebackType | None],
     ) -> None:
         sio.write("\n")
         Console(file=sio, color_system=color_system, no_color=no_color).print(
@@ -71,10 +71,12 @@ def rich_exception_formatter_factory(
 def _process_formatter(processor: Processor) -> structlog.stdlib.ProcessorFormatter:
     """Use _process_formatter to configure a structlog.stdlib.ProcessFormatter.
 
-    It will automatically add log level and timestamp fields to any log entries not originating from structlog.
+    It will automatically add log level and timestamp fields to any log entries
+    not originating from structlog.
 
     Args:
-        processor: A structlog message processor such as structlog.dev.ConsoleRenderer.
+        processor: A structlog message processor such as
+            `structlog.dev.ConsoleRenderer`.
 
     Returns:
         A configured log processor.
@@ -119,15 +121,18 @@ def console_log_formatter(
 
 def key_value_formatter(
     sort_keys: bool = False,
-    key_order: Sequence[str] | None = None,
+    key_order: t.Sequence[str] | None = None,
     drop_missing: bool = False,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter that renders lines in key=value format.
 
     Args:
         sort_keys: Whether to sort keys when formatting.
-        key_order: List of keys that should be rendered in this exact order. Missing keys will be rendered as None, extra keys depending on *sort_keys* and the dict class.
-        drop_missing: When True, extra keys in *key_order* will be dropped rather than rendered as None.
+        key_order: List of keys that should be rendered in this exact order.
+            Missing keys will be rendered as None, extra keys depending on
+            *sort_keys* and the dict class.
+        drop_missing: When True, extra keys in *key_order* will be dropped
+            rather than rendered as None.
 
     Returns:
         A configured key=value formatter.

--- a/src/meltano/core/manifest/contexts.py
+++ b/src/meltano/core/manifest/contexts.py
@@ -9,9 +9,9 @@ WARNING: This module is currently just here to flesh out an idea for how
 from __future__ import annotations
 
 import os
+import typing as t
 from collections.abc import Mapping
 from contextlib import contextmanager, suppress
-from typing import Iterator
 
 from meltano.core.manifest.manifest import Manifest
 
@@ -26,7 +26,7 @@ def _get_active_manifest() -> Manifest:
 
 
 @contextmanager
-def _manifest_context(manifest: Manifest) -> Iterator[None]:
+def _manifest_context(manifest: Manifest) -> t.Iterator[None]:
     _active_manifest.append(manifest)
     try:
         yield
@@ -35,7 +35,7 @@ def _manifest_context(manifest: Manifest) -> Iterator[None]:
 
 
 @contextmanager  # noqa: WPS210
-def _env_context(env: Mapping[str, str]) -> Iterator[None]:
+def _env_context(env: Mapping[str, str]) -> t.Iterator[None]:
     unique_keys = env.keys() - os.environ.keys()
     shared_keys = env.keys() & os.environ.keys()
     prev = {k: v for k, v in os.environ.items() if k in shared_keys}
@@ -51,7 +51,7 @@ def _env_context(env: Mapping[str, str]) -> Iterator[None]:
 
 
 @contextmanager
-def manifest_context(manifest: Manifest) -> Iterator[None]:
+def manifest_context(manifest: Manifest) -> t.Iterator[None]:
     """Establish a context within which Meltano can run using a given manifest.
 
     All relevant general (i.e. excluding plugin-specific, schedule-specific,
@@ -72,7 +72,7 @@ def manifest_context(manifest: Manifest) -> Iterator[None]:
 
 
 @contextmanager
-def plugin_context(plugin_name: str) -> Iterator[None]:
+def plugin_context(plugin_name: str) -> t.Iterator[None]:
     """Establish a context within which a plugin can be run.
 
     All relevant env vars for the specified plugin will be set in the process
@@ -105,7 +105,7 @@ def plugin_context(plugin_name: str) -> Iterator[None]:
 
 
 @contextmanager
-def schedule_context(schedule_name: str) -> Iterator[None]:
+def schedule_context(schedule_name: str) -> t.Iterator[None]:
     """Establish a context within which a schedule can be run.
 
     All relevant env vars for the specified schedule will be set in the process
@@ -133,7 +133,7 @@ def schedule_context(schedule_name: str) -> Iterator[None]:
 
 
 @contextmanager
-def job_context(job_name: str) -> Iterator[None]:
+def job_context(job_name: str) -> t.Iterator[None]:
     """Establish a context within which a job can be run.
 
     All relevant env vars for the specified job will be set in the process for

--- a/src/meltano/core/manifest/jsonschema.py
+++ b/src/meltano/core/manifest/jsonschema.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import typing as t
 from collections.abc import Generator
 from contextlib import suppress
-from typing import Any
 
 
 def meltano_config_env_locations(
-    manifest_schema: dict[str, Any],
+    manifest_schema: dict[str, t.Any],
     env_definition_ref: str = "#/$defs/env",
 ) -> set[str]:
     """Find all locations within a Meltano manifest file that can have an env field.
@@ -27,7 +27,7 @@ def meltano_config_env_locations(
 class JsonschemaRefLocationParser:
     """Minimal jsonschema parser that finds the locations of a specified ref."""
 
-    def __init__(self, schema: dict[str, Any], target_ref: str) -> None:
+    def __init__(self, schema: dict[str, t.Any], target_ref: str) -> None:
         """Initialize the `JsonschemaRefLocationParser`.
 
         Args:
@@ -36,11 +36,11 @@ class JsonschemaRefLocationParser:
         """
         self.root_schema = schema
         self.target_ref = target_ref
-        self._resolved_refs: dict[str, Any] = {}
+        self._resolved_refs: dict[str, t.Any] = {}
 
     def parse(  # noqa: C901
         self,
-        schema: dict[str, Any] | None = None,
+        schema: dict[str, t.Any] | None = None,
         path: tuple[str, ...] = (),
     ) -> Generator[str, None, None]:
         """Parse the jsonschema to find the locations of the target ref.
@@ -74,7 +74,7 @@ class JsonschemaRefLocationParser:
             elif schema["type"] == "array" and "items" in schema:
                 yield from self.parse(schema["items"], (*path, "[]"))
 
-    def resolve_ref(self, ref: str, path: tuple[str, ...]) -> dict[str, Any]:
+    def resolve_ref(self, ref: str, path: tuple[str, ...]) -> dict[str, t.Any]:
         """Resolve a local jsonschema ref into a schema.
 
         Args:

--- a/src/meltano/core/meltano_file.py
+++ b/src/meltano/core/meltano_file.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Iterable
+import typing as t
 
 from meltano.core.behavior.canonical import Canonical
 from meltano.core.environment import Environment
@@ -94,7 +94,7 @@ class MeltanoFile(Canonical):
         return [Schedule.parse(obj) for obj in schedules]
 
     @staticmethod
-    def load_environments(environments: Iterable[dict]) -> list[Environment]:
+    def load_environments(environments: t.Iterable[dict]) -> list[Environment]:
         """Parse `Environment` objects from python objects.
 
         Args:
@@ -106,7 +106,7 @@ class MeltanoFile(Canonical):
         return [Environment.parse(obj) for obj in environments]
 
     @staticmethod
-    def load_job_tasks(jobs: Iterable[dict]) -> list[TaskSets]:
+    def load_job_tasks(jobs: t.Iterable[dict]) -> list[TaskSets]:
         """Parse `TaskSets` objects from python objects.
 
         Args:

--- a/src/meltano/core/meltano_invoker.py
+++ b/src/meltano/core/meltano_invoker.py
@@ -6,9 +6,9 @@ import os
 import platform
 import subprocess
 import sys
+import typing as t
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Iterable
 
 from meltano.core.project import Project
 from meltano.core.project_settings_service import SettingValueStore
@@ -32,10 +32,10 @@ class MeltanoInvoker:
 
     def invoke(
         self,
-        args: Iterable[str],
+        args: t.Iterable[str],
         command: str = MELTANO_COMMAND,
         env: dict[str, str] | None = None,
-        **kwargs: Any,
+        **kwargs: t.Any,
     ) -> subprocess.CompletedProcess:
         """Invoke meltano or other provided command.
 

--- a/src/meltano/core/plugin/command.py
+++ b/src/meltano/core/plugin/command.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import shlex
-from typing import TypeVar
+import typing as t
 
 from meltano.core.behavior.canonical import Canonical
 from meltano.core.container.container_spec import ContainerSpec
 from meltano.core.error import Error
 from meltano.core.utils import expand_env_vars
 
-TCommand = TypeVar("TCommand")
+TCommand = t.TypeVar("TCommand")
 
 
 class UndefinedEnvVarError(Error):

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import typing as t
 
 import structlog
 
@@ -17,7 +17,7 @@ from meltano.core.plugin_install_service import (
 from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.venv_service import VirtualEnv
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from os import PathLike
     from pathlib import Path
 

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import Any, Iterable
+import typing as t
 
 from meltano.core.plugin.base import PluginDefinition, PluginRef, PluginType, Variant
 from meltano.core.plugin.command import Command
@@ -280,7 +280,7 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
         return uniques_in(prefixes)
 
     @property
-    def extra_config(self) -> dict[str, Any]:
+    def extra_config(self) -> dict[str, t.Any]:
         """Return plugin extra config.
 
         Returns:
@@ -289,7 +289,7 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
         return {f"_{key}": value for key, value in self.extras.items()}
 
     @property
-    def config_with_extras(self) -> dict[str, Any]:
+    def config_with_extras(self) -> dict[str, t.Any]:
         """Return config with extras.
 
         Returns:
@@ -385,7 +385,7 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
 
     def get_requirements(
         self,
-        plugin_types: Iterable[PluginType] | None = None,
+        plugin_types: t.Iterable[PluginType] | None = None,
     ) -> dict[PluginType, list[PluginRequirement]]:
         """Return the requirements for this plugin.
 

--- a/src/meltano/core/plugin/requirements.py
+++ b/src/meltano/core/plugin/requirements.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TypeVar
+import typing as t
 
 from meltano.core.behavior import NameEq
 from meltano.core.behavior.canonical import Canonical
 
-TReq = TypeVar("TReq", bound="PluginRequirement")
+TReq = t.TypeVar("TReq", bound="PluginRequirement")
 
 
 class PluginRequirement(NameEq, Canonical):

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any
+import typing as t
 
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project import Project
@@ -194,7 +194,7 @@ class PluginSettingsService(SettingsService):  # noqa: WPS214
         self.plugin.config_with_extras = config_with_extras
         self.project.plugins.update_plugin(self.plugin)
 
-    def update_meltano_environment_config(self, config_with_extras: dict[str, Any]):
+    def update_meltano_environment_config(self, config_with_extras: dict[str, t.Any]):
         """Update environment configuration in `meltano.yml`.
 
         Args:

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -10,8 +10,8 @@ from functools import singledispatch
 
 from meltano.core.behavior.visitor import visit_with
 
-Node = t.t.Dict[str, t.t.Any]
-T = t.t.TypeVar("T", bound="CatalogRule")
+Node = t.Dict[str, t.Any]
+T = t.TypeVar("T", bound="CatalogRule")
 
 
 class CatalogRule:

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import fnmatch
 import logging
 import re
+import typing as t
 from collections import OrderedDict
 from enum import Enum, auto
 from functools import singledispatch
-from typing import Any, Dict, Iterable, NamedTuple, TypeVar
 
 from meltano.core.behavior.visitor import visit_with
 
-Node = Dict[str, Any]
-T = TypeVar("T", bound="CatalogRule")
+Node = t.t.Dict[str, t.t.Any]
+T = t.t.TypeVar("T", bound="CatalogRule")
 
 
 class CatalogRule:
@@ -95,7 +95,7 @@ class SchemaRule(CatalogRule):
         self.payload = payload
 
 
-class SelectPattern(NamedTuple):
+class SelectPattern(t.NamedTuple):
     """A pattern for selecting streams and properties."""
 
     stream_pattern: str
@@ -139,7 +139,7 @@ class SelectPattern(NamedTuple):
         )
 
 
-def select_metadata_rules(patterns: Iterable[str]) -> list[MetadataRule]:
+def select_metadata_rules(patterns: t.Iterable[str]) -> list[MetadataRule]:
     """Create metadata rules from `select` patterns.
 
     Args:
@@ -184,7 +184,7 @@ def select_metadata_rules(patterns: Iterable[str]) -> list[MetadataRule]:
     return include_rules + exclude_rules
 
 
-def select_filter_metadata_rules(patterns: Iterable[str]) -> list[MetadataRule]:
+def select_filter_metadata_rules(patterns: t.Iterable[str]) -> list[MetadataRule]:
     """Create metadata rules from `select_filter` patterns.
 
     Args:
@@ -434,7 +434,7 @@ class MetadataExecutor(CatalogExecutor):
                 node["metadata"], f"{path}.metadata", rule.key, rule.value
             )
 
-    def set_metadata(self, node: Node, path: str, key: str, value: Any):
+    def set_metadata(self, node: Node, path: str, key: str, value: t.Any):
         """Set selection and inclusion keys in a metadata node."""
         # Unsupported fields cannot be selected
         if (
@@ -460,7 +460,7 @@ class SchemaExecutor(CatalogExecutor):
 
     def ensure_property(self, breadcrumb: list[str]):  # noqa: WPS231
         """Create nodes for the breadcrumb and schema extra that matches."""
-        next_node: dict[str, Any] = self._stream["schema"]
+        next_node: dict[str, t.Any] = self._stream["schema"]
 
         for idx, key in enumerate(breadcrumb):
             # If the key contains shell-style wildcards,
@@ -532,7 +532,7 @@ class ListExecutor(CatalogExecutor):
         self.properties[stream].add(prop)
 
 
-class SelectedNode(NamedTuple):
+class SelectedNode(t.NamedTuple):
     """Selection type and key of a node."""
 
     key: str
@@ -573,7 +573,7 @@ class ListSelectedExecutor(CatalogExecutor):
             A proper `SelectionType` given the inclusion and selection metadata.
         """
         try:
-            metadata: dict[str, Any] = node["metadata"]
+            metadata: dict[str, t.Any] = node["metadata"]
         except KeyError:
             return SelectionType.EXCLUDED
 

--- a/src/meltano/core/plugin_discovery_service.py
+++ b/src/meltano/core/plugin_discovery_service.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import io
 import logging
 import re
+import typing as t
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Iterable
 
 import requests
 from ruamel.yaml import YAMLError
@@ -23,7 +23,7 @@ from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.utils import NotFound, find_named
 from meltano.core.yaml import yaml
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 
@@ -360,7 +360,7 @@ class PluginDiscoveryService(  # noqa: WPS214 (too many public methods)
             for plugin_type in PluginType
         }
 
-    def plugins(self) -> Iterable[PluginDefinition]:
+    def plugins(self) -> t.Iterable[PluginDefinition]:
         """Generate all plugins.
 
         Yields:

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -7,10 +7,10 @@ import functools
 import logging
 import os
 import sys
+import typing as t
 from dataclasses import dataclass
 from enum import Enum
 from multiprocessing import cpu_count
-from typing import Any, Callable, Iterable, Mapping
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -18,7 +18,6 @@ if sys.version_info >= (3, 8):
 else:
     from cached_property import cached_property
     from typing_extensions import Protocol
-
 
 from meltano.core.error import (
     AsyncSubprocessError,
@@ -136,7 +135,7 @@ class PluginInstallService:  # noqa: WPS214
     def __init__(
         self,
         project: Project,
-        status_cb: Callable[[PluginInstallState], Any] = noop,
+        status_cb: t.Callable[[PluginInstallState], t.Any] = noop,
         parallelism: int | None = None,
         clean: bool = False,
         force: bool = False,
@@ -170,7 +169,7 @@ class PluginInstallService:  # noqa: WPS214
 
     @staticmethod
     def remove_duplicates(
-        plugins: Iterable[ProjectPlugin], reason: PluginInstallReason
+        plugins: t.Iterable[ProjectPlugin], reason: PluginInstallReason
     ):
         """Deduplicate list of plugins, keeping the last occurrences.
 
@@ -226,7 +225,7 @@ class PluginInstallService:  # noqa: WPS214
 
     def install_plugins(
         self,
-        plugins: Iterable[ProjectPlugin],
+        plugins: t.Iterable[ProjectPlugin],
         reason=PluginInstallReason.INSTALL,
     ) -> tuple[PluginInstallState]:
         """
@@ -251,7 +250,7 @@ class PluginInstallService:  # noqa: WPS214
 
     async def install_plugins_async(
         self,
-        plugins: Iterable[ProjectPlugin],
+        plugins: t.Iterable[ProjectPlugin],
         reason=PluginInstallReason.INSTALL,
     ) -> tuple[PluginInstallState]:
         """Install all the provided plugins.
@@ -464,7 +463,7 @@ async def install_pip_plugin(
     clean: bool = False,
     force: bool = False,
     venv_service: VenvService | None = None,
-    env: Mapping[str, str] | None = None,
+    env: t.Mapping[str, str] | None = None,
     **kwargs,
 ):
     """Install the plugin with pip.

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -6,10 +6,10 @@ import asyncio
 import enum
 import logging
 import os
+import typing as t
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Generator
 
 from structlog.stdlib import get_logger
 
@@ -127,7 +127,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
         self,
         project: Project,
         plugin: ProjectPlugin,
-        context: Any | None = None,
+        context: t.Any | None = None,
         output_handlers: dict | None = None,
         run_dir: Path | None = None,
         config_dir: Path | None = None,
@@ -388,7 +388,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
 
         return env
 
-    def Popen_options(self) -> dict[str, Any]:  # noqa: N802
+    def Popen_options(self) -> dict[str, t.Any]:  # noqa: N802
         """Get options for subprocess.Popen.
 
         Returns:
@@ -401,10 +401,10 @@ class PluginInvoker:  # noqa: WPS214, WPS230
         self,
         *args: str,
         require_preparation: bool = True,
-        env: dict[str, Any] | None = None,
+        env: dict[str, t.Any] | None = None,
         command: str | None = None,
         **kwargs,
-    ) -> Generator[list[str], dict[str, Any], dict[str, Any]]:  # noqa: WPS221
+    ) -> t.Generator[list[str], dict[str, t.Any], dict[str, t.Any]]:  # noqa: WPS221
         env = env or {}
 
         if require_preparation and not self._prepared:

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 import json
+import typing as t
 from hashlib import sha256
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
 
 from structlog.stdlib import get_logger
 
 from meltano.core.plugin.base import PluginRef, StandalonePlugin
 from meltano.core.plugin.project_plugin import ProjectPlugin
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 logger = get_logger(__name__)
@@ -64,7 +64,7 @@ class PluginLock:
     def load(
         self,
         create: bool = False,
-        loader: Callable = lambda x: StandalonePlugin(**json.load(x)),
+        loader: t.Callable = lambda x: StandalonePlugin(**json.load(x)),
     ) -> StandalonePlugin:
         """Load the plugin lockfile.
 

--- a/src/meltano/core/plugin_remove_service.py
+++ b/src/meltano/core/plugin_remove_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+import typing as t
 
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_location_remove import (
@@ -29,7 +29,7 @@ class PluginRemoveService:
 
     def remove_plugins(
         self,
-        plugins: Sequence[ProjectPlugin],
+        plugins: t.Sequence[ProjectPlugin],
         plugin_status_cb=noop,
         removal_manager_status_cb=noop,
     ) -> tuple[int, int]:

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -8,9 +8,9 @@ import logging
 import os
 import sys
 import threading
+import typing as t
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
 import fasteners
 from dotenv import dotenv_values
@@ -37,7 +37,7 @@ if sys.version_info >= (3, 8):
 else:
     from cached_property import cached_property
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.meltano_file import MeltanoFile as MeltanoFileTypeHint
 
 
@@ -311,7 +311,7 @@ class Project(Versioned):  # noqa: WPS214
         from meltano.core.meltano_file import MeltanoFile
         from meltano.core.settings_service import FEATURE_FLAG_PREFIX, FeatureFlags
 
-        conf: dict[str, Any] = yaml.load(self.meltanofile)
+        conf: dict[str, t.Any] = yaml.load(self.meltanofile)
         if conf is None:
             raise EmptyMeltanoFileException()
 

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import logging
+import typing as t
 from collections import OrderedDict
 from copy import copy
 from os import PathLike
 from pathlib import Path
-from typing import Any, Mapping, TypeVar
 
 from atomicwrites import atomic_write
 from ruamel.yaml import CommentedMap, CommentedSeq, YAMLError
@@ -84,9 +84,9 @@ class ProjectFiles:  # noqa: WPS214
         included_file_contents = self._load_included_files()
 
         # If the exact same objects are loaded again, use the cached result:
-        k = TypeVar("k")
+        k = t.TypeVar("k")
 
-        def id_vals(x: dict[k, Any]) -> dict[k, int]:
+        def id_vals(x: dict[k, t.Any]) -> dict[k, int]:
             return {k: id(v) for k, v in x.items()}
 
         if self._cached_loaded is None or id_vals(prev_raw_contents_map) != id_vals(
@@ -357,6 +357,6 @@ class ProjectFiles:  # noqa: WPS214
             schedules = file_dict.get("schedules", CommentedSeq())
             original_schedules.copy_attributes(schedules)
 
-    def _write_file(self, file_path: PathLike, contents: Mapping):
+    def _write_file(self, file_path: PathLike, contents: t.Mapping):
         with atomic_write(file_path, overwrite=True) as fl:
             yaml.dump(contents, fl)

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import enum
 import sys
+import typing as t
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Generator
 
 import structlog
 
@@ -26,7 +26,7 @@ if sys.version_info >= (3, 8):
 else:
     from cached_property import cached_property
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -72,7 +72,7 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
         self._prefer_source = None
 
     @contextmanager
-    def disallow_discovery_yaml(self) -> Generator[None, None, None]:
+    def disallow_discovery_yaml(self) -> t.Generator[None, None, None]:
         """Disallow the discovery yaml from being used.
 
         This is useful when you want to add a plugin to the project without
@@ -328,7 +328,7 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
             for plugin_type in PluginType
         }
 
-    def plugins(self, ensure_parent=True) -> Generator[ProjectPlugin, None, None]:
+    def plugins(self, ensure_parent=True) -> t.Generator[ProjectPlugin, None, None]:
         """Return all plugins.
 
         Args:

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+import typing as t
 
 import structlog
 from dotenv import dotenv_values
@@ -13,7 +13,7 @@ from meltano.core.setting_definition import SettingDefinition
 from meltano.core.settings_service import SettingsService, SettingValueStore
 from meltano.core.utils import nest_object
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 logger = structlog.get_logger(__name__)

--- a/src/meltano/core/schedule.py
+++ b/src/meltano/core/schedule.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import cast
+import typing as t
 
 from meltano.core.behavior import NameEq
 from meltano.core.behavior.canonical import Canonical
@@ -105,8 +105,8 @@ class Schedule(NameEq, Canonical):  # noqa: WPS230
         if self.job:
             raise NotImplementedError
         return [
-            cast(str, self.extractor),
-            cast(str, self.loader),
+            t.cast(str, self.extractor),
+            t.cast(str, self.loader),
             f"--transform={self.transform}",
             f"--state-id={self.name}",
         ]

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
+import typing as t
 from datetime import date, datetime
 from enum import Enum
-from typing import Any, Iterable
 
 from ruamel.yaml import Representer
 
@@ -101,7 +101,7 @@ class YAMLEnum(str, Enum):
         return dumper.represent_scalar("tag:yaml.org,2002:str", str(obj))
 
     @classmethod
-    def to_yaml(cls, representer: Representer, node: Any):
+    def to_yaml(cls, representer: Representer, node: t.Any):
         """Represent as yaml.
 
         Args:
@@ -231,7 +231,7 @@ class SettingDefinition(NameEq, Canonical):
         return f"<SettingDefinition {self.name} ({self.kind})>"
 
     @classmethod
-    def from_missing(cls, defs: Iterable[SettingDefinition], config: dict, **kwargs):
+    def from_missing(cls, defs: t.Iterable[SettingDefinition], config: dict, **kwargs):
         """Create SettingDefinition instances for missing settings.
 
         Args:
@@ -257,9 +257,9 @@ class SettingDefinition(NameEq, Canonical):
     def from_key_value(
         cls,
         key: str,
-        value: Any,
+        value: t.Any,
         custom: bool = True,
-        default: Any | bool = False,
+        default: t.Any | bool = False,
     ):
         """Create SettingDefinition instance from key-value pair.
 
@@ -349,11 +349,11 @@ class SettingDefinition(NameEq, Canonical):
                 env_keys.extend(utils.to_env_var(prefix, alias) for prefix in prefixes)
 
         if include_custom:
-            env_keys.extend(env for env in self.env_aliases)
+            env_keys.extend(self.env_aliases)
 
         return [EnvVar(key) for key in utils.uniques_in(env_keys)]
 
-    def cast_value(self, value: Any) -> Any:
+    def cast_value(self, value: t.Any) -> t.Any:  # noqa: C901
         """Cast given value.
 
         Args:
@@ -389,7 +389,7 @@ class SettingDefinition(NameEq, Canonical):
 
         return value
 
-    def post_process_value(self, value: Any) -> Any:
+    def post_process_value(self, value: t.Any) -> t.Any:
         """Post-process given value.
 
         Args:
@@ -407,7 +407,7 @@ class SettingDefinition(NameEq, Canonical):
 
         return value
 
-    def stringify_value(self, value: Any) -> str:
+    def stringify_value(self, value: t.Any) -> str:
         """Return value in string form.
 
         Args:

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -1,15 +1,16 @@
 """Storage Managers for Meltano Configuration."""
 
+
 from __future__ import annotations
 
 import logging
+import typing as t
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from copy import deepcopy
 from enum import Enum
 from functools import reduce
 from operator import eq
-from typing import TYPE_CHECKING, Any
 
 import dotenv
 import sqlalchemy
@@ -21,7 +22,7 @@ from meltano.core.setting import Setting
 from meltano.core.setting_definition import SettingDefinition, SettingMissingError
 from meltano.core.utils import flatten, pop_at_path, set_at_path
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.settings_service import SettingsService
 
 
@@ -78,10 +79,10 @@ class StoreNotSupportedError(Error):
 
 
 def cast_setting_value(
-    value: Any,
-    metadata: dict[str, Any],
+    value: t.Any,
+    metadata: dict[str, t.Any],
     setting_def: SettingDefinition | None,
-) -> tuple[Any, dict[str, Any]]:
+) -> tuple[t.Any, dict[str, t.Any]]:
     """Cast a setting value according to its setting defition.
 
     Args:
@@ -237,7 +238,7 @@ class SettingsStoreManager(ABC):
         self,
         name: str,
         path: list[str],
-        value: Any,
+        value: t.t.Any,
         setting_def: SettingDefinition | None = None,
     ) -> None:
         """Unimplemented set method.
@@ -365,12 +366,9 @@ class BaseEnvStoreManager(SettingsStoreManager):
 
         vals_with_metadata = []
         for env_var in self.setting_env_vars(setting_def):
-            try:
+            with suppress(KeyError):
                 value = env_var.get(self.env)
                 vals_with_metadata.append((value, {"env_var": env_var.key}))
-            except KeyError:
-                pass
-
         if len(vals_with_metadata) > 1:
             if reduce(eq, (val for val, _ in vals_with_metadata)):
                 raise MultipleEnvVarsSetException(
@@ -669,7 +667,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         self,
         name: str,
         path: list[str],
-        value: Any,
+        value: t.Any,
         setting_def: SettingDefinition | None = None,
     ) -> dict:
         """Set value by name in the Meltano YAML File.
@@ -807,7 +805,7 @@ class MeltanoEnvStoreManager(MeltanoYmlStoreManager):
         self.ensure_supported()
 
     @property
-    def flat_config(self) -> dict[str, Any]:
+    def flat_config(self) -> dict[str, t.Any]:
         """Get dictionary of flattened configuration.
 
         Returns:
@@ -930,7 +928,7 @@ class DbStoreManager(SettingsStoreManager):
         self,
         name: str,
         path: list[str],
-        value: Any,
+        value: t.Any,
         setting_def: SettingDefinition | None = None,
     ) -> dict:
         """Set value by name in the system database.
@@ -1251,9 +1249,12 @@ class AutoStoreManager(SettingsStoreManager):
             return None
 
         # value is env-specific
-        if setting_def and setting_def.env_specific:
-            if self.ensure_supported(store=SettingValueStore.DOTENV):
-                return SettingValueStore.DOTENV
+        if (
+            setting_def
+            and setting_def.env_specific
+            and self.ensure_supported(store=SettingValueStore.DOTENV)
+        ):
+            return SettingValueStore.DOTENV
 
         # no active meltano environment
         if not self.project.environment:
@@ -1420,12 +1421,9 @@ class AutoStoreManager(SettingsStoreManager):
             An empty dictionary.
         """
         for store in self.stores:
-            try:
+            with suppress(StoreNotSupportedError):
                 manager = self.manager_for(store)
                 manager.reset()
-            except StoreNotSupportedError:
-                pass
-
         return {}
 
     def find_setting(self, name: str) -> SettingDefinition | None:

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -238,7 +238,7 @@ class SettingsStoreManager(ABC):
         self,
         name: str,
         path: list[str],
-        value: t.t.Any,
+        value: t.Any,
         setting_def: SettingDefinition | None = None,
     ) -> None:
         """Unimplemented set method.

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import datetime
 import json
-from typing import Any
+import typing as t
 
 import structlog
 from sqlalchemy.orm import Session
@@ -91,7 +91,7 @@ class StateService:  # noqa: WPS214
         return self._state_store_manager
 
     @staticmethod
-    def validate_state(state: dict[str, Any]):
+    def validate_state(state: dict[str, t.Any]):
         """Check that the given state str is valid.
 
         Args:
@@ -186,9 +186,11 @@ class StateService:  # noqa: WPS214
             state_id_src: the state_id to get state from
             state_id_dst: the state_id_to merge state onto
         """
-        src_state_dict = self.get_state(state_id_src)
-        src_state = json.dumps(src_state_dict)
-        self.add_state(state_id_dst, src_state, payload_flags=Payload.INCOMPLETE_STATE)
+        self.add_state(
+            state_id_dst,
+            json.dumps(self.get_state(state_id_src)),
+            payload_flags=Payload.INCOMPLETE_STATE,
+        )
 
     def copy_state(self, state_id_src: str, state_id_dst: str):
         """Copy state from Job state_id_src onto Job state_id_dst.
@@ -197,9 +199,7 @@ class StateService:  # noqa: WPS214
             state_id_src: the state_id to get state from
             state_id_dst: the state_id_to copy state onto
         """
-        src_state_dict = self.get_state(state_id_src)
-        src_state = json.dumps(src_state_dict)
-        self.set_state(state_id_dst, src_state)
+        self.set_state(state_id_dst, json.dumps(self.get_state(state_id_src)))
 
     def move_state(self, state_id_src: str, state_id_dst: str):
         """Move state from Job state_id_src to Job state_id_dst.
@@ -208,7 +208,5 @@ class StateService:  # noqa: WPS214
             state_id_src: the state_id to get state from and clear
             state_id_dst: the state_id_to move state onto
         """
-        src_state_dict = self.get_state(state_id_src)
-        src_state = json.dumps(src_state_dict)
-        self.set_state(state_id_dst, src_state)
+        self.set_state(state_id_dst, json.dumps(self.get_state(state_id_src)))
         self.clear_state(state_id_src)

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import platform
+import typing as t
 from enum import Enum
-from typing import Mapping
 from urllib.parse import urlparse
 
 from sqlalchemy.orm import Session
@@ -45,7 +45,7 @@ class StateBackend(str, Enum):
     @property
     def _managers(
         self,
-    ) -> Mapping[str, type[StateStoreManager]]:
+    ) -> t.Mapping[str, type[StateStoreManager]]:
         """Get mapping of StateBackend to associated StateStoreManager.
 
         Returns:

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import os
 import platform
 import sys
+import typing as t
 import uuid
 from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterable
 from warnings import warn
 
 import psutil
@@ -53,7 +53,7 @@ class EnvironmentContext(SelfDescribingJson):
     notable_flag_env_vars = {"CODESPACES", *ci_markers}
 
     @classmethod
-    def _notable_flag_env_vars(cls) -> Iterable[str]:
+    def _notable_flag_env_vars(cls) -> t.Iterable[str]:
         for env_var_name in cls.notable_flag_env_vars:
             with suppress(KeyError):  # Skip unset env vars
                 env_var_value = os.environ[env_var_name]
@@ -83,7 +83,7 @@ class EnvironmentContext(SelfDescribingJson):
         )
 
     @cached_property
-    def system_info(self) -> dict[str, Any]:
+    def system_info(self) -> dict[str, t.Any]:
         """Get system information.
 
         Returns:
@@ -120,7 +120,7 @@ class EnvironmentContext(SelfDescribingJson):
         return f"{datetime.utcfromtimestamp(process.create_time()).isoformat()}Z"
 
     @cached_property
-    def process_info(self) -> dict[str, Any]:
+    def process_info(self) -> dict[str, t.Any]:
         """Obtain the process information for the current process.
 
         Returns:

--- a/src/meltano/core/tracking/contexts/exception.py
+++ b/src/meltano/core/tracking/contexts/exception.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import sys
+import typing as t
 import uuid
+from contextlib import suppress
 from pathlib import Path
 from types import TracebackType
-from typing import Dict, List, Union
 
 from snowplow_tracker import SelfDescribingJson
 
@@ -15,9 +16,9 @@ from meltano.core.utils import hash_sha256
 
 BASE_PATHS = (sys.prefix, sys.exec_prefix, sys.base_prefix, sys.base_exec_prefix)
 
-TracebackLevelsJSON = List[Dict[str, Union[str, int]]]
-ExceptionContextJSON = Dict[
-    str, Union[str, TracebackLevelsJSON, "ExceptionContextJSON"]
+TracebackLevelsJSON = t.List[t.Dict[str, t.Union[str, int]]]
+ExceptionContextJSON = t.Dict[
+    str, t.Union[str, TracebackLevelsJSON, "ExceptionContextJSON"]
 ]
 
 
@@ -104,10 +105,9 @@ def get_relative_traceback_path(tb: TracebackType) -> str | None:
     path = Path(str_path)
 
     for base_path in BASE_PATHS:
-        try:
+        with suppress(ValueError):
+            # Try to make the path relative to each base path until one works
             return path.relative_to(base_path).as_posix()
-        except ValueError:  # Path could not be made relative to `base_path`
-            pass  # Try making it relative to the next base path
 
     if path.parts[-1] in {"__init__.py", "__main__.py"}:
         # Include the module directory if the file is `__init__.py` or `__main__.py`

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -8,13 +8,13 @@ import locale
 import os
 import re
 import sys
+import typing as t
 import uuid
 from collections.abc import Mapping
 from contextlib import contextmanager, suppress
 from datetime import datetime
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -33,7 +33,7 @@ from meltano.core.tracking.schemas import (
 )
 from meltano.core.utils import format_exception
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from meltano.core.tracking.contexts import (  # noqa: F401
         CliEvent,
         EnvironmentContext,
@@ -76,7 +76,7 @@ def check_url(url: str) -> bool:
     return bool(re.match(URL_REGEX, url))
 
 
-class TelemetrySettings(NamedTuple):
+class TelemetrySettings(t.NamedTuple):
     """Settings which control telemetry and anonymous usage stats.
 
     These are stored within `analytics.json`.
@@ -431,7 +431,7 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
 
     def _uuid_from_str(
         self,
-        from_val: Any | None,
+        from_val: t.Any | None,
         warn: bool,  # noqa: WPS442
     ) -> uuid.UUID | None:
         """Safely convert string to a UUID. Return None if invalid UUID.

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -1,5 +1,6 @@
 """Defines helpers for the core codebase."""
 
+
 from __future__ import annotations
 
 import asyncio
@@ -12,27 +13,22 @@ import os
 import re
 import sys
 import traceback
+import typing as t
+from contextlib import suppress
 from copy import copy, deepcopy
 from datetime import date, datetime, time
 from enum import IntEnum
 from functools import reduce
 from operator import setitem
 from pathlib import Path
-from typing import (  # noqa: WPS235
-    Any,
-    Callable,
-    Iterable,
-    Mapping,
-    MutableMapping,
-    NamedTuple,
-    Sequence,
-    TypeVar,
-    overload,
-)
 
 import flatten_dict
 from requests.auth import HTTPBasicAuth
-from typing_extensions import runtime_checkable
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol, runtime_checkable
+else:
+    from typing_extensions import Protocol, runtime_checkable
 
 from meltano.core.error import MeltanoError
 
@@ -48,11 +44,6 @@ try:
     asyncio_all_tasks = asyncio.all_tasks
 except AttributeError:
     asyncio_all_tasks = asyncio.Task.all_tasks
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 
 
 class NotFound(Exception):
@@ -89,7 +80,7 @@ def click_run_async(func):
 
 
 # from https://github.com/jonathanj/compose/blob/master/compose.py
-def compose(*fs: Callable[[Any], Any]):
+def compose(*fs: t.Callable[[t.Any], t.Any]):
     """Create a composition of unary functions.
 
     Args:
@@ -253,7 +244,7 @@ def to_env_var(*xs):
     return "_".join(xs)
 
 
-def flatten(d: dict, reducer: str | Callable = "tuple", **kwargs):
+def flatten(d: dict, reducer: str | t.Callable = "tuple", **kwargs):
     """Flatten a dictionary with `dot` and `env_var` reducers.
 
     Wrapper arround `flatten_dict.flatten`.
@@ -274,7 +265,7 @@ def flatten(d: dict, reducer: str | Callable = "tuple", **kwargs):
     return flatten_dict.flatten(d, reducer, **kwargs)
 
 
-def compact(xs: Iterable) -> Iterable:
+def compact(xs: t.Iterable) -> t.Iterable:
     """Remove None values from an iterable.
 
     Args:
@@ -303,17 +294,17 @@ def truthy(val: str) -> bool:
     return str(val).lower() in TRUTHY
 
 
-@overload
+@t.overload
 def coerce_datetime(d: None) -> None:
     ...  # noqa: WPS428
 
 
-@overload
+@t.overload
 def coerce_datetime(d: datetime) -> datetime:
     ...  # noqa: WPS428
 
 
-@overload
+@t.overload
 def coerce_datetime(d: date) -> datetime:
     ...  # noqa: WPS428
 
@@ -330,18 +321,15 @@ def coerce_datetime(d):
     if d is None:
         return None
 
-    if isinstance(d, datetime):
-        return d
-
-    return datetime.combine(d, time())
+    return d if isinstance(d, datetime) else datetime.combine(d, time())
 
 
-@overload
+@t.overload
 def iso8601_datetime(d: None) -> None:
     ...  # noqa: WPS428
 
 
-@overload
+@t.overload
 def iso8601_datetime(d: str) -> datetime:
     ...  # noqa: WPS428
 
@@ -358,11 +346,8 @@ def iso8601_datetime(d):
     ]
 
     for format_string in isoformats:
-        try:
+        with suppress(ValueError):
             return coerce_datetime(datetime.strptime(d, format_string))
-        except ValueError:
-            pass
-
     raise ValueError(f"{d} is not a valid UTC date.")
 
 
@@ -371,10 +356,10 @@ class _GetItemProtocol(Protocol):
         ...  # noqa: WPS428
 
 
-_G = TypeVar("_G", bound=_GetItemProtocol)
+_G = t.TypeVar("_G", bound=_GetItemProtocol)
 
 
-def find_named(xs: Iterable[_G], name: str, obj_type: type | None = None) -> _G:
+def find_named(xs: t.Iterable[_G], name: str, obj_type: type | None = None) -> _G:
     """Find an object by its 'name' key.
 
     Args:
@@ -406,12 +391,7 @@ def makedirs(func):
 
         # if there is an extension, only create the base dir
         _, ext = os.path.splitext(path)
-        if ext:
-            directory = os.path.dirname(path)
-        else:
-            directory = path
-
-        os.makedirs(directory, exist_ok=True)
+        os.makedirs(os.path.dirname(path) if ext else path, exist_ok=True)
         return path
 
     return decorate
@@ -484,7 +464,7 @@ ENV_VAR_PATTERN = re.compile(
     re.VERBOSE,
 )
 
-Expandable = TypeVar("Expandable", str, Mapping[str, "Expandable"])
+Expandable = t.TypeVar("Expandable", str, t.Mapping[str, "Expandable"])
 
 
 class EnvVarMissingBehavior(IntEnum):
@@ -497,7 +477,7 @@ class EnvVarMissingBehavior(IntEnum):
 
 def expand_env_vars(
     raw_value: Expandable,
-    env: Mapping[str, str],
+    env: t.Mapping[str, str],
     *,
     if_missing: EnvVarMissingBehavior = EnvVarMissingBehavior.use_empty_str,
     flat: bool = False,
@@ -530,7 +510,7 @@ def expand_env_vars(
     """  # noqa: DAR402
     if_missing = EnvVarMissingBehavior(if_missing)
 
-    if not isinstance(raw_value, (str, Mapping)):
+    if not isinstance(raw_value, (str, t.Mapping)):
         return raw_value
 
     def replacer(match: re.Match) -> str:
@@ -559,25 +539,25 @@ def expand_env_vars(
 # `raw_value` is a dict, as opposed to once per key-value pair.
 def _expand_env_vars(
     raw_value: Expandable,
-    replacer: Callable[[re.Match], str],
+    replacer: t.Callable[[re.Match], str],
     flat: bool,
 ) -> Expandable:
-    if isinstance(raw_value, Mapping):
+    if isinstance(raw_value, t.Mapping):
         if flat:
             return {k: ENV_VAR_PATTERN.sub(replacer, v) for k, v in raw_value.items()}
         return {
             k: _expand_env_vars(v, replacer, flat)
-            if isinstance(v, (str, Mapping))
+            if isinstance(v, (str, t.Mapping))
             else v
             for k, v in raw_value.items()
         }
     return ENV_VAR_PATTERN.sub(replacer, raw_value)
 
 
-T = TypeVar("T")
+T = t.TypeVar("T")
 
 
-def uniques_in(original: Sequence[T]) -> list[T]:
+def uniques_in(original: t.Sequence[T]) -> list[T]:
     """Get unique elements from an iterable while preserving order.
 
     Args:
@@ -646,7 +626,7 @@ def format_exception(exception: BaseException) -> str:
     )
 
 
-def safe_hasattr(obj: Any, name: str) -> bool:
+def safe_hasattr(obj: t.Any, name: str) -> bool:
     """Safely checks if an object has a given attribute.
 
     This is a hacky workaround for the fact that `hasattr` is not allowed by WPS.
@@ -719,7 +699,7 @@ def get_no_color_flag() -> bool:
     return get_boolean_env_var("NO_COLOR")
 
 
-class MergeStrategy(NamedTuple):
+class MergeStrategy(t.NamedTuple):
     """Strategy to be used when merging instances of a type.
 
     The first value of this tuple, `applicable_for_instance_of`, is a type or
@@ -739,8 +719,9 @@ class MergeStrategy(NamedTuple):
     """
 
     applicable_for_instance_of: type | tuple[type, ...]
-    behavior: Callable[
-        [MutableMapping[str, Any], str, Any, tuple[MergeStrategy, ...] | None], None
+    behavior: t.Callable[
+        [t.MutableMapping[str, t.Any], str, t.Any, tuple[MergeStrategy, ...] | None],
+        None,
     ]
 
 
@@ -748,7 +729,7 @@ class MergeStrategy(NamedTuple):
 class Extendable(Protocol):
     """A type protocol for types which have an `extend` method."""
 
-    def extend(self, x: Any) -> None:
+    def extend(self, x: t.Any) -> None:
         """Extend the current instance with another value.
 
         Args:
@@ -758,7 +739,7 @@ class Extendable(Protocol):
 
 default_deep_merge_strategies: tuple[MergeStrategy, ...] = (
     MergeStrategy(
-        Mapping,
+        t.Mapping,
         lambda x, k, v, s: setitem(
             x, k, _deep_merge(x.setdefault(k, v.__class__()), v, strategies=s)
         ),
@@ -770,7 +751,7 @@ default_deep_merge_strategies: tuple[MergeStrategy, ...] = (
 )
 
 
-TMapping = TypeVar("TMapping", bound=Mapping)
+TMapping = t.TypeVar("TMapping", bound=t.Mapping)
 
 
 def deep_merge(

--- a/src/meltano/core/validation_service.py
+++ b/src/meltano/core/validation_service.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import typing as t
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import TypeVar
 
 from sqlalchemy.orm.session import sessionmaker
 
@@ -14,7 +14,7 @@ from meltano.core.project import Project
 
 EXIT_CODE_OK = 0
 
-T = TypeVar("T", bound="ValidationsRunner")  # noqa: WPS111
+T = t.TypeVar("T", bound="ValidationsRunner")  # noqa: WPS111
 
 
 class ValidationOutcome(str, Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 import logging
 import os
-from collections import Counter
+import typing as t
+from collections import Counter, abc
 from copy import deepcopy
 from http import HTTPStatus
-from typing import Any, Mapping
 
 import pytest
 import requests
@@ -72,8 +72,7 @@ class MockAdapter(BaseAdapter):
             hub[index_key] = {}
             for plugin in discovery.get(plugin_type, []):
                 plugin_name = plugin["name"]
-                hub[index_key][plugin_name] = {}
-                hub[index_key][plugin_name]["variants"] = {}
+                hub[index_key][plugin_name] = {"variants": {}}
                 default_variant = None
 
                 variants = plugin.pop("variants", [])
@@ -158,8 +157,8 @@ class MockAdapter(BaseAdapter):
         stream: bool = False,
         timeout: float | tuple[float, float] | tuple[float, None] | None = None,
         verify: bool | str = True,
-        cert: Any | None = None,
-        proxies: Mapping[str, str] | None = None,
+        cert: t.Any | None = None,
+        proxies: abc.Mapping[str, str] | None = None,
     ):
         _, endpoint = request.path_url.split("/meltano/api/v1/plugins")
 

--- a/tests/fixtures/cli.py
+++ b/tests/fixtures/cli.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 import os
+import typing as t
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 from click import Command
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 from fixtures.utils import cd, tmp_project
 from meltano.core.project_files import ProjectFiles
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from click.testing import Result
 
     from fixtures.docker import SnowplowMicro

--- a/tests/fixtures/db/__init__.py
+++ b/tests/fixtures/db/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
+import typing as t
 import warnings
 from contextlib import closing
-from typing import Generator
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch  # noqa: WPS436
@@ -16,7 +16,7 @@ from meltano.core.project import Project
 
 
 @pytest.fixture(scope="session", autouse=True)
-def engine_uri_env(engine_uri: str) -> Generator:
+def engine_uri_env(engine_uri: str) -> t.Generator:
     """Use the correct meltano database URI for these tests."""
     # No session monkey patch yet https://github.com/pytest-dev/pytest/issues/363
     monkeypatch = MonkeyPatch()

--- a/tests/fixtures/docker/snowplow.py
+++ b/tests/fixtures/docker/snowplow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from typing import Any
+import typing as t
 from urllib.request import urlopen
 
 import backoff
@@ -28,7 +28,7 @@ class SnowplowMicro:
         self.all()  # Wait until a connection is established
 
     @backoff.on_exception(backoff.expo, ConnectionError, max_tries=5)
-    def get(self, endpoint: str) -> Any:
+    def get(self, endpoint: str) -> t.Any:
         with urlopen(f"{self.url}/{endpoint}") as response:
             return json.load(response)
 
@@ -36,11 +36,11 @@ class SnowplowMicro:
         """Get a dict counting the number of good/bad events, and the total number of events."""
         return self.get("all")
 
-    def good(self) -> list[dict[str, Any]]:
+    def good(self) -> list[dict[str, t.Any]]:
         """Get a list of good events."""
         return self.get("good")
 
-    def bad(self) -> list[dict[str, Any]]:
+    def bad(self) -> list[dict[str, t.Any]]:
         """Get a list of bad events (e.g. those which failed schema validation)."""
         return self.get("bad")
 

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 import re
+import typing as t
 from pathlib import Path
 from types import TracebackType
-from typing import cast
 
 import pytest
 
@@ -65,7 +65,7 @@ class TestLogFormatters:
         path = tmp_path / "my_module.py"
         path.write_text("cause_an_error()\n")
 
-        tb = cast(
+        tb = t.cast(
             TracebackType,
             FakeTraceback(
                 [

--- a/tests/meltano/core/test_environment_variables.py
+++ b/tests/meltano/core/test_environment_variables.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import platform
 import subprocess
-from typing import NamedTuple
+import typing as t
 
 import pytest
 
@@ -12,7 +12,7 @@ from meltano.core.settings_service import FEATURE_FLAG_PREFIX, FeatureFlags
 from meltano.core.utils import EnvironmentVariableNotSetError
 
 
-class EnvVarResolutionExpectation(NamedTuple):
+class EnvVarResolutionExpectation(t.NamedTuple):
     expected_env_values: dict
     meltanofile_updates: dict = {}
     terminal_env: dict = {}
@@ -43,51 +43,39 @@ def _meltanofile_update_dict(
         "executable": "pwd",
     }
     if top_level_plugin_setting:
-        setting.update({"value": "top_level_plugin_setting"})
+        setting["value"] = "top_level_plugin_setting"
     if top_level_plugin_config:
-        utility.update({"config": {"from": "top_level_plugin_config"}})
+        utility["config"] = {"from": "top_level_plugin_config"}
     if top_level_env:
-        env.update({"TEST_ENV_VAR_RESOLUTION_FROM": "top_level_env"})
+        env["TEST_ENV_VAR_RESOLUTION_FROM"] = "top_level_env"
     if top_level_plugin_env:
-        utility.update(
-            {"env": {"TEST_ENV_VAR_RESOLUTION_FROM": "top_level_plugin_env"}}
-        )
+        utility["env"] = {"TEST_ENV_VAR_RESOLUTION_FROM": "top_level_plugin_env"}
     if environment_level_plugin_config:
-        environment.update(
-            {
-                "config": {
-                    "plugins": {
-                        "utilities": [
-                            {
-                                "name": plugin_name,
-                                "config": {"from": "environment_level_plugin_config"},
-                            }
-                        ]
+        environment["config"] = {
+            "plugins": {
+                "utilities": [
+                    {
+                        "name": plugin_name,
+                        "config": {"from": "environment_level_plugin_config"},
                     }
-                }
+                ]
             }
-        )
+        }
     if environment_level_env:
-        environment.update(
-            {"env": {"TEST_ENV_VAR_RESOLUTION_FROM": "environment_level_env"}}
-        )
+        environment["env"] = {"TEST_ENV_VAR_RESOLUTION_FROM": "environment_level_env"}
     if environment_level_plugin_env:
-        environment.update(
-            {
-                "config": {
-                    "plugins": {
-                        "utilities": [
-                            {
-                                "name": plugin_name,
-                                "env": {
-                                    "TEST_ENV_VAR_RESOLUTION_FROM": "environment_level_plugin_env"
-                                },
-                            }
-                        ]
+        environment["config"] = {
+            "plugins": {
+                "utilities": [
+                    {
+                        "name": plugin_name,
+                        "env": {
+                            "TEST_ENV_VAR_RESOLUTION_FROM": "environment_level_plugin_env"
+                        },
                     }
-                }
+                ]
             }
-        )
+        }
     if environment_level_plugin_config_indirected:
         environment.update(
             {

--- a/tests/meltano/core/tracking/test_exception.py
+++ b/tests/meltano/core/tracking/test_exception.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import inspect
 import json
 import platform
+import typing as t
 import uuid
 import warnings
 from pathlib import Path
 from platform import python_version_tuple
-from typing import Any
 
 import pytest
 from jsonschema import ValidationError, validate
@@ -34,7 +34,7 @@ class CustomException(Exception):
     """A custom exception type to be used in `test_complex_exception_context`."""
 
 
-def is_valid_exception_context(instance: dict[str, Any]) -> bool:
+def is_valid_exception_context(instance: dict[str, t.Any]) -> bool:
     try:
         with warnings.catch_warnings():
             # Ignore the misleading warning thrown by `jsonschema`:

--- a/tests/meltano/core/tracking/test_plugins.py
+++ b/tests/meltano/core/tracking/test_plugins.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+import typing as t
 
 from meltano.core.block.plugin_command import plugin_command_invoker
 from meltano.core.plugin.project_plugin import ProjectPlugin
@@ -55,7 +55,7 @@ class TestPluginsTrackingContext:
         assert not plugin_with_no_parent.get("parent_name_hash")
 
     @staticmethod
-    def assert_plugin_attributes(plugin_dict: dict[str, Any], plugin: ProjectPlugin):
+    def assert_plugin_attributes(plugin_dict: dict[str, t.Any], plugin: ProjectPlugin):
         for dict_key, plugin_key in (
             ("name_hash", "name"),
             ("namespace_hash", "namespace"),

--- a/tests/meltano/core/tracking/test_project_context.py
+++ b/tests/meltano/core/tracking/test_project_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import typing as t
 
 import pytest
 
@@ -8,7 +8,7 @@ from asserts import assert_cli_runner
 from meltano.cli import cli
 from meltano.core.utils import hash_sha256
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from fixtures.cli import MeltanoCliRunner
     from fixtures.docker import SnowplowMicro
     from meltano.core.project import Project

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+import typing as t
 import uuid
 from contextlib import contextmanager, suppress
 from http import server as server_lib
 from threading import Thread
 from time import sleep
-from typing import TYPE_CHECKING, Any
 
 import mock
 import pytest
@@ -23,11 +23,11 @@ from meltano.core.tracking.contexts.project import ProjectContext
 from meltano.core.tracking.tracker import TelemetrySettings, Tracker
 from meltano.core.utils import hash_sha256
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from fixtures.docker import SnowplowMicro
 
 
-def load_analytics_json(project: Project) -> dict[str, Any]:
+def load_analytics_json(project: Project) -> dict[str, t.Any]:
     with open(project.meltano_dir() / "analytics.json") as analytics_json_file:
         return json.load(analytics_json_file)
 


### PR DESCRIPTION
The flake8 plugin [`flake8-typing-as-t`](https://pypi.org/project/flake8-typing-as-t/) has been added to enforce this convention.

Closes #7334