### PR TITLE
fix: `meltano install --parallelism` error

### DIFF
--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -151,12 +151,22 @@ class PluginInstallService:  # noqa: WPS214
         """
         self.project = project
         self.status_cb = status_cb
-        if parallelism is None:
-            self.parallelism = cpu_count()
-        elif parallelism < 1:
-            self.parallelism = sys.maxsize
+        self._parallelism = parallelism
         self.clean = clean
         self.force = force
+
+    @cached_property
+    def parallelism(self) -> int:
+        """Return the number of parallel installation processes to use.
+
+        Returns:
+            The number of parallel installation processes to use.
+        """
+        if self._parallelism is None:
+            return cpu_count()
+        elif self._parallelism < 1:
+            return sys.maxsize
+        return self._parallelism
 
     @cached_property
     def semaphore(self):

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -10,8 +10,11 @@ from meltano.core.plugin_install_service import (
 
 
 class TestPluginInstallService:
-    @pytest.fixture
-    def subject(self, project):
+    @pytest.fixture(
+        params=({}, {"parallelism": -1}, {"parallelism": 2}),
+        ids=("default", "-p=-1", "-p=2"),
+    )
+    def subject(self, project, request):
         with open(project.meltanofile, "w") as file:
             file.write(
                 yaml.dump(
@@ -38,7 +41,7 @@ class TestPluginInstallService:
                 )
             )
         project.refresh()
-        return PluginInstallService(project)
+        return PluginInstallService(project, **request.param)
 
     def test_default_init_should_not_fail(self, subject):
         assert subject


### PR DESCRIPTION
The update to the tests should prevent another regression like this.

Closes #7370