### PR TITLE
docs: part1/2 gsg refresh target-postgres for meltanolabs

### DIFF
--- a/docs/src/_getting-started/part1.md
+++ b/docs/src/_getting-started/part1.md
@@ -147,18 +147,23 @@ If you see the extractor's help message printed, the plugin was definitely insta
 ```console
 $ meltano invoke tap-github --help
 2022-09-19T09:32:05.162591Z [info     ] Environment 'dev' is active
-usage: tap-github [-h] -c CONFIG [-s STATE] [-p PROPERTIES] [--catalog CATALOG] [-d]
+Usage: tap-github [OPTIONS]
 
-options:
-  -h, --help            show this help message and exit
-  -c CONFIG, --config CONFIG
-                        Config file
-  -s STATE, --state STATE
-                        State file
-  -p PROPERTIES, --properties PROPERTIES
-                        Property selections: DEPRECATED, Please use --catalog instead
-  --catalog CATALOG     Catalog file
-  -d, --discover        Do schema discovery
+  Execute the Singer tap.
+
+Options:
+  --state PATH              Use a bookmarks file for incremental replication.
+  --catalog PATH            Use a Singer catalog file with the tap.
+  --test TEXT               Use --test to sync a single record for each
+                            stream. Use --test=schema to test schema output
+                            without syncing records.
+  --discover                Run the tap in discovery mode.
+  --config TEXT             Configuration file location or 'ENV' to use
+                            environment variables.
+  --format [json|markdown]  Specify output style for --about
+  --about                   Display package metadata and settings.
+  --version                 Display the package version.
+  --help                    Show this message and exit.
 ```
 </div>
 
@@ -171,6 +176,7 @@ The GitHub tap requires [configuration](/guide/configuration) before it can star
 ```bash
 $ meltano config tap-github set --interactive
 ```
+
 2. Follow the prompts to step through all available settings, the ones you'll need to fill out are repositories, start_date and your private_token.
 <br>
 <div class="termy">
