### PR TITLE
fix: Print right variant name in instructions to switch a plugin variant

### DIFF
--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -334,7 +334,7 @@ def add_plugin(
                 "1. Update `variant` and `pip_url` in your `meltano.yml` project file:",
             )
             click.echo(f"\tname: {plugin.name}")
-            click.echo(f"\tvariant: {new_plugin.name}")
+            click.echo(f"\tvariant: {new_plugin.variant}")
             click.echo(f"\tpip_url: {new_plugin.pip_url}")
 
             click.echo("2. Reinstall the plugin:")

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -157,6 +157,8 @@ class TestCliAdd:
                 in res.stderr
             )
             assert "To switch from the current" in res.stdout
+            assert "name: tap-mock" in res.stdout
+            assert "variant: singer-io" in res.stdout
 
     @pytest.mark.order(2)
     def test_add_transform(self, project, cli_runner):


### PR DESCRIPTION
Closes https://github.com/meltano/meltano/issues/7392
