### PR TITLE
chore: Ignore coverage for t.TYPE_CHECKING blocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -484,7 +484,7 @@ source = [
 [tool.coverage.report]
 exclude_lines = [
   "pragma: no cover",
-  "if TYPE_CHECKING:",
+  '''if (t\.)?TYPE_CHECKING:''',
   "\\.\\.\\.",
 ]
 precision = 2


### PR DESCRIPTION
Since we're adopting the `import typing as t` convention
