### PR TITLE
chore: Collect select hashed env vars in telemetry

### DIFF
--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -49,8 +49,26 @@ def _get_parent_context_uuid_str() -> str | None:
 class EnvironmentContext(SelfDescribingJson):
     """Environment context for the Snowplow tracker."""
 
-    ci_markers = {"GITHUB_ACTIONS", "CI"}
-    notable_flag_env_vars = {"CODESPACES", *ci_markers}
+    ci_markers = {
+        "GITHUB_ACTIONS",
+        "CI",
+    }
+    notable_flag_env_vars = {
+        "CODESPACES",
+        *ci_markers,
+    }
+    notable_hashed_env_vars = {
+        "CODESPACE_NAME",
+        "GITHUB_REPOSITORY",
+        "GITHUB_USER",
+    }
+
+    @classmethod
+    def _notable_hashed_env_vars(cls) -> t.Iterable[str]:
+        for env_var_name in cls.notable_hashed_env_vars:
+            with suppress(KeyError):  # Skip unset env vars
+                env_var_value = os.environ[env_var_name]
+                yield env_var_name, hash_sha256(env_var_value)
 
     @classmethod
     def _notable_flag_env_vars(cls) -> t.Iterable[str]:
@@ -75,6 +93,7 @@ class EnvironmentContext(SelfDescribingJson):
                     get_boolean_env_var(marker) for marker in self.ci_markers
                 ),
                 "notable_flag_env_vars": dict(self._notable_flag_env_vars()),
+                "notable_hashed_env_vars": dict(self._notable_hashed_env_vars()),
                 "python_version": platform.python_version(),
                 "python_implementation": platform.python_implementation(),
                 **self.system_info,

--- a/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-3-0
+++ b/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-3-0
@@ -185,6 +185,7 @@
         "is_dev_build",
         "is_ci_environment",
         "notable_flag_env_vars",
+        "notable_hashed_env_vars",
         "python_version",
         "python_implementation",
         "system_name",

