### PR TITLE
fix: Remove having to set `MELTANO_CLOUD_ORGANIZATION_ID` for the `run` command

### DIFF
--- a/src/cloud-cli/meltano/cloud/api/client.py
+++ b/src/cloud-cli/meltano/cloud/api/client.py
@@ -224,23 +224,21 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
 
     async def run_project(
         self,
-        tenant_resource_key: str,
-        project_id: str,
         deployment: str,
         job_or_schedule: str,
     ):
         """Run a Meltano project in Meltano Cloud.
 
         Args:
-            tenant_resource_key: The tenant resource key.
-            project_id: The Meltano Cloud project ID.
             deployment: The name of the Meltano Cloud deployment in which to run.
             job_or_schedule: The name of the job or schedule to run.
         """
         async with self.authenticated():
             url = (
                 "/run/v1/external/"
-                f"{tenant_resource_key}/{project_id}/{deployment}/{job_or_schedule}"
+                f"{self.config.tenant_resource_key}/"
+                f"{self.config.internal_project_id}/"
+                f"{deployment}/{job_or_schedule}"
             )
             await self._json_request(
                 "POST",

--- a/src/cloud-cli/meltano/cloud/cli/run.py
+++ b/src/cloud-cli/meltano/cloud/cli/run.py
@@ -3,37 +3,18 @@
 from __future__ import annotations
 
 import asyncio
-import os
+import typing as t
 
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.api.config import MeltanoCloudConfig
 from meltano.cloud.cli.base import cloud
 
-
-def get_env_var(name: str) -> str:
-    """Expect an environment variable to be set.
-
-    Args:
-        name: The environment variable name.
-
-    Returns:
-        The environment variable value.
-
-    Raises:
-        UsageError: If the environment variable is not set.
-    """
-    try:
-        return os.environ[name]
-    except KeyError:
-        msg = f"Environment variable {name} is not set."
-        raise click.UsageError(msg)
+if t.TYPE_CHECKING:
+    from meltano.cloud.api.config import MeltanoCloudConfig
 
 
 async def run_project(
-    organization_id: str,
-    project_id: str,
     deployment: str,
     job_or_schedule: str,
     config: MeltanoCloudConfig,
@@ -41,8 +22,6 @@ async def run_project(
     """Run a project in Meltano Cloud.
 
     Args:
-        organization_id: The Meltano Cloud Organization ID.
-        project_id: The Meltano Cloud project ID.
         deployment: The name of the Meltano Cloud deployment to run in.
         job_or_schedule: The name of the job or schedule to run.
         config: the meltano config to use
@@ -52,8 +31,6 @@ async def run_project(
     """
     async with MeltanoCloudClient(config=config) as client:
         return await client.run_project(
-            organization_id,
-            project_id,
             deployment,
             job_or_schedule,
         )
@@ -66,22 +43,17 @@ async def run_project(
     required=True,
     help="The name of the Meltano Cloud deployment to run in.",
 )
-@click.option("--project-id", required=True, help="The Meltano Cloud project ID.")
 @click.pass_context
 def run(
     ctx: click.Context,
     job_or_schedule: str,
     deployment: str,
-    project_id: str,
 ) -> None:
     """Run a Meltano project in Meltano Cloud."""
     click.echo("Running a Meltano project in Meltano Cloud.")
-    organization_id = get_env_var("MELTANO_CLOUD_ORGANIZATION_ID")
 
     result = asyncio.run(
         run_project(
-            organization_id,
-            project_id,
             deployment,
             job_or_schedule,
             ctx.obj["config"],

--- a/src/cloud-cli/tests/cli/test_run.py
+++ b/src/cloud-cli/tests/cli/test_run.py
@@ -6,7 +6,6 @@ import json
 import typing as t
 from urllib.parse import urljoin
 
-import pytest
 from aioresponses import aioresponses
 from click.testing import CliRunner
 
@@ -22,15 +21,12 @@ class TestCloudRun:
 
     def test_run_ok(
         self,
-        monkeypatch: pytest.MonkeyPatch,
         tenant_resource_key: str,
         internal_project_id: str,
         client: MeltanoCloudClient,
         config: MeltanoCloudConfig,
     ):
         """Test the `run` subcommand."""
-        monkeypatch.setenv("MELTANO_CLOUD_ORGANIZATION_ID", tenant_resource_key)
-
         deployment = "sandbox"
         job_or_schedule = "daily"
         path = (
@@ -57,8 +53,6 @@ class TestCloudRun:
                     str(config.config_path),
                     "run",
                     job_or_schedule,
-                    "--project-id",
-                    internal_project_id,
                     "--deployment",
                     deployment,
                 ],


### PR DESCRIPTION
I missed this in my previous PR. 