### PR TITLE
docs: gsg to use utility dbt-postgres vs transformer

### DIFF
--- a/docs/src/_getting-started/part1.md
+++ b/docs/src/_getting-started/part1.md
@@ -216,7 +216,7 @@ This will add the configuration to your [`meltano.yml` project file](/concepts/p
           config:
             start_date: '2022-01-01'
             repositories:
-              - sbalnojan/meltano-lightdash
+              - sbalnojan/meltano-example-el
   ```
 
 It will also add your secret auth token to the file `.env`:
@@ -243,7 +243,7 @@ $ meltano config tap-github
 {
   "auth_token": "ghp_XXX",
   "repositories": [
-  &ensp;&ensp;"sbalnojan/meltano-lightdash"
+  &ensp;&ensp;"sbalnojan/meltano-example-el"
   ],
   "start_date": "2022-01-01"
 }
@@ -324,7 +324,7 @@ This will add the [selection rules](/concepts/plugins#select-extra) to your [`me
       config:
         start_date: '2022-01-01'
         repositories:
-        - sbalnojan/meltano-lightdash
+        - sbalnojan/meltano-example-el
   ```
 
 
@@ -374,7 +374,7 @@ $ meltano run tap-github target-jsonl
 2022-09-19T13:53:36.403099Z [info     ] Environment 'dev' is active
 2022-09-19T13:53:41.062802Z [info     ] Found state from 2022-09-19 13:53:17.415907.
 2022-09-19T13:53:41.071885Z [warning  ] No state was found, complete import.
-2022-09-19T13:53:43.054384Z [info     ] INFO Starting sync of repository: sbalnojan/meltano-lightdash cmd_type=elb consumer=False name=tap-github producer=True stdio=stderr string_id=tap-github
+2022-09-19T13:53:43.054384Z [info     ] INFO Starting sync of repository: sbalnojan/meltano-example-el cmd_type=elb consumer=False name=tap-github producer=True stdio=stderr string_id=tap-github
 2022-09-19T13:53:43.553171Z [info     ] INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.4796161651611328, "tags": {"endpoint": "commits", "http_status_code": 200, "status": "succeeded"}} cmd_type=elb consumer=False name=tap-github producer=True stdio=stderr string_id=tap-github
 2022-09-19T13:53:43.561190Z [info     ] INFO METRIC: {"type": "counter", "metric": "record_count", "value": 1, "tags": {"endpoint": "commits"}} cmd_type=elb consumer=False name=tap-github producer=True stdio=stderr string_id=tap-github</span>
 2022-09-19T13:53:43.735250Z [info     ] Incremental state has been updated at 2022-09-19 13:53:43.734535.
@@ -390,7 +390,7 @@ You can verify that it worked by looking inside the newly created file called ``
 
 ```console
 $ cat output/commits.jsonl
-{"sha": "409bdd601e0531833665f538bccecd0f69e101c0", "url": "https://api.github.com/repos/sbalnojan/meltano-lightdash/commits/409bdd601e0531833665f538bccecd0f69e101c0"}
+{"sha": "409bdd601e0531833665f538bccecd0f69e101c0", "url": "https://api.github.com/repos/sbalnojan/meltano-example-el/commits/409bdd601e0531833665f538bccecd0f69e101c0"}
 ```
 
 </div>

--- a/docs/src/_getting-started/part2.md
+++ b/docs/src/_getting-started/part2.md
@@ -173,7 +173,7 @@ Run your newly added extractor and loader in a pipeline using [`meltano run`](/r
 <div class="termy">
 
 ```console
-$ meltano run tap-github target-postgres --full-refresh
+$ meltano run tap-github target-postgres
 2022-09-20T13:16:13.885045Z [warning  ] No state was found, complete import.
 2022-09-20T13:16:15.441183Z [info     ] INFO Starting sync of repository: [...]
 2022-09-20T13:16:15.901789Z [info     ] INFO METRIC: {"type": "timer", "metric": "http_request_duration",[...]

--- a/docs/src/_getting-started/part2.md
+++ b/docs/src/_getting-started/part2.md
@@ -173,7 +173,7 @@ Run your newly added extractor and loader in a pipeline using [`meltano run`](/r
 <div class="termy">
 
 ```console
-$ meltano run tap-github target-postgres
+$ meltano run tap-github target-postgres --full-refresh
 2022-09-20T13:16:13.885045Z [warning  ] No state was found, complete import.
 2022-09-20T13:16:15.441183Z [info     ] INFO Starting sync of repository: [...]
 2022-09-20T13:16:15.901789Z [info     ] INFO METRIC: {"type": "timer", "metric": "http_request_duration",[...]

--- a/docs/src/_getting-started/part3.md
+++ b/docs/src/_getting-started/part3.md
@@ -67,41 +67,35 @@ dbt uses different [adapters](https://docs.getdbt.com/docs/supported-data-platfo
 <div class="termy">
 
 ```console
-$ meltano add transformer dbt-postgres
-2022-09-22T11:32:35.601357Z [info     ] Environment 'dev' is active
-Added transformer 'dbt-postgres' to your Meltano project
+$ meltano add utility dbt-postgres
+Added utility 'dbt-postgres' to your Meltano project
 Variant:        dbt-labs (default)
 Repository:     https://github.com/dbt-labs/dbt-core
-Documentation:  https://docs.meltano.com/guide/transformation
+Documentation:  https://hub.meltano.com/utilities/dbt-postgres--dbt-labs
 
-Adding required file bundle 'files-dbt-postgres' to your Meltano project...
-Variant:        meltano (default)
-Repository:     https://github.com/meltano/files-dbt-postgres
-Documentation:  https://hub.meltano.com/files/files-dbt-postgres
+Installing utility 'dbt-postgres'...
+Installed utility 'dbt-postgres'
 
-Installing transformer 'dbt-postgres'...
----> 100%
-Installing file bundle 'files-dbt-postgres'..
----> 100%
-Installed file bundle 'files-dbt-postgres'
-
-Adding 'files-dbt-postgres' files to project...
-Created transform/.gitignore (files-dbt-postgres)
-Created transform/dbt_project (files-dbt-postgres).yml
-Created transform/models/.gitkeep (files-dbt-postgres)
-Created transform/profiles/postgres/profiles (files-dbt-postgres).yml
-
-Installed transformer 'dbt-postgres'
-Installed 2/2 plugins
-
-To learn more about transformer 'dbt-postgres', visit https://docs.meltano.com/guide/transformation
-To learn more about file bundle 'files-dbt-postgres', visit https://hub.meltano.com/files/files-dbt-postgres
+To learn more about utility 'dbt-postgres', visit https://hub.meltano.com/utilities/dbt-postgres--dbt-labs
 ```
 
 </div>
 
 <br />
-As you can see, this adds both the transformer as well as a [file bundle](/concepts/plugins#file-bundles) to your project. You can verify that this worked by viewing the newly populated directory `transform`.
+The dbt-postgres utility can be used to scaffold your dbt project directory by running `meltano invoke dbt-postgres:initialize`:
+
+<div class="termy">
+
+```console
+$ meltano invoke dbt-postgres:initialize
+creating dbt project directory path=PosixPath('transform')
+creating dbt profiles directory path=PosixPath('[...]/transform/profiles/postgres')
+dbt initialized                dbt_ext_type=postgres dbt_profiles_dir=PosixPath('[...]/transform/profiles/postgres') dbt_project_dir=PosixPath('transform')
+```
+
+</div>
+
+You can verify that this worked by viewing the newly populated directory `transform`.
 
 ## Configure dbt
 Configure the dbt-postgres transformer to use the same configuration as our target-postgres loader using `meltano config`:
@@ -109,17 +103,17 @@ Configure the dbt-postgres transformer to use the same configuration as our targ
 <div class="termy">
 ```console
 $ meltano config dbt-postgres set host localhost
-&ensp;&ensp;Transformer 'dbt-postgres' setting 'host' was set in `meltano.yml`: 'localhost'
+&ensp;&ensp;Utility 'dbt-postgres' setting 'host' was set in `meltano.yml`: 'localhost'
 $ meltano config dbt-postgres set port 5432
-&ensp;&ensp;Transformer 'dbt-postgres' setting 'port' was set in `meltano.yml`: 5432
+&ensp;&ensp;Utility 'dbt-postgres' setting 'port' was set in `meltano.yml`: 5432
 $ meltano config dbt-postgres set user meltano
-&ensp;&ensp;Transformer 'dbt-postgres' setting 'user' was set in `meltano.yml`: 'meltano'
+&ensp;&ensp;Utility 'dbt-postgres' setting 'user' was set in `meltano.yml`: 'meltano'
 $ meltano config dbt-postgres set password password
-&ensp;&ensp;Transformer 'dbt-postgres' setting 'password' was set in `.env`: 'password'
+&ensp;&ensp;Utility 'dbt-postgres' setting 'password' was set in `.env`: '(redacted)'
 $ meltano config dbt-postgres set dbname postgres
-&ensp;&ensp;Transformer 'dbt-postgres' setting 'dbname' was set in `meltano.yml`: 'postgres'
+&ensp;&ensp;Utility 'dbt-postgres' setting 'dbname' was set in `meltano.yml`: 'postgres'
 $ meltano config dbt-postgres set schema analytics
-&ensp;&ensp;Transformer 'dbt-postgres' setting 'schema' was set in `meltano.yml`: 'analytics'
+&ensp;&ensp;Utility 'dbt-postgres' setting 'schema' was set in `meltano.yml`: 'analytics'
 ```
 </div>
 
@@ -172,8 +166,24 @@ To create the actual table, we run the dbt model via `meltano invoke dbt-postgre
 ```console
 $ meltano invoke dbt-postgres:run
 2022-09-22T12:30:31.842691Z [info     ] Environment 'dev' is active
-12:31:01  Running with dbt=1.1.2
-12:31:02  Found 1 model, 0 tests, 0 snapshots, 0 analyses, 167 macros, 0 operations, 0 seed files, 1 source, 0 exposures, 0 metrics
+Extension executing `dbt clean`...
+12:31:00  Running with dbt=1.3.3
+12:31:00  Checking ../.meltano/transformers/dbt/target/*
+12:31:00  Checking dbt_packages/*
+12:31:00  Cleaned dbt_packages/*
+12:31:00  Checking logs/*
+12:31:00  Cleaned logs/*
+12:31:00  Finished cleaning all paths.
+
+
+Extension executing `dbt deps`...
+12:31:01  Running with dbt=1.3.3
+12:31:01  Warning: No packages were found in packages.yml
+
+
+Extension executing `dbt run`...
+12:31:01  Running with dbt=1.3.3
+12:31:02  Found 1 model, 0 tests, 0 snapshots, 0 analyses, 289 macros, 0 operations, 0 seed files, 1 source, 0 exposures, 0 metrics
 12:31:02
 12:31:03  Concurrency: 2 threads (target='dev')
 12:31:03


### PR DESCRIPTION
@sbalnojan let me know what you think about these updates:

- switch to using utility dbt-postgres over the transformer + file bundle
- it also looks like on part 2 we're pulling commits from `sbalnojan/meltano-lightdash` then in part 3 we're using `sbalnojan/meltano-example-el`. Does it make a difference? I noticed the lightdash repo only gave me 1 record vs the example-el gave me many. I just noticed that it switched between parts. It might be less confusing for users if we chose one for the full tutorial.