### PR TITLE
ci: Run CodeQL scan on `cloud` branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "cloud" ]
   pull_request: {}
   schedule:
     - cron: '37 10 * * 5'


### PR DESCRIPTION
This should stop the bot spam in our PRs targeting `cloud`, per the warning annotations seen here: https://github.com/meltano/meltano/actions/runs/4489784989