### PR TITLE
fix: Error in `meltano add` when using env var proxies (e.g. `HTTP_PROXY`)

### DIFF
--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -230,7 +230,7 @@ class MeltanoHubService(PluginRepository):  # noqa: WPS214
         prep = self._build_request("GET", url)
         settings = self.session.merge_environment_settings(
             prep.url,
-            None,
+            {},
             None,
             None,
             None,


### PR DESCRIPTION
Closes https://github.com/meltano/meltano/issues/7346
