### PR TITLE
style: Add initial Ruff config & pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,12 @@ repos:
           - "eslint-plugin-vue@9.8.0"
           - "prettier@2.8.1"
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.257
+    hooks:
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
+
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -606,7 +606,6 @@ select = [
     "F401", # Permit unused imports in `__init__.py` files
 ]
 
-
 [tool.ruff.flake8-annotations]
 allow-star-arg-any = true
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -573,40 +573,24 @@ backend-path = ["scripts"]
 target-version = "py37"
 line-length = 88
 exclude = [
-    "src/meltano/migrations/*",
-    "src/webapp/*",
-    "src/meltano/api/*",
-    "src/meltano/cli/ui.py",
+  "src/meltano/migrations/*",
+  "src/webapp/*",
+  "src/meltano/api/*",
+  "src/meltano/cli/ui.py",
 ]
 ignore = [
-    "ANN101", # Missing type annotation for `self` in method
-    "ANN102", # Missing type annotation for `cls` in class method
+  "ANN101", # Missing type annotation for `self` in method
+  "ANN102", # Missing type annotation for `cls` in class method
 ]
 select = [
-    "E",   # pycodestyle (error)
-    "W",   # pycodestyle (warning)
-    "F",   # pyflakes
-    # "ANN", # flake8-annotations
-    # "COM", # flake8-commas
-    # "D",   # pydocstyle/flake8-docstrings
-    # "ICN", # flake8-import-conventions
-    # "I",   # isort
-    # "INP", # flake8-no-pep420
-    # "ISC", # flake8-implicit-str-concat
-    # "PIE", # flake8-pie
-    # "PT",  # flake8-pytest-style
-    # "RET", # flake8-return
-    # "RSE", # flake8-raise
-    # "SIM", # flake8-simplify
-    # "T10", # flake8-debugger
-    # "T20", # flake8-print
-    # "UP",  # pyupgrade
-    # "YTT", # flake8-2020
+  "E",   # pycodestyle (error)
+  "F",   # pyflakes
+  "W",   # pycodestyle (warning)
 ]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = [
-    "F401", # Permit unused imports in `__init__.py` files
+  "F401", # Permit unused imports in `__init__.py` files
 ]
 
 [tool.ruff.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -613,7 +613,7 @@ suppress-dummy-args = true
 
 [tool.ruff.flake8-pytest-style]
 fixture-parentheses = false
-parametrize-names-type = "csv"
+parametrize-values-type = "tuple"
 
 [tool.ruff.isort]
 known-first-party = ["meltano", "fixtures"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -563,3 +563,58 @@ module = [
 requires = ["poetry-core==1.5.0"]
 build-backend = "build:api"
 backend-path = ["scripts"]
+
+[tool.ruff]
+target-version = "py37"
+line-length = 88
+exclude = [
+    "src/meltano/migrations/*",
+    "src/webapp/*",
+]
+ignore = [
+    "ANN101", # Missing type annotation for `self` in method
+    "ANN102", # Missing type annotation for `cls` in class method
+]
+select = [
+    "E",   # pycodestyle (error)
+    "W",   # pycodestyle (warning)
+    "F",   # pyflakes
+    # "ANN", # flake8-annotations
+    # "COM", # flake8-commas
+    # "D",   # pydocstyle/flake8-docstrings
+    # "ICN", # flake8-import-conventions
+    # "I",   # isort
+    # "INP", # flake8-no-pep420
+    # "ISC", # flake8-implicit-str-concat
+    # "PIE", # flake8-pie
+    # "PT",  # flake8-pytest-style
+    # "RET", # flake8-return
+    # "RSE", # flake8-raise
+    # "SIM", # flake8-simplify
+    # "T10", # flake8-debugger
+    # "T20", # flake8-print
+    # "UP",  # pyupgrade
+    # "YTT", # flake8-2020
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = [
+    "F401", # Permit unused imports in `__init__.py` files
+]
+
+
+[tool.ruff.flake8-annotations]
+allow-star-arg-any = true
+mypy-init-return = true
+suppress-dummy-args = true
+
+[tool.ruff.flake8-pytest-style]
+fixture-parentheses = false
+parametrize-names-type = "csv"
+
+[tool.ruff.isort]
+known-first-party = ["meltano", "fixtures"]
+required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,8 @@ exclude = [
   "*.md",
   "src/webapp/node_modules/",
   "src/meltano/migrations/",
+  "src/meltano/api/",
+  "src/meltano/cli/ui.py",
 ]
 format = "colored"
 inline_quotes = "double"
@@ -570,6 +572,8 @@ line-length = 88
 exclude = [
     "src/meltano/migrations/*",
     "src/webapp/*",
+    "src/meltano/api/*",
+    "src/meltano/cli/ui.py",
 ]
 ignore = [
     "ANN101", # Missing type annotation for `self` in method

--- a/src/meltano/api/controllers/errors.py
+++ b/src/meltano/api/controllers/errors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 
 class InvalidFileNameError(Exception):
-    """Occurs when an invalid file name is provided."""
+    """An invalid file name is provided."""
 
     def __init__(self, name):
         self.name = name

--- a/src/meltano/api/controllers/orchestrations.py
+++ b/src/meltano/api/controllers/orchestrations.py
@@ -104,7 +104,8 @@ def validate_plugin_config(
         resolved_file_path = project.root_dir(value).resolve()
         if not str(resolved_file_path).startswith(f"{uploads_directory}/"):
             logging.warning(
-                "Cannot set a file configuration to a path outside the project directory"
+                "Cannot set a file configuration to a path outside the "
+                "project directory"
             )
             return False
 
@@ -140,7 +141,10 @@ def _handle(ex):
         jsonify(
             {
                 "error": True,
-                "code": f"A pipeline with the name '{ex.schedule.name}' already exists. Try renaming the pipeline.",
+                "code": (
+                    f"A pipeline with the name '{ex.schedule.name}' "
+                    "already exists. Try renaming the pipeline."
+                ),
             }
         ),
         409,
@@ -171,7 +175,10 @@ def _handle(ex):
         jsonify(
             {
                 "error": True,
-                "code": f"The file '{ex.file.filename}' must be one of the following types: {ex.extensions}",
+                "code": (
+                    f"The file '{ex.file.filename}' must be one of the "
+                    f"following types: {ex.extensions}"
+                ),
             }
         ),
         400,
@@ -184,7 +191,10 @@ def _handle(ex):
         jsonify(
             {
                 "error": True,
-                "code": f"The file '{ex.file.filename}' is empty or exceeds the {ex.max_file_size} size limit.",
+                "code": (
+                    f"The file '{ex.file.filename}' is empty or exceeds the "
+                    f"{ex.max_file_size} size limit."
+                ),
             }
         ),
         400,
@@ -454,7 +464,8 @@ def test_plugin_configuration(plugin_ref) -> Response:  # noqa: WPS210
 def get_pipeline_schedules():
     """Endpoint for getting the pipeline schedules.
 
-    Note that unless the ff ENABLE_API_SCHEDULED_JOB_LIST is enabled this endpoint will filter out scheduled jobs.
+    Note that unless the ff ENABLE_API_SCHEDULED_JOB_LIST is enabled this
+    endpoint will filter out scheduled jobs.
 
     Returns:
         JSON containing the pipline schedules.
@@ -474,8 +485,8 @@ def get_pipeline_schedules():
 
     for schedule in schedules:
         if schedule.get("job") and jobs_in_list:
-            # we only return API results for scheduled jobs if the feature flag is explicitly enabled
-            # as the UI is not job aware yet.
+            # We only return API results for scheduled jobs if the feature flag
+            # is explicitly enabled as the UI is not job aware yet.
             formatted_schedules.append(schedule)
         elif not schedule.get("job"):  # a legacy elt task
             finder = JobFinder(schedule["name"])

--- a/src/meltano/api/controllers/upload_helper.py
+++ b/src/meltano/api/controllers/upload_helper.py
@@ -12,7 +12,7 @@ ALLOWED_EXTENSIONS = {"json"}
 
 
 class InvalidFileTypeError(Exception):
-    """Occurs when a file does not meet our file type criteria."""
+    """A file does not meet our file type criteria."""
 
     def __init__(self, file):
         self.file = file
@@ -20,7 +20,7 @@ class InvalidFileTypeError(Exception):
 
 
 class InvalidFileSizeError(Exception):
-    """Occurs when a file does not conform to MAX_FILE_SIZE."""
+    """A file does not conform to MAX_FILE_SIZE."""
 
     def __init__(self, file):
         self.file = file
@@ -46,7 +46,8 @@ class UploadHelper:
         return file.filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
     def is_valid_size(self, file):
-        # File size calculated due to multipart/form data (initial header content-length may differ when complete file data has been uploaded)
+        # File size calculated due to multipart/form data (initial header
+        # content-length may differ when complete file data has been uploaded)
         file.seek(0, SEEK_END)
         file_size = file.tell()
         file.seek(0)  # Return to 0 so subsequent write occurs from beginning of file

--- a/src/meltano/api/events/notification_events.py
+++ b/src/meltano/api/events/notification_events.py
@@ -94,7 +94,8 @@ class NotificationEvents:
             # ensure it is not a duplicate mail
             if subscription.recipient in sent_recipients:
                 logger.debug(
-                    f"Skipping duplicate notification for recipient '{subscription.recipient}'."
+                    "Skipping duplicate notification for "
+                    f"recipient '{subscription.recipient}'."
                 )
                 continue
 

--- a/src/meltano/api/json.py
+++ b/src/meltano/api/json.py
@@ -13,12 +13,19 @@ class KeyFrozenDict(dict):
     """Dict subclass that marks the dict as "frozen"."""
 
 
-def freeze_keys(d: dict):
-    """Mark the dictionary as frozen - no automatic conversion will be operated on it."""
-    if isinstance(d, KeyFrozenDict):
-        return d
+def freeze_keys(d: dict) -> KeyFrozenDict:
+    """Mark the dictionary as frozen.
 
-    return KeyFrozenDict(d)
+    No automatic conversion will be operated on it.
+
+    Args:
+        d: The dictionary to mark as frozen.
+
+    Returns:
+        A shallow copy of the dict with a `dict` subclass that denotes the
+        dictionary as being frozen.
+    """
+    return d if isinstance(d, KeyFrozenDict) else KeyFrozenDict(d)
 
 
 class JSONScheme(str, Enum):
@@ -32,11 +39,7 @@ def key_convert(obj, converter):
         for k, v in obj.items():
             # humps fails to convert undescored values
             # see https://github.com/nficano/humps/issues/2
-            if k.startswith("_"):
-                new_k = k
-            else:
-                new_k = converter(k)
-
+            new_k = k if k.startswith("_") else converter(k)
             if new_k in converted:
                 raise ValueError(f"Naming scheme conversion conflict on `{new_k}`")
 

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -46,8 +46,8 @@ if t.TYPE_CHECKING:
     from meltano.core.tracking.tracker import Tracker
 
 
-# Holds the exit code for error reporting during process exiting. In particular, a function
-# registered by the `atexit` module uses this value.
+# Holds the exit code for error reporting during process exiting. In
+# particular, a function registered by the `atexit` module uses this value.
 exit_code: None | int = None
 
 atexit_handler_registered = False

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -56,7 +56,10 @@ if t.TYPE_CHECKING:
 @click.option(
     "--custom",
     is_flag=True,
-    help="Add a custom plugin. The command will prompt you for the package's base plugin description metadata.",
+    help=(
+        "Add a custom plugin. The command will prompt you for the package's "
+        "base plugin description metadata."
+    ),
 )
 @click.option(
     "--no-install",
@@ -165,5 +168,6 @@ def _print_plugins(plugins):
             printed_empty_line = True
 
         click.echo(
-            f"To learn more about {plugin.type.descriptor} '{plugin.name}', visit {docs_url}"
+            f"To learn more about {plugin.type.descriptor} '{plugin.name}', "
+            f"visit {docs_url}"
         )

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -126,7 +126,8 @@ def cli(  # noqa: C901,WPS231
             fg="yellow",
         )
         click.echo(
-            "For more details, visit https://docs.meltano.com/guide/installation#upgrading-meltano-version"
+            "For more details, visit "
+            "https://docs.meltano.com/guide/installation#upgrading-meltano-version"
         )
         sys.exit(3)
 

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -211,13 +211,14 @@ def config(  # noqa: WPS231
     cls=PartialInstrumentedCmd,
     name="list",
     short_help=(
-        "List all settings for the specified plugin with their names, environment variables, and current values."
+        "List all settings for the specified plugin with their names, "
+        "environment variables, and current values."
     ),
 )
 @click.option("--extras", is_flag=True)
 @click.pass_context
 def list_settings(ctx, extras: bool):
-    """List all settings for the specified plugin with their names, environment variables, and current values."""
+    """List all settings for the specified plugin with their names, environment variables, and current values."""  # noqa: E501
     settings = ctx.obj["settings"]
     session = ctx.obj["session"]
     tracker = ctx.obj["tracker"]
@@ -318,7 +319,8 @@ def reset(ctx, store):
     except StoreNotSupportedError as err:
         tracker.track_command_event(CliEvent.aborted)
         raise CliError(
-            f"{settings.label.capitalize()} settings in {store.label} could not be reset: {err}"
+            f"{settings.label.capitalize()} settings in {store.label} could "
+            f"not be reset: {err}"
         ) from err
 
     store = metadata["store"]
@@ -412,7 +414,8 @@ def unset(ctx, setting_name, store):
     except StoreNotSupportedError as err:
         tracker.track_command_event(CliEvent.aborted)
         raise CliError(
-            f"{settings.label.capitalize()} setting '{path}' in {store.label} could not be unset: {err}"
+            f"{settings.label.capitalize()} setting '{path}' in {store.label} "
+            f"could not be unset: {err}"
         ) from err
 
     name = metadata["name"]

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -259,10 +259,7 @@ async def _redirect_output(log, output_logger):
     )
 
     with meltano_stdout.redirect_logging(ignore_errors=(CliError,)):
-        async with (
-            meltano_stdout.redirect_stdout(),
-            meltano_stderr.redirect_stderr(),
-        ):  # noqa: WPS316
+        async with meltano_stdout.redirect_stdout(), meltano_stderr.redirect_stderr():  # noqa: WPS316, E501
             try:
                 yield
             except CliError as err:

--- a/src/meltano/cli/environment.py
+++ b/src/meltano/cli/environment.py
@@ -26,7 +26,7 @@ def meltano_environment(project: Project, ctx: click.Context):
     Manage Environments.
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#environment
-    """
+    """  # noqa: E501
     ctx.obj[ENVIRONMENT_SERVICE_KEY] = EnvironmentService(project)
 
 

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -32,7 +32,10 @@ if t.TYPE_CHECKING:
     "-p",
     type=click.INT,
     default=None,
-    help="Limit the number of plugins to install in parallel. Defaults to the number of cores.",
+    help=(
+        "Limit the number of plugins to install in parallel. "
+        "Defaults to the number of cores."
+    ),
 )
 @click.option(
     "--force",

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -63,7 +63,7 @@ To learn more about configuration options, see the [link=https://docs.meltano.co
 {%- endfor %}
 
 {% if plugin_url %}To learn more about {{ plugin_name | safe }} and its settings, visit [link={{ plugin_url }}]{{ plugin_url }}[/link]{% endif %}
-"""
+"""  # noqa: E501
 
 
 class InteractiveConfig:  # noqa: WPS230, WPS214
@@ -144,21 +144,25 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
 
         pre = [
             Text.from_markup(
-                f"[bold underline][{PLUGIN_COLOR}]{self.settings.label.capitalize()}[/{PLUGIN_COLOR}][/bold underline] Setting {index} of {last_index}"
+                f"[bold underline][{PLUGIN_COLOR}]"
+                f"{self.settings.label.capitalize()}[/{PLUGIN_COLOR}]"
+                f"[/bold underline] Setting {index} of {last_index}"
             )
         ]
 
         if setting_def.is_extra:
             pre.append(
                 Text.from_markup(
-                    "[yellow1]Custom Extra: plugin-specific options handled by Meltano[/yellow1]"
+                    "[yellow1]Custom Extra: plugin-specific options handled "
+                    "by Meltano[/yellow1]"
                 )
             )
 
         elif setting_def.is_custom:
             pre.append(
                 Text.from_markup(
-                    "[yellow1]Custom Setting: possibly unsupported by the plugin[/yellow1]"
+                    "[yellow1]Custom Setting: possibly unsupported by the "
+                    "plugin[/yellow1]"
                 )
             )
 
@@ -211,7 +215,8 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         if docs_url:
             post.append(
                 Text.from_markup(
-                    f" To learn more about {self.settings.label} and its settings, visit [link={docs_url}]{docs_url}[/link]"
+                    f" To learn more about {self.settings.label} and its "
+                    f"settings, visit [link={docs_url}]{docs_url}[/link]"
                 )
             )
 
@@ -388,7 +393,8 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
             else:
                 self.tracker.track_command_event(CliEvent.aborted)
             raise CliError(
-                f"{settings.label.capitalize()} setting '{path}' could not be set in {store.label}: {err}"
+                f"{settings.label.capitalize()} setting '{path}' could not be "
+                f"set in {store.label}: {err}"
             ) from err
 
         name = metadata["name"]
@@ -397,7 +403,10 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         if is_redacted:
             value = REDACTED_VALUE
         click.secho(
-            f"{settings.label.capitalize()} setting '{name}' was set in {store.label}: {value!r}",
+            (
+                f"{settings.label.capitalize()} setting '{name}' was set in "
+                "{store.label}: {value!r}"
+            ),
             fg=VALUE_COLOR,
         )
 

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -405,7 +405,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         click.secho(
             (
                 f"{settings.label.capitalize()} setting '{name}' was set in "
-                "{store.label}: {value!r}"
+                f"{store.label}: {value!r}"
             ),
             fg=VALUE_COLOR,
         )

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -45,7 +45,10 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--print-var",
-    help="Print to stdout the values for the provided environment variables, as passed to the plugininvoker context. Useful for debugging.",
+    help=(
+        "Print to stdout the values for the provided environment variables, "
+        "as passed to the plugininvoker context. Useful for debugging."
+    ),
     multiple=True,
 )
 @click.option(

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -126,7 +126,7 @@ def job(project, ctx):
     \tmeltano job remove <job_name>
 
     \bRead more at https://docs.meltano.com/reference/command-line-interface#jobs
-    """
+    """  # noqa: E501
     ctx.obj["project"] = project
     ctx.obj["task_sets_service"] = TaskSetsService(project)
 
@@ -179,7 +179,7 @@ def add(ctx, job_name: str, raw_tasks: str):
     \t# The list of tasks must be yaml formatted and consist of a list of strings, list of string lists, or mix of both.
     \tmeltano job add NAME --tasks '["tap mapper target", "tap2 target2", ...]'
     \tmeltano job add NAME --tasks '[["tap target dbt:run", "tap2 target2", ...], ...]'
-    """
+    """  # noqa: E501
     task_sets_service: TaskSetsService = ctx.obj["task_sets_service"]
     tracker: Tracker = ctx.obj["tracker"]
     project: Project = ctx.obj["project"]
@@ -236,7 +236,7 @@ def set_cmd(ctx, job_name: str, raw_tasks: str):
     \t# The list of tasks must be yaml formatted and consist of a list of strings, list string lists, or mix of both.
     \tmeltano job set NAME --tasks '["tap mapper target", "tap2 target2", ...]'
     \tmeltano job set NAME --tasks '[["tap target dbt:run", "tap2 target2", ...], ...]'
-    """
+    """  # noqa: E501
     tracker: Tracker = ctx.obj["tracker"]
     project: Project = ctx.obj["project"]
     task_sets_service: TaskSetsService = ctx.obj["task_sets_service"]
@@ -277,7 +277,10 @@ def remove(ctx, job_name: str):  # noqa: WPS442
 
 
 def _validate_tasks(project: Project, task_set: TaskSets, ctx: click.Context) -> bool:
-    """Validate the job's tasks by attempting to parse them into valid Blocks and using the Block's validation logic.
+    """Validate a job's tasks.
+
+    Validates the tasks by attempting to parse them into valid `Blocks`, and by
+    using the `Block` validation logic.
 
     Args:
         project: Project to use.

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -34,12 +34,18 @@ logger = structlog.getLogger(__name__)
 )
 @click.option(
     "--dry-run",
-    help="Do not run, just parse the invocation, validate it, and explain what would be executed.",
+    help=(
+        "Do not run, just parse the invocation, validate it, and explain what "
+        "would be executed."
+    ),
     is_flag=True,
 )
 @click.option(
     "--full-refresh",
-    help="Perform a full refresh (ignore state left behind by any previous runs). Applies to all pipelines.",
+    help=(
+        "Perform a full refresh (ignore state left behind by any previous "
+        "runs). Applies to all pipelines."
+    ),
     is_flag=True,
 )
 @click.option(
@@ -50,7 +56,10 @@ logger = structlog.getLogger(__name__)
 @click.option(
     "--force",
     "-f",
-    help="Force a new run even if a pipeline with the same State ID is already present. Applies to all pipelines.",
+    help=(
+        "Force a new run even if a pipeline with the same State ID is already "
+        "present. Applies to all pipelines."
+    ),
     is_flag=True,
 )
 @click.option(
@@ -145,15 +154,16 @@ async def _run_blocks(
         with tracker.with_contexts(tracking_ctx):
             tracker.track_block_event(blk_name, BlockEvents.initialized)
         if dry_run:
+            msg = f"Dry run, but would have run block {idx + 1}/{len(parsed_blocks)}."
             if isinstance(blk, BlockSet):
                 logger.info(
-                    f"Dry run, but would have run block {idx + 1}/{len(parsed_blocks)}.",
+                    msg,
                     block_type=blk_name,
                     comprised_of=[plugin.string_id for plugin in blk.blocks],
                 )
             elif isinstance(blk, PluginCommandBlock):
                 logger.info(
-                    f"Dry run, but would have run block {idx + 1}/{len(parsed_blocks)}.",
+                    msg,
                     block_type=blk_name,
                     comprised_of=f"{blk.string_id}:{blk.command}",
                 )

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -125,7 +125,7 @@ def add(ctx, name, job, extractor, loader, transform, interval, start_date):
     \b\nNote that the --job option and --extractor/--loader options are mutually exclusive.
 
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#schedule
-    """
+    """  # noqa: E501
     if job and (extractor or loader):
         raise click.ClickException(
             "Cannot mix --job with --extractor/--loader/--transform"
@@ -205,12 +205,16 @@ def list(ctx, format):  # noqa: WPS125
             for txt_schedule in schedule_service.schedules():
                 if txt_schedule.job:
                     click.echo(
-                        f"[{txt_schedule.interval}] job {txt_schedule.name}: {txt_schedule.job} → {task_sets_service.get(txt_schedule.job).tasks}"
+                        f"[{txt_schedule.interval}] job {txt_schedule.name}: "
+                        f"{txt_schedule.job} → "
+                        f"{task_sets_service.get(txt_schedule.job).tasks}"
                     )
                 else:
                     markers = transform_elt_markers[txt_schedule.transform]
                     click.echo(
-                        f"[{txt_schedule.interval}] elt {txt_schedule.name}: {txt_schedule.extractor} {markers[0]} {txt_schedule.loader} {markers[1]} transforms"
+                        f"[{txt_schedule.interval}] elt {txt_schedule.name}: "
+                        f"{txt_schedule.extractor} {markers[0]} "
+                        f"{txt_schedule.loader} {markers[1]} transforms"
                     )
 
         elif format == "json":
@@ -287,7 +291,8 @@ def _update_job_schedule(
     """
     if not candidate.job:
         raise click.ClickException(
-            f"Cannot update schedule {candidate.name} with job only flags as its a elt schedule"
+            f"Cannot update schedule {candidate.name} with job only flags as "
+            "its a elt schedule"
         )
     if job:
         candidate.job = job
@@ -320,7 +325,8 @@ def _update_elt_schedule(
     """
     if candidate.job:
         raise click.ClickException(
-            f"Cannot update schedule {candidate.name} with elt only flags as its a scheduled job"
+            f"Cannot update schedule {candidate.name} with elt only flags as "
+            "its a scheduled job"
         )
 
     if extractor:
@@ -354,7 +360,7 @@ def set_cmd(ctx, name, interval, job, extractor, loader, transform):
 
     Usage:
         meltano schedule set <name> [--interval <interval>] [--job <job>] [--extractor <extractor>] [--loader <loader>] [--transform <transform>]
-    """
+    """  # noqa: E501
     schedule_service: ScheduleService = ctx.obj["schedule_service"]
     candidate = schedule_service.find_schedule(name)
 

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -1,4 +1,5 @@
 """State management in CLI."""
+
 from __future__ import annotations
 
 import json
@@ -28,7 +29,7 @@ logger = structlog.getLogger(__name__)
 
 
 class MutuallyExclusiveOptionsError(Exception):
-    """Occurs when mutually exclusive options are provided incorrectly."""
+    """Mutually exclusive options are provided incorrectly."""
 
     def __init__(self, *options: str) -> None:
         """Instantiate the error.
@@ -163,7 +164,7 @@ def copy_state(
     dst_state_id: str,
     force: bool,
 ):
-    """Copy state to another job id."""
+    """Copy state to another job ID."""
     # Retrieve state for copying
     state_service: StateService = (
         state_service_from_state_id(project, src_state_id) or ctx.obj[STATE_SERVICE_KEY]
@@ -172,7 +173,8 @@ def copy_state(
     state_service.copy_state(src_state_id, dst_state_id)
 
     logger.info(
-        f"State for {dst_state_id} was successfully copied from {src_state_id} at {dt.utcnow():%Y-%m-%d %H:%M:%S}."  # noqa: WPS323
+        f"State for {dst_state_id} was successfully copied from "
+        f"{src_state_id} at {dt.utcnow():%Y-%m-%d %H:%M:%S}."  # noqa: WPS323
     )
 
 
@@ -191,7 +193,7 @@ def move_state(
     dst_state_id: str,
     force: bool,
 ):
-    """Move state to another job id, clearing the original."""
+    """Move state to another job ID, clearing the original."""
     # Retrieve state for moveing
     state_service: StateService = (
         state_service_from_state_id(project, dst_state_id) or ctx.obj[STATE_SERVICE_KEY]
@@ -200,7 +202,8 @@ def move_state(
     state_service.move_state(src_state_id, dst_state_id)
 
     logger.info(
-        f"State for {src_state_id} was successfully moved to {dst_state_id} at {dt.utcnow():%Y-%m-%d %H:%M:%S}."  # noqa: WPS323
+        f"State for {src_state_id} was successfully moved to {dst_state_id} "
+        f"at {dt.utcnow():%Y-%m-%d %H:%M:%S}."  # noqa: WPS323
     )
 
 
@@ -248,7 +251,8 @@ def merge_state(
     elif from_state_id:
         state_service.merge_state(from_state_id, state_id)
     logger.info(
-        f"State for {state_id} was successfully merged at {dt.utcnow():%Y-%m-%d %H:%M:%S}."  # noqa: WPS323
+        f"State for {state_id} was successfully "
+        f"merged at {dt.utcnow():%Y-%m-%d %H:%M:%S}."  # noqa: WPS323
     )
 
 
@@ -289,7 +293,8 @@ def set_state(
     elif state:
         state_service.set_state(state_id, state)
     logger.info(
-        f"State for {state_id} was successfully set at {dt.utcnow():%Y-%m-%d %H:%M:%S}."  # noqa: WPS323
+        f"State for {state_id} was successfully set "
+        f"at {dt.utcnow():%Y-%m-%d %H:%M:%S}."  # noqa: WPS323
     )
 
 

--- a/src/meltano/cli/ui.py
+++ b/src/meltano/cli/ui.py
@@ -163,7 +163,8 @@ def setup(ctx, server_name, **flags):
     ui_cfg_path = project.root_dir("ui.cfg")
     if ui_cfg_path.exists():
         raise CliError(
-            f"Found existing secrets in file '{ui_cfg_path}'. Please delete this file and rerun this command to regenerate the secrets."
+            f"Found existing secrets in file '{ui_cfg_path}'. Please delete "
+            "this file and rerun this command to regenerate the secrets."
         )
 
     def generate_secret():
@@ -174,14 +175,18 @@ def setup(ctx, server_name, **flags):
         value, source = project.settings.get_with_source(setting_name)
         if source is not SettingValueStore.DEFAULT:
             click.echo(
-                f"Setting '{setting_name}' has already been set in {source.label}. Please unset it manually and rerun this command to regenerate this secret."
+                f"Setting '{setting_name}' has already been set in "
+                f"{source.label}. Please unset it manually and rerun this "
+                "command to regenerate this secret."
             )
         else:
             set_setting_env(setting_name, generate_secret())
 
     click.echo(
-        "The server name and generated secrets have been stored in your project's `.env` file."
+        "The server name and generated secrets have been stored in your "
+        "project's `.env` file."
     )
     click.echo(
-        "In production, you will likely want to move these settings to actual environment variables, since `.env` is in `.gitignore` by default."
+        "In production, you will likely want to move these settings to actual "
+        "environment variables, since `.env` is in `.gitignore` by default."
     )

--- a/src/meltano/cli/upgrade.py
+++ b/src/meltano/cli/upgrade.py
@@ -105,7 +105,8 @@ def all(ctx, pip_url, force, skip_package):
                 )
         else:
             click.echo(
-                "Then, run `meltano upgrade --skip-package` to upgrade your project based on the latest version."
+                "Then, run `meltano upgrade --skip-package` to upgrade your "
+                "project based on the latest version."
             )
 
 

--- a/src/meltano/cli/user.py
+++ b/src/meltano/cli/user.py
@@ -44,7 +44,10 @@ def user(ctx, project):
     "-G",
     multiple=True,
     default=[],
-    help="Add the user to the role. Meltano ships with two built-in roles: admin and regular.",
+    help=(
+        "Add the user to the role. Meltano ships with two built-in roles: "
+        "admin and regular."
+    ),
 )
 @click.pass_context
 def add(ctx, username, password, role, **flags):

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -107,24 +107,25 @@ def _prompt_plugin_namespace(plugin_type, plugin_name):
         f"Adding new custom {plugin_type.descriptor} with name '{plugin_name}'...",
         fg="green",
     )
-    click.echo()
-
     click.echo(
-        f"Specify the plugin's {click.style('namespace', fg='blue')}, which will serve as the:"
+        f"\nSpecify the plugin's {click.style('namespace', fg='blue')}, which "
+        "will serve as the:\n"
+        "- identifier to find related/compatible plugins"
     )
-    click.echo("- identifier to find related/compatible plugins")
     if plugin_type == PluginType.EXTRACTORS:
-        click.echo("- default database schema (`load_schema` extra),")
-        click.echo("  for use by loaders that support a target schema")
+        click.echo(
+            "- default database schema (`load_schema` extra),"
+            "  for use by loaders that support a target schema"
+        )
     elif plugin_type == PluginType.LOADERS:
-        click.echo("- default target database dialect (`dialect` extra),")
-        click.echo("  for use by transformers that connect with the database")
-    click.echo()
-
+        click.echo(
+            "- default target database dialect (`dialect` extra),"
+            "  for use by transformers that connect with the database"
+        )
     click.echo(
-        "Hit Return to accept the default: plugin name with underscores instead of dashes"
+        "\nHit Return to accept the default: plugin name with underscores "
+        "instead of dashes"
     )
-    click.echo()
 
     return click.prompt(
         click.style("(namespace)", fg="blue"),
@@ -134,21 +135,18 @@ def _prompt_plugin_namespace(plugin_type, plugin_name):
 
 
 def _prompt_plugin_pip_url(plugin_name: str) -> str | None:
-    click.echo()
     click.echo(
-        f"Specify the plugin's {click.style('`pip install` argument', fg='blue')}, for example:"
+        "\nSpecify the plugin's "
+        f"{click.style('`pip install` argument', fg='blue')}, for example:"
+        "- PyPI package name:\n"
+        f"\t{plugin_name}\n"
+        "- Git repository URL:\n"
+        "\tgit+https://<PLUGIN REPO URL>.git\n"
+        "- local directory, in editable/development mode:\n"
+        f"\t-e extract/{plugin_name}\n"
+        "- 'n' if using a local executable (nothing to install)\n\n"
+        "Default: plugin name as PyPI package name\n"
     )
-    click.echo("- PyPI package name:")
-    click.echo(f"\t{plugin_name}")
-    click.echo("- Git repository URL:")
-    click.echo("\tgit+https://<PLUGIN REPO URL>.git")
-    click.echo("- local directory, in editable/development mode:")
-    click.echo(f"\t-e extract/{plugin_name}")
-    click.echo("- 'n' if using a local executable (nothing to install)")
-    click.echo()
-    click.echo("Default: plugin name as PyPI package name")
-    click.echo()
-
     result = click.prompt(
         click.style("(pip_url)", fg="blue"), type=str, default=plugin_name
     )
@@ -161,13 +159,10 @@ def _prompt_plugin_executable(pip_url: str | None, plugin_name: str) -> str:
     if pip_url is None:
         derived_from = "the plugin name"
         prompt_request = "executable path"
-
-    click.echo()
-    click.echo(f"Specify the plugin's {click.style(prompt_request, fg='blue')}")
-    click.echo()
-    click.echo(f"Default: name derived from {derived_from}")
-    click.echo()
-
+    click.echo(
+        f"\nSpecify the plugin's {click.style(prompt_request, fg='blue')}\n"
+        f"\nDefault: name derived from {derived_from}\n"
+    )
     plugin_basename = os.path.basename(pip_url or plugin_name)
     package_name, _ = os.path.splitext(plugin_basename)
     return click.prompt(click.style("(executable)", fg="blue"), default=package_name)
@@ -177,26 +172,19 @@ def _prompt_plugin_capabilities(plugin_type):
     if plugin_type != PluginType.EXTRACTORS:
         return []
 
-    click.echo()
     click.echo(
-        f"Specify the tap's {click.style('supported Singer features', fg='blue')} (executable flags), for example:"
+        f"\nSpecify the tap's {click.style('supported Singer features', fg='blue')} "
+        "(executable flags), for example:\n"
+        "\t`catalog`: supports the `--catalog` flag\n"
+        "\t`discover`: supports the `--discover` flag\n"
+        "\t`properties`: supports the `--properties` flag\n"
+        "\t`state`: supports the `--state` flag\n\n"
+        "To find out what features a tap supports, reference its "
+        "documentation or try one of the tricks under"
+        "https://docs.meltano.com/guide/integration#troubleshooting.\n\n"
+        "Multiple capabilities can be separated using commas.\n\n"
+        "Default: no capabilities\n"
     )
-    click.echo("\t`catalog`: supports the `--catalog` flag")
-    click.echo("\t`discover`: supports the `--discover` flag")
-    click.echo("\t`properties`: supports the `--properties` flag")
-    click.echo("\t`state`: supports the `--state` flag")
-    click.echo()
-    click.echo(
-        "To find out what features a tap supports, reference its documentation or try one"
-    )
-    click.echo(
-        "of the tricks under https://docs.meltano.com/guide/integration#troubleshooting."
-    )
-    click.echo()
-    click.echo("Multiple capabilities can be separated using commas.")
-    click.echo()
-    click.echo("Default: no capabilities")
-    click.echo()
 
     return click.prompt(
         click.style("(capabilities)", fg="blue"),
@@ -216,43 +204,29 @@ def _prompt_plugin_settings(plugin_type):
     }:
         return []
 
-    click.echo()
     click.echo(
-        f"Specify the {plugin_type.descriptor}'s {click.style('supported settings', fg='blue')} "
+        f"\nSpecify the {plugin_type.descriptor}'s "
+        f"{click.style('supported settings', fg='blue')}\n"
+        "Multiple setting names (keys) can be separated using commas.\n\n"
+        "A setting kind can be specified alongside the name (key) by using "
+        "the `:` delimiter,\n"
+        "e.g. `port:integer` to set the kind `integer` for the name `port`\n\n"
+        "Supported setting kinds:"
     )
-    click.echo()
-    click.echo("Multiple setting names (keys) can be separated using commas.")
-    click.echo()
-    click.echo(
-        "A setting kind can be specified alongside the name (key) by using the `:` delimiter,"
-    )
-    click.echo("e.g. `port:integer` to set the kind `integer` for the name `port`")
-    click.echo()
-    click.echo("Supported setting kinds:")
     click.echo(
         " | ".join([click.style(kind.value, fg="magenta") for kind in SettingKind])
     )
-    click.echo()
     click.echo(
-        "- Credentials and other sensitive setting types should use the "
-        + click.style("password", fg="magenta")
-        + " kind."
-    )
-    click.echo(
+        "\n- Credentials and other sensitive setting types should use the "
+        f"{click.style('password', fg='magenta')} kind.\n"
         "- If not specified, setting kind defaults to "
-        + click.style("string", fg="magenta")
-        + "."
-    )
-    click.echo(
+        f"{click.style('string', fg='magenta')}.\n"
         "- Nested properties can be represented using the `.` separator, "
-        + 'e.g. `auth.username` for `{ "auth": { "username": value } }`.'
+        'e.g. `auth.username` for `{ "auth": { "username": value } }`.\n'
+        f"- To find out what settings a {plugin_type.descriptor} supports, "
+        "reference its documentation.\n"
+        "\nDefault: no settings\n"
     )
-    click.echo(
-        f"- To find out what settings a {plugin_type.descriptor} supports, reference its documentation."
-    )
-    click.echo()
-    click.echo("Default: no settings")
-    click.echo()
 
     settings: dict | None = None
     while settings is None:  # noqa:  WPS426  # allows lambda in loop
@@ -318,66 +292,52 @@ def add_plugin(
         plugin = err.plugin
 
         click.secho(
-            f"{plugin_type.descriptor.capitalize()} '{plugin_name}' already exists in your Meltano project",
+            (
+                f"{plugin_type.descriptor.capitalize()} '{plugin_name}' "
+                "already exists in your Meltano project"
+            ),
             fg="yellow",
             err=True,
         )
 
         if variant and variant != plugin.variant:
             variant = plugin.find_variant(variant)
-
-            click.echo()
             click.echo(
-                f"To switch from the current '{plugin.variant}' variant to '{variant.name}':"
-            )
-            click.echo(
-                "1. Update `variant` and `pip_url` in your `meltano.yml` project file:"
-            )
-            click.echo(f"\tname: {plugin.name}")
-            click.echo(f"\tvariant: {variant.name}")
-            click.echo(f"\tpip_url: {variant.pip_url}")
-
-            click.echo("2. Reinstall the plugin:")
-            click.echo(f"\tmeltano install {plugin_type.singular} {plugin.name}")
-
-            click.echo(
-                "3. Check if the configuration is still valid (and make changes until it is):"
-            )
-            click.echo(f"\tmeltano config {plugin.name} list")
-            click.echo()
-            click.echo(
-                "To learn more, visit https://docs.meltano.com/guide/plugin-management#switching-from-one-variant-to-another"
-            )
-
-            click.echo()
-            click.echo(
-                f"Alternatively, to keep the existing '{plugin.name}' with variant '{plugin.variant}',"
-            )
-            click.echo(
-                f"add variant '{variant.name}' as a separate plugin with its own unique name:"
-            )
-            click.echo(
-                "\tmeltano add {type} {name}--{variant} --inherit-from {name} --variant {variant}".format(
-                    type=plugin_type.singular, name=plugin.name, variant=variant.name
-                )
-            )
-
-            click.echo()
-            click.echo(
-                "To learn more, visit https://docs.meltano.com/guide/plugin-management#multiple-variants"
+                f"\nTo switch from the current '{plugin.variant}' variant "
+                f"to '{variant.name}':\n"
+                "1. Update `variant` and `pip_url` in your `meltano.yml` "
+                "project file:\n"
+                f"\tname: {plugin.name}\n"
+                f"\tvariant: {variant.name}\n"
+                f"\tpip_url: {variant.pip_url}\n"
+                "2. Reinstall the plugin:\n"
+                f"\tmeltano install {plugin_type.singular} {plugin.name}\n"
+                "3. Check if the configuration is still valid (and make "
+                "changes until it is):\n"
+                f"\tmeltano config {plugin.name} list\n\n"
+                "To learn more, visit "
+                "https://docs.meltano.com/guide/plugin-management#switching-from-one-variant-to-another\n\n"  # noqa: E501
+                f"Alternatively, to keep the existing '{plugin.name}' with "
+                f"variant '{plugin.variant}', add variant '{variant.name}' as "
+                "a separate plugin with its own unique name:\n"
+                f"\tmeltano add {plugin_type.singular} "
+                f"{plugin.name}--{variant.name} --inherit-from {plugin.name} "
+                f"--variant {variant.name}\n\n"
+                "To learn more, visit "
+                "https://docs.meltano.com/guide/plugin-management#multiple-variants"
             )
         else:
             click.echo(
-                "To add it to your project another time so that each can be configured differently,"
-            )
-            click.echo(
-                "add a new plugin inheriting from the existing one with its own unique name:"
-            )
-            click.echo(
-                f"\tmeltano add {plugin_type.singular} {plugin.name}--new --inherit-from {plugin.name}"
+                "To add it to your project another time so that each can be "
+                "configured differently,\n"
+                "add a new plugin inheriting from the existing one with its "
+                "own unique name:\n"
+                f"\tmeltano add {plugin_type.singular} {plugin.name}--new "
+                f"--inherit-from {plugin.name}"
             )
     except LockfileAlreadyExistsError as exc:
-        # TODO: This is a BasePlugin, not a ProjectPlugin, as this method should return! Results in `KeyError: venv_name`
+        # TODO: This is a BasePlugin, not a ProjectPlugin, as this method
+        # should return! Results in `KeyError: venv_name`
         plugin = exc.plugin
         click.secho(
             f"Plugin definition is already locked at {exc.path}.",
@@ -484,7 +444,7 @@ def install_plugins(
 
 @contextmanager
 def propagate_stop_signals(proc):
-    """When a stop signal is received, send it to `proc` and wait for it to terminate."""
+    """Propagate stop signals to `proc`, then wait for it to terminate."""
 
     def _handler(sig, _):  # noqa: WPS430
         proc.send_signal(sig)
@@ -510,7 +470,8 @@ def check_dependencies_met(
         plugin_service: Plugin service to use when checking for dependencies.
 
     Returns:
-        A tuple with dependency check outcome (True/False), and a string message with details of the check.
+        A tuple with dependency check outcome (True/False), and a string
+        message with details of the check.
     """
     passed = True
     messages = []
@@ -649,18 +610,18 @@ class InstrumentedGroupMixin(InstrumentedCmdMixin):
 
 
 class InstrumentedDefaultGroup(InstrumentedGroupMixin, DefaultGroup):
-    """A variation of a `DefaultGroup` that instruments its invocation by updating the telemetry context."""
+    """Click group with telemetry instrumentation and a default command."""
 
 
 class InstrumentedGroup(InstrumentedGroupMixin, click.Group):
-    """A `click.Group` that instruments its invocation by updating the telemetry context."""
+    """Click group with telemetry instrumentation."""
 
 
 class InstrumentedCmd(InstrumentedCmdMixin, click.Command):
-    """A `click.Command` that automatically fires telemetry events when invoked.
+    """Click command that automatically fires telemetry events when invoked.
 
-    Both starting and ending events are fired. The ending event fired is dependent on whether invocation of the command
-    resulted in an Exception.
+    Both starting and ending events are fired. The ending event fired is
+    dependent on whether invocation of the command resulted in an Exception.
     """
 
     def invoke(self, ctx: click.Context):
@@ -682,7 +643,10 @@ class InstrumentedCmd(InstrumentedCmdMixin, click.Command):
 
 
 class PartialInstrumentedCmd(InstrumentedCmdMixin, click.Command):
-    """A `click.Command` that automatically fires an instrumentation 'start' event, if a tracker is available."""
+    """Click command with partial telemetry instrumentation.
+
+    Only automatically fires a 'start' event.
+    """
 
     def invoke(self, ctx):
         """Invoke the requested command firing only a start event."""

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -124,7 +124,7 @@ def _prompt_plugin_namespace(plugin_type, plugin_name):
         )
     click.echo(
         "\nHit Return to accept the default: plugin name with underscores "
-        "instead of dashes"
+        "instead of dashes\n"
     )
 
     return click.prompt(

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -290,8 +290,6 @@ def add_plugin(
         print_added_plugin(plugin)
     except PluginAlreadyAddedException as err:
         plugin = err.plugin
-        new_plugin = err.new_plugin
-
         click.secho(
             (
                 f"{plugin_type.descriptor.capitalize()} '{plugin_name}' "
@@ -300,12 +298,11 @@ def add_plugin(
             fg="yellow",
             err=True,
         )
-
         if variant and variant != plugin.variant:
-            variant = plugin.find_variant(variant)
+            new_plugin = err.new_plugin
             click.echo(
                 f"\nTo switch from the current '{plugin.variant}' variant "
-                f"to '{variant.name}':\n"
+                f"to '{new_plugin.variant}':\n"
                 "1. Update `variant` and `pip_url` in your `meltano.yml` "
                 "project file:\n"
                 f"\tname: {plugin.name}\n"

--- a/src/meltano/core/behavior/hookable.py
+++ b/src/meltano/core/behavior/hookable.py
@@ -1,8 +1,8 @@
-"""
-Hookable class and supporting functions, classes, and decorators.
+"""Hookable class and supporting functions, classes, and decorators.
 
-This module contains the Hookable class which allows for implementation of a classic before/after hook pattern. Allowing
-you to register functions to be called before or after given trigger.
+This module contains the Hookable class which allows for implementation of a
+classic before/after hook pattern. Allowing you to register functions to be
+called before or after given trigger.
 """
 from __future__ import annotations
 
@@ -64,13 +64,17 @@ class HookObject(metaclass=Hookable):
 
     @asynccontextmanager
     async def trigger_hooks(self, hook_name, *args, **kwargs):
-        """
-        Trigger all registered before and after functions for a given hook - yielding to the caller in between.
+        """Trigger all registered before and after functions for a given hook.
+
+        Yields to the caller in between triggers.
 
         Args:
             hook_name: The hook who's registered functions that should be triggered
+            args: Positional arguments to pass to the hooks being triggered.
+            kwargs: Keyword arguments to pass to the hooks being triggered.
 
-        Yields: None
+        Yields:
+            `None`
 
         Examples:
             async with self.obj.trigger_hooks("cleanup", self):

--- a/src/meltano/core/behavior/versioned.py
+++ b/src/meltano/core/behavior/versioned.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 
 class IncompatibleVersionError(Exception):
-    """Occurs when a component is incompatible with its representation."""
+    """A component is incompatible with its representation."""
 
     def __init__(self, message, file_version: int, version: int):
         super().__init__(message)

--- a/src/meltano/core/block/__init__.py
+++ b/src/meltano/core/block/__init__.py
@@ -1,9 +1,3 @@
-"""The block module implements and supports the Meltano 'block' architecture.
+"""The block module implements and supports the Meltano 'block' architecture."""
 
-Currently comprised of:
-
-BlockSet interface spec
-- ExtractLoadBlock - a block set implementing basic ELT functionality using lower level IOBlocks.
-IOBlock interface spec
-- SingerBlock - a IOBlock implementation wrapping singer plugins.
-"""
+from __future__ import annotations

--- a/src/meltano/core/block/blockset.py
+++ b/src/meltano/core/block/blockset.py
@@ -1,4 +1,5 @@
-"""This holds the actual BlockSet meta class as well as related components such as exceptions."""
+"""`BlockSet` metaclass and related components."""
+
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
@@ -18,10 +19,12 @@ class BlockSetValidationError(Exception):
 
 
 class BlockSet(metaclass=ABCMeta):
-    """Currently the only complex block set is our ExtractLoadBlocks type.
+    """Currently the only complex block set is our `ExtractLoadBlocks` type.
 
-    Theoretically, this is the bare minimum that we need to run and terminate (i.e. early abort) a block set. So anything
-    implementing a run(), terminate(), and validate_set() method currently satisfies the BlockSet interface.
+    Theoretically, this is the bare minimum that we need to run and terminate
+    (i.e. early abort) a block set. So anything implementing a `run`,
+    `terminate`, and `validate_set` method currently satisfies the `BlockSet`
+    interface.
     """
 
     @abstractmethod

--- a/src/meltano/core/block/future_utils.py
+++ b/src/meltano/core/block/future_utils.py
@@ -19,10 +19,11 @@ def all_done(tasks: list[Task], done: set[Task]) -> bool:
 
 
 def first_failed_future(exception_future: Task, done: set[Task]) -> Task | None:
-    """Check if a future is in a set of completed futures and return the first failed (if any).
+    """Check if a future is completed and return the first failed (if any).
 
     Args:
-        exception_future: The future you want to check and who's futures should be returned if an exception was raised.
+        exception_future: The future you want to check and who's futures should
+            be returned if an exception was raised.
         done: The set of completed futures you want to search.
 
     Returns:
@@ -39,15 +40,24 @@ def first_failed_future(exception_future: Task, done: set[Task]) -> Task | None:
 
 
 def handle_producer_line_length_limit_error(
-    exception: Exception, line_length_limit: int, stream_buffer_size: int
+    exception: Exception,
+    line_length_limit: int,
+    stream_buffer_size: int,
 ):
-    """
-    Handle and wrap asyncio.LimitOverrunError's from producers, emitting an useful log line along the way.
+    """Handle `asyncio.LimitOverrunError` from producers.
 
-    TODO: reuse from runner/singer.py
-    StreamReader.readline can raise a ValueError wrapping a LimitOverrunError:
-    https://github.com/python/cpython/blob/v3.8.7/Lib/asyncio/streams.py#L549
+    Args:
+        exception: The exception to handle, which should be a `ValueError` with
+            a `asyncio.LimitOverrunError` as its context.
+        line_length_limit: The message size limit.
+        stream_buffer_size: The stream buffer size.
+
+    Raises:
+        RunnerError: An exception raised from the `asyncio.LimitOverrunError`.
     """
+    # TODO: reuse from runner/singer.py
+    # StreamReader.readline can raise a ValueError wrapping a LimitOverrunError:
+    # https://github.com/python/cpython/blob/v3.8.7/Lib/asyncio/streams.py#L549
     if not isinstance(exception, ValueError):
         return
 
@@ -56,12 +66,17 @@ def handle_producer_line_length_limit_error(
         return
 
     logging.error(
-        f"The extractor generated a message exceeding the message size limit of {human_size(line_length_limit)} (half the buffer size of {human_size(stream_buffer_size)})."
+        "The extractor generated a message exceeding the message size limit "
+        f"of {human_size(line_length_limit)} (half the buffer size "
+        f"of {human_size(stream_buffer_size)})."
     )
     logging.error(
-        "To let this message be processed, increase the 'elt.buffer_size' setting to at least double the size of the largest expected message, and try again."
+        "To let this message be processed, increase the 'elt.buffer_size' "
+        "setting to at least double the size of the largest expected message, "
+        "and try again."
     )
     logging.error(
-        "To learn more, visit https://docs.meltano.com/reference/settings#eltbuffer_size"
+        "To learn more, visit "
+        "https://docs.meltano.com/reference/settings#eltbuffer_size"
     )
     raise RunnerError("Output line length limit exceeded") from exception

--- a/src/meltano/core/block/ioblock.py
+++ b/src/meltano/core/block/ioblock.py
@@ -1,4 +1,4 @@
-"""The actual `IOBlock` interface is one of the lower level blocks for use with various `BlockSet` implementations."""
+"""A low-level block type for use with `BlockSet` implementations."""
 
 from __future__ import annotations
 
@@ -9,34 +9,35 @@ from meltano.core.logging.utils import SubprocessOutputWriter
 
 
 class IOBlock(metaclass=ABCMeta):
-    """The IOBlock interface is a basic block that Consumes, Produces, or Consume and Produces (Transforms) output.
+    """A block that consumes, produces, or both (i.e. transforms) output.
 
-    Underlying implementation could be subprocesses (ala Singer Plugins), or stream transformers, basically,
-    any class that satisfies the IOBlock interface.
+    Underlying implementation could be subprocesses (e.g. Singer Plugins), or
+    stream transformers, or any class that satisfies the `IOBlock` interface.
     """
 
     @property
     @abstractmethod
     def stdin(self) -> StreamWriter | None:
-        """If a block requires input, return the StreamWriter that should be used for writes.
+        """Get the `StreamWriter` that should be used for writes, if any.
+
+        Raises:
+            NotImplementedError
 
         Returns:
             StreamWriter
-        Raises:
-            NotImplementedError
         """
         raise NotImplementedError
 
     @property
     @abstractmethod
     def consumer(self) -> bool:
-        """Consumer indicates whether or not this block is a consumer and requires input."""
+        """Indicate whether this block is a consumer and requires input."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def producer(self) -> bool:
-        """Indicate whether or not this block is a producer of output."""
+        """Indicate whether this block is a producer of output."""
         raise NotImplementedError
 
     @property
@@ -79,7 +80,8 @@ class IOBlock(metaclass=ABCMeta):
     async def start(self) -> None:
         """Start the block.
 
-        Whatever that might entail (spwaning a process, spinning up a async task that will handle transforms, etc)
+        Whatever that might entail (spwaning a process, spinning up a async
+        task that will handle transforms, etc).
 
         Raises:
             NotImplementedError
@@ -91,7 +93,7 @@ class IOBlock(metaclass=ABCMeta):
         """Stop a block.
 
         Args:
-            kill: whether or not to send a SIGKILL. If false, a SIGTERM is sent.
+            kill: Whether to send a SIGKILL. If false, a SIGTERM is sent.
 
         Raises:
             NotImplementedError

--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -1,4 +1,7 @@
-"""Utilities for turning a string list of plugins into a usable list of `BlockSet` and `PluginCommand` objects."""
+"""Utilities for parsing string lists of plugins.
+
+Turns string lists of plugins into `BlockSet` and `PluginCommand` instances.
+"""
 
 from __future__ import annotations
 
@@ -75,9 +78,11 @@ class BlockParser:  # noqa: D101
             log: Logger to use.
             project: Project to use.
             blocks: List of block names to parse.
-            full_refresh: Whether to perform a full refresh (applies to all found sets).
+            full_refresh: Whether to perform a full refresh (applies to all
+                found sets).
             no_state_update: Whether to run with or without state updates.
-            force: Whether to force a run if a job is already running (applies to all found sets).
+            force: Whether to force a run if a job is already running (applies
+                to all found sets).
             state_id_suffix: State ID suffix to use.
 
         Raises:
@@ -111,7 +116,8 @@ class BlockParser:  # noqa: D101
 
             if plugin and task_sets_service.exists(name):
                 raise click.ClickException(
-                    f"Ambiguous reference to '{name}' which matches a job name AND a plugin name."
+                    f"Ambiguous reference to '{name}' which matches a job "
+                    "name AND a plugin name."
                 )
 
             if plugin.type == PluginType.MAPPERS:
@@ -159,17 +165,17 @@ class BlockParser:  # noqa: D101
     def find_blocks(
         self, offset: int = 0
     ) -> t.Generator[BlockSet | PluginCommandBlock, None, None]:
-        """
-        Find all blocks in the invocation.
+        """Find all blocks in the invocation.
 
         Args:
             offset: Offset to start from.
 
         Yields:
-            Generator of blocks (either BlockSet or PluginCommandBlock).
+            Blocks (either BlockSet or PluginCommandBlock).
 
         Raises:
-            BlockSetValidationError: If unknown command is found or if a unexpected block sequence is found.
+            BlockSetValidationError: If unknown command is found or if a
+                unexpected block sequence is found.
         """
         cur = offset
         while cur < len(self._plugins):
@@ -193,7 +199,8 @@ class BlockParser:  # noqa: D101
                 cur += 1
             else:
                 raise BlockSetValidationError(
-                    f"Unknown command type or bad block sequence at index {cur + 1}, starting block '{plugin.name}'"  # noqa: WPS237
+                    "Unknown command type or bad block sequence at index "
+                    f"{cur + 1}, starting block '{plugin.name}'"  # noqa: WPS237
                 )
 
     def _find_plugin_or_mapping(self, name: str) -> ProjectPlugin | None:
@@ -229,15 +236,13 @@ class BlockParser:  # noqa: D101
         self,
         offset: int = 0,
     ) -> tuple[ExtractLoadBlocks | None, int]:  # noqa: WPS231, WPS213
-        """
-        Search a list of project plugins trying to find an extract ExtractLoad block set.
+        """Search plugins to find an extract EL block set.
 
         Args:
             offset: Optional starting offset for search.
 
         Returns:
-            The ExtractLoad object.
-            Offset for remaining plugins.
+            The `ExtractLoadBlocks` object, and offset for remaining plugins.
 
         Raises:
             BlockSetValidationError: If the block set is not valid.
@@ -287,18 +292,20 @@ class BlockParser:  # noqa: D101
                     mapping=self._mappings_ref.get(next_block),
                     idx=next_block,
                 )
-                # Checks to see if the mapper plugin name is the same as the mappings name
-                # If they both match then a validation error is raised because the
-                # meltano run command needs the mappings name to obtain the settings to
-                # pass to the parent mapper plugin.  We also want to fail if the user names them
-                # the same to stop errors due to ambiguous commands.
+                # Checks to see if the mapper plugin name is the same as the
+                # mappings name. If they both match then a validation error is
+                # raised because the meltano run command needs the mappings
+                # name to obtain the settings to pass to the parent mapper
+                # plugin. We also want to fail if the user names them the same
+                # to stop errors due to ambiguous commands.
                 if plugin.name == self._mappings_ref.get(next_block):
                     self.log.warning(
                         "Found unexpected mapper plugin name. ",
                         plugin_name=plugin.name,
                     )
                     raise BlockSetValidationError(
-                        f"Expected unique mappings name not the mapper plugin name: {plugin.name}."
+                        f"Expected unique mappings name not the mapper plugin "
+                        f"name: {plugin.name}."
                     )
                 else:
                     blocks.append(builder.make_block(plugin))

--- a/src/meltano/core/block/plugin_command.py
+++ b/src/meltano/core/block/plugin_command.py
@@ -1,4 +1,4 @@
-"""A `CommandBlock` pattern supporting Meltano plugin's command like `dbt:run`, `dbt:docs` or `dbt:test`."""
+"""Classes & functions for plugin commands like `dbt:run`, `dbt:docs` or `dbt:test`."""
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ class PluginCommandBlock(metaclass=ABCMeta):
     @property
     @abstractmethod
     def command(self) -> str | None:
-        """Command is the specific plugin command to use when invoking the plugin (if any)."""
+        """Get the plugin command to use when invoking the plugin (if any)."""
         raise NotImplementedError
 
     @abstractmethod
@@ -47,7 +47,7 @@ class PluginCommandBlock(metaclass=ABCMeta):
 
 
 class InvokerCommand(InvokerBase, PluginCommandBlock):
-    """A basic PluginCommandBlock interface implementation that supports running plugin commands."""
+    """`PluginCommandBlock` that supports invoking plugin commands."""
 
     def __init__(
         self,
@@ -101,7 +101,7 @@ class InvokerCommand(InvokerBase, PluginCommandBlock):
 
     @property
     def command_args(self) -> str | None:
-        """Command args are the specific plugin command args to use when invoking the plugin (if any).
+        """Get the command args to use when invoking the plugin.
 
         Returns:
             The command args if any.
@@ -153,7 +153,8 @@ def plugin_command_invoker(
         plugin: Plugin to make command from.
         project: Project to use.
         command: the command to invoke on the plugin i.e. `run` in dbt run.
-        command_args: any additional command args that should be passed in during invocation.
+        command_args: any additional command args that should be passed in
+            during invocation.
         run_dir: Optional directory to run commands in.
 
     Returns:

--- a/src/meltano/core/block/singer.py
+++ b/src/meltano/core/block/singer.py
@@ -61,7 +61,7 @@ class InvokerBase:  # noqa: WPS230, WPS214
 
     @property
     def command(self) -> str | None:
-        """Command is the specific plugin command to use when invoking the plugin (if any).
+        """Get the command to use when invoking the plugin.
 
         Returns:
             The command to use when invoking the plugin.
@@ -128,7 +128,8 @@ class InvokerBase:  # noqa: WPS230, WPS214
             The stdout proxy future.
 
         Raises:
-            IOLinkError: If the processes is not running and so - there is no IO to proxy.
+            IOLinkError: If the processes is not running and so there is no IO
+                to proxy.
         """
         if self.process_handle is None:
             raise IOLinkError("No IO to proxy, process not running")
@@ -148,7 +149,8 @@ class InvokerBase:  # noqa: WPS230, WPS214
             The stderr proxy future.
 
         Raises:
-            IOLinkError: If the processes is not running and so - there is no IO to proxy.
+            IOLinkError: If the processes is not running and so there is no IO
+                to proxy.
         """
         if self.process_handle is None:
             raise IOLinkError("No IO to proxy, process not running")
@@ -289,7 +291,7 @@ class SingerBlock(InvokerBase, IOBlock):
 
     @property
     def producer(self) -> bool:
-        """Whether or not this plugin is a producer.
+        """Whether this plugin is a producer.
 
         Currently if the underlying plugin is of type extractor, it is a producer.
 
@@ -300,7 +302,7 @@ class SingerBlock(InvokerBase, IOBlock):
 
     @property
     def consumer(self) -> bool:
-        """Whether or not this plugin is a consumer.
+        """Whether this plugin is a consumer.
 
         Currently if the underlying plugin is of type loader, it is a consumer.
 
@@ -311,7 +313,7 @@ class SingerBlock(InvokerBase, IOBlock):
 
     @property
     def has_state(self) -> bool:
-        """Whether or not this plugin has state.
+        """Whether this plugin has state.
 
         Returns:
             bool indicating whether this plugin has state
@@ -345,7 +347,7 @@ class SingerBlock(InvokerBase, IOBlock):
         """Stop (kill) the underlying process and cancel output proxying.
 
         Args:
-            kill: whether or not to send a SIGKILL. If false, a SIGTERM is sent.
+            kill: Whether to send a SIGKILL. If false, a SIGTERM is sent.
         """
         if self.process_handle is None:
             return

--- a/src/meltano/core/db.py
+++ b/src/meltano/core/db.py
@@ -157,15 +157,15 @@ def ensure_schema_exists(
         schema_name: The name of the schema.
         grant_roles: Roles to grant to the specified schema.
     """
-    schema_identifier = schema_name
     group_identifiers = ",".join(grant_roles)
 
-    create_schema = text(f"CREATE SCHEMA IF NOT EXISTS {schema_identifier}")
+    create_schema = text(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
     grant_select_schema = text(
-        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {schema_identifier} GRANT SELECT ON TABLES TO {group_identifiers}"
+        f"ALTER DEFAULT PRIVILEGES IN SCHEMA {schema_name} GRANT SELECT ON "
+        f"TABLES TO {group_identifiers}"
     )
     grant_usage_schema = text(
-        f"GRANT USAGE ON SCHEMA {schema_identifier} TO {group_identifiers}"
+        f"GRANT USAGE ON SCHEMA {schema_name} TO {group_identifiers}"
     )
 
     with engine.connect() as conn, conn.begin():

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -323,7 +323,8 @@ class ELTContextBuilder:  # noqa: WPS214
         """Include full refresh flag when building context.
 
         Args:
-            full_refresh: Flag. Perform a full refresh (ignore state left behind by any previous runs).
+            full_refresh: Whether to perform a full refresh (ignore state left
+                behind by any previous runs).
 
         Returns:
             Updated ELTContextBuilder instance.

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -21,7 +21,7 @@ class NoActiveEnvironment(Exception):  # noqa: N818
 
 
 class EnvironmentNameContainsStateIdDelimiterError(Exception):
-    """Occurs when an environment name contains the state ID component delimiter."""
+    """An environment name contains the state ID component delimiter."""
 
     def __init__(self, name: str):
         """Create a new exception.

--- a/src/meltano/core/environment_service.py
+++ b/src/meltano/core/environment_service.py
@@ -8,7 +8,7 @@ from meltano.core.utils import find_named
 
 
 class EnvironmentAlreadyExistsError(Exception):
-    """Occurs when an environment already exists."""
+    """An environment already exists."""
 
     def __init__(self, environment: Environment):
         """Create a new exception.
@@ -42,17 +42,18 @@ class EnvironmentService:
         """
         return self.add_environment(Environment(name=name))
 
-    def add_environment(self, environment: Environment):
+    def add_environment(self, environment: Environment) -> Environment:
         """Add an Environment object to `meltano.yml`.
 
         Args:
-            environment: An instance of meltano.core.environment.Environment to add.
+            environment: An environment to add.
 
         Raises:
-            EnvironmentAlreadyExistsError: If an Environment with the same name already exists.
+            EnvironmentAlreadyExistsError: If an environment with the same name
+                already exists.
 
         Returns:
-            The newly added Environment.
+            The newly added environment.
         """
         with self.project.meltano_update() as meltano:
             # guard if it already exists

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -109,7 +109,7 @@ class MeltanoConfigurationError(MeltanoError):
 
 
 class ProjectNotFound(Error):
-    """Occurs when a Project is instantiated outside of a meltano project structure."""
+    """A Project is instantiated outside of a meltano project structure."""
 
     def __init__(self, project: Project):
         """Instantiate the error.
@@ -123,7 +123,7 @@ class ProjectNotFound(Error):
 
 
 class ProjectReadonly(Error):
-    """Occurs when attempting to update a readonly project."""
+    """Attempting to update a readonly project."""
 
     def __init__(self):
         """Instantiate the error."""

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -162,8 +162,10 @@ class Job(SystemModel):  # noqa: WPS214
     def is_stale(self):
         """Return whether Job has gone stale.
 
-        Running jobs with a heartbeat are considered stale after no heartbeat is recorded for 5 minutes.
-        Legacy jobs without a heartbeat are considered stale after being in the running state for 24 hours.
+        Running jobs with a heartbeat are considered stale after no heartbeat
+        is recorded for 5 minutes.
+        Legacy jobs without a heartbeat are considered stale after being in
+        the running state for 24 hours.
 
         Returns:
             bool indicating whether this Job is stale
@@ -213,22 +215,20 @@ class Job(SystemModel):  # noqa: WPS214
         Returns:
             bool indicating whether the given state is transitable from this job's state
         """
-        if self.state is state:
-            return True
+        return True if self.state is state else state.name in self.state.transitions()
 
-        return state.name in self.state.transitions()
-
-    def transit(self, state: State) -> (State, State):
+    def transit(self, state: State) -> tuple[State, State]:
         """Transition this job into the given state.
 
         Args:
-            state: the state to transition this job to
+            state: The state to transition this job to
 
         Returns:
-            a tuple with the original state and the new state
+            A tuple with the original state and the new state
 
         Raises:
-            ImpossibleTransitionError: when this job cannot transition into the given state
+            ImpossibleTransitionError: when this job cannot transition into the
+                given state
         """
         transition = (self.state, state)
 
@@ -246,13 +246,15 @@ class Job(SystemModel):  # noqa: WPS214
     async def run(self, session):
         """Run wrapped code in context of a job.
 
-        Transitions state to RUNNING and SUCCESS/FAIL as appropriate and records heartbeat every second.
+        Transitions state to RUNNING and SUCCESS/FAIL as appropriate and
+        records heartbeat every second.
 
         Args:
             session: the session to use for writing to the db
 
         Raises:
-            BaseException: re-raises an exception occurring in the job running in this context
+            BaseException: re-raises an exception occurring in the job running
+                in this context
         """  # noqa: DAR301
         try:
             self.start()
@@ -270,7 +272,6 @@ class Job(SystemModel):  # noqa: WPS214
 
             self.fail(error=self._error_message(err))
             self.save(session)
-
             raise
 
     def start(self):
@@ -316,9 +317,13 @@ class Job(SystemModel):  # noqa: WPS214
         """Represent as a string.
 
         Returns:
-            a string representation of the job
+            A string representation of the job.
         """
-        return f"<Job(id='{self.id}', job_name='{self.job_name}', state='{self.state}', started_at='{self.started_at}', ended_at='{self.ended_at}')>"
+        return (
+            f"<Job(id='{self.id}', job_name='{self.job_name}', "
+            f"state='{self.state}', started_at='{self.started_at}', "
+            f"ended_at='{self.ended_at}')>"
+        )
 
     def save(self, session):
         """Save the job in the db.

--- a/src/meltano/core/job/stale_job_failer.py
+++ b/src/meltano/core/job/stale_job_failer.py
@@ -30,5 +30,6 @@ def fail_stale_jobs(session: Session, state_id: str | None = None) -> None:
 
         error = job.payload["error"]
         logger.info(
-            f"Marked stale run{with_state_id} that started at {job.started_at} as failed: {error}"
+            f"Marked stale run{with_state_id} that started at "
+            f"{job.started_at} as failed: {error}"
         )

--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -255,7 +255,9 @@ class Out:  # noqa: WPS230
                 yield
 
     def writeline(self, line: str) -> None:
-        """Write a line to the underlying structured logger, cleaning up any dangling control chars.
+        """Write a line to the underlying structured logger.
+
+        Cleans up any dangling control chars.
 
         Args:
             line: A line to write.

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -33,7 +33,7 @@ LEVELS = {  # noqa: WPS407
     "critical": logging.CRITICAL,
 }
 DEFAULT_LEVEL = "info"
-FORMAT = "[%(asctime)s] [%(process)d|%(threadName)10s|%(name)s] [%(levelname)s] %(message)s"  # noqa: WPS323
+FORMAT = "[%(asctime)s] [%(process)d|%(threadName)10s|%(name)s] [%(levelname)s] %(message)s"  # noqa: WPS323, E501
 
 
 def parse_log_level(log_level: dict[str, int]) -> int:
@@ -169,11 +169,12 @@ def setup_logging(  # noqa: WPS210
 
 
 def change_console_log_level(log_level: int = logging.DEBUG) -> None:
-    """Change the log level for the current root logger, but only on the 'console' handler.
+    """Change the log level for the root logger, but only on the 'console' handler.
 
-    Most useful when you want change the log level on the fly for console output, but want to respect other aspects
-    of any potential logging.yaml sourced configs. Note that if a logging.yaml config without a 'console' handler
-    is used, this will not override the log level.
+    Most useful when you want change the log level on the fly for console
+    output, but want to respect other aspects of any potential `logging.yaml`
+    sourced configs. Note that if a `logging.yaml` config without a 'console'
+    handler is used, this will not override the log level.
 
     Args:
         log_level: set log levels to provided level.
@@ -186,13 +187,13 @@ def change_console_log_level(log_level: int = logging.DEBUG) -> None:
 
 
 class SubprocessOutputWriter(Protocol):
-    """SubprocessOutputWriter is a basic interface definition suitable for use with capture_subprocess_output."""
+    """A basic interface suitable for use with `capture_subprocess_output`."""
 
     def writelines(self, lines: str):
-        """Any type with a writelines method accepting a string could be used as an output writer.
+        """Write the provided lines to an output.
 
         Args:
-            lines: string to write
+            lines: String to write
         """
 
 
@@ -224,8 +225,9 @@ async def capture_subprocess_output(
     for the subprocess to end.
 
     Args:
-        reader: asyncio.StreamReader object that is the output stream of the subprocess.
-        line_writers: any object thats a StreamWriter or has a writelines method accepting a string.
+        reader: `asyncio.StreamReader` object that is the output stream of the
+            subprocess.
+        line_writers: A `StreamWriter`, or object has a compatible writelines method.
     """
     while not reader.at_eof():
         line = await reader.readline()

--- a/src/meltano/core/meltano_file.py
+++ b/src/meltano/core/meltano_file.py
@@ -119,10 +119,15 @@ class MeltanoFile(Canonical):
 
     @staticmethod
     def get_plugins_for_mappings(mapper_config: dict) -> list[ProjectPlugin]:
-        """Mapper plugins are a special case. They are not a single plugin, but actually a list of plugins generated from the mapping config defined within the mapper config.
+        """Get plugins for mappings.
+
+        Mapper plugins are a special case. They are not a single plugin, but
+        actually a list of plugins generated from the mapping config defined
+        within the mapper config.
 
         Args:
-            mapper_config: The dict representation of a mapper config found in in meltano.yml.
+            mapper_config: The dict representation of a mapper config found in
+                in `meltano.yml`.
 
         Returns:
             A list of `ProjectPlugin` instances.

--- a/src/meltano/core/migration_service.py
+++ b/src/meltano/core/migration_service.py
@@ -26,7 +26,7 @@ class MigrationError(Exception):
 
 
 class MigrationUneededException(Exception):
-    """Occurs when no migrations are needed."""
+    """No migrations are needed."""
 
 
 class MigrationService:
@@ -107,7 +107,8 @@ class MigrationService:
         except Exception as err:
             logging.exception(str(err))
             raise MigrationError(
-                "Cannot upgrade the system database. It might be corrupted or was created before database migrations where introduced (v0.34.0)"
+                "Cannot upgrade the system database. It might be corrupted or "
+                "was created before database migrations where introduced (v0.34.0)"
             )
         finally:
             conn.close()

--- a/src/meltano/core/plugin/airflow.py
+++ b/src/meltano/core/plugin/airflow.py
@@ -5,6 +5,7 @@ import configparser
 import logging
 import os
 import subprocess
+from contextlib import suppress
 
 from packaging.version import Version
 
@@ -161,7 +162,10 @@ class Airflow(BasePlugin):
 
         if exit_code:
             raise AsyncSubprocessError(
-                "Airflow metadata database could not be initialized: `airflow initdb` failed",
+                (
+                    "Airflow metadata database could not be initialized: "
+                    "`airflow initdb` failed"
+                ),
                 handle,
             )
 
@@ -175,8 +179,6 @@ class Airflow(BasePlugin):
             invoker: the active PluginInvoker
         """
         config_file = invoker.files["config"]
-        try:
+        with suppress(FileNotFoundError):
             config_file.unlink()
             logging.debug(f"Deleted configuration at {config_file}")
-        except FileNotFoundError:
-            pass

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -38,16 +38,15 @@ class VariantNotFoundError(Exception):
         Returns:
             The string representation of the error.
         """
-        return "{type} '{name}' variant '{variant}' is not known to Meltano. Variants: {variant_labels}".format(
-            type=self.plugin.type.descriptor.capitalize(),
-            name=self.plugin.name,
-            variant=self.variant_name,
-            variant_labels=self.plugin.variant_labels,
+        return (
+            f"{self.plugin.type.descriptor.capitalize()} '{self.plugin.name}' "
+            f"variant '{self.variant_name}' is not known to Meltano. "
+            f"Variants: {self.plugin.variant_labels}"
         )
 
 
 class PluginRefNameContainsStateIdDelimiterError(Exception):
-    """Occurs when a name in reference to a plugin contains the state ID component delimiter string."""
+    """A name in reference to a plugin contains the state ID component delimiter."""
 
     def __init__(self, name: str):
         """Create a new exception.
@@ -56,7 +55,8 @@ class PluginRefNameContainsStateIdDelimiterError(Exception):
             name: The name of the plugin.
         """
         super().__init__(
-            f"The plugin name '{name}' cannot contain the state ID component delimiter string '{STATE_ID_COMPONENT_DELIMITER}'"
+            f"The plugin name '{name}' cannot contain the state ID component "
+            f"delimiter string '{STATE_ID_COMPONENT_DELIMITER}'"
         )
 
 
@@ -199,7 +199,8 @@ class PluginRef(Canonical):
             kwargs: Additional keyword arguments.
 
         Raises:
-            PluginRefNameContainsStateIdDelimiterError: If the name contains the state ID component delimiter string.
+            PluginRefNameContainsStateIdDelimiterError: If the name contains
+                the state ID component delimiter string.
         """
         if STATE_ID_COMPONENT_DELIMITER in name:
             raise PluginRefNameContainsStateIdDelimiterError(name)

--- a/src/meltano/core/plugin/command.py
+++ b/src/meltano/core/plugin/command.py
@@ -14,7 +14,7 @@ TCommand = t.TypeVar("TCommand")
 
 
 class UndefinedEnvVarError(Error):
-    """Occurs when an environment variable is used as a command argument but is not set."""
+    """An environment variable is used as a command argument but is not set."""
 
     def __init__(self, command_name, var):
         """Initialize UndefinedEnvVarError.
@@ -24,8 +24,9 @@ class UndefinedEnvVarError(Error):
             var: Environment variable name.
         """
         super().__init__(
-            f"Command '{command_name}' referenced unset environment variable '{var}' in an argument. "
-            + "Set the environment variable or update the command definition."
+            f"Command '{command_name}' referenced unset environment variable "
+            f"'{var}' in an argument. Set the environment variable or update "
+            "the command definition."
         )
 
 

--- a/src/meltano/core/plugin/error.py
+++ b/src/meltano/core/plugin/error.py
@@ -15,7 +15,10 @@ class PluginNotFoundError(Exception):
             self.plugin_name = plugin_or_name
 
     def __str__(self):
-        return f"{self.plugin_type.capitalize()} '{self.plugin_name}' is not known to Meltano"
+        return (
+            f"{self.plugin_type.capitalize()} '{self.plugin_name}' is not "
+            "known to Meltano"
+        )
 
 
 class PluginParentNotFoundError(Exception):
@@ -27,10 +30,9 @@ class PluginParentNotFoundError(Exception):
         self.parent_not_found_error = parent_not_found_error
 
     def __str__(self):
-        return "Could not find parent plugin for {type} '{name}': {error}".format(
-            type=self.plugin.type.descriptor,
-            name=self.plugin.name,
-            error=self.parent_not_found_error,
+        return (
+            f"Could not find parent plugin for {self.plugin.type.descriptor} "
+            f"'{self.plugin.name}': {self.parent_not_found_error}"
         )
 
 
@@ -42,11 +44,14 @@ class PluginNotSupportedError(Exception):
         self.plugin = plugin
 
     def __str__(self):
-        return f"Operation not supported for {self.plugin.type.descriptor} '{self.plugin.name}'"
+        return (
+            "Operation not supported for "
+            f"{self.plugin.type.descriptor} '{self.plugin.name}'"
+        )
 
 
 class PluginExecutionError(Exception):
-    """Base exception for problems that stem from the execution of a plugin (sub-process)."""
+    """Error stemming from the execution of a plugin (sub-process)."""
 
 
 class PluginLacksCapabilityError(Exception):

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -85,9 +85,20 @@ class FilePlugin(BasePlugin):  # noqa: WPS214
         """
         return "\n".join(
             (
-                f"# This file is managed by the '{self.name}' {self.type.descriptor} and updated automatically when `meltano upgrade` is run.",
-                f"# To prevent any manual changes from being overwritten, remove the {self.type.descriptor} from `meltano.yml` or disable automatic updates:",
-                f"#     meltano config --plugin-type={self.type} {self.name} set _update {relative_path} false",
+                (
+                    f"# This file is managed by the '{self.name}' "
+                    f"{self.type.descriptor} and updated automatically when "
+                    "`meltano upgrade` is run."
+                ),
+                (
+                    f"# To prevent any manual changes from being overwritten, "
+                    f"remove the {self.type.descriptor} from `meltano.yml` or "
+                    "disable automatic updates:"
+                ),
+                (
+                    f"#     meltano config --plugin-type={self.type} "
+                    f"{self.name} set _update {relative_path} false"
+                ),
             )
         )
 

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -38,12 +38,9 @@ class CyclicInheritanceError(Exception):
             A formatted error message string.
         """
         return (
-            "{type} '{name}' cannot inherit from '{ancestor}', "
-            "which itself inherits from '{name}'"
-        ).format(
-            type=self.plugin.type.descriptor.capitalize(),
-            name=self.plugin.name,
-            ancestor=self.ancestor.name,
+            f"{self.plugin.type.descriptor.capitalize()} '{self.plugin.name}' "
+            f"cannot inherit from '{self.ancestor.name}', which itself "
+            f"inherits from '{self.plugin.name}'"
         )
 
 
@@ -98,13 +95,15 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
             inherit_from if inherit_from and inherit_from != name else None
         )
 
-        # If a custom definition is provided, its properties will come before all others in meltano.yml
+        # If a custom definition is provided, its properties will come before
+        # all others in meltano.yml
         self.custom_definition = None
         self._flattened.add("custom_definition")
 
         self._parent = None
         if not self.inherit_from and namespace:
-            # When not explicitly inheriting, a namespace indicates an embedded custom plugin definition
+            # When not explicitly inheriting, a namespace indicates an
+            # embedded custom plugin definition
             self.custom_definition = PluginDefinition(
                 plugin_type,
                 name,
@@ -125,7 +124,7 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
             extras = self.custom_definition.extras
             self.custom_definition.extras = {}
 
-            # Typically, the parent is set from ProjectPluginsService.current_plugins,
+            # Typically, the parent is set from `ProjectPluginsService.current_plugins`,
             # where we have access to the discoverable plugin definitions coming from
             # PluginDiscoveryService, but here we can set the parent directly.
             self.parent = base_plugin_factory(self.custom_definition, variant)
@@ -159,8 +158,8 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
         self._defaults[self.VARIANT_ATTR] = lambda _: default_variant
 
         if self.inherit_from:
-            # When explicitly inheriting from a project plugin or discoverable definition,
-            # derive default values from our own name
+            # When explicitly inheriting from a project plugin or discoverable
+            # definition, derive default values from our own name
             self._defaults["namespace"] = lambda plugin: plugin.name.replace("-", "_")
             self._defaults["label"] = lambda plugin: (
                 f"{plugin.parent.label}: {plugin.name}"
@@ -168,9 +167,10 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
                 else plugin.name
             )
         else:
-            # When shadowing a discoverable definition with the same name (no `inherit_from`),
-            # or an embedded custom definition (with `namespace`), fall back on parent's
-            # values derived from its name instead
+            # When shadowing a discoverable definition with the same name (no
+            # `inherit_from`), or an embedded custom definition (with
+            # `namespace`), fall back on parent's values derived from its name
+            # instead
             self._fallbacks.update(["namespace", "label"])
 
         self.config = copy.deepcopy(config or {})
@@ -236,7 +236,8 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
         """Return all commands for this plugin.
 
         Returns:
-            Dictionary of supported commands, including those inherited from the parent plugin.
+            Dictionary of supported commands, including those inherited from
+            the parent plugin.
         """
         return {**self._parent.all_commands, **self.commands}
 
@@ -245,7 +246,8 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
         """Return the test commands for this plugin.
 
         Returns:
-            Dictionary of supported test commands, including those inherited from the parent plugin.
+            Dictionary of supported test commands, including those inherited
+            from the parent plugin.
         """
         return {
             name: command
@@ -373,7 +375,8 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
         """Return the venv name this plugin should use.
 
         Returns:
-            The name of this plugins parent if both pip urls are the same, else this plugins name.
+            The name of this plugins parent if both pip urls are the same, else
+            this plugins name.
         """
         if not self.inherit_from:
             return self.name
@@ -410,7 +413,8 @@ class ProjectPlugin(PluginRef):  # noqa: WPS230, WPS214 # too many attrs and met
         """Return all requires for this plugin.
 
         Returns:
-            List of supported requires, including those inherited from the parent plugin.
+            List of supported requires, including those inherited from the
+            parent plugin.
         """
         return self.get_requirements(plugin_types=None)
 

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -85,14 +85,14 @@ class PluginSettingsService(SettingsService):  # noqa: WPS214
                     if_missing=EnvVarMissingBehavior(strict_env_var_mode),
                 )
 
-            self.env_override.update(
-                environment_env
-            )  # active Meltano Environment top level `env:` key
+            # active Meltano Environment top level `env:` key
+            self.env_override.update(environment_env)
 
         environment_plugin_env = (
             self.environment_plugin_config.env if self.environment_plugin_config else {}
         )
-        # env vars stored under the `env:` key of the plugin definition of the active meltano Environment
+        # env vars stored under the `env:` key of the plugin definition of the
+        # active meltano Environment
         self.env_override.update(environment_plugin_env)
 
     @property

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -92,9 +92,8 @@ class PluginSettingsService(SettingsService):  # noqa: WPS214
         environment_plugin_env = (
             self.environment_plugin_config.env if self.environment_plugin_config else {}
         )
-        self.env_override.update(
-            environment_plugin_env
-        )  # env vars stored under the `env:` key of the plugin definition of the active meltano Environment
+        # env vars stored under the `env:` key of the plugin definition of the active meltano Environment
+        self.env_override.update(environment_plugin_env)
 
     @property
     def project_settings_service(self):

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -10,9 +10,17 @@ from meltano.core.utils import nest_object
 
 
 class SingerPlugin(BasePlugin):
-    def __init__(self, *args, **kwargs):
-        """Canonical class leads to  an error if the UUID is defined here directly. Also, This data attribute must be defined or we'll get errors from Canonical."""
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize a `SingerPlugin`.
+
+        Args:
+            args: Positional arguments for the super class.
+            kwargs: Keyword arguments for the super class.
+        """
         super().__init__(*args, **kwargs)
+        # Canonical class leads to an error if the UUID is defined here
+        # directly. Also, this data attribute must be defined or we'll get
+        # errors from Canonical.
         self._instance_uuid: str | None = None
 
     def process_config(self, flat_config):

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -44,7 +44,7 @@ class CatalogRule:
             breadcrumb: JSON property breadcrumb.
 
         Returns:
-            A boolean representing whether the stream ID or breadcrumb matches the rules.
+            Whether the stream ID or breadcrumb matches the rules.
         """
         patterns = (
             self.tap_stream_id
@@ -116,7 +116,12 @@ class SelectPattern(t.NamedTuple):
         Example:
 
         >>> SelectPattern.parse("!a.b.c")
-        SelectedPattern(stream_pattern='a', property_pattern='b.c', negated=True, raw='!a.b.c')
+        SelectedPattern(
+            stream_pattern='a',
+            property_pattern='b.c',
+            negated=True,
+            raw='!a.b.c'
+        )
         """
         raw = pattern
 
@@ -424,7 +429,7 @@ class MetadataExecutor(CatalogExecutor):
         breadcrumb = node["breadcrumb"]
 
         logging.debug(
-            "Visiting metadata node for tap_stream_id '%s', breadcrumb '%s'",  # noqa: WPS323
+            "Visiting metadata node for tap_stream_id '%s', breadcrumb '%s'",  # noqa: WPS323, E501
             tap_stream_id,
             breadcrumb,
         )
@@ -577,19 +582,13 @@ class ListSelectedExecutor(CatalogExecutor):
         except KeyError:
             return SelectionType.EXCLUDED
 
-        inclusion: str = metadata.get("inclusion")
-        selected: bool | None = metadata.get("selected")
-        selected_by_default: bool = metadata.get("selected-by-default", False)
-
-        if inclusion == "automatic":
+        if metadata.get("inclusion") == "automatic":
             return SelectionType.AUTOMATIC
-
-        if selected is True:
+        if metadata.get("selected") is True or (
+            metadata.get("selected") is None
+            and metadata.get("selected-by-default", False)
+        ):
             return SelectionType.SELECTED
-
-        if selected is None and selected_by_default:
-            return SelectionType.SELECTED
-
         return SelectionType.EXCLUDED
 
     def stream_node(self, node: Node, path: str):

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -1,7 +1,4 @@
-"""SingerTarget and supporting classes.
-
-This module contains the SingerTarget class as well as a supporting BookmarkWriter class.
-"""
+"""SingerTarget and supporting classes."""
 from __future__ import annotations
 
 import json
@@ -20,7 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 class BookmarkWriter:
-    """A basic bookmark writer suitable for use as an output handler."""
+    """A basic bookmark writer suitable for use as an output handler.
+
+    Has a writelines method to support ingesting and persisting state messages.
+    """
 
     def __init__(
         self,
@@ -29,13 +29,14 @@ class BookmarkWriter:
         payload_flag: int = Payload.STATE,
         state_service: StateService | None = None,
     ):
-        """Bookmark writer with a writelines implementation to support ingesting and persisting state messages.
+        """Initialize the `BookmarkWriter`.
 
         Args:
-            job: meltano elt job associated with this invocation and who's state will be updated.
+            job: meltano elt job associated with this invocation and whose
+                state will be updated.
             session: SQLAlchemy session/engine object to be used to update state.
-            payload_flag: a valid payload flag, one of Payload.STATE or Payload.INCOMPLETE_STATE.
-            state_service: StateService to use for bookmarking state.
+            payload_flag: A payload flag.
+            state_service: `StateService` to use for bookmarking state.
         """
         self.job = job
         self.session = session
@@ -72,7 +73,8 @@ class BookmarkWriter:
             )
         except Exception:
             logger.warning(
-                "Unable to persist state, or received state is invalid, incremental state has not been updated"
+                "Unable to persist state, or received state is invalid, "
+                "incremental state has not been updated"
             )
         else:
             logger.info(f"Incremental state has been updated at {datetime.utcnow()}.")
@@ -137,10 +139,14 @@ class SingerTarget(SingerPlugin):
         self.setup_bookmark_writer(plugin_invoker)
 
     def setup_bookmark_writer(self, plugin_invoker: PluginInvoker):
-        """Configure the bookmark writer as an additional output handler on the invoker if running in a pipeline context.
+        """Configure the bookmark writer.
 
-        This leverages calling back to PluginInvokers.add_output_handler to attach an additional
-        output handler (the BookmarkWriter) to handle persisting state messages.
+        If running in a pipeline context, we configure the bookmark writer as
+        an additional output handler on the invoker.
+
+        This leverages calling back to `PluginInvokers.add_output_handler` to
+        attach an additional output handler (the `BookmarkWriter`) to handle
+        persisting state messages.
 
         Args:
             plugin_invoker: The invocation handler whose `add_out_handler` method

--- a/src/meltano/core/plugin/superset.py
+++ b/src/meltano/core/plugin/superset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from contextlib import suppress
 
 import structlog
 
@@ -82,8 +83,8 @@ class Superset(BasePlugin):
             if custom_config_path.exists():
                 config_script_lines.extend(
                     [
-                        "from importlib.util import module_from_spec, spec_from_file_location",
-                        f'spec = spec_from_file_location("superset_config", {str(custom_config_path)!r})',
+                        "from importlib.util import module_from_spec, spec_from_file_location",  # noqa: E501
+                        f'spec = spec_from_file_location("superset_config", {str(custom_config_path)!r})',  # noqa: E501
                         "custom_config = module_from_spec(spec)",
                         'sys.modules["superset_config"] = custom_config',
                         "spec.loader.exec_module(custom_config)",
@@ -125,7 +126,10 @@ class Superset(BasePlugin):
 
         if exit_code:
             raise AsyncSubprocessError(
-                "Superset metadata database could not be initialized: `superset db upgrade` failed",
+                (
+                    "Superset metadata database could not be initialized: "
+                    "`superset db upgrade` failed"
+                ),
                 handle,
             )
 
@@ -151,7 +155,10 @@ class Superset(BasePlugin):
 
         if exit_code:
             raise AsyncSubprocessError(
-                "Superset default roles and permissions could not be created: `superset init` failed",
+                (
+                    "Superset default roles and permissions could not be "
+                    "created: `superset init` failed"
+                ),
                 handle,
             )
 
@@ -165,8 +172,6 @@ class Superset(BasePlugin):
             invoker: the active PluginInvoker
         """
         config_file = invoker.files["config"]
-        try:
+        with suppress(FileNotFoundError):
             config_file.unlink()
             logging.debug(f"Deleted configuration at {config_file}")
-        except FileNotFoundError:
-            pass

--- a/src/meltano/core/plugin_discovery_service.py
+++ b/src/meltano/core/plugin_discovery_service.py
@@ -31,15 +31,16 @@ REQUEST_TIMEOUT_SECONDS = 30.0
 
 
 class DiscoveryInvalidError(Exception):
-    """Occurs when the discovery.yml fails to be parsed."""
+    """The discovery.yml fails to be parsed."""
 
 
 class DiscoveryUnavailableError(Exception):
-    """Occurs when the discovery.yml cannot be found or downloaded."""
+    """The discovery.yml cannot be found or downloaded."""
 
 
 # Increment this version number whenever the schema of discovery.yml is changed.
-# See https://docs.meltano.com/contribute/plugins#discoveryyml-version for more information.
+# See https://docs.meltano.com/contribute/plugins#discoveryyml-version for
+# more information.
 VERSION = 22
 
 
@@ -208,11 +209,14 @@ class PluginDiscoveryService(  # noqa: WPS214 (too many public methods)
                 errored = True
 
                 logging.warning(
-                    f"{description.capitalize()} has version {err.file_version}, while this version of Meltano requires version {err.version}."
+                    f"{description.capitalize()} has version "
+                    f"{err.file_version}, while this version of Meltano "
+                    f"requires version {err.version}."
                 )
                 if err.file_version > err.version:
                     logging.warning(
-                        "Please install the latest compatible version of Meltano using `meltano upgrade`."
+                        "Please install the latest compatible version of "
+                        "Meltano using `meltano upgrade`."
                     )
             except DiscoveryInvalidError as err:
                 errored = True

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -1,4 +1,4 @@
-"""Install plugins into the project, using pip in separate virtual environments by default."""
+"""Install plugins into the project, using pip in separate venv by default."""
 
 from __future__ import annotations
 
@@ -183,18 +183,18 @@ class PluginInstallService:  # noqa: WPS214
     ):
         """Deduplicate list of plugins, keeping the last occurrences.
 
-        Trying to install multiple plugins into the same venv via `asyncio.run` will fail
-        due to a race condition between the duplicate installs. This is particularly
-        problematic if `clean` is set as one async `clean` operation causes the other
-        install to fail.
+        Trying to install multiple plugins into the same venv via `asyncio.run`
+        will fail due to a race condition between the duplicate installs. This
+        is particularly problematic if `clean` is set as one async `clean`
+        operation causes the other install to fail.
 
         Args:
             plugins: An iterable containing plugins to dedupe.
             reason: Plugins install reason.
 
         Returns:
-            A tuple containing a list of PluginInstallState instance (for skipped plugins)
-            and a deduplicated list of plugins to install.
+            A tuple containing a list of PluginInstallState instance (for
+            skipped plugins) and a deduplicated list of plugins to install.
         """
         seen_venvs = set()
         deduped_plugins = []
@@ -390,14 +390,16 @@ class PluginInstallService:  # noqa: WPS214
     def _is_mapping(plugin: ProjectPlugin) -> bool:
         """Check if a plugin is a mapping, as mappings are not installed.
 
-        Mappings are PluginType.MAPPERS with extra attribute of `_mapping` which will indicate
-        that this instance of the plugin is actually a mapping - and should not be installed.
+        Mappings are `PluginType.MAPPERS` with extra attribute of `_mapping`
+        which will indicate that this instance of the plugin is actually a
+        mapping - and should not be installed.
 
         Args:
             plugin: ProjectPlugin to evaluate.
 
         Returns:
-            A boolean determining if the given plugin is a mapping (of type PluginType.MAPPERS).
+            A boolean determining if the given plugin is a mapping (of type
+            `PluginType.MAPPERS`).
         """
         return plugin.type == PluginType.MAPPERS and plugin.extra_config.get("_mapping")
 
@@ -415,7 +417,7 @@ class PluginInstallService:  # noqa: WPS214
             A special env var (with lowest precedence) `$MELTANO__PYTHON_VERSION`
             is included, and has the value
             `<major Python version>.<minor Python version>`.
-        """
+        """  # noqa: E501
         plugin_settings_service = PluginSettingsService(self.project, plugin)
         with self.project.settings.feature_flag(
             FeatureFlags.STRICT_ENV_VAR_MODE, raise_error=False
@@ -426,7 +428,9 @@ class PluginInstallService:  # noqa: WPS214
                 if_missing=EnvVarMissingBehavior(strict_env_var_mode),
             )
             return {
-                "MELTANO__PYTHON_VERSION": f"{sys.version_info.major}.{sys.version_info.minor}",
+                "MELTANO__PYTHON_VERSION": (
+                    f"{sys.version_info.major}.{sys.version_info.minor}"
+                ),
                 **expanded_project_env,
                 **expand_env_vars(
                     plugin_settings_service.project.dotenv_env,

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -54,7 +54,7 @@ class InvokerError(Error):
 
 
 class ExecutableNotFoundError(InvokerError):
-    """Occurs when the executable could not be found."""
+    """The executable could not be found."""
 
     def __init__(self, plugin: PluginRef, executable: str):
         """Initialize ExecutableNotFoundError.
@@ -469,7 +469,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
         service = ContainerService()
 
         logger.debug("Running containerized command", command=plugin_command)
-        async with self._invoke(*args, **kwargs) as (proc_args, _, proc_env):
+        async with self._invoke(*args, **kwargs) as (_proc_args, _, proc_env):
             plugin_name = self.plugin.name
             random_id = uuid.uuid4()
             name = f"meltano-{plugin_name}--{plugin_command}-{random_id}"
@@ -479,7 +479,7 @@ class PluginInvoker:  # noqa: WPS214, WPS230
         return info["State"]["ExitCode"]
 
     async def dump(self, file_id: str) -> str:
-        """Dump a plugin file by id.
+        """Dump a plugin file by ID.
 
         Args:
             file_id: Dump this file identifier.
@@ -504,8 +504,10 @@ class PluginInvoker:  # noqa: WPS214, WPS230
         """Append an output handler for a given stdio stream.
 
         Args:
-            src: stdio source you'd like to subscribe, likely either 'stdout' or 'stderr'
-            handler: either a StreamWriter or an object matching the utils.SubprocessOutputWriter proto
+            src: stdio source you'd like to subscribe, likely either 'stdout'
+                or 'stderr'
+            handler: A `StreamWriter` or object matching the
+                `utils.SubprocessOutputWriter` protocol
         """
         if self.output_handlers:
             self.output_handlers[src].append(handler)

--- a/src/meltano/core/plugin_location_remove.py
+++ b/src/meltano/core/plugin_location_remove.py
@@ -1,4 +1,4 @@
-"""Defines PluginLocationRemoveStatus, PluginLocationRemoveManager, DbRemoveManager, MeltanoYmlRemoveManager and InstallationRemoveManager."""
+"""Defines plugin removers."""
 
 from __future__ import annotations
 
@@ -74,7 +74,7 @@ class PluginLocationRemoveManager(ABC):
 
 
 class DbRemoveManager(PluginLocationRemoveManager):
-    """Handle removal of a plugin's settings from the system database `plugin_settings` table."""
+    """Handle removal from the system db `plugin_settings` table."""
 
     def __init__(self, plugin, project):
         """Construct a DbRemoveManager instance.
@@ -88,7 +88,7 @@ class DbRemoveManager(PluginLocationRemoveManager):
         self.session = project_engine(project)[1]
 
     def remove(self):
-        """Remove the plugin's settings from the system database `plugin_settings` table.
+        """Remove the plugin's settings from the system db `plugin_settings` table.
 
         Returns:
             The remove status.

--- a/src/meltano/core/plugin_test_service.py
+++ b/src/meltano/core/plugin_test_service.py
@@ -95,8 +95,9 @@ class ExtractorTestService(PluginTestService):
 
         returncode = await process.wait()
 
-        # considered valid if subprocess is terminated (exit status < 0) on RECORD message received
-        # see https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.returncode
+        # Considered valid if subprocess is terminated (exit status < 0) on
+        # RECORD message received. See
+        # https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.returncode  # noqa: E501
         return (
             returncode < 0,
             last_line if returncode else "No RECORD message received",

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -228,7 +228,8 @@ class Project(Versioned):  # noqa: WPS214
         except OSError as error:
             if error.errno == errno.EOPNOTSUPP:
                 logger.warning(
-                    f"Could not create symlink: {error}\nPlease make sure that the underlying filesystem supports symlinks."
+                    f"Could not create symlink: {error}\nPlease make sure "
+                    "that the underlying filesystem supports symlinks."
                 )
             else:
                 raise
@@ -258,17 +259,19 @@ class Project(Versioned):  # noqa: WPS214
         """Find a Project.
 
         Args:
-            project_root: The path to the root directory of the project. If not supplied,
-                infer from PROJECT_ROOT_ENV or the current working directory and it's parents.
-            activate: Save the found project so that future calls to `find` will
-                continue to use this project.
+            project_root: The path to the root directory of the project. If not
+                supplied, infer from PROJECT_ROOT_ENV or the current working
+                directory and it's parents.
+            activate: Save the found project so that future calls to `find`
+                will continue to use this project.
 
         Returns:
             the found project
 
         Raises:
-            ProjectNotFound: if the provided `project_root` is not a Meltano project, or
-                the current working directory is not a Meltano project or a subfolder of one.
+            ProjectNotFound: if the provided `project_root` is not a Meltano
+                project, or the current working directory is not a Meltano
+                project or a subfolder of one.
         """
         if cls._default:
             return cls._default

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -34,7 +34,7 @@ MULTI_FILE_KEYS = {
 
 
 class InvalidIncludePathError(Exception):
-    """Occurs when an included file path matches a provided pattern but is not a valid config file."""
+    """Included file path matches a provided pattern but is not a valid config file."""
 
 
 class ProjectFiles:  # noqa: WPS214
@@ -145,8 +145,8 @@ class ProjectFiles:  # noqa: WPS214
             List of paths matching the given glob patterns.
 
         Raises:
-            InvalidIncludePathError: If a path is matched by a pattern but is not a valid
-                file.
+            InvalidIncludePathError: If a path is matched by a pattern but is
+                not a valid file.
         """
         include_paths = []
         for pattern in include_path_patterns:
@@ -177,7 +177,8 @@ class ProjectFiles:  # noqa: WPS214
             key_path_string = ":".join(key)
             existing_key_file_path = self._plugin_file_map.get(key)
             logger.critical(
-                f'Plugin with path "{key_path_string}" already added in file {existing_key_file_path}.'
+                f'Plugin with path "{key_path_string}" already added in '
+                f"file {existing_key_file_path}."
             )
             raise Exception("Duplicate plugin name found.")
         else:
@@ -236,7 +237,8 @@ class ProjectFiles:  # noqa: WPS214
                 raise exc
             else:
                 self._raw_contents_map[str(path)] = contents
-                # TODO: validate dict schema (https://gitlab.com/meltano/meltano/-/issues/3029)
+                # TODO: validate dict schema
+                # https://gitlab.com/meltano/meltano/-/issues/3029
                 self._index_file(include_file_path=path, include_file_contents=contents)
                 included_file_contents.append(contents)
         return included_file_contents

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -193,7 +193,8 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
         if "@" in plugin_name:
             plugin_name, profile_name = plugin_name.split("@", 2)
             logger.warning(
-                f"Plugin configuration profiles are no longer supported, ignoring `@{profile_name}` in plugin name."
+                "Plugin configuration profiles are no longer supported, "
+                f"ignoring `@{profile_name}` in plugin name."
             )
 
         try:
@@ -335,7 +336,7 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
             ensure_parent: If True, ensure that plugin has a parent plugin set.
 
         Yields:
-            A generator of all plugins.
+            Plugins.
         """
         yield from (
             plugin

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -53,11 +53,14 @@ class ProjectSettingsService(SettingsService):  # noqa: WPS214
             config_override=config_override,
         )
 
+        # terminal env vars are already present from `SettingService.env`
         self.env_override = {
-            # terminal environment variables already present from SettingService.env
-            **self.project.env,  # static, project-level envs (e.g. MELTANO_ENVIRONMENT)
-            **self.project.meltano.env,  # env vars stored in the base `meltano.yml` `env:` key
-            **self.env_override,  # overrides
+            # static, project-level env vars (e.g. MELTANO_ENVIRONMENT)
+            **self.project.env,
+            # env vars stored in the base `meltano.yml` `env:` key
+            **self.project.meltano.env,
+            # overrides
+            **self.env_override,
         }
 
         self.config_override = {  # noqa: WPS601
@@ -86,8 +89,9 @@ class ProjectSettingsService(SettingsService):  # noqa: WPS214
     def ensure_project_id(self) -> None:
         """Ensure `project_id` is configured properly.
 
-        Every `meltano.yml` file should contain the `project_id` key-value pair. It should be
-        present in the top-level config, rather than in any environment-level configs.
+        Every `meltano.yml` file should contain the `project_id`
+        key-value pair. It should be present in the top-level config, rather
+        than in any environment-level configs.
 
         If it is not present, it will be restored from `analytics.json` if possible.
         """
@@ -164,13 +168,13 @@ class ProjectSettingsService(SettingsService):  # noqa: WPS214
         self.project.config_service.update_config(config)
 
     def process_config(self, config) -> dict:
-        """Process configuration dictionary for presentation in `meltano config meltano`.
+        """Process configuration dict for presentation in `meltano config meltano`.
 
         Args:
             config: Config to process.
 
         Returns:
-            Processed configuration dictionary for presentation in `meltano config meltano`.
+            Processed configuration dict for presentation in `meltano config meltano`.
         """
         return nest_object(config)
 

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -242,7 +242,7 @@ class SingerRunner(Runner):
         logging.error(
             f"The extractor generated a message exceeding the message size "
             f"limit of {human_size(line_length_limit)} (half the buffer size "
-            "of {human_size(stream_buffer_size)})."
+            f"of {human_size(stream_buffer_size)})."
         )
         logging.error(
             "To let this message be processed, increase the 'elt.buffer_size' "

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -42,8 +42,8 @@ class SingerRunner(Runner):
 
         # The StreamReader line length limit also acts as half the buffer size,
         # which cannot be set directly:
-        # - https://github.com/python/cpython/blob/v3.8.7/Lib/asyncio/streams.py#L395-L396
-        # - https://github.com/python/cpython/blob/v3.8.7/Lib/asyncio/streams.py#L482
+        # https://github.com/python/cpython/blob/v3.8.7/Lib/asyncio/streams.py#L395-L396
+        # https://github.com/python/cpython/blob/v3.8.7/Lib/asyncio/streams.py#L482
         stream_buffer_size = self.context.project.settings.get("elt.buffer_size")
         line_length_limit = stream_buffer_size // 2
 
@@ -96,7 +96,8 @@ class SingerRunner(Runner):
             capture_subprocess_output(p_target.stderr, loader_log)
         )
 
-        # Wait for tap or target to complete, or for one of the output handlers to raise an exception.
+        # Wait for tap or target to complete, or for one of the output handlers
+        # to raise an exception.
         tap_process_future = asyncio.ensure_future(p_tap.wait())
         target_process_future = asyncio.ensure_future(p_target.wait())
         output_exception_future = asyncio.ensure_future(
@@ -116,7 +117,8 @@ class SingerRunner(Runner):
             return_when=asyncio.FIRST_COMPLETED,
         )
 
-        # If `output_exception_future` completes first, one of the output handlers raised an exception or all completed successfully.
+        # If `output_exception_future` completes first, one of the output
+        # handlers raised an exception or all completed successfully.
         if output_exception_future in done:
             output_futures_done, _ = output_exception_future.result()
             output_futures_failed = [
@@ -128,7 +130,8 @@ class SingerRunner(Runner):
             if output_futures_failed:
                 # If any output handler raised an exception, re-raise it.
 
-                # Special behavior for the tap stdout handler raising a line length limit error.
+                # Special behavior for the tap stdout handler raising a line
+                # length limit error.
                 if tap_stdout_future in output_futures_failed:
                     self._handle_tap_line_length_limit_error(
                         tap_stdout_future.exception(),
@@ -139,8 +142,9 @@ class SingerRunner(Runner):
                 failed_future = output_futures_failed.pop()
                 raise failed_future.exception()
             else:
-                # If all of the output handlers completed without raising an exception,
-                # we still need to wait for the tap or target to complete.
+                # If all of the output handlers completed without raising an
+                # exception, we still need to wait for the tap or target to
+                # complete.
                 done, _ = await asyncio.wait(
                     [tap_process_future, target_process_future],
                     return_when=asyncio.FIRST_COMPLETED,
@@ -152,9 +156,11 @@ class SingerRunner(Runner):
             if tap_process_future in done:
                 tap_code = tap_process_future.result()
             else:
-                # If the target completes before the tap, it failed before processing all tap output
+                # If the target completes before the tap, it failed before
+                # processing all tap output
 
-                # Kill tap and cancel output processing since there's no more target to forward messages to
+                # Kill tap and cancel output processing since there's no more
+                # target to forward messages to
                 p_tap.kill()
                 await tap_process_future
                 tap_stdout_future.cancel()
@@ -166,7 +172,8 @@ class SingerRunner(Runner):
             # Wait for all buffered target output to be processed
             await asyncio.wait([target_stdout_future, target_stderr_future])
         else:  # if tap_process_future in done:
-            # If the tap completes before the target, the target should have a chance to process all tap output
+            # If the tap completes before the target, the target should have a
+            # chance to process all tap output
             tap_code = tap_process_future.result()
 
             # Wait for all buffered tap output to be processed
@@ -233,12 +240,17 @@ class SingerRunner(Runner):
             return
 
         logging.error(
-            f"The extractor generated a message exceeding the message size limit of {human_size(line_length_limit)} (half the buffer size of {human_size(stream_buffer_size)})."
+            f"The extractor generated a message exceeding the message size "
+            f"limit of {human_size(line_length_limit)} (half the buffer size "
+            "of {human_size(stream_buffer_size)})."
         )
         logging.error(
-            "To let this message be processed, increase the 'elt.buffer_size' setting to at least double the size of the largest expected message, and try again."
+            "To let this message be processed, increase the 'elt.buffer_size' "
+            "setting to at least double the size of the largest expected "
+            "message, and try again."
         )
         logging.error(
-            "To learn more, visit https://docs.meltano.com/reference/settings#eltbuffer_size"
+            "To learn more, visit "
+            "https://docs.meltano.com/reference/settings#eltbuffer_size"
         )
         raise RunnerError("Output line length limit exceeded") from exception

--- a/src/meltano/core/schedule_service.py
+++ b/src/meltano/core/schedule_service.py
@@ -21,7 +21,7 @@ from meltano.core.utils import NotFound, coerce_datetime, find_named, iso8601_da
 
 
 class ScheduleAlreadyExistsError(MeltanoError):
-    """Occurs when a schedule already exists."""
+    """A schedule already exists."""
 
     def __init__(self, schedule: Schedule):
         """Initialize the exception.
@@ -34,7 +34,7 @@ class ScheduleAlreadyExistsError(MeltanoError):
 
 
 class ScheduleDoesNotExistError(MeltanoError):
-    """Occurs when a schedule does not exist."""
+    """A schedule does not exist."""
 
     def __init__(self, name: str):
         """Initialize the exception.
@@ -52,7 +52,7 @@ class ScheduleDoesNotExistError(MeltanoError):
 
 
 class ScheduleNotFoundError(MeltanoError):
-    """Occurs when a schedule for a namespace cannot be found."""
+    """A schedule for a namespace cannot be found."""
 
     def __init__(self, namespace: str):
         """Initialize the exception.
@@ -68,7 +68,7 @@ class ScheduleNotFoundError(MeltanoError):
 
 
 class BadCronError(MeltanoError):
-    """Occurs when a cron expression is invalid."""
+    """A cron expression is invalid."""
 
     def __init__(self, cron: str):
         """Initialize the exception.
@@ -260,7 +260,8 @@ class ScheduleService:  # noqa: WPS214
         """Search for a Schedule that runs for a certain plugin namespace.
 
         Example:
-            `tap_carbon` would yield the first schedule that runs for the `tap-carbon` extractor.
+            `tap_carbon` would yield the first schedule that runs for the
+            `tap-carbon` extractor.
 
         Args:
             namespace: The plugin namespace to search.

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -66,7 +66,7 @@ class EnvVar:
 
 
 class SettingMissingError(Error):
-    """Occurs when a setting is missing."""
+    """A setting is missing."""
 
     def __init__(self, name: str):
         """Instantiate SettingMissingError.
@@ -179,7 +179,8 @@ class SettingDefinition(NameEq, Canonical):
             name: Setting name.
             aliases: Setting alias names.
             env: Setting target environment variable.
-            env_aliases: Deprecated. Used to delegate alternative environment variables for overriding this setting's value.
+            env_aliases: Deprecated. Used to delegate alternative environment
+                variables for overriding this setting's value.
             kind: Setting kind.
             value: Setting value.
             label: Setting label.
@@ -192,8 +193,10 @@ class SettingDefinition(NameEq, Canonical):
             protected: A protected setting cannot be changed from the UI.
             env_specific: Flag for environment-specific setting.
             custom: Custom setting flag.
-            value_processor: Used with `kind: object` to pre-process the keys in a particular way.
-            value_post_processor: Used with `kind: object` to post-process the keys in a particular way.
+            value_processor: Used with `kind: object` to pre-process the keys
+                in a particular way.
+            value_post_processor: Used with `kind: object` to post-process the
+                keys in a particular way.
             attrs: Keyword arguments to pass to parent class.
         """
         aliases = aliases or []
@@ -303,7 +306,7 @@ class SettingDefinition(NameEq, Canonical):
 
         Returns:
             True if setting is a config extra.
-        """
+        """  # noqa: E501
         return self.name.startswith("_")
 
     @property

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -60,7 +60,7 @@ class FeatureFlags(Enum):
 
 
 class FeatureNotAllowedException(Exception):
-    """Occurs when a disallowed code path is run."""
+    """A disallowed code path is run."""
 
     def __init__(self, feature):
         """Instantiate the error.
@@ -220,7 +220,8 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
             extras: extra setting definitions to include
             source: the SettingsStore to use
             source_manager: the SettingsStoreManager to use
-            kwargs: additional keyword args to pass during SettingsStoreManager instantiation
+            kwargs: additional keyword args to pass during SettingsStoreManager
+                instantiation
 
         Returns:
             dict of config with metadata
@@ -255,7 +256,7 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
 
         Args:
             *args: args to pass to config_with_metadata
-            process: whether or not to process the config
+            process: Whether to process the config
             **kwargs: additional kwargs to pass to config_with_metadata
 
         Returns:
@@ -317,12 +318,13 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
 
         Args:
             name: the name of the setting to get
-            redacted: whether or not the setting is redacted
-            source: the SettingsStore to use
-            source_manager: the SettingsStoreManager to use
-            setting_def: get this SettingDefinition instead of name
-            expand_env_vars: whether or not to expand nested environment variables
-            **kwargs: additional keyword args to pass during SettingsStoreManager instantiation
+            redacted: Whether the setting is redacted
+            source: the `SettingsStore` to use
+            source_manager: the `SettingsStoreManager` to use
+            setting_def: get this `SettingDefinition` instead of name
+            expand_env_vars: Whether to expand nested environment variables
+            **kwargs: additional keyword args to pass during
+                `SettingsStoreManager` instantiation
 
         Returns:
             a tuple of the setting value and metadata
@@ -419,7 +421,10 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
 
         if setting_def is None and metadata["source"] is SettingValueStore.DEFAULT:
             warnings.warn(
-                f"Unknown setting {name!r} - the default value `{value!r}` will be used",
+                (
+                    f"Unknown setting {name!r} - the default value "
+                    f"`{value!r}` will be used"
+                ),
                 RuntimeWarning,
             )
 
@@ -460,7 +465,8 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
             path: the key for the setting
             value: the value to set the setting to
             store: the store to set the value in
-            **kwargs: additional keyword args to pass during SettingsStoreManager instantiation
+            **kwargs: additional keyword args to pass during
+                `SettingsStoreManager` instantiation
 
         Returns:
             the new value and metadata for the setting
@@ -518,7 +524,8 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
         Args:
             path: the key for the setting
             store: the store to set the value in
-            **kwargs: additional keyword args to pass during SettingsStoreManager instantiation
+            **kwargs: additional keyword args to pass during
+                SettingsStoreManager instantiation
 
         Returns:
             the metadata for the setting
@@ -551,7 +558,8 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
 
         Args:
             store: the store to set the value in
-            **kwargs: additional keyword args to pass during SettingsStoreManager instantiation
+            **kwargs: additional keyword args to pass during
+                `SettingsStoreManager` instantiation
 
         Returns:
             the metadata for the setting
@@ -608,15 +616,17 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
         except StopIteration as err:
             raise SettingMissingError(name) from err
 
+    # TODO: The `for_writing` parameter is unsued, but referenced elsewhere.
+    # Callers should be updated to not use it, and then it should be removed.
     def setting_env_vars(self, setting_def, for_writing=False):
         """Get environment variables for the given setting definition.
 
         Args:
-            setting_def: the setting definition to get env vars for
-            for_writing: unused but referenced elsewhere # TODO: clean up refs at some point
+            setting_def: The setting definition to get env vars for.
+            for_writing: Unused parameter.
 
         Returns:
-            environment variables for given setting
+            Environment variables for given setting
         """
         return setting_def.env_vars(self.env_prefixes)
 
@@ -654,7 +664,8 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
             true if the feature flag is enabled, else false
 
         Raises:
-            FeatureNotAllowedException: if raise_error is True and feature flag is disallowed
+            FeatureNotAllowedException: if `raise_error` is `True` and feature
+                flag is disallowed
         """
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "Unknown setting", RuntimeWarning)

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class ConflictingSettingValueException(Exception):  # noqa: N818
-    """Occurs when a setting has multiple conflicting values via aliases."""
+    """A setting has multiple conflicting values via aliases."""
 
     def __init__(self, setting_names):
         """Instantiate the error.
@@ -52,7 +52,7 @@ class ConflictingSettingValueException(Exception):  # noqa: N818
 
 
 class MultipleEnvVarsSetException(Exception):  # noqa: N818
-    """Occurs when a setting value is set via multiple environment variable names."""
+    """A setting value is set via multiple environment variable names."""
 
     def __init__(self, names):
         """Instantiate the error.
@@ -108,9 +108,10 @@ def cast_setting_value(
 class SettingValueStore(str, Enum):
     """Setting Value Store.
 
-    Note: The declaration order of stores determins store precedence when using the Auto store manager.
-            This is because the `.readables()` and `.writables()` methods return ordered lists that
-            the Auto store manager iterates over when retrieveing setting values.
+    Note: The declaration order of stores determins store precedence when using
+        the Auto store manager. This is because the `.readables()` and
+        `.writables()` methods return ordered lists that the Auto store manager
+        iterates over when retrieveing setting values.
     """
 
     CONFIG_OVERRIDE = "config_override"
@@ -148,7 +149,9 @@ class SettingValueStore(str, Enum):
         Returns:
             SettingsStoreManager for this store.
         """
-        managers = {  # ordering here is not significant, other than being consistent with the order of precedence.
+        # ordering here is not significant, other than being consistent with
+        # the order of precedence.
+        managers = {
             self.CONFIG_OVERRIDE: ConfigOverrideStoreManager,
             self.ENV: EnvStoreManager,
             self.DOTENV: DotEnvStoreManager,
@@ -448,13 +451,16 @@ class DotEnvStoreManager(BaseEnvStoreManager):
         self._env = None
 
     def ensure_supported(self, method: str = "get") -> None:
-        """Ensure named method is supported and project is not read-only and the passed method is supported.
+        """Ensure named method is supported.
+
+        Checks that the project is not read-only and an environment is active.
 
         Args:
             method: Setting method (get, set, etc.)
 
         Raises:
-            StoreNotSupportedError: if the project is read-only or named method is not "get".
+            StoreNotSupportedError: If the project is read-only or named method
+                is not "get".
         """
         if method != "get" and self.project.readonly:
             raise StoreNotSupportedError(ProjectReadonly())
@@ -606,13 +612,16 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         self._flat_config = None
 
     def ensure_supported(self, method: str = "get") -> None:
-        """Ensure named method is supported and project is not read-only and an environment is active.
+        """Ensure named method is supported.
+
+        Checks that the project is not read-only and an environment is active.
 
         Args:
             method: Setting method (get, set, etc.)
 
         Raises:
-            StoreNotSupportedError: if the project is read-only or named method is not "get".
+            StoreNotSupportedError: If the project is read-only or named method
+                is not "get".
         """
         if method != "get" and self.project.readonly:
             raise StoreNotSupportedError(ProjectReadonly())
@@ -822,7 +831,8 @@ class MeltanoEnvStoreManager(MeltanoYmlStoreManager):
             method: Setting method (get, set, etc.)
 
         Raises:
-            StoreNotSupportedError: if the project is read-only or no environment is active.
+            StoreNotSupportedError: if the project is read-only or no
+                environment is active.
         """
         super().ensure_supported(method)
         if not self.settings_service.supports_environments:
@@ -870,7 +880,7 @@ class DbStoreManager(SettingsStoreManager):
 
         Args:
             args: Positional arguments to pass to parent class.
-            bulk:  Flag to determine whether parent metadata is returned alongside child.
+            bulk: Flag to determine whether parent metadata is returned alongside child.
             session: SQLAlchemy Session to use when querying the system database.
             kwargs: Keyword arguments to pass to parent class.
         """
@@ -1147,7 +1157,7 @@ class DefaultStoreManager(SettingsStoreManager):
 
 
 class AutoStoreManager(SettingsStoreManager):
-    """Automatic store manager, for determining the appropriate store based on current context."""
+    """Manager that determines the appropriate store based on current context."""
 
     label = "the system database, `meltano.yml`, and `.env`"
     writable = True
@@ -1226,7 +1236,8 @@ class AutoStoreManager(SettingsStoreManager):
 
         Args:
             name: Setting name.
-            setting_def: SettingDefinition. If None is passed, one will be discovered using `self.find_setting(name)`.
+            setting_def: The setting definition. If `None`, one will be
+                discovered using `self.find_setting(name)`.
 
         Returns:
             A SettingValueStore, if found, else None.
@@ -1272,8 +1283,8 @@ class AutoStoreManager(SettingsStoreManager):
         # any remaining config routed to meltano environment
         if self.ensure_supported(store=SettingValueStore.MELTANO_ENV):
             return SettingValueStore.MELTANO_ENV
-        # fall back to root `meltano.yml`
-        # this is required for Meltano settings, which cannot be stored in an Environment
+        # Fall back to root `meltano.yml`. This is required for Meltano
+        # settings, which cannot be stored in an Environment
         if self.ensure_supported(store=SettingValueStore.MELTANO_YML):
             return SettingValueStore.MELTANO_YML
         # fall back to dotenv
@@ -1350,13 +1361,15 @@ class AutoStoreManager(SettingsStoreManager):
             name: Setting name.
             path: Setting path.
             value: New Setting value.
-            setting_def: SettingDefinition. If none is passed, one will be discovered using `self.find_setting(name)`.
+            setting_def: Setting definition. If none is passed, one will be
+                discovered using `self.find_setting(name)`.
 
         Returns:
             A dictionary of metadata pertaining to the set operation.
 
         Raises:
-            StoreNotSupportedError: exception encountered when attempting to write to store.
+            StoreNotSupportedError: exception encountered when attempting to
+                write to store.
         """
         setting_def = setting_def or self.find_setting(name)
         store = self.auto_store(name, setting_def=setting_def)
@@ -1376,12 +1389,13 @@ class AutoStoreManager(SettingsStoreManager):
         path: list[str],
         setting_def: SettingDefinition | None = None,
     ) -> dict:
-        """Unset value, by name, path and SettingDefinition, in all stores.
+        """Unset value, by name, path and `SettingDefinition`, in all stores.
 
         Args:
             name: Setting name.
             path: Setting path.
-            setting_def: SettingDefinition. If none is passed, one will be discovered using `self.find_setting(name)`.
+            setting_def: Setting definition. If none is passed, one will be
+                discovered using `self.find_setting(name)`.
 
         Returns:
             A metadata dictionary containing details of the last value unset.

--- a/src/meltano/core/sqlalchemy.py
+++ b/src/meltano/core/sqlalchemy.py
@@ -44,7 +44,8 @@ class GUID(TypeDecorator):
     Uses PostgreSQL's UUID type, otherwise uses
     CHAR(32), storing as stringified hex values.
 
-    Reference: https://docs.sqlalchemy.org/en/13/core/custom_types.html#backend-agnostic-guid-type
+    Reference:
+    https://docs.sqlalchemy.org/en/13/core/custom_types.html#backend-agnostic-guid-type
     """
 
     impl = CHAR

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -22,7 +22,7 @@ logger = structlog.getLogger(__name__)
 
 
 class InvalidJobStateError(Exception):
-    """Occurs when invalid job state is parsed."""
+    """Invalid job state is parsed."""
 
 
 class StateService:  # noqa: WPS214
@@ -115,7 +115,8 @@ class StateService:  # noqa: WPS214
         """Add state for the given Job.
 
         Args:
-            job: either an existing Job or a state_id that future runs may look up state for.
+            job: either an existing Job or a state_id that future runs may look
+                up state for.
             new_state: the state to add for the given job.
             payload_flags: the payload_flags to set for the job
             validate: whether to validate the supplied state
@@ -161,7 +162,7 @@ class StateService:  # noqa: WPS214
         Args:
             state_id: the state_id to set state for
             new_state: the state to update to
-            validate: whether or not to validate the supplied state.
+            validate: Whether to validate the supplied state.
         """
         self.add_state(
             state_id,
@@ -175,7 +176,7 @@ class StateService:  # noqa: WPS214
 
         Args:
             state_id: the state_id to clear state for
-            save: whether or not to immediately save the state
+            save: Whether to immediately save the state
         """
         self.state_store_manager.clear(state_id)
 

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -7,15 +7,15 @@ from meltano.core.job_state import JobState
 
 
 class UnsupportedStateBackendURIError(Exception):
-    """Occurs when a provided state backend URI is not supported."""
+    """Provided state backend URI is not supported."""
 
 
 class MissingStateBackendSettingsError(Exception):
-    """Occurs when required setting values for a configured State Backend are missing from the Meltano project."""
+    """Required setting values for a configured State Backend are missing."""
 
 
 class StateIDLockedError(Exception):
-    """Occurs whan a job attempts to acquire a lock on an already-locked state ID."""
+    """A job attempted to acquire a lock on an already-locked state ID."""
 
 
 class StateStoreManager(ABC):

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class InvalidStateBackendConfigurationException(Exception):
-    """Occurs when state backend configuration is invalid."""
+    """State backend configuration is invalid."""
 
 
 class BaseFilesystemStateStoreManager(StateStoreManager):  # noqa: WPS214
@@ -186,7 +186,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):  # noqa: WPS214
         return self.get_path(state_id, filename="lock")
 
     def is_locked(self, state_id: str) -> bool:
-        """Indicate whether or not the given state_id is currently locked.
+        """Indicate whether the given state_id is currently locked.
 
         Args:
             state_id: the state_id to check

--- a/src/meltano/core/state_store/google.py
+++ b/src/meltano/core/state_store/google.py
@@ -60,7 +60,8 @@ class GCSStateStoreManager(BaseFilesystemStateStoreManager):
         Args:
             bucket: the bucket to store state in
             prefix: the prefix to store state at
-            application_credentials: application credentials to  use in authenticating to GCS
+            application_credentials: application credentials to use in
+                authenticating to GCS
             kwargs: additional keyword args to pass to parent
         """
         super().__init__(**kwargs)

--- a/src/meltano/core/state_store/s3.py
+++ b/src/meltano/core/state_store/s3.py
@@ -101,7 +101,8 @@ class S3StateStoreManager(BaseFilesystemStateStoreManager):
             A boto3.Client.
 
         Raises:
-            InvalidStateBackendConfigurationException: when configured AWS settings are invalid.
+            InvalidStateBackendConfigurationException: when configured AWS
+                settings are invalid.
         """
         with requires_boto3():
             if self.aws_secret_access_key and self.aws_access_key_id:
@@ -110,11 +111,11 @@ class S3StateStoreManager(BaseFilesystemStateStoreManager):
                     aws_secret_access_key=self.aws_secret_access_key,
                 )
                 return session.client("s3", endpoint_url=self.endpoint_url)
-            elif self.aws_secret_access_key and not self.aws_access_key_id:
+            elif self.aws_secret_access_key:
                 raise InvalidStateBackendConfigurationException(
                     "AWS secret access key configured, but not AWS access key ID."
                 )
-            elif self.aws_access_key_id and not self.aws_secret_access_key:
+            elif self.aws_access_key_id:
                 raise InvalidStateBackendConfigurationException(
                     "AWS access key ID configured, but no AWS secret access key."
                 )

--- a/src/meltano/core/task_sets.py
+++ b/src/meltano/core/task_sets.py
@@ -48,18 +48,17 @@ def _flat_split(items):
     for el in items:
         if isinstance(el, Iterable) and not isinstance(el, str):
             yield from _flat_split(el)
+        elif " " in el:
+            yield from _flat_split(el.split(" "))
         else:
-            if " " in el:
-                yield from _flat_split(el.split(" "))
-            else:
-                yield el
+            yield el
 
 
 class TaskSets(NameEq, Canonical):
-    """A job is a named entity that holds one or more Task's that can be executed by meltano."""
+    """A named entity that holds one or more tasks that can be executed by Meltano."""
 
     def __init__(self, name: str, tasks: list[str] | list[list[str]]):
-        """Initialize a TaskSets.
+        """Initialize a `TaskSets`.
 
         Args:
             name: The name of the job.
@@ -71,10 +70,11 @@ class TaskSets(NameEq, Canonical):
         self.tasks = tasks
 
     def _as_args(self, preserve_top_level: bool = False) -> list[str] | list[list[str]]:
-        """Convert the job's tasks into invocable representations, suitable for passing as a cli args or block names.
+        """Get job tasks as CLI args.
 
         Args:
-            preserve_top_level: Whether to preserve the defined top level task list to allow for fine-grained executions.
+            preserve_top_level: Whether to preserve the defined top level task
+                list to allow for fine-grained executions.
 
         Returns:
             The run arguments.
@@ -92,10 +92,13 @@ class TaskSets(NameEq, Canonical):
 
     @property
     def flat_args(self) -> list[str] | list[list[str]]:
-        """Convert job's tasks to a single invocable representations. For passing as a cli argument or as block names.
+        """Convert job's tasks to a single invocable representations.
+
+        For passing as a cli argument or as block names.
 
         Example:
-            TaskSets(name="foo", tasks=["tap target", "some:cmd"]).flat_args -> ["tap", "target", "some:cmd"]
+            >>> TaskSets(name="foo", tasks=["tap target", "some:cmd"]).flat_args
+            ["tap", "target", "some:cmd"]
 
         Returns:
             The run arguments.
@@ -104,21 +107,24 @@ class TaskSets(NameEq, Canonical):
 
     @property
     def flat_args_per_set(self) -> list[str] | list[list[str]]:
-        """Convert the job's tasks into perk task representations (preserving top level list hierarchy).
+        """Convert the job's tasks into perk task representations.
+
+        Preserves top level list hierarchy.
 
         Example:
-            TaskSets(name="foo", tasks=[["tap trgt"], ["some:cmd"]).flat_args_per_set -> [["tap", "trgt"], ["some:cmd"]]
+        >>> TaskSets(name="foo", tasks=[["a b"], ["some:cmd"]).flat_args_per_set
+        [["a", "b"], ["some:cmd"]]
 
         Returns:
             The per-task run arguments.
-        """
+        """  # noqa: F721
         return self._as_args(preserve_top_level=True)
 
 
 def tasks_from_yaml_str(name: str, yaml_str: str) -> TaskSets:
     """Create a TaskSets from a yaml string.
 
-    The resulting object is validated against the TASKS_JSON_SCHEMA.
+    The resulting object is validated against the `TASKS_JSON_SCHEMA`.
 
     Args:
         name: The name of the job.
@@ -128,7 +134,8 @@ def tasks_from_yaml_str(name: str, yaml_str: str) -> TaskSets:
         The TaskSets.
 
     Raises:
-        InvalidTasksError: If the yaml string failed to parse or failed to validate against the TASKS_JSON_SCHEMA.
+        InvalidTasksError: If the yaml string failed to parse or failed to
+            validate against the `TASKS_JSON_SCHEMA`.
     """
     tasks = []
     try:

--- a/src/meltano/core/task_sets_service.py
+++ b/src/meltano/core/task_sets_service.py
@@ -10,7 +10,7 @@ logger = structlog.getLogger(__name__)
 
 
 class JobAlreadyExistsError(Exception):
-    """Occurs when a TaskSet (aka job) already exists."""
+    """A TaskSet (aka job) already exists."""
 
     def __init__(self, name: str):
         """Initialize a JobAlreadyExistsError.
@@ -22,7 +22,7 @@ class JobAlreadyExistsError(Exception):
 
 
 class JobNotFoundError(Exception):
-    """Occurs when a TaskSet (aka job) does not exists."""
+    """A TaskSet (aka job) does not exists."""
 
     def __init__(self, name: str):
         """Initialize a JobNotFoundError.

--- a/src/meltano/core/tracking/contexts/cli.py
+++ b/src/meltano/core/tracking/contexts/cli.py
@@ -13,11 +13,13 @@ from meltano.core.utils import hash_sha256
 class CliEvent(Enum):
     """The kind of event that is occurring in the command-line interface."""
 
-    # The cli command has started, this is fired automatically in most cases when the command is called.
+    # The cli command has started, this is fired automatically in most cases
+    # when the command is called.
     started = auto()
-    # Optionally, a command may fire a `inflight` event to signal that its execution is in progress. This is useful for
-    # commands that are long-running and may take a long time to finish, and allows them to emit an event with collected
-    # contexts.
+    # Optionally, a command may fire a `inflight` event to signal that its
+    # execution is in progress. This is useful for commands that are
+    # long-running and may take a long time to finish, and allows them to
+    # emit an event with collected contexts.
     inflight = auto()
     # The cli command has completed without errors.
     completed = auto()

--- a/src/meltano/core/tracking/contexts/exception.py
+++ b/src/meltano/core/tracking/contexts/exception.py
@@ -26,7 +26,7 @@ class ExceptionContext(SelfDescribingJson):
     """Exception context for the Snowplow tracker."""
 
     def __init__(self):
-        """Initialize the exceptions context with the exceptions currently being handled."""
+        """Init the exceptions context with the exceptions currently being handled."""
         ex = sys.exc_info()[1]
         super().__init__(
             ExceptionContextSchema.url,
@@ -44,8 +44,8 @@ def get_exception_json(ex: BaseException) -> ExceptionContextJSON:
         ex: The exception from which data will be extracted.
 
     Returns:
-        A JSON-compatible dictionary of anonymized telemetry data compliant with the exception
-        context schema for an exception.
+        A JSON-compatible dictionary of anonymized telemetry data compliant
+        with the exception context schema for an exception.
     """
     cause, context, tb = ex.__cause__, ex.__context__, ex.__traceback__  # noqa: WPS609
     return {
@@ -82,7 +82,8 @@ def get_traceback_json(tb: TracebackType) -> TracebackLevelsJSON:
 def get_relative_traceback_path(tb: TracebackType) -> str | None:
     """Get an anonymous path from a traceback by making it relative if possible.
 
-    The path is made relative to the first element in `BASE_PATHS` it can be made relative to.
+    The path is made relative to the first element in `BASE_PATHS` it can be
+    made relative to.
 
     Args:
         tb: The traceback from which to extract the path info.
@@ -91,7 +92,8 @@ def get_relative_traceback_path(tb: TracebackType) -> str | None:
         The first valid option of the following is returned:
         - If the path is `'<stdin>'`: `'<stdin>'`
         - If possible: the path made relative to a path in `BASE_PATHS`
-        - If the file name is `__init__.py` or `__main__.py`: `'.../<module name>/<file name>.py'`.
+        - If the file name is `__init__.py` or `__main__.py`:
+            `'.../<module name>/<file name>.py'`.
         - Otherwise: `'.../<filename>.py'`.
     """
     try:

--- a/src/meltano/core/tracking/contexts/plugins.py
+++ b/src/meltano/core/tracking/contexts/plugins.py
@@ -19,9 +19,11 @@ logger = get_logger(__name__)
 
 def _from_plugin(plugin: ProjectPlugin, cmd: str | None) -> dict:
     if not plugin or not safe_hasattr(plugin, "info"):
-        # don't try to snag any info for this plugin, we're somehow badly malformed (unittest?), or where passed None.
-        # this event will be routed to the "bad" bucket on the snowplow side. That makes it detectable on our end,
-        # unlike if we had just filtered it out completely.
+        # Don't try to snag any info for this plugin, we're somehow badly
+        # malformed (unittest?), or where passed None. This event will be
+        # routed to the "bad" bucket on the snowplow side. That makes it
+        # detectable on our end, unlike if we had just filtered it out
+        # completely.
         logger.debug(
             "Plugin tracker context some how encountered plugin without info attr."
         )
@@ -104,21 +106,21 @@ class PluginsTrackingContext(SelfDescribingJson):
         if isinstance(blk, PluginCommandBlock):
             return cls([(blk.context.plugin, blk.command)])
         raise TypeError(
-            "Parameter 'blk' must be an instance of 'BlockSet' or 'PluginCommandBlock', "
-            + f"not {type(blk)!r}"
+            "Parameter 'blk' must be an instance of 'BlockSet' or "
+            f"'PluginCommandBlock', not {type(blk)!r}"
         )
 
     @classmethod
     def from_blocks(
         cls, parsed_blocks: list[BlockSet | PluginCommandBlock]
     ) -> PluginsTrackingContext:
-        """Create a PluginsTrackingContext from a list of BlockSets or PluginCommandBlocks.
+        """Create a `PluginsTrackingContext` from blocks.
 
         Args:
             parsed_blocks: The blocks to create the context from.
 
         Returns:
-            The PluginsTrackingContext for the given blocks.
+            The `PluginsTrackingContext` for the given blocks.
         """
         plugins: list[tuple[ProjectPlugin, str]] = []
         for blk in parsed_blocks:

--- a/src/meltano/core/tracking/contexts/project.py
+++ b/src/meltano/core/tracking/contexts/project.py
@@ -69,12 +69,13 @@ class ProjectContext(SelfDescribingJson):
 
     @property
     def environment_name(self) -> str | None:
-        """Get the name of the active environment, or `None` if there is no active environment.
+        """Get the name of the active environment.
 
         Only the hash of this value is reported to Snowplow.
 
         Returns:
-            The name of the active environment, or `None` if there is no active environment.
+            The name of the active environment, or `None` if there is no active
+            environment.
         """
         return self._environment_name
 
@@ -101,8 +102,8 @@ class ProjectContext(SelfDescribingJson):
     def project_uuid(self) -> uuid.UUID:
         """Obtain the `project_id` from the project config file.
 
-        If it is not found (e.g. first time run), generate a valid v4 UUID, and and store it in the
-        project config file.
+        If it is not found (e.g. first time run), generate a valid v4 UUID,
+        and and store it in the project config file.
 
         Returns:
             The project UUID.
@@ -114,7 +115,8 @@ class ProjectContext(SelfDescribingJson):
                 # Project ID might already be a UUID
                 project_id = uuid.UUID(project_id_str)
             except ValueError:
-                # If the project ID is not a UUID, then we hash it, and use the hash to make a UUID
+                # If the project ID is not a UUID, then we hash it, and use the
+                # hash to make a UUID
                 project_id = uuid.UUID(hash_sha256(project_id_str)[::2])
                 self._project_uuid_source = ProjectUUIDSource.derived
             else:

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager, suppress
 from datetime import datetime
 from enum import Enum, auto
 from pathlib import Path
-from traceback import format_exception
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -32,6 +31,7 @@ from meltano.core.tracking.schemas import (
     ExitEventSchema,
     TelemetryStateChangeEventSchema,
 )
+from meltano.core.utils import format_exception
 
 if t.TYPE_CHECKING:
     from meltano.core.tracking.contexts import (  # noqa: F401
@@ -309,7 +309,7 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
         except Exception as err:
             logger.debug(
                 "Failed to submit unstruct event to Snowplow, error",
-                err="".join(format_exception(type(err), err, err.__traceback__)),
+                err=format_exception(err),
             )
 
     def track_command_event(self, event: CliEvent) -> None:
@@ -384,7 +384,7 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
                     "Failed to submit 'telemetry_state_change' unstruct event "
                     "to Snowplow, error"
                 ),
-                err="".join(format_exception(type(err), err, err.__traceback__)),
+                err=format_exception(err),
             )
 
     @property

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -338,7 +338,8 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
         self.save_telemetry_settings()
 
         if self.snowplow_tracker is None:
-            return  # The Snowplow tracker is not available (e.g. because no endpoints are set)
+            # The Snowplow tracker is not available (e.g. because no endpoints are set)
+            return
 
         logger.debug(
             "Telemetry state change detected. A one-time "

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager, suppress
 from datetime import datetime
 from enum import Enum, auto
 from pathlib import Path
+from traceback import format_exception
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -31,7 +32,6 @@ from meltano.core.tracking.schemas import (
     ExitEventSchema,
     TelemetryStateChangeEventSchema,
 )
-from meltano.core.utils import format_exception
 
 if t.TYPE_CHECKING:
     from meltano.core.tracking.contexts import (  # noqa: F401
@@ -183,7 +183,10 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
                 return uuid.UUID(uuid_str)
             except ValueError:
                 warn(
-                    f"Invalid telemetry client UUID {uuid_str!r} from $MELTANO_CLIENT_ID",
+                    (
+                        f"Invalid telemetry client UUID {uuid_str!r} from "
+                        "$MELTANO_CLIENT_ID"
+                    ),
                     RuntimeWarning,
                 )
         if stored_telemetry_settings.client_id is not None:
@@ -199,8 +202,9 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
         """
         from meltano.core.tracking.contexts import ExceptionContext
 
-        # The `ExceptionContext` is re-created every time this is accessed because it details the
-        # exceptions that are being processed when it is created.
+        # The `ExceptionContext` is re-created every time this is accessed
+        # because it details the exceptions that are being processed when it
+        # is created.
         return (*self._contexts, ExceptionContext())
 
     def telemetry_state_change_check(
@@ -243,14 +247,16 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
                 >>> Tracker(project).timezone_name
                 'Europe/Berlin'
 
-            The timezone name as an IANA timezone abbreviation because the full name was not found:
+            The timezone name as an IANA timezone abbreviation because the full
+            name was not found:
 
                 >>> Tracker(project).timezone_name
                 'CET'
 
         Returns:
-            The local timezone as an IANA TZ database name if possible, or abbreviation otherwise.
-        """
+            The local timezone as an IANA TZ database name if possible, or
+            abbreviation otherwise.
+        """  # noqa: F821
         try:
             return tzlocal.get_localzone_name()
         except Exception:
@@ -293,7 +299,8 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
         """Fire an unstructured tracking event.
 
         Args:
-            event_json: The SelfDescribingJson event to track. See the Snowplow documentation for more information.
+            event_json: The SelfDescribingJson event to track. See the Snowplow
+                documentation for more information.
         """
         if not self.can_track():
             return
@@ -302,7 +309,7 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
         except Exception as err:
             logger.debug(
                 "Failed to submit unstruct event to Snowplow, error",
-                err=format_exception(err),
+                err="".join(format_exception(type(err), err, err.__traceback__)),
             )
 
     def track_command_event(self, event: CliEvent) -> None:
@@ -361,7 +368,8 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
         try:
             self.snowplow_tracker.track_unstruct_event(
                 event_json,
-                # If tracking is disabled, then include only the minimal Snowplow contexts required
+                # If tracking is disabled, then include only the minimal
+                # Snowplow contexts required
                 self.contexts
                 if self.send_anonymous_usage_stats
                 else tuple(
@@ -372,8 +380,11 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
             )
         except Exception as err:
             logger.debug(
-                "Failed to submit 'telemetry_state_change' unstruct event to Snowplow, error",
-                err=format_exception(err),
+                (
+                    "Failed to submit 'telemetry_state_change' unstruct event "
+                    "to Snowplow, error"
+                ),
+                err="".join(format_exception(type(err), err, err.__traceback__)),
             )
 
     @property
@@ -405,7 +416,10 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
 
         if missing_keys:
             logger.debug(
-                "'analytics.json' has missing keys, and will be overwritten with new 'analytics.json'",
+                (
+                    "'analytics.json' has missing keys, and will be "
+                    "overwritten with new 'analytics.json'"
+                ),
                 missing_keys=missing_keys,
             )
             return TelemetrySettings(None, None, None)
@@ -494,7 +508,8 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
 
         cli.atexit_handler_registered = True
 
-        # Provide `meltano.cli` with this tracker to track the exit event with more context.
+        # Provide `meltano.cli` with this tracker to track the exit event with
+        # more context.
         cli.exit_event_tracker = self
 
         # As a fallback, use atexit to help ensure the exit event is sent.
@@ -510,8 +525,9 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
 
         start_time = datetime.utcfromtimestamp(Process().create_time())
 
-        # This is the reported "end time" for this process, though in reality the process will end
-        # a short time after this time as it takes time to emit the event.
+        # This is the reported "end time" for this process, though in reality
+        # the process will end a short time after this time as it takes time
+        # to emit the event.
         now = datetime.utcnow()
 
         self.track_unstruct_event(

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -19,11 +19,11 @@ from meltano.core.project_plugins_service import PluginType
 
 
 class UpgradeError(Exception):
-    """Occurs when the Meltano upgrade fails."""
+    """The Meltano upgrade fails."""
 
 
 class AutomaticPackageUpgradeError(Exception):
-    """Occurs when an automatic upgrade of Meltano fails."""
+    """An automatic upgrade of Meltano fails."""
 
     def __init__(self, reason: str, instructions: str):
         """Initialize the `AutomaticPackageUpgradeError`.
@@ -78,7 +78,11 @@ class UpgradeService:
 
         elif os.path.exists("/.dockerenv"):
             fail_reason = "it is installed inside Docker"
-            instructions = "pull the latest Docker image using `docker pull meltano/meltano` and recreate any containers you may have created"
+            instructions = (
+                "pull the latest Docker image using "
+                "`docker pull meltano/meltano` and recreate any containers "
+                "you may have created"
+            )
 
         elif os.getenv("NOX_CURRENT_SESSION") == "tests":
             fail_reason = "it is installed inside a Nox test session"
@@ -117,9 +121,10 @@ class UpgradeService:
         try:
             self._upgrade_package(pip_url, force)
         except AutomaticPackageUpgradeError as err:
-            click.echo(
-                f"{click.style('The `meltano` package could not be upgraded automatically', fg='red')} because {err.reason}."
+            msg = click.style(
+                "The `meltano` package could not be upgraded automatically", fg="red"
             )
+            click.echo(f"{msg} because {err.reason}.")
             if err.instructions:
                 click.echo(f"To upgrade manually, {err.instructions}.")
             return False
@@ -170,7 +175,8 @@ class UpgradeService:
 
             if not package_upgraded:
                 click.echo(
-                    "Then, run `meltano upgrade --skip-package` to upgrade your project based on the latest version."
+                    "Then, run `meltano upgrade --skip-package` to upgrade "
+                    "your project based on the latest version."
                 )
                 return
 

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -49,7 +49,7 @@ except AttributeError:
 
 
 class NotFound(Exception):
-    """Occurs when an element is not found."""
+    """An element is not found."""
 
     def __init__(self, name, obj_type=None):
         """Create a new exception.
@@ -65,13 +65,13 @@ class NotFound(Exception):
 
 
 def click_run_async(func):
-    """Small decorator to allow click invoked functions to leverage `asyncio.run` and be declared as async.
+    """Run decorated Click commands with `asyncio.run`.
 
     Args:
-        func: the function to run async
+        func: The function to run asynchronously.
 
     Returns:
-        A function which runs the given function async
+        A function which runs the given function asynchronously.
     """
 
     @functools.wraps(func)
@@ -94,7 +94,8 @@ def compose(*fs: t.Callable[[t.Any], t.Any]):
         ```
 
     Returns:
-        The composition of the provided unary functions, which itself is a unary function.
+        The composition of the provided unary functions, which itself is a
+        unary function.
     """
     return functools.reduce(lambda f, g: lambda x: f(g(x)), compact(fs), lambda x: x)
 
@@ -157,9 +158,9 @@ def merge(src, dest):
             `src` at depth.
 
     Examples:
-        >>> a = { 'first' : { 'all_rows' : { 'pass' : 'dog', 'number' : '1' } } }
-        >>> b = { 'first' : { 'all_rows' : { 'fail' : 'cat', 'number' : '5' } } }
-        >>> merge(b, a) == { 'first' : { 'all_rows' : { 'pass' : 'dog', 'fail' : 'cat', 'number' : '5' } } }
+        >>> a = {'f' :{'all_rows': {'pass': 'dog', 'n': '1'}}}
+        >>> b = {'f' :{'all_rows': {'fail': 'cat', 'n': '5'}}}
+        >>> merge(b, a) == {'f': {'all_rows': {'pass': 'dog', 'fail': 'cat', 'n': '5'}}}
         True
 
     Returns:
@@ -439,7 +440,7 @@ def set_at_path(d, path, value):
 
 
 class EnvironmentVariableNotSetError(MeltanoError):
-    """Occurs when a referenced environment variable is not set."""
+    """A referenced environment variable is not set."""
 
     def __init__(self, env_var: str):
         """Initialize the error.
@@ -613,21 +614,6 @@ def hash_sha256(value: str | bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
-def format_exception(exception: BaseException) -> str:
-    """Get the exception with its traceback in the standard format it would have been printed with.
-
-    Args:
-        exception: The exception value to be turned into a string.
-
-    Returns:
-        A string that shows the exception object as it would have been printed had it been raised
-        and not caught.
-    """
-    return "".join(
-        traceback.format_exception(type(exception), exception, exception.__traceback__)
-    )
-
-
 def safe_hasattr(obj: t.Any, name: str) -> bool:
     """Safely checks if an object has a given attribute.
 
@@ -693,10 +679,10 @@ def get_boolean_env_var(env_var: str, default: bool = False) -> bool:
 
 
 def get_no_color_flag() -> bool:
-    """Get the value of the NO_COLOR environment variable.
+    """Get the truth value of the `NO_COLOR` environment variable.
 
     Returns:
-        True if the NO_COLOR environment variable is set to a truthy value, False otherwise.
+        Whether the `NO_COLOR` environment variable is set to a truthy value.
     """
     return get_boolean_env_var("NO_COLOR")
 

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -614,6 +614,21 @@ def hash_sha256(value: str | bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
+def format_exception(exception: BaseException) -> str:
+    """Get the exception with its traceback formatted as it would have been printed.
+
+    Args:
+        exception: The exception value to be turned into a string.
+
+    Returns:
+        A string that shows the exception object as it would have been printed
+        had it been raised and not caught.
+    """
+    return "".join(
+        traceback.format_exception(type(exception), exception, exception.__traceback__)
+    )
+
+
 def safe_hasattr(obj: t.Any, name: str) -> bool:
     """Safely checks if an object has a given attribute.
 

--- a/src/meltano/core/utils/pidfile.py
+++ b/src/meltano/core/utils/pidfile.py
@@ -52,7 +52,7 @@ class PIDFile:
 
 
 class UnknownProcessError(Exception):
-    """Occurs when the PIDFile doesn't yield a readable PID."""
+    """The PIDFile doesn't yield a readable PID."""
 
     def __init__(self, pid_file: PIDFile):
         self.pid_file = pid_file

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -165,7 +165,8 @@ class VenvService:  # noqa: WPS214
         """
         if not clean and self.requires_clean_install(pip_install_args):
             logger.debug(
-                f"Packages for '{self.namespace}/{self.name}' have changed so performing a clean install."
+                f"Packages for '{self.namespace}/{self.name}' have changed so "
+                "performing a clean install."
             )
             clean = True
 

--- a/src/meltano/core/yaml.py
+++ b/src/meltano/core/yaml.py
@@ -59,5 +59,6 @@ def load(path: os.PathLike) -> CommentedMap:
     return parsed
 
 
-# Alias to provide a clean interface when using this module via `from meltano.core import yaml`
+# Alias to provide a clean interface when using this
+# module via `from meltano.core import yaml`
 dump = yaml.dump

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,10 @@ class MockAdapter(BaseAdapter):
                         default_variant = variant_name
 
                     hub[index_key][plugin_name]["variants"][variant_name] = {
-                        "ref": f"{api_url}/plugins/{plugin_type}/{plugin_name}--{variant_name}"
+                        "ref": (
+                            f"{api_url}/plugins/{plugin_type}/"
+                            f"{plugin_name}--{variant_name}"
+                        )
                     }
 
                     plugin_key = f"/{plugin_type}/{plugin_name}--{variant_name}"
@@ -102,7 +105,10 @@ class MockAdapter(BaseAdapter):
                     default_variant = variant_name
 
                     hub[index_key][plugin_name]["variants"][variant_name] = {
-                        "ref": f"{api_url}/plugins/{plugin_type}/{plugin_name}--{variant_name}"
+                        "ref": (
+                            f"{api_url}/plugins/{plugin_type}/"
+                            f"{plugin_name}--{variant_name}"
+                        )
                     }
 
                     plugin_key = f"/{plugin_type}/{plugin_name}--{variant_name}"

--- a/tests/fixtures/docker/snowplow.py
+++ b/tests/fixtures/docker/snowplow.py
@@ -33,7 +33,7 @@ class SnowplowMicro:
             return json.load(response)
 
     def all(self) -> dict[str, int]:
-        """Get a dict counting the number of good/bad events, and the total number of events."""
+        """Get a dict counting the # of good/bad events, and the total # of events."""
         return self.get("all")
 
     def good(self) -> list[dict[str, t.Any]]:
@@ -51,18 +51,20 @@ class SnowplowMicro:
 
 @pytest.fixture(scope="session")
 def snowplow_session(request) -> SnowplowMicro | None:
-    """Start a Snowplow Micro Docker container, then yield a `SnowplowMicro` instance for it.
+    """Start a Snowplow Micro Docker container, then yield a `SnowplowMicro` instance.
 
-    The environment variable `$MELTANO_SNOWPLOW_COLLECTOR_ENDPOINTS` is set to a list containing
-    only the collector endpoint exposed by Snowplow Micro in Docker.
+    The environment variable `$MELTANO_SNOWPLOW_COLLECTOR_ENDPOINTS` is set to
+    a list containing only the collector endpoint exposed by Snowplow Micro in
+    Docker.
 
     Yields:
-        A `SnowplowMicro` instance which will collect events fired within tests, and can be queried
-        to obtain info about the fired events, or `None` if the creation of a `SnowplowMicro`
-        instance failed.
+        A `SnowplowMicro` instance which will collect events fired within
+        tests, and can be queried to obtain info about the fired events, or
+        `None` if the creation of a `SnowplowMicro` instance failed.
     """
     try:
-        # Getting the `docker_services` fixture essentially causes `docker-compose up` to be run
+        # Getting the `docker_services` fixture essentially causes
+        # `docker-compose up` to be run
         request.getfixturevalue("docker_services")
         args = ("docker", "port", f"pytest{os.getpid()}_snowplow_1")
         proc = subprocess.run(args, capture_output=True, text=True)

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -83,7 +83,8 @@ class TestCliAdd:
                     if (required_plugin_ref._type) == PluginType.FILES and (
                         required_plugin_ref.name == "dbt"
                     ):
-                        # file bundles with no managed files are added but do not appear in meltano.yml
+                        # File bundles with no managed files are added but
+                        # do not appear in meltano.yml
                         assert (
                             f"Adding required file bundle '{required_plugin_ref.name}'"
                             in res.stdout
@@ -172,7 +173,7 @@ class TestCliAdd:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         # if plugin is locked, we actually wouldn't expect it to update.
         # So we must remove lockfile
@@ -223,7 +224,7 @@ class TestCliAdd:
     def test_add_files_that_already_exists(self, project, cli_runner):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         # dbt lockfile was created in an upstream test. Need to remove.
         shutil.rmtree(project.root_dir("plugins/files"), ignore_errors=True)
@@ -387,9 +388,9 @@ class TestCliAdd:
             )
             assert res.exit_code == 1
             assert (
-                "Could not find parent plugin for extractor 'tap-foo': Extractor 'tap-bar' is not known to Meltano"
-                in str(res.exception)
-            )
+                "Could not find parent plugin for extractor 'tap-foo': "
+                "Extractor 'tap-bar' is not known to Meltano"
+            ) in str(res.exception)
 
     def test_add_custom(self, project, cli_runner):
         pip_url = "-e path/to/tap-custom"
@@ -565,7 +566,8 @@ class TestCliAdd:
                     if (required_plugin_ref._type) == PluginType.FILES and (
                         required_plugin_ref.name == "dbt"
                     ):
-                        # file bundles with no managed files are added but do not appear in meltano.yml
+                        # File bundles with no managed files are added but do
+                        # not appear in meltano.yml
                         assert (
                             f"Adding required file bundle '{required_plugin_ref.name}'"
                             in res.stdout

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -15,7 +15,7 @@ class TestCliConfig:
     def test_config(self, project: Project, cli_runner, tap):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         result = cli_runner.invoke(cli, ["config", tap.name])
         assert_cli_runner(result)
@@ -33,7 +33,7 @@ class TestCliConfig:
     def test_config_env(self, project: Project, cli_runner, tap):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         result = cli_runner.invoke(cli, ["config", "--format=env", tap.name])
         assert_cli_runner(result)
@@ -54,9 +54,9 @@ class TestCliConfig:
         )
         assert_cli_runner(result)
         assert (
-            "Meltano setting 'cli.log_config' was set in `meltano.yml`: 'log_config.yml'"
-            in result.stdout
-        )
+            "Meltano setting 'cli.log_config' was set in `meltano.yml`: "
+            "'log_config.yml'"
+        ) in result.stdout
 
     def test_config_test(self, project: Project, cli_runner, tap):
         mock_invoke = mock.Mock()

--- a/tests/meltano/cli/test_elt.py
+++ b/tests/meltano/cli/test_elt.py
@@ -241,7 +241,7 @@ class TestWindowsELT:
         # the error for some reason
         assert (
             "ELT command not supported on Windows. Please use the run command "
-            "as documented here "
+            "as documented here: "
             "https://docs.meltano.com/reference/command-line-interface#run"
         ) in str(result.exception)
 

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -93,7 +93,7 @@ class TestCliInvoke:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         async def async_generator(*args, **kwargs):

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -111,7 +111,8 @@ def target_process(process_mock_factory, target):
 def mapper_process(process_mock_factory, mapper):
     mapper = process_mock_factory(mapper)
 
-    # Have `mapper.wait` take 1s to make sure the mapper always finishes after the tap but before the target
+    # Have `mapper.wait` take 1s to make sure the mapper always finishes after
+    # the tap but before the target
     async def wait_mock():
         await asyncio.sleep(1)
         return mapper.wait.return_value
@@ -235,7 +236,10 @@ class TestCliRunScratchpadOne:
             asyncio_mock2.create_subprocess_exec = create_subprocess_exec
             with pytest.raises(
                 Exception,
-                match="Unknown command type or bad block sequence at index 1, starting block 'tap-mock'",
+                match=(
+                    "Unknown command type or bad block sequence at index 1, "
+                    "starting block 'tap-mock'"
+                ),
             ):
                 result = cli_runner.invoke(cli, args, catch_exceptions=False)
                 assert result.exit_code == 1
@@ -247,7 +251,10 @@ class TestCliRunScratchpadOne:
             asyncio_mock3.create_subprocess_exec = create_subprocess_exec
             with pytest.raises(
                 Exception,
-                match="Unknown command type or bad block sequence at index 3, starting block 'target-mock'",
+                match=(
+                    "Unknown command type or bad block sequence at index 3, "
+                    "starting block 'target-mock'"
+                ),
             ):
                 result = cli_runner.invoke(cli, args, catch_exceptions=False)
                 assert result.exit_code == 1
@@ -352,7 +359,8 @@ class TestCliRunScratchpadOne:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(side_effect=(tap_process, target_process))
 
-        # verify that a state ID with custom suffix from command option is generated for an ELB run
+        # Verify that a state ID with custom suffix from command option is
+        # generated for an ELB run
         args = ["run", tap.name, target.name, "--state-id-suffix", "test-suffix"]
 
         with mock.patch.object(SingerTap, "discover_catalog"), mock.patch.object(
@@ -420,7 +428,8 @@ class TestCliRunScratchpadOne:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(side_effect=(tap_process, target_process))
 
-        # verify that a state ID with custom suffix from active environment is generated for an ELB run
+        # Verify that a state ID with custom suffix from active environment is
+        # generated for an ELB run
         project.activate_environment("dev")
         project.environment.state_id_suffix = state_id_suffix
 
@@ -459,7 +468,8 @@ class TestCliRunScratchpadOne:
         dbt_process,
         job_logging_service,
     ):
-        # Verify that requesting the same command plugin multiple time with different args works
+        # Verify that requesting the same command plugin multiple time with
+        # different args works
         invoke_async = AsyncMock(
             side_effect=(
                 dbt_process,
@@ -645,7 +655,8 @@ class TestCliRunScratchpadOne:
         dbt_process,
         job_logging_service,
     ):
-        # in this scenario, the tap fails on the third read. Target should still complete, but dbt should not.
+        # In this scenario, the tap fails on the third read. Target should still
+        # complete, but dbt should not.
         args = ["run", tap.name, target.name, "dbt:run"]
 
         tap_process.wait.return_value = 1
@@ -662,9 +673,9 @@ class TestCliRunScratchpadOne:
             result = cli_runner.invoke(cli, args)
 
             assert (
-                "Run invocation could not be completed as block failed: Extractor failed"
-                in str(result.exception)
-            )
+                "Run invocation could not be completed as block failed: "
+                "Extractor failed"
+            ) in str(result.exception)
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -717,7 +728,8 @@ class TestCliRunScratchpadOne:
     ):
         args = ["run", tap.name, target.name, "dbt:run"]
 
-        # Have `tap_process.wait` take 2s to make sure the target can fail before tap finishes
+        # Have `tap_process.wait` take 2s to make sure the target can fail
+        # before tap finishes
         async def tap_wait_mock():
             await asyncio.sleep(2)
             return tap_process.wait.return_value
@@ -726,13 +738,15 @@ class TestCliRunScratchpadOne:
 
         # Writing to target stdin will fail because (we'll pretend) it has already died
         target_process.stdin = mock.Mock(spec=asyncio.StreamWriter)
-        # capture_subprocess_output writer will return and close the pipe when either BrokenPipeError or ConnectionResetError is enccountered
-        # it does not itself reraise the exception - so you shouldn't expect to see these.
+        # capture_subprocess_output writer will return and close the pipe when
+        # either BrokenPipeError or ConnectionResetError is enccountered it
+        # does not itself reraise the exception - so you shouldn't expect to see these.
         target_process.stdin.write.side_effect = BrokenPipeError
         target_process.stdin.drain = AsyncMock(side_effect=ConnectionResetError)
         target_process.stdin.wait_closed = AsyncMock(return_value=True)
 
-        # Have `target_process.wait` take 1s to make sure the `stdin.write`/`drain` exceptions can be raised
+        # Have `target_process.wait` take 1s to make sure the
+        # `stdin.write`/`drain` exceptions can be raised
         async def target_wait_mock():
             await asyncio.sleep(1)
             return 1
@@ -775,7 +789,8 @@ class TestCliRunScratchpadOne:
             assert completed_events[0]["err"] == "RunnerError('Loader failed')"
             assert completed_events[0]["exit_codes"]["loaders"] == 1
 
-            # the tap should NOT have finished, we'll have a write of the SCHEMA message and then nothing further:
+            # The tap should NOT have finished, we'll have a write of the
+            # SCHEMA message and then nothing further:
             assert matcher.event_matches("SCHEMA")
             assert not matcher.event_matches("RECORD")
             assert not matcher.event_matches("STATE")
@@ -903,9 +918,9 @@ class TestCliRunScratchpadOne:
             result = cli_runner.invoke(cli, args)
 
             assert (
-                "Run invocation could not be completed as block failed: Extractor and loader failed"
-                in str(result.exception)
-            )
+                "Run invocation could not be completed as block failed: "
+                "Extractor and loader failed"
+            ) in str(result.exception)
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -961,7 +976,8 @@ class TestCliRunScratchpadOne:
     ):
         args = ["run", tap.name, target.name]
 
-        # Raise a ValueError wrapping a LimitOverrunError, like StreamReader.readline does:
+        # Raise a `ValueError` wrapping a `LimitOverrunError`, like
+        # `StreamReader.readline` does:
         # https://github.com/python/cpython/blob/v3.8.7/Lib/asyncio/streams.py#L549
         try:  # noqa: WPS328
             raise asyncio.LimitOverrunError(
@@ -975,7 +991,8 @@ class TestCliRunScratchpadOne:
             except ValueError as wrapper_err:
                 tap_process.stdout.readline.side_effect = wrapper_err
 
-        # Have `tap_process.wait` take 1s to make sure the LimitOverrunError exception can be raised before tap finishes
+        # Have `tap_process.wait` take 1s to make sure the `LimitOverrunError`
+        # exception can be raised before tap finishes
         async def wait_mock():
             await asyncio.sleep(1)
             return tap_process.wait.return_value
@@ -987,9 +1004,9 @@ class TestCliRunScratchpadOne:
             result = cli_runner.invoke(cli, args)
 
             assert (
-                "Run invocation could not be completed as block failed: Output line length limit exceeded"
-                in str(result.exception)
-            )
+                "Run invocation could not be completed as block failed: "
+                "Output line length limit exceeded"
+            ) in str(result.exception)
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -1055,12 +1072,16 @@ class TestCliRunScratchpadOne:
             asyncio_mock2.create_subprocess_exec = create_subprocess_exec
             with pytest.raises(
                 Exception,
-                match="block violates set requirements: Expected unique mappings name not the mapper plugin name: mapper-collision-01",
+                match=(
+                    "block violates set requirements: Expected unique mappings "
+                    "name not the mapper plugin name: mapper-collision-01"
+                ),
             ):
                 result = cli_runner.invoke(cli, args, catch_exceptions=False)
                 assert result.exit_code == 1
 
-        # test mapper/mapping name collision detection - mappings name same a mapper plugin name
+        # Test mapper/mapping name collision detection - mappings name same a
+        # mapper plugin name
         project_add_service.add(
             PluginType.MAPPERS,
             "mapper-collision-02",
@@ -1087,7 +1108,10 @@ class TestCliRunScratchpadOne:
             asyncio_mock2.create_subprocess_exec = create_subprocess_exec
             with pytest.raises(
                 Exception,
-                match="block violates set requirements: Expected unique mappings name not the mapper plugin name: mapper-collision-02",
+                match=(
+                    "block violates set requirements: Expected unique mappings "
+                    "name not the mapper plugin name: mapper-collision-02"
+                ),
             ):
                 result = cli_runner.invoke(cli, args, catch_exceptions=False)
                 assert result.exit_code == 1
@@ -1141,9 +1165,9 @@ class TestCliRunScratchpadOne:
             result = cli_runner.invoke(cli, args, catch_exceptions=True)
             assert result.exit_code == 1
             assert (
-                "Error: Ambiguous mapping name mock-mapping-dupe, found multiple matches."
-                in result.stderr
-            )
+                "Error: Ambiguous mapping name mock-mapping-dupe, "
+                "found multiple matches."
+            ) in result.stderr
 
     @pytest.mark.backend("sqlite")
     @mock.patch(
@@ -1164,7 +1188,8 @@ class TestCliRunScratchpadOne:
         dbt_process,
         job_logging_service,
     ):
-        # in this scenario, the map fails on the second read. Target should still complete, but dbt should not.
+        # In this scenario, the map fails on the second read. Target should
+        # still complete, but dbt should not.
         args = ["run", tap.name, "mock-mapping-0", target.name, "dbt:run"]
 
         mapper_process.wait.return_value = 1
@@ -1199,7 +1224,8 @@ class TestCliRunScratchpadOne:
             # the tap should have completed successfully
             matcher.event_matches("tap done")
 
-            # we should see a debug line for from the run manager indicating a intermediate block failed
+            # We should see a debug line for from the run manager indicating a
+            # intermediate block failed
             matcher.event_matches("Intermediate block in sequence failed.")
 
             # the failed block should have been the mapper
@@ -1259,10 +1285,11 @@ class TestCliRunScratchpadOne:
                 "All ExtractLoadBlocks validated, starting execution."
             )
 
-            # we should have seen the --dry-run specific log line
+            # We should have seen the --dry-run specific log line
             assert matcher.event_matches("Dry run, but would have run block 1/1.")
 
-            # we should NOT see any mock done events, and definitely no block completion log lines
+            # We should NOT see any mock done events, and definitely no block
+            # completion log lines
             assert not matcher.find_by_event("tap done")
             assert not matcher.find_by_event("target done")
             assert not matcher.find_by_event("Block run completed.")
@@ -1294,7 +1321,8 @@ class TestCliRunScratchpadOne:
                 "colors": colors,
             }
 
-        # in this scenario, the tap fails on the third read. Target should still complete.
+        # In this scenario, the tap fails on the third read. Target should
+        # still complete.
         args = ["run", tap.name, target.name]
 
         tap_process.wait.return_value = 1

--- a/tests/meltano/cli/test_schedule.py
+++ b/tests/meltano/cli/test_schedule.py
@@ -74,7 +74,8 @@ class TestCliSchedule:
         assert schedule.job == "mock-job"
         assert schedule.interval == "@yearly"  # not anytime soon ;)
 
-        # test default schedule case where no argument (set, remove, add, etc) is provided
+        # Test default schedule case where no argument (set, remove, add, etc)
+        # is provided
         with mock.patch(
             "meltano.cli.schedule.ScheduleService", return_value=schedule_service
         ):

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -38,7 +38,7 @@ class TestCliState:
         assert state.state_service_from_state_id(project, state_id) is None
 
     @pytest.mark.parametrize("state_id", conventional_state_ids)
-    def test_state_service_from_state_id_returns_state_service_convention(  # noqa: WPS118
+    def test_state_service_from_state_id_returns_state_service_convention(  # noqa: WPS118, E501
         self, project, state_id
     ):
         with mock.patch(
@@ -134,20 +134,16 @@ class TestCliState:
 
     def test_merge_from_string(self, state_service, state_ids, cli_runner):
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
-            job_pairs = []
-            for idx in range(0, len(state_ids) - 1, 2):
-                job_pairs.append((state_ids[idx], state_ids[idx + 1]))
+            job_pairs = [
+                (state_ids[idx], state_ids[idx + 1])
+                for idx in range(0, len(state_ids) - 1, 2)
+            ]
             for job_src, job_dst in job_pairs:
                 job_src_state = state_service.get_state(job_src)
                 job_dst_state = state_service.get_state(job_dst)
                 result = cli_runner.invoke(
                     cli,
-                    [
-                        "state",
-                        "merge",
-                        job_dst,
-                        json.dumps(job_src_state),
-                    ],
+                    ["state", "merge", job_dst, json.dumps(job_src_state)],
                 )
                 assert_cli_runner(result)
                 assert state_service.get_state(job_dst) == merge(
@@ -159,12 +155,13 @@ class TestCliState:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
-            job_pairs = []
-            for idx in range(0, len(state_ids) - 1, 2):
-                job_pairs.append((state_ids[idx], state_ids[idx + 1]))
+            job_pairs = [
+                (state_ids[idx], state_ids[idx + 1])
+                for idx in range(0, len(state_ids) - 1, 2)
+            ]
             for job_src, job_dst in job_pairs:
                 job_src_state = state_service.get_state(job_src)
                 job_dst_state = state_service.get_state(job_dst)
@@ -182,9 +179,10 @@ class TestCliState:
 
     def test_merge_from_job(self, state_service, state_ids, cli_runner):
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
-            job_pairs = []
-            for idx in range(0, len(state_ids) - 1, 2):
-                job_pairs.append((state_ids[idx], state_ids[idx + 1]))
+            job_pairs = [
+                (state_ids[idx], state_ids[idx + 1])
+                for idx in range(0, len(state_ids) - 1, 2)
+            ]
             for job_src, job_dst in job_pairs:
                 job_state_src = state_service.get_state(job_src)
                 job_state_dst = state_service.get_state(job_dst)
@@ -197,9 +195,10 @@ class TestCliState:
 
     def test_copy_over_existing(self, state_service, state_ids, cli_runner):
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
-            job_pairs = []
-            for idx in range(0, len(state_ids) - 1, 2):
-                job_pairs.append((state_ids[idx], state_ids[idx + 1]))
+            job_pairs = [
+                (state_ids[idx], state_ids[idx + 1])
+                for idx in range(0, len(state_ids) - 1, 2)
+            ]
             for job_src, job_dst in job_pairs:
                 job_src_state = state_service.get_state(job_src)
                 result = cli_runner.invoke(
@@ -223,9 +222,10 @@ class TestCliState:
 
     def test_move(self, state_service, state_ids, cli_runner):
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
-            job_pairs = []
-            for idx in range(0, len(state_ids) - 1, 2):
-                job_pairs.append((state_ids[idx], state_ids[idx + 1]))
+            job_pairs = [
+                (state_ids[idx], state_ids[idx + 1])
+                for idx in range(0, len(state_ids) - 1, 2)
+            ]
             for job_src, job_dst in job_pairs:
                 job_src_state = state_service.get_state(job_src)
                 result = cli_runner.invoke(

--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -15,7 +15,7 @@ class TestCliUpgrade:
     def test_upgrade(self, project, cli_runner):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         result = cli_runner.invoke(cli, ["upgrade"])
         assert_cli_runner(result)
@@ -46,7 +46,7 @@ class TestCliUpgrade:
     def test_upgrade_package(self, project, cli_runner):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         result = cli_runner.invoke(cli, ["upgrade", "package"])
         assert_cli_runner(result)
@@ -60,7 +60,7 @@ class TestCliUpgrade:
     def test_upgrade_files(self, session, project, cli_runner):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         result = cli_runner.invoke(cli, ["upgrade", "files"])
         output = result.stdout + result.stderr
@@ -154,7 +154,7 @@ class TestCliUpgrade:
     def test_upgrade_files_glob_path(self, session, project, cli_runner):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         result = cli_runner.invoke(cli, ["add", "files", "airflow"])

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -308,8 +308,8 @@ class TestExtractLoadBlocks:
 
             await elb._link_io()
 
-            # explicitly check the counts of each block's output to ensure they are linked
-            # count is going to be logger + 1 for next blocks stdin
+            # Explicitly check the counts of each block's output to ensure they
+            # are linked count is going to be logger + 1 for next blocks stdin
             assert len(elb.blocks[0].outputs) == 2
 
             # block0 should write output to block1 stdin
@@ -570,7 +570,7 @@ class TestExtractLoadBlocks:
 
             assert elb.context.job.job_name == "test:tap-mock-to-target-mock"
 
-            # just to be sure, we'll double-check the state_id is the same for each block
+            # Just to be sure, we double-check that state_id is the same for each block
             for block in blocks:
                 assert block.context.job.job_name == "test:tap-mock-to-target-mock"
 
@@ -582,7 +582,6 @@ class TestExtractLoadBlocks:
 
 class TestExtractLoadUtils:
     def test_generate_state_id(self):
-        """Verify that a state ID is generated correctly given an active environment and optional suffix."""
         block1 = mock.Mock(spec=IOBlock)
         block1.string_id = "block1"
 
@@ -592,17 +591,17 @@ class TestExtractLoadUtils:
         project = mock.Mock()
         project.environment = Environment(name="test")
 
+        # Verify that a state ID is generated correctly given an active
+        # environment and optional suffix.
         assert (
             generate_state_id(project, None, block1, block2) == "test:block1-to-block2"
         )
-
         assert (
             generate_state_id(project, "suffix", block1, block2)
             == "test:block1-to-block2:suffix"
         )
 
     def test_generate_state_id_no_environment(self):
-        """Verify an error is raised when attempting to generate a state ID with no active environment."""
         block1 = mock.Mock(spec=IOBlock)
         block1.string_id = "block1"
 
@@ -612,11 +611,12 @@ class TestExtractLoadUtils:
         project = mock.Mock()
         project.environment = None
 
+        # Verify an error is raised when attempting to generate a state ID
+        # with no active environment.
         with pytest.raises(RunnerError):
             generate_state_id(project, None, block1, block2)
 
     def test_generate_state_id_component_contains_delimiter(self):
-        """Verify an error is raised when attempting to generate a state ID with a component that contains the defined delimiter string."""
         block1 = mock.Mock(spec=IOBlock)
         block1.string_id = "block1"
 
@@ -626,5 +626,7 @@ class TestExtractLoadUtils:
         project = mock.Mock()
         project.environment = Environment(name="test")
 
+        # Verify an error is raised when attempting to generate a state ID
+        # with a component that contains the defined delimiter string.
         with pytest.raises(RunnerError):
             generate_state_id(project, STATE_ID_COMPONENT_DELIMITER, block1, block2)

--- a/tests/meltano/core/block/test_parser.py
+++ b/tests/meltano/core/block/test_parser.py
@@ -5,6 +5,5 @@ from meltano.core.block.parser import is_command_block
 
 class TestParserUtils:
     def test_is_command_block(self, tap, dbt):
-        """Verify that the is_command_block function returns True when the block is an IOBlock and has a command."""
         assert not is_command_block(tap)
         assert is_command_block(dbt)

--- a/tests/meltano/core/block/test_singer.py
+++ b/tests/meltano/core/block/test_singer.py
@@ -168,7 +168,8 @@ class TestSingerBlocks:
 
         # This test is a great proxy for general io tests
         # if you link the output logger, you can use structlog's capture method
-        # to capture the output and check output was actually consumed AND linked correctly.
+        # to capture the output and check output was actually consumed AND
+        # linked correctly.
         with capture_logs() as cap_logs:
             await producer.start()
 

--- a/tests/meltano/core/container/test_container_spec.py
+++ b/tests/meltano/core/container/test_container_spec.py
@@ -66,7 +66,7 @@ class TestContainerService:
         """Check Docker container config from container spec."""
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         config = spec.get_docker_config()
         assert config == payload

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -96,7 +96,7 @@ class TestJob:
     async def test_run_interrupted(self, session):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/2842"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/2842"
             )
         subject = self.sample_job({"original_state": 1}).save(session)
         with pytest.raises(KeyboardInterrupt):
@@ -112,7 +112,7 @@ class TestJob:
     async def test_run_terminated(self, session):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/2842"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/2842"
             )
         subject = self.sample_job({"original_state": 1}).save(session)
 

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -48,7 +48,8 @@ class TestOutputLogger:
     @pytest.fixture(name="redirect_handler")
     def redirect_handler(self, subject: OutputLogger) -> logging.Handler:
         formatter = structlog.stdlib.ProcessorFormatter(
-            processor=structlog.processors.JSONRenderer(),  # use a json renderer so output is easier to verify
+            # use a json renderer so output is easier to verify
+            processor=structlog.processors.JSONRenderer(),
         )
         handler = logging.FileHandler(subject.file)
         handler.setFormatter(formatter)

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -59,7 +59,7 @@ class TestOutputLogger:
     async def test_stdio_capture(self, log, subject, log_output):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         stdout_out = subject.out("stdout")
@@ -107,7 +107,7 @@ class TestOutputLogger:
     async def test_out_writers(self, log, subject, log_output):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         writer_out = subject.out("writer")
@@ -160,7 +160,7 @@ class TestOutputLogger:
     async def test_set_custom_logger(self, log, subject, log_output):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         logger = structlog.getLogger()
@@ -185,7 +185,7 @@ class TestOutputLogger:
     async def test_logging_redirect(self, log, subject, log_output, redirect_handler):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         logging_out = subject.out("logging")
@@ -213,7 +213,7 @@ class TestOutputLogger:
     def test_logging_exception(self, log, subject, redirect_handler):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         logging_out = subject.out("logging")

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -394,7 +394,7 @@ class TestSingerTap:
                     "UniqueEntitiesName": {"replication-key": "created_at"},
                     "UniqueEntitiesName.created_at": {"is-replication-key": True},
                 },
-                "metadata.UniqueEntitiesName.properties.payload.properties.hash.custom-metadata": "custom-value",
+                "metadata.UniqueEntitiesName.properties.payload.properties.hash.custom-metadata": "custom-value",  # noqa: E501
                 "_schema": {
                     "UniqueEntitiesName": {
                         "code": {"anyOf": [{"type": "string"}, {"type": "null"}]}
@@ -712,7 +712,8 @@ class TestSingerTap:
             True  # no output so return eof immediately
         )
 
-        # first check needs to be false so loop starts read, after 1 line, we'll return true
+        # First check needs to be false so loop starts read, after 1 line,
+        # we'll return true
         process_mock.stdout.at_eof.side_effect = (False, True)
         process_mock.stdout.readline = AsyncMock(return_value=b'{"discovered": true}\n')
 

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -712,10 +712,8 @@ class TestSingerTap:
             True  # no output so return eof immediately
         )
 
-        process_mock.stdout.at_eof.side_effect = (
-            False,
-            True,
-        )  # first check needs to be false so loop starts read, after 1 line, we'll return true
+        # first check needs to be false so loop starts read, after 1 line, we'll return true
+        process_mock.stdout.at_eof.side_effect = (False, True)
         process_mock.stdout.readline = AsyncMock(return_value=b'{"discovered": true}\n')
 
         invoke_async = AsyncMock(return_value=process_mock)

--- a/tests/meltano/core/plugin/test_plugin.py
+++ b/tests/meltano/core/plugin/test_plugin.py
@@ -397,7 +397,8 @@ class TestProjectPlugin:
         inherited_tap.namespace = None
         inherited_tap.label = None
 
-        # Shadowing plugins (with the same name as their parent) inherit namespace and label
+        # Shadowing plugins (with the same name as their parent) inherit
+        # namespace and label
         assert tap.namespace == base_plugin.namespace == "tap_mock"
         assert tap.label == base_plugin.label == "Mock"
 

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -388,7 +388,7 @@ class TestPluginSettingsService:
         assert env_vars(service, "schema", for_writing=True) == [
             "MOCKED_SCHEMA",  # Custom `env`
             "TARGET_MOCK_ALTERNATIVE_SCHEMA",  # Name and namespace prefix
-            "TARGET_MOCK_SCHEMA",  # Parent name  prefix
+            "TARGET_MOCK_SCHEMA",  # Parent name prefix
             "MOCK_SCHEMA",  # Parent namespace prefix
             "MELTANO_LOAD_SCHEMA",  # Generic prefix
         ]
@@ -511,7 +511,7 @@ class TestPluginSettingsService:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         monkeypatch.setenv("VAR", "hello world!")
         monkeypatch.setenv("FOO", "42")

--- a/tests/meltano/core/plugin/test_superset.py
+++ b/tests/meltano/core/plugin/test_superset.py
@@ -46,7 +46,7 @@ class TestSuperset:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         run_dir = project.run_dir("superset")
         config_path = run_dir.joinpath("superset_config.py")

--- a/tests/meltano/core/state_store/test_db.py
+++ b/tests/meltano/core/state_store/test_db.py
@@ -10,8 +10,8 @@ from meltano.core.state_store import DBStateStoreManager
 
 class TestDBStateStoreManager:
     @pytest.fixture
-    def subject(self, session, state_ids_with_jobs):
-        return DBStateStoreManager(session=session)
+    def subject(self, job_history_session, state_ids_with_jobs):
+        return DBStateStoreManager(session=job_history_session)
 
     def test_get_state(
         self, subject: DBStateStoreManager, state_ids_with_expected_states

--- a/tests/meltano/core/state_store/test_db.py
+++ b/tests/meltano/core/state_store/test_db.py
@@ -10,8 +10,8 @@ from meltano.core.state_store import DBStateStoreManager
 
 class TestDBStateStoreManager:
     @pytest.fixture
-    def subject(self, job_history_session, state_ids_with_jobs):
-        return DBStateStoreManager(session=job_history_session)
+    def subject(self, session, state_ids_with_jobs):
+        return DBStateStoreManager(session=session)
 
     def test_get_state(
         self, subject: DBStateStoreManager, state_ids_with_expected_states

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -235,7 +235,8 @@ class TestAZStorageStateStoreManager:
         mock_container_client.container_name = subject.container_name
         subject.client.get_container_client.return_value = mock_container_client
         mock_container_client.get_blob_client.side_effect = ResourceNotFoundError(
-            "Operation returned an invalid status 'The specified blob does not exist.'\nErrorCode:BlobNotFound"
+            "Operation returned an invalid status 'The specified blob does "
+            "not exist.'\nErrorCode:BlobNotFound"
         )
         try:
             with subject.get_reader("nonexistent"):
@@ -252,7 +253,8 @@ class TestAZStorageStateStoreManager:
         mock_container_client.container_name = subject.container_name
         subject.client.get_container_client.return_value = mock_container_client
         mock_container_client.get_blob_client.side_effect = ResourceNotFoundError(
-            "Operation returned an invalid status 'The specified container does not exist.'\nErrorCode:ContainerNotFound"
+            "Operation returned an invalid status 'The specified container "
+            "does not exist.'\nErrorCode:ContainerNotFound"
         )
         try:
             with subject.get_reader("nonexistent"):

--- a/tests/meltano/core/test_environment_service.py
+++ b/tests/meltano/core/test_environment_service.py
@@ -69,7 +69,7 @@ class TestEnvironmentService:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         new_environment = subject.add("new-environment")
         assert subject.list_environments() == [new_environment]

--- a/tests/meltano/core/test_environment_variables.py
+++ b/tests/meltano/core/test_environment_variables.py
@@ -70,7 +70,7 @@ def _meltanofile_update_dict(
                     {
                         "name": plugin_name,
                         "env": {
-                            "TEST_ENV_VAR_RESOLUTION_FROM": "environment_level_plugin_env"
+                            "TEST_ENV_VAR_RESOLUTION_FROM": "environment_level_plugin_env"  # noqa: E501
                         },
                     }
                 ]
@@ -125,7 +125,7 @@ _env_var_resolution_expectations = {
         _meltanofile_update_dict(environment_level_env=True),
         _terminal_env_var,
     ),
-    "04 Environment-level plugin env (with terminal context)": EnvVarResolutionExpectation(
+    "04 Environment-level plugin env (with terminal context)": EnvVarResolutionExpectation(  # noqa: E501
         {"TEST_ENV_VAR_RESOLUTION_FROM": "environment_level_plugin_env"},
         _meltanofile_update_dict(environment_level_plugin_env=True),
         _terminal_env_var,
@@ -168,7 +168,7 @@ _env_var_resolution_expectations = {
         ),
         _terminal_env_var,
     ),
-    "12 Environment-level plugin config (with terminal context)": EnvVarResolutionExpectation(
+    "12 Environment-level plugin config (with terminal context)": EnvVarResolutionExpectation(  # noqa: E501
         {"TEST_ENV_VAR_RESOLUTION_FROM": "environment_level_env"},
         _meltanofile_update_dict(
             environment_level_env=True,
@@ -231,7 +231,7 @@ class TestEnvVarResolution:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         for key, val in terminal_env.items():

--- a/tests/meltano/core/test_meltano_invoker.py
+++ b/tests/meltano/core/test_meltano_invoker.py
@@ -24,7 +24,7 @@ class TestMeltanoInvoker:
     def test_invoke(self, subject: MeltanoInvoker):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         process = subject.invoke(["--version"], stdout=subprocess.PIPE)
         assert process.returncode == 0
@@ -48,7 +48,7 @@ class TestMeltanoInvoker:
     def test_invoke_executable(self, subject: MeltanoInvoker, project: Project):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         process_mock = mock.Mock(returncode=0)
         with mock.patch("subprocess.run", return_value=process_mock) as run_mock:
@@ -61,7 +61,8 @@ class TestMeltanoInvoker:
             # If a different command is used...
             subject.invoke(["--version"], command="gunicorn")
 
-            # ...the symlink is not relevant and we find the executable next to the `python` executable
+            # ...the symlink is not relevant and we find the executable next
+            # to the `python` executable
             gunicorn_path = Path(os.path.dirname(sys.executable), "gunicorn")
             assert run_mock.call_args[0][0][0] == str(gunicorn_path)
 

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -23,7 +23,7 @@ class TestPluginInstallService:
                             "extractors": [
                                 {
                                     "name": "tap-gitlab",
-                                    "pip_url": "git+https://gitlab.com/meltano/tap-gitlab.git",
+                                    "pip_url": "git+https://gitlab.com/meltano/tap-gitlab.git",  # noqa: E501
                                 },
                                 {
                                     "name": "tap-gitlab--child-1",
@@ -33,7 +33,7 @@ class TestPluginInstallService:
                             "loaders": [
                                 {
                                     "name": "target-csv",
-                                    "pip_url": "git+https://gitlab.com/meltano/target-csv.git",
+                                    "pip_url": "git+https://gitlab.com/meltano/target-csv.git",  # noqa: E501
                                 }
                             ],
                         }

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -79,7 +79,7 @@ class TestPluginInvoker:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         subject = plugin_invoker_factory(tap)
         async with subject.prepared(session):
@@ -129,9 +129,9 @@ class TestPluginInvoker:
             await plugin_invoker.invoke_async(command="cmd")
 
         assert (
-            "Command 'cmd' referenced unset environment variable '$ENV_VAR_ARG' in an argument"
-            in str(err.value)
-        )
+            "Command 'cmd' referenced unset environment "
+            "variable '$ENV_VAR_ARG' in an argument"
+        ) in str(err.value)
 
     def test_alternate_command_executable(self, plugin_invoker):
         exec_args = plugin_invoker.exec_args(
@@ -160,7 +160,7 @@ class TestPluginInvoker:
     ):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
         nonpip_plugin_invoker.plugin.executable = executable_str
         exec_args = nonpip_plugin_invoker.exec_args()

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -26,13 +26,13 @@ class TestPluginRemoveService:
                             "extractors": [
                                 {
                                     "name": "tap-gitlab",
-                                    "pip_url": "git+https://gitlab.com/meltano/tap-gitlab.git",
+                                    "pip_url": "git+https://gitlab.com/meltano/tap-gitlab.git",  # noqa: E501
                                 }
                             ],
                             "loaders": [
                                 {
                                     "name": "target-csv",
-                                    "pip_url": "git+https://gitlab.com/meltano/target-csv.git",
+                                    "pip_url": "git+https://gitlab.com/meltano/target-csv.git",  # noqa: E501
                                 }
                             ],
                         }

--- a/tests/meltano/core/test_plugin_test_service.py
+++ b/tests/meltano/core/test_plugin_test_service.py
@@ -33,9 +33,8 @@ class TestPluginTestServiceFactory:
 
         with pytest.raises(PluginNotSupportedError) as err:
             PluginTestServiceFactory(self.mock_invoker).get_test_service()
-            assert (
-                str(err.value)
-                == f"Operation not supported for {target.type.descriptor} '{target.name}'"
+            assert str(err.value) == (
+                f"Operation not supported for {target.type.descriptor} {target.name!r}"
             )
 
 

--- a/tests/meltano/core/test_project.py
+++ b/tests/meltano/core/test_project.py
@@ -104,7 +104,7 @@ class TestProject:
     def test_meltano_concurrency(self, project, concurrency):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         payloads = [{f"test_{i}": i} for i in range(1, concurrency["cases"] + 1)]

--- a/tests/meltano/core/test_project_files.py
+++ b/tests/meltano/core/test_project_files.py
@@ -111,7 +111,7 @@ class TestProjectFiles:
     def test_resolve_from_subdir(self, project_files, cd_temp_subdir):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         assert Path.cwd() == cd_temp_subdir
@@ -129,7 +129,7 @@ class TestProjectFiles:
     def test_resolve_from_any_dir(self, project_files, cd_temp_dir):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         assert Path.cwd() == cd_temp_dir

--- a/tests/meltano/core/test_project_init_service.py
+++ b/tests/meltano/core/test_project_init_service.py
@@ -87,7 +87,8 @@ def test_project_init_no_write_permission(tmp_path: Path, pushd):
 
     protected_dir = tmp_path.joinpath("protected")
     protected_dir.mkdir()
-    protected_dir.chmod(stat.S_IREAD | stat.S_IEXEC)  # read and execute, but not write
+    # read and execute, but not write
+    protected_dir.chmod(stat.S_IREAD | stat.S_IEXEC)
     pushd(protected_dir)
 
     project_dir = protected_dir.joinpath("test_project")
@@ -102,7 +103,8 @@ def test_project_init_no_write_permission(tmp_path: Path, pushd):
 def test_project_init_missing_parent_directory(tmp_path: Path, pushd):
     if platform.system() == "Windows":
         pytest.xfail(
-            "Windows can't remove a directory that is in use. See https://docs.python.org/3/library/os.html#os.remove"
+            "Windows can't remove a directory that is in use. "
+            "See https://docs.python.org/3/library/os.html#os.remove"
         )
 
     missing_dir = tmp_path.joinpath("missing")

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -146,9 +146,16 @@ class TestScheduleService:
         self, subject, session, tap, target, plugin_settings_service_factory
     ):
         # curry the `add_elt` method to remove some arguments
-        add_elt = lambda name, start_date: subject.add_elt(  # noqa: E731
-            session, name, tap.name, target.name, "run", "@daily", start_date=start_date
-        )
+        def add_elt(name, start_date):
+            return subject.add_elt(  # noqa: E731
+                session,
+                name,
+                tap.name,
+                target.name,
+                "run",
+                "@daily",
+                start_date=start_date,
+            )
 
         mock_date = datetime(2002, 1, 1)  # noqa: WPS432
 

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -101,7 +101,7 @@ class TestScheduleService:
     def test_remove_schedule(self, subject):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         schedules = list(subject.schedules())
@@ -180,7 +180,7 @@ class TestScheduleService:
     def test_run_elt_schedule(self, subject, session, tap, target):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         schedule = subject.add_elt(
@@ -222,7 +222,7 @@ class TestScheduleService:
     def test_run_job_schedule(self, subject, session, tap, target):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         schedule = subject.add(

--- a/tests/meltano/core/test_settings_store.py
+++ b/tests/meltano/core/test_settings_store.py
@@ -338,7 +338,8 @@ class TestAutoStoreManager:
             # Even though `.env` can't be overwritten
             assert_value_source("from_dotenv", Store.DOTENV)
 
-        # Falls back on system database when neither `.env` or `meltano.yml` are supported
+        # Falls back on system database when
+        # neither `.env` or `meltano.yml` are supported
         with unsupported(Store.DOTENV), unsupported(Store.MELTANO_YML):
             metadata = set_value("from_db")
             assert metadata["store"] == Store.DB

--- a/tests/meltano/core/test_state_service.py
+++ b/tests/meltano/core/test_state_service.py
@@ -29,10 +29,7 @@ class TestStateService:
             assert state_service.get_state(state_id) == expected_state
 
     def test_list_state(self, state_service, state_ids_with_expected_states):
-        assert state_service.list_state() == {
-            state_id: expected_state
-            for (state_id, expected_state) in state_ids_with_expected_states
-        }
+        assert state_service.list_state() == dict(state_ids_with_expected_states)
 
     def test_add_state(self, state_service, payloads):
         mock_state_id = "nonexistent"
@@ -44,7 +41,7 @@ class TestStateService:
     def test_set_state(self, job_history_session, jobs, payloads, state_service):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         for job in jobs:
@@ -58,9 +55,7 @@ class TestStateService:
             assert state_service.get_state(job.job_name) == payloads.mock_empty_payload
 
     def test_merge_state(self, job_history_session, jobs, state_service):
-        job_pairs = []
-        for idx in range(0, len(jobs) - 1, 2):
-            job_pairs.append((jobs[idx], jobs[idx + 1]))
+        job_pairs = [(jobs[idx], jobs[idx + 1]) for idx in range(0, len(jobs) - 1, 2)]
         for job_src, job_dst in job_pairs:
             state_src = state_service.get_state(job_src.job_name)
             state_dst = state_service.get_state(job_dst.job_name)
@@ -69,18 +64,20 @@ class TestStateService:
             assert merged_dst == state_service.get_state(job_dst.job_name)
 
     def test_copy(self, state_ids, state_service):
-        state_id_pairs = []
-        for idx in range(0, len(state_ids) - 1, 2):
-            state_id_pairs.append((state_ids[idx], state_ids[idx + 1]))
+        state_id_pairs = [
+            (state_ids[idx], state_ids[idx + 1])
+            for idx in range(0, len(state_ids) - 1, 2)
+        ]
         for state_id_src, state_id_dst in state_id_pairs:
             state_src = state_service.get_state(state_id_src)
             state_service.copy_state(state_id_src, state_id_dst)
             assert state_service.get_state(state_id_dst) == state_src
 
     def test_move(self, state_ids, state_service):
-        state_id_pairs = []
-        for idx in range(0, len(state_ids) - 1, 2):
-            state_id_pairs.append((state_ids[idx], state_ids[idx + 1]))
+        state_id_pairs = [
+            (state_ids[idx], state_ids[idx + 1])
+            for idx in range(0, len(state_ids) - 1, 2)
+        ]
         for state_id_src, state_id_dst in state_id_pairs:
             state_src = state_service.get_state(state_id_src)
             state_service.move_state(state_id_src, state_id_dst)

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -29,7 +29,7 @@ class TestVenvService:
     async def test_clean_install(self, project, subject: VenvService):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         await subject.install(["example"], clean=True)
@@ -81,7 +81,7 @@ class TestVenvService:
     async def test_install(self, project, subject: VenvService):
         if platform.system() == "Windows":
             pytest.xfail(
-                "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
+                "Fails on Windows: https://github.com/meltano/meltano/issues/3444"
             )
 
         # Make sure the venv exists already

--- a/tests/meltano/core/tracking/test_exception.py
+++ b/tests/meltano/core/tracking/test_exception.py
@@ -38,8 +38,9 @@ def is_valid_exception_context(instance: dict[str, t.Any]) -> bool:
     try:
         with warnings.catch_warnings():
             # Ignore the misleading warning thrown by `jsonschema`:
-            #     The metaschema specified by `$schema` was not found. Using the latest draft to
-            #     validate, but this will raise an error in the future.
+            #     The metaschema specified by `$schema` was not found. Using
+            #     the latest draft to validate, but this will raise an error
+            #     in the future.
             # This is a bug in `jsonschema`, as our value for `$schema` is fine.
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             validate(instance, EXCEPTION_CONTEXT_SCHEMA)
@@ -94,9 +95,7 @@ def test_simple_exception_context():
 
 def test_complex_exception_context():
     if platform.system() == "Windows":
-        pytest.xfail(
-            "Doesn't pass on windows, this is currently being tracked here https://github.com/meltano/meltano/issues/3444"
-        )
+        pytest.xfail("Fails on Windows: https://github.com/meltano/meltano/issues/3444")
 
     line_nums: list[int] = []
     file_not_found_error = None
@@ -144,8 +143,8 @@ def test_complex_exception_context():
         "context_uuid": ctx.data["context_uuid"],
         "exception": {
             "type": "CustomException",
-            "str_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            "repr_hash": "ad9443d77d731da456747bd47282a51afe86be7058533f44dcc979320ad62c73",
+            "str_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",  # noqa: E501
+            "repr_hash": "ad9443d77d731da456747bd47282a51afe86be7058533f44dcc979320ad62c73",  # noqa: E501
             "traceback": [
                 {
                     "file": f".../{THIS_FILE_BASENAME}",
@@ -155,8 +154,8 @@ def test_complex_exception_context():
             "cause": None,
             "context": {
                 "type": "ValueError",
-                "str_hash": "1009263b7f48917b8f0edafcfc8a06d22156122fbcbfbb7c9139f420b8472e0c",
-                "repr_hash": "0015450e35aed13f4802973752ee45d02c8f8eaa5d57417962986f4b8ef1bf88",
+                "str_hash": "1009263b7f48917b8f0edafcfc8a06d22156122fbcbfbb7c9139f420b8472e0c",  # noqa: E501
+                "repr_hash": "0015450e35aed13f4802973752ee45d02c8f8eaa5d57417962986f4b8ef1bf88",  # noqa: E501
                 "traceback": [
                     {
                         "file": f".../{THIS_FILE_BASENAME}",

--- a/tests/meltano/core/tracking/test_plugins.py
+++ b/tests/meltano/core/tracking/test_plugins.py
@@ -41,12 +41,13 @@ class TestPluginsTrackingContext:
                 self.assert_plugin_attributes(plugin_dict, dbt)
                 assert plugin_dict.get("command") == "test"
 
-        # verify that passing a None object results in an empty plugin context.
+        # Verify that passing a None object results in an empty plugin context.
         plugin_ctx = PluginsTrackingContext([(None, None)])
         assert plugin_ctx.data.get("plugins") == [{}]
 
-        # verify that passing a plugin with no parent does not result in an error.
-        # most likely this is a plugin that is not installed and is being removed or somehow referenced.
+        # Verify that passing a plugin with no parent does not result in an
+        # error. Most likely this is a plugin that is not installed and is
+        # being removed or somehow referenced.
         tap.parent = None
         plugin_ctx = PluginsTrackingContext([(tap, None)])
         assert len(plugin_ctx.data.get("plugins")) == 1

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -117,7 +117,8 @@ class TestTracker:
 
         original_project_id = project.settings.get("project_id")
 
-        # Delete the project ID from `meltano.yml`, but leave it unchanged in `analytics.json`
+        # Delete the project ID from `meltano.yml`,
+        # but leave it unchanged in `analytics.json`
         config = project.settings.meltano_yml_config
         del config["project_id"]
         project.settings.update_meltano_yml_config(config)
@@ -125,9 +126,10 @@ class TestTracker:
         # creates a new `ProjectSettingsService`, restoring the `project_id`.
         restored_project_id = project.settings.get("project_id")
 
-        # Depending on what tests were run before this one, the project ID might have been randomly
-        # generated, or taken from `analytics.json`, so we accept the restored one if it is equal
-        # to the original, or if it is equal after the same transformation that gets applied to the
+        # Depending on what tests were run before this one, the project ID
+        # might have been randomly generated, or taken from `analytics.json`,
+        # so we accept the restored one if it is equal to the original, or if
+        # it is equal after the same transformation that gets applied to the
         # project ID when it is originally stored in `analytics.json`.
         assert original_project_id == restored_project_id or (
             str(uuid.UUID(hash_sha256(original_project_id)[::2])) == restored_project_id
@@ -217,9 +219,10 @@ class TestTracker:
         # creates a new `ProjectSettingsService`, restoring the `project_id`.
         restored_project_id = project.settings.get("project_id")
 
-        # Depending on what tests were run before this one, the project ID might have been randomly
-        # generated, or taken from `analytics.json`, so we accept the restored one if it is equal
-        # to the original, or if it is equal after the same transformation that gets applied to the
+        # Depending on what tests were run before this one, the project ID
+        # might have been randomly generated, or taken from `analytics.json`,
+        # so we accept the restored one if it is equal to the original, or if
+        # it is equal after the same transformation that gets applied to the
         # project ID when it is originally stored in `analytics.json`.
         assert original_project_id == restored_project_id or (
             str(uuid.UUID(hash_sha256(original_project_id)[::2])) == restored_project_id


### PR DESCRIPTION
This PR adds an initial config for Ruff, and runs it as a `pre-commit` check.

To enable the `E`, `W`, and `F` rule classes, the existing `E501` (i.e. line too long) issues had to be addressed. I could've had ruff put a noqa comment on all of them, but decided instead of clean them up.

This Ruff config comes from the SDK. Most of the rule classes used by the SDK have been commented out. After this PR has been merged, we can uncomment them one at a time, and fix/autofix or noqa as appropriate. Once the `I` rule class has been enabled, we should be able to remove isort. Similarly, once the `UP` rule class has been enabled, we should be able to remove pyupgrade.

I've added the Meltano API src directory and CLI UI implementation to the exclude-list for both Flakeheaven and Ruff, since they're deprecated and scheduled for removal, so there isn't much reason to invest effort into improving them.

In addition to the changes to accommodate the line length limit, as per usual, some suggestions made by [Sourcery](https://sourcery.ai/) were accepted when I was editing files for other purposes.

Relates to:
- #7383