### PR TITLE
fix: Display the right message when adding a new variant of an existing plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,9 @@ types-requests = "^2.28.9"
 [tool.poetry.scripts]
 meltano = "meltano.cli:main"
 
+[tool.black]
+line-length = 88
+
 [tool.isort]
 add_imports = [
   "from __future__ import annotations",

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -316,6 +316,7 @@ def add_plugin(
         print_added_plugin(plugin)
     except PluginAlreadyAddedException as err:
         plugin = err.plugin
+        new_plugin = err.new_plugin
 
         click.secho(
             f"{plugin_type.descriptor.capitalize()} '{plugin_name}' already exists in your Meltano project",
@@ -324,18 +325,17 @@ def add_plugin(
         )
 
         if variant and variant != plugin.variant:
-            variant = plugin.find_variant(variant)
-
             click.echo()
             click.echo(
-                f"To switch from the current '{plugin.variant}' variant to '{variant.name}':"
+                f"To switch from the current '{plugin.variant}' variant to "
+                f"'{new_plugin.variant}':",
             )
             click.echo(
-                "1. Update `variant` and `pip_url` in your `meltano.yml` project file:"
+                "1. Update `variant` and `pip_url` in your `meltano.yml` project file:",
             )
             click.echo(f"\tname: {plugin.name}")
-            click.echo(f"\tvariant: {variant.name}")
-            click.echo(f"\tpip_url: {variant.pip_url}")
+            click.echo(f"\tvariant: {new_plugin.name}")
+            click.echo(f"\tpip_url: {new_plugin.pip_url}")
 
             click.echo("2. Reinstall the plugin:")
             click.echo(f"\tmeltano install {plugin_type.singular} {plugin.name}")
@@ -351,14 +351,18 @@ def add_plugin(
 
             click.echo()
             click.echo(
-                f"Alternatively, to keep the existing '{plugin.name}' with variant '{plugin.variant}',"
+                f"Alternatively, to keep the existing '{plugin.name}' with variant "
+                f"'{plugin.variant}',",
             )
             click.echo(
-                f"add variant '{variant.name}' as a separate plugin with its own unique name:"
+                f"add variant '{new_plugin.variant}' as a separate plugin with its own "
+                "unique name:",
             )
             click.echo(
                 "\tmeltano add {type} {name}--{variant} --inherit-from {name} --variant {variant}".format(
-                    type=plugin_type.singular, name=plugin.name, variant=variant.name
+                    type=plugin_type.singular,
+                    name=plugin.name,
+                    variant=new_plugin.variant,
                 )
             )
 

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -45,13 +45,15 @@ class DefinitionSource(str, enum.Enum):
 class PluginAlreadyAddedException(Exception):
     """Raised when a plugin is already added to the project."""
 
-    def __init__(self, plugin: PluginRef):
+    def __init__(self, plugin: PluginRef, new_plugin: PluginRef):
         """Create a new Plugin Already Added Exception.
 
         Args:
             plugin: The plugin that was already added.
+            new_plugin: The plugin that was attempted to be added.
         """
         self.plugin = plugin
+        self.new_plugin = new_plugin
         super().__init__()
 
 
@@ -126,7 +128,7 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
 
         with suppress(PluginNotFoundError):
             existing_plugin = self.get_plugin(plugin)
-            raise PluginAlreadyAddedException(existing_plugin)
+            raise PluginAlreadyAddedException(existing_plugin, plugin)
 
         with self.update_plugins() as plugins:
             if plugin.type not in plugins:

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -139,6 +139,25 @@ class TestCliAdd:
                 reason=PluginInstallReason.ADD,
             )
 
+    @pytest.mark.order(1)
+    def test_add_different_variant(self, cli_runner):
+        with mock.patch("meltano.cli.add.install_plugins") as install_plugin_mock:
+            install_plugin_mock.return_value = True
+            res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock"])
+            assert res.exit_code == 0, res.stdout
+            assert "Added extractor 'tap-mock" in res.stdout
+
+            res = cli_runner.invoke(
+                cli,
+                ["add", "extractor", "tap-mock", "--variant", "singer-io"],
+            )
+            assert res.exit_code == 0, res.stdout
+            assert (
+                "Extractor 'tap-mock' already exists in your Meltano project"
+                in res.stderr
+            )
+            assert "To switch from the current" in res.stdout
+
     @pytest.mark.order(2)
     def test_add_transform(self, project, cli_runner):
         # adding Transforms requires the legacy 'dbt' Transformer


### PR DESCRIPTION
- Add failing test
- Implement fix

Related:

- Closes https://github.com/meltano/meltano/issues/7392
- https://github.com/meltano/meltano/issues/7393