--- a/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-3-0
+++ b/src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-3-0
@@ -1,0 +1,203 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Schema for a Snowplow context describing the environment in which the Meltano process is executing",
+    "self": {
+        "vendor": "com.meltano",
+        "name": "environment_context",
+        "format": "jsonschema",
+        "version": "1-3-0"
+    },
+    "type": "object",
+    "properties": {
+        "context_uuid": {
+            "description": "A UUID that uniquely identifies an instance of this context",
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "parent_context_uuid": {
+            "description": "The environment context UUID of the closest Meltano process above this one in the process tree",
+            "type": [
+                "string",
+                "null"
+            ],
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "minLength": 36,
+            "maxLength": 36
+        },
+        "meltano_version": {
+            "description": "The version of Meltano in use",
+            "type": "string",
+            "maxLength": 256
+        },
+        "is_dev_build": {
+            "description": "Whether the installed version of Meltano is a dev build",
+            "type": "boolean"
+        },
+        "is_ci_environment": {
+            "description": "Whether Meltano is running in a CI environment",
+            "type": "boolean"
+        },
+        "notable_flag_env_vars": {
+            "description": "Select environment variable flags",
+            "type": "object",
+            "additionalProperties": {
+                "description": "Boolean values of select env vars, or null if the truth value of the env var could not be determined",
+                "type": [
+                    "boolean",
+                    "null"
+                ]
+            }
+        },
+        "notable_hashed_env_vars": {
+            "description": "Select hashed environment variables",
+            "type": "object",
+            "additionalProperties": {
+                "description": "Hashed values of select env vars",
+                "type": "string",
+                "pattern": "^[a-fA-F0-9]{64}$",
+                "maxLength": 64,
+                "minLength": 64
+            }
+        },
+        "python_version": {
+            "description": "The version of Python in use",
+            "type": "string",
+            "maxLength": 256
+        },
+        "python_implementation": {
+            "description": "The Python implementation in use",
+            "type": "string",
+            "maxLength": 256
+        },
+        "system_name": {
+            "description": "The system/OS name, e.g. 'Linux', 'Darwin', 'Java', 'Windows', etc.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "system_release": {
+            "description": "The system's release, e.g. '2.2.0', 'NT', etc.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "system_version": {
+            "description": "The system's release version, e.g. '#124-Ubuntu SMP Thu Apr 14 19:46:19 UTC 2022'",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "machine": {
+            "description": "The machine type, e.g. 'x86_64', 'i386', 'arm64', etc.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "windows_edition": {
+            "description": "The Windows edition, e.g. 'Enterprise', 'IoTUAP', 'ServerStandard', 'nanoserver', etc.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "freedesktop_id": {
+            "description": "The 'ID' field of the Freedesktop os-release standard, e.g. 'linuxmint'",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "freedesktop_id_like": {
+            "description": "The 'ID_LIKE' field of the Freedesktop os-release standard, e.g. 'ubuntu'",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "freedesktop_version_id": {
+            "description": "The 'VERSION_ID' field of the Freedesktop os-release standard, e.g. '20.3'",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 256
+        },
+        "num_cpu_cores": {
+            "description": "The total number of logical CPU cores",
+            "type": "integer",
+            "multipleOf": 1,
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "num_cpu_cores_available": {
+            "description": "The number of logical CPU cores available to the process",
+            "type": "integer",
+            "multipleOf": 1,
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "process_hierarchy": {
+            "description": "An array of objects detailing each process in the hierarchy from the current one to the init process",
+            "type": "array",
+            "items": {
+                "description": "Details about a process within the process hierarchy",
+                "type": "object",
+                "properties": {
+                    "process_name_hash": {
+                        "description": "The hashed name of the process",
+                        "type": "string",
+                        "pattern": "^[a-fA-F0-9]{64}$",
+                        "maxLength": 64,
+                        "minLength": 64
+                    },
+                    "process_creation_timestamp": {
+                        "description": "The date and time the process was created in the ISO 8601 format",
+                        "type": "string",
+                        "pattern": "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?(?:Z|[+-][01]\\d:[0-5]\\d)$",
+                        "maxLength": 64
+                    }
+                },
+                "required": [
+                    "process_name_hash",
+                    "process_creation_timestamp"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [
+        "context_uuid",
+        "parent_context_uuid",
+        "meltano_version",
+        "is_dev_build",
+        "is_ci_environment",
+        "notable_flag_env_vars",
+        "python_version",
+        "python_implementation",
+        "system_name",
+        "system_release",
+        "system_version",
+        "machine",
+        "windows_edition",
+        "freedesktop_id",
+        "freedesktop_id_like",
+        "freedesktop_version_id",
+        "num_cpu_cores",
+        "num_cpu_cores_available",
+        "process_hierarchy"
+    ],
+    "additionalProperties": false
+}

--- a/src/meltano/core/tracking/schemas.py
+++ b/src/meltano/core/tracking/schemas.py
@@ -28,7 +28,7 @@ class IgluSchema:
 CliContextSchema = IgluSchema("cli_context", "1-1-0")
 CliEventSchema = IgluSchema("cli_event", "1-0-1")
 BlockEventSchema = IgluSchema("block_event", "1-0-0")
-EnvironmentContextSchema = IgluSchema("environment_context", "1-2-0")
+EnvironmentContextSchema = IgluSchema("environment_context", "1-3-0")
 ExceptionContextSchema = IgluSchema("exception_context", "1-0-0")
 ExitEventSchema = IgluSchema("exit_event", "1-0-1")
 PluginsContextSchema = IgluSchema("plugins_context", "1-0-0")

--- a/tests/meltano/core/tracking/test_environment_context.py
+++ b/tests/meltano/core/tracking/test_environment_context.py
@@ -5,9 +5,10 @@ import random
 import pytest
 
 from meltano.core.tracking.contexts.environment import EnvironmentContext
+from meltano.core.utils import hash_sha256
 
 
-def test_environment_context(monkeypatch: pytest.MonkeyPatch):
+def test_notable_flag_env_vars(monkeypatch: pytest.MonkeyPatch):
     for notable_flag_env_var in EnvironmentContext.notable_flag_env_vars:
         monkeypatch.delenv(notable_flag_env_var, raising=False)
 
@@ -27,3 +28,22 @@ def test_environment_context(monkeypatch: pytest.MonkeyPatch):
     check(("Yes", "TRUE", "1", "true", "y", "on", "t"), True)
     check(("No", "FALSE", "0", "false", "n", "off", "f"), False)
     check(("trew", "Fallse", "nah", "si", "okay", "01"), None)
+
+
+def test_notable_hashed_env_vars(monkeypatch: pytest.MonkeyPatch):
+    for notable_hashed_env_var in EnvironmentContext.notable_hashed_env_vars:
+        monkeypatch.delenv(notable_hashed_env_var, raising=False)
+    assert EnvironmentContext().data["notable_hashed_env_vars"] == {}  # noqa: WPS520
+
+    github_username = "test_user"
+    monkeypatch.setenv("GITHUB_USER", github_username)
+    assert EnvironmentContext().data["notable_hashed_env_vars"] == {
+        "GITHUB_USER": hash_sha256(github_username),
+    }
+
+    github_repo = "test_owner/test_repo"
+    monkeypatch.setenv("GITHUB_REPOSITORY", github_repo)
+    assert EnvironmentContext().data["notable_hashed_env_vars"] == {
+        "GITHUB_USER": hash_sha256(github_username),
+        "GITHUB_REPOSITORY": hash_sha256(github_repo),
+    }


### PR DESCRIPTION
Diff between environment context version 1-2-0 and 1-3-0:

```diff
*** src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-2-0     2023-02-01 23:58:05.905685997 -0500
--- src/meltano/core/tracking/iglu-client-embedded/schemas/com.meltano/environment_context/jsonschema/1-3-0     2023-03-20 12:54:49.932914818 -0400
***************
*** 6,10 ****
          "name": "environment_context",
          "format": "jsonschema",
!         "version": "1-2-0"
      },
      "type": "object",
--- 6,10 ----
          "name": "environment_context",
          "format": "jsonschema",
!         "version": "1-3-0"
      },
      "type": "object",
***************
*** 51,54 ****
--- 51,65 ----
              }
          },
+         "notable_hashed_env_vars": {
+             "description": "Select hashed environment variables",
+             "type": "object",
+             "additionalProperties": {
+                 "description": "Hashed values of select env vars",
+                 "type": "string",
+                 "pattern": "^[a-fA-F0-9]{64}$",
+                 "maxLength": 64,
+                 "minLength": 64
+             }
+         },
          "python_version": {
              "description": "The version of Python in use",
***************
*** 175,178 ****
--- 186,190 ----
          "is_ci_environment",
          "notable_flag_env_vars",
+         "notable_hashed_env_vars",
          "python_version",
          "python_implementation",
```

Once approved, I will publish environment context version 1-3-0 to Snowcat Cloud.

Closes https://github.com/meltano/internal-data/issues/94