@@ -208,7 +214,7 @@ This will add the configuration to your [`meltano.yml` project file](/concepts/p
       extractors:
         - name: tap-github
           config:
-            start_date: 2022-01-01
+            start_date: '2022-01-01'
             repositories:
               - sbalnojan/meltano-lightdash
   ```
@@ -235,7 +241,10 @@ $ meltano config tap-github
 2022-09-19T11:26:23.573556Z [info     ] The default environment (dev) will be ignored for `meltano config`. To configure a specific Environment, please use option `--environment=[]`.
 
 {
-  "repository": "sbalnojan/meltano-lightdash",
+  "auth_token": "ghp_XXX",
+  "repositories": [
+  &ensp;&ensp;"sbalnojan/meltano-lightdash"
+  ],
   "start_date": "2022-01-01"
 }
 ```
@@ -313,8 +322,9 @@ This will add the [selection rules](/concepts/plugins#select-extra) to your [`me
       variant: meltanolabs
       pip_url: git+https://github.com/MeltanoLabs/tap-github.git
       config:
-        start_date: 2022-01-01
-        repository: sbalnojan/meltano-lightdash
+        start_date: '2022-01-01'
+        repositories:
+        - sbalnojan/meltano-lightdash
   ```
 
 
@@ -333,15 +343,15 @@ To test that the extraction process works, we add a JSON target.
 
 ```console
 $ meltano add loader target-jsonl</span>
-2022-09-19T13:47:42.389423Z [info     ] Environment 'dev' is active
-To add it to your project another time so that each can be configured differently,
-add a new plugin inheriting from the existing one with its own unique name:
- &nbsp;&nbsp;&nbsp;&nbsp;meltano add loader target-jsonl--new --inherit-from target-jsonl
+Added loader 'target-jsonl' to your Meltano project
+Variant:        andyh1203 (default)
+Repository:     https://github.com/andyh1203/target-jsonl
+Documentation:  https://hub.meltano.com/loaders/target-jsonl--andyh1203
 
 Installing loader 'target-jsonl'...
 Installed loader 'target-jsonl'
 
-To learn more about loader 'target-jsonl', visit https://hub.meltano.com/loaders/target-jsonl
+To learn more about loader 'target-jsonl', visit https://hub.meltano.com/loaders/target-jsonl--andyh1203
 ```
 </div>
 <br />

--- a/docs/src/_getting-started/part2.md
+++ b/docs/src/_getting-started/part2.md
@@ -69,11 +69,19 @@ Use the ```meltano invoke target-postgres --help``` command to test that the ins
 
 ```console
 $ meltano invoke target-postgres --help
-usage: target-postgres [-h] [-c CONFIG]
+Usage: target-postgres [OPTIONS]
 
-optional arguments:
--h, --help            show this help message and exit
--c CONFIG, --config CONFIG Config file
+  Execute the Singer target.
+
+Options:
+  --input FILENAME          A path to read messages from instead of from
+                            standard in.
+  --config TEXT             Configuration file location or 'ENV' to use
+                            environment variables.
+  --format [json|markdown]  Specify output style for --about
+  --about                   Display package metadata and settings.
+  --version                 Display the package version.
+  --help                    Show this message and exit.
 ```
 </div>
 
@@ -98,15 +106,15 @@ password [env: TARGET_POSTGRES_PASSWORD] current value: None (default)
 database [env: TARGET_POSTGRES_DATABASE] current value: 'postgres' (from `meltano.yml`)
 &ensp;&ensp;Database: Database name. Note if sqlalchemy_url is set this will be ignored.
 [...]
-add_metadata_columns [env: TARGET_POSTGRES_ADD_METADATA_COLUMNS] current value: False (default)
-&ensp;&ensp;Add Metadata Columns: Useful if you want to load multiple streams from one tap to multiple Postgres schemas.
+add_record_metadata [env: TARGET_POSTGRES_ADD_RECORD_METADATA] current value: None (default)
+&ensp;&ensp;Add Record Metadata: Note that this must be enabled for activate_version to work!This adds _sdc_extracted_at, _sdc_batched_at, and more to every table. See https://sdk.meltano.com/en/latest/implementation/record_metadata.html for more information.
 [...]
 
-To learn more about loader 'target-postgres' and its settings, visit https://hub.meltano.com/loaders/target-postgres
+To learn more about loader 'target-postgres' and its settings, visit https://hub.meltano.com/loaders/target-postgres--meltanolabs
 ```
 </div>
 <br />
-Fill in the details for these four attributes, and set add_metadata_columns to True by using the `meltano config target-postgres set ATTRIBUTE VALUE` command:
+Fill in the details for these four attributes, and set add_record_metadata to True by using the `meltano config target-postgres set ATTRIBUTE VALUE` command:
 
  <div class="termy">
 
@@ -114,11 +122,11 @@ Fill in the details for these four attributes, and set add_metadata_columns to T
 $ meltano config target-postgres set user meltano
 &ensp;&ensp;Loader 'target-postgres' setting 'user' was set in `meltano.yml`: 'meltano'
 $ meltano config target-postgres set password password
-&ensp;&ensp;Loader 'target-postgres' setting 'password' was set in `.env`: 'password'
+&ensp;&ensp;Loader 'target-postgres' setting 'password' was set in `.env`: '(redacted)'
 $ meltano config target-postgres set database postgres
-&ensp;&ensp;Loader 'target-postgres' setting 'dbname' was set in `meltano.yml`: 'postgres'
-$ meltano config target-postgres set add_metadata_columns True
-&ensp;&ensp;Loader 'target-postgres' setting 'add_metadata_columns' was set in `meltano.yml`: True
+&ensp;&ensp;Loader 'target-postgres' setting 'database' was set in `meltano.yml`: 'postgres'
+$ meltano config target-postgres set add_record_metadata True
+&ensp;&ensp;Loader 'target-postgres' setting 'add_record_metadata' was set in `meltano.yml`: True
 $ meltano config target-postgres set host localhost
 &ensp;&ensp;Loader 'target-postgres' setting 'host' was set in `meltano.yml`: localhost
 ```
@@ -135,7 +143,7 @@ This will add the non-sensitive configuration to your [`meltano.yml` project fil
          config:
            user: meltano
            database: postgres
-           add_metadata_columns: true
+           add_record_metadata: true
            host: localhost
    ```
 
@@ -147,10 +155,11 @@ You can use `meltano config target-postgres` to check the configuration, includi
 ```console
 $ meltano config target-postgres
 {
-&ensp;&ensp;&ensp;&ensp;"host": "postgres",
+&ensp;&ensp;&ensp;&ensp;"host": "localhost",
 &ensp;&ensp;&ensp;&ensp;"user": "meltano",
+&ensp;&ensp;&ensp;&ensp;"password": "password",
 &ensp;&ensp;&ensp;&ensp;"database": "postgres",
-&ensp;&ensp;&ensp;&ensp;"add_metadata_columns": "True"
+&ensp;&ensp;&ensp;&ensp;"add_record_metadata": true
 }
 ```
 </div>


### PR DESCRIPTION
Related to a message in slack https://meltano.slack.com/archives/CMN8HELB0/p1678134699744109 and https://github.com/meltano/hub/pull/1184.

It looks like the guide was switched to using the meltano labs variant but some settings weren't fully updated. It also looked like the add_record_metadata setting wasnt on the hub yet either.

