### PR TITLE
fix: Add error and log for locking unknown plugins

### DIFF
--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -77,6 +77,10 @@ def lock(
 
     tracked_plugins = []
 
+    if not plugins:
+        raise CliError("No matching plugin(s) found")
+
+    click.echo(f"Locking {len(plugins)} plugin(s)...")
     for plugin in plugins:
         descriptor = f"{plugin.type.descriptor} {plugin.name}"
         if plugin.is_custom():

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -78,7 +78,9 @@ def lock(
     tracked_plugins = []
 
     if not plugins:
-        raise CliError("No matching plugin(s) found")
+        tracker.track_command_event(CliEvent.aborted)
+        errmsg = "No matching plugin(s) found"
+        raise CliError(errmsg)
 
     click.echo(f"Locking {len(plugins)} plugin(s)...")
     for plugin in plugins:

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -20,6 +20,7 @@ from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
+    from meltano.core.tracking import Tracker
 
 
 __all__ = ["lock"]
@@ -54,7 +55,7 @@ def lock(
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#lock
     """
-    tracker = ctx.obj["tracker"]
+    tracker: Tracker = ctx.obj["tracker"]
 
     lock_service = PluginLockService(project)
     if (all_plugins and plugin_name) or not (all_plugins or plugin_name):

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from click.testing import CliRunner
 
-from meltano.cli import cli
+from meltano.cli import CliError, cli
 from meltano.core.hub import MeltanoHubService
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_lock_service import PluginLock
@@ -103,3 +103,9 @@ class TestLock:
         assert "Lockfile exists" not in result.stdout
         assert "Locked definition for extractor tap-mock" in result.stdout
         assert "Extractor tap-mock-inherited is an inherited plugin" in result.stdout
+
+    def test_lock_plugin_not_found(self, cli_runner: CliRunner):
+        result = cli_runner.invoke(cli, ["lock", "not-a-plugin"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, CliError)
+        assert "No matching plugin(s) found" in str(result.exception)


### PR DESCRIPTION
Closes https://github.com/meltano/meltano/issues/7356

I have it raising an error right now but I could change it to log instead if we want it to pass. I thought an error made more sense but I do see that install currently just logs `Installing 0 plugins...` in a similar situation of not finding the specified plugin.