### PR TITLE
chore: Misc updates to Cloud CLI config command

### DIFF
--- a/src/cloud-cli/meltano/cloud/api/client.py
+++ b/src/cloud-cli/meltano/cloud/api/client.py
@@ -28,22 +28,9 @@ if t.TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
-
 __all__ = ["MeltanoCloudClient"]
 
 logger = get_logger()
-
-
-def _cleanup_params(params: dict) -> dict:
-    """Remove None values from params.
-
-    Args:
-        params: The params to clean.
-
-    Returns:
-        The cleaned params.
-    """
-    return {k: v for k, v in params.items() if v is not None}
 
 
 class MeltanoCloudError(Exception):
@@ -159,6 +146,18 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
         with self.headers(self.auth.get_auth_header()):
             yield
 
+    @staticmethod
+    def clean_params(params: dict) -> dict:
+        """Remove None values from params.
+
+        Args:
+            params: The params to clean.
+
+        Returns:
+            The cleaned params.
+        """
+        return {k: v for k, v in params.items() if v is not None}
+
     @asynccontextmanager
     async def _raw_request(
         self,
@@ -196,7 +195,7 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
         path: str,
         base_url: str | None = None,
         **kwargs: t.Any,
-    ) -> dict | str:
+    ) -> dict[str, t.Any] | list[t.Any] | str | int | float | None:
         """Make a request to the Meltano Cloud API.
 
         Args:
@@ -308,7 +307,7 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
                 return await self._json_request(
                     "GET",
                     url,
-                    params=_cleanup_params(params),
+                    params=self.clean_params(params),
                 )
             except MeltanoCloudError as ex:
                 if ex.response.status == HTTPStatus.UNPROCESSABLE_ENTITY:

--- a/src/cloud-cli/meltano/cloud/cli/base.py
+++ b/src/cloud-cli/meltano/cloud/cli/base.py
@@ -2,15 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
 import typing as t
 from dataclasses import dataclass
-from functools import partial
+from functools import partial, wraps
 from pathlib import Path
 
 import click
 
 from meltano.cloud.api.auth import MeltanoCloudAuth
 from meltano.cloud.api.config import MeltanoCloudConfig
+
+
+def run_async(f: t.Callable[..., t.Coroutine[t.Any, t.Any, t.Any]]):
+    """Run the given async function using `asyncio.run`.
+
+    Args:
+        f: An async function.
+
+    Returns:
+        The given function wrapped so as to run within `asyncio.run`.
+    """
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
 
 
 @dataclass

--- a/src/cloud-cli/meltano/cloud/cli/config.py
+++ b/src/cloud-cli/meltano/cloud/cli/config.py
@@ -1,92 +1,136 @@
-"""Cloud Config CLI."""
+"""Meltano Cloud config CLI."""
 
 from __future__ import annotations
+
+import typing as t
 
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.api.config import MeltanoCloudConfig
-from meltano.cloud.cli.base import cloud
+from meltano.cloud.cli.base import cloud, pass_context, run_async
+
+if t.TYPE_CHECKING:
+    from meltano.cloud.cli.base import MeltanoCloudCLIContext
+
+MAX_PAGE_SIZE = 250
 
 
 @cloud.group("config")
-@click.pass_context
-def config(context: click.Context) -> None:  # noqa: WPS120
-    """Meltano Cloud `config` command."""
+def config() -> None:
+    """Configure Meltano Cloud project settings and secrets."""
 
 
-class CloudConfigClient(MeltanoCloudClient):
-    """Cloud Config Client."""
+class ConfigCloudClient(MeltanoCloudClient):
+    """Meltano Cloud config Client."""
 
     secrets_service_prefix = "/secrets/v1/"
 
     @property
-    def _tenant_prefix(self):
-        return f"{self.config.tenant_resource_key}/{self.config.project_id}/"
+    def _tenant_prefix(self) -> str:
+        return f"{self.config.tenant_resource_key}/{self.config.internal_project_id}/"
 
-    def list_all(self):
-        """List Cloud Config keys."""
-        url = self.secrets_service_prefix + self._tenant_prefix
-        with self.authenticated():
-            with self._raw_request("GET", url) as response:
-                return response
+    async def list_items(
+        self,
+        page_size: int | None = None,
+        page_token: str | None = None,
+    ):
+        """List Meltano Cloud config keys."""
+        params: dict[str, t.Any] = {
+            "page_size": page_size,
+            "page_token": page_token,
+        }
+        async with self.authenticated():
+            return await self._json_request(
+                "GET",
+                self.secrets_service_prefix + self._tenant_prefix,
+                params=self.clean_params(params),
+            )
 
-    def set_value(self, secret_name: str, secret_value: str):
-        """Set Cloud Config secret."""
-        url = self.secrets_service_prefix + self._tenant_prefix
-        body = {"name": secret_name.upper(), "value": secret_value}
-        with self.authenticated():
-            with self._raw_request("POST", url, body=body) as response:
-                return response
+    async def set_value(self, secret_name: str, secret_value: str):
+        """Set Meltano Cloud config secret."""
+        async with self.authenticated():
+            return await self._json_request(
+                "PUT",
+                self.secrets_service_prefix + self._tenant_prefix,
+                json={"name": secret_name, "value": secret_value},
+            )
 
-    def delete(self, secret_name: str):
-        """Delete Cloud Config secret."""
-        url = (
-            self.secrets_service_prefix,
-            self._tenant_prefix,
-            f"{secret_name.upper()}",
-        )
-        with self.authenticated():
-            with self._raw_request("DELETE", url) as response:
-                return response
+    async def delete(self, secret_name: str):
+        """Delete Meltano Cloud config secret."""
+        async with self.authenticated():
+            return await self._json_request(
+                "DELETE",
+                self.secrets_service_prefix + self._tenant_prefix + secret_name,
+            )
 
 
 @config.group()
-@click.pass_context
-def env(context: click.Context) -> None:  # noqa: WPS120
-    """Meltano Cloud `config` command."""
+def env() -> None:
+    """Configure Meltano Cloud environment variable secrets."""
 
 
 @env.command("list")
-@click.pass_context
-def list_all(context: click.Context) -> None:
-    """List all Cloud Config."""
-    cfg: MeltanoCloudConfig = context.obj["config"]
-    with CloudConfigClient(config=cfg) as client:
-        click.echo("Listing Cloud Config...")
-        response = client.list_all()
-        for secret in response.json.items():
-            click.echo(secret["name"], nl=True)
+@click.option(
+    "--limit",
+    required=False,
+    type=int,
+    default=10,
+    help="The maximum number of history items to display.",
+)
+@pass_context
+@run_async
+async def list_items(
+    context: MeltanoCloudCLIContext,
+    limit: int,
+) -> None:
+    """List Meltano Cloud config items."""
+    page_token = None
+    page_size = min(limit, MAX_PAGE_SIZE)
+    results: list[dict[str, str]] = []
+
+    async with ConfigCloudClient(config=context.config) as client:
+        while True:
+            response = await client.list_items(
+                page_token=page_token,
+                page_size=page_size,
+            )
+
+            results.extend(response["results"])
+
+            if response["pagination"] and len(results) < limit:
+                page_token = response["pagination"]["next_page_token"]
+            else:
+                break
+
+    for secret in results[:limit]:
+        click.echo(secret["name"])
 
 
 @env.command("set")
 @click.argument("secret_name", type=str, required=True)
-@click.password_option()
-@click.pass_context
-def set_value(context: click.Context, secret_name: str, password) -> None:
-    """Create new Cloud Config."""
-    cfg: MeltanoCloudConfig = context.obj["config"]
-    with CloudConfigClient(config=cfg) as client:
-        client.set_value(secret_name=secret_name.upper(), secret_value=password)
-        click.echo(f"Successfully created '{secret_name.upper()}'.")
+@click.password_option("--value")
+@pass_context
+@run_async
+async def set_value(
+    context: MeltanoCloudCLIContext,
+    secret_name: str,
+    value: str,
+) -> None:
+    """Create a new Meltano Cloud config item."""
+    async with ConfigCloudClient(config=context.config) as client:
+        await client.set_value(secret_name=secret_name, secret_value=value)
+        click.echo(f"Successfully set config item {secret_name!r}.")
 
 
 @env.command()
 @click.argument("secret_name", type=str, required=True)
-@click.pass_context
-def delete(context: click.Context, secret_name) -> None:
-    """Delete existing Cloud Config."""
-    cfg: MeltanoCloudConfig = context.obj["config"]
-    with CloudConfigClient(config=cfg) as client:
-        client.delete(secret_name=secret_name.upper())
-        click.echo(f"Successfully deleted '{secret_name.upper()}'.")
+@pass_context
+@run_async
+async def delete(
+    context: MeltanoCloudCLIContext,
+    secret_name,
+) -> None:
+    """Delete an existing Meltano Cloud config item."""
+    async with ConfigCloudClient(config=context.config) as client:
+        await client.delete(secret_name=secret_name)
+        click.echo(f"Successfully deleted config item {secret_name!r}.")

--- a/src/cloud-cli/meltano/cloud/cli/history.py
+++ b/src/cloud-cli/meltano/cloud/cli/history.py
@@ -11,11 +11,12 @@ import click
 import tabulate
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.cli.base import MeltanoCloudCLIContext, cloud, pass_context
+from meltano.cloud.cli.base import cloud, pass_context
 
 if t.TYPE_CHECKING:
     from meltano.cloud.api.config import MeltanoCloudConfig
     from meltano.cloud.api.types import CloudExecution
+    from meltano.cloud.cli.base import MeltanoCloudCLIContext
 
 MAX_PAGE_SIZE = 250
 UTC = datetime.timezone.utc

--- a/src/cloud-cli/meltano/cloud/cli/login.py
+++ b/src/cloud-cli/meltano/cloud/cli/login.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import typing as t
 
 import click
 
 from meltano.cloud.cli import cloud
-from meltano.cloud.cli.base import MeltanoCloudCLIContext, pass_context
+from meltano.cloud.cli.base import pass_context
+
+if t.TYPE_CHECKING:
+    from meltano.cloud.cli.base import MeltanoCloudCLIContext
 
 
 @cloud.command

--- a/src/cloud-cli/meltano/cloud/cli/logs.py
+++ b/src/cloud-cli/meltano/cloud/cli/logs.py
@@ -9,10 +9,11 @@ import typing as t
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.cli.base import MeltanoCloudCLIContext, cloud, pass_context
+from meltano.cloud.cli.base import cloud, pass_context
 
 if t.TYPE_CHECKING:
     from meltano.cloud.api.config import MeltanoCloudConfig
+    from meltano.cloud.cli.base import MeltanoCloudCLIContext
 
 
 @cloud.group()

--- a/src/cloud-cli/meltano/cloud/cli/run.py
+++ b/src/cloud-cli/meltano/cloud/cli/run.py
@@ -8,10 +8,11 @@ import typing as t
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.cli.base import MeltanoCloudCLIContext, cloud, pass_context
+from meltano.cloud.cli.base import cloud, pass_context
 
 if t.TYPE_CHECKING:
     from meltano.cloud.api.config import MeltanoCloudConfig
+    from meltano.cloud.cli.base import MeltanoCloudCLIContext
 
 
 async def run_project(

--- a/src/cloud-cli/meltano/cloud/cli/schedule.py
+++ b/src/cloud-cli/meltano/cloud/cli/schedule.py
@@ -9,15 +9,11 @@ from http import HTTPStatus
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient, MeltanoCloudError
-from meltano.cloud.cli.base import (
-    MeltanoCloudCLIContext,
-    cloud,
-    pass_context,
-    shared_option,
-)
+from meltano.cloud.cli.base import cloud, pass_context, shared_option
 
 if t.TYPE_CHECKING:
     from meltano.cloud.api.config import MeltanoCloudConfig
+    from meltano.cloud.cli.base import MeltanoCloudCLIContext
 
 
 class SchedulesCloudClient(MeltanoCloudClient):

--- a/src/cloud-cli/tests/api/test_cloud_config.py
+++ b/src/cloud-cli/tests/api/test_cloud_config.py
@@ -61,9 +61,9 @@ class TestMeltanoCloudConfig:
         subject: MeltanoCloudConfig,
     ):
         self.config_assertions(subject)
-        monkeypatch.setenv("MELTANO_CLOUD_PROJECT_ID", "project-id-from-env-var")
+        monkeypatch.setenv("MELTANO_CLOUD_INTERNAL_PROJECT_ID", "project-id-from-env-var")
         monkeypatch.setenv("MELTANO_CLOUD_APP_CLIENT_ID", "app-client-id-from-env-var")
-        assert subject.project_id == "project-id-from-env-var"
+        assert subject.internal_project_id == "project-id-from-env-var"
         assert subject.app_client_id == "app-client-id-from-env-var"
 
     def test_refresh(

--- a/src/cloud-cli/tests/api/test_cloud_config.py
+++ b/src/cloud-cli/tests/api/test_cloud_config.py
@@ -61,7 +61,9 @@ class TestMeltanoCloudConfig:
         subject: MeltanoCloudConfig,
     ):
         self.config_assertions(subject)
-        monkeypatch.setenv("MELTANO_CLOUD_INTERNAL_PROJECT_ID", "project-id-from-env-var")
+        monkeypatch.setenv(
+            "MELTANO_CLOUD_INTERNAL_PROJECT_ID", "project-id-from-env-var"
+        )
         monkeypatch.setenv("MELTANO_CLOUD_APP_CLIENT_ID", "app-client-id-from-env-var")
         assert subject.internal_project_id == "project-id-from-env-var"
         assert subject.app_client_id == "app-client-id-from-env-var"


### PR DESCRIPTION
Relates to:
- https://github.com/meltano/infra/pull/539

Basic manual tests have been successful using:
- `meltano cloud config env list` -> no output; a `INFO` log message would probably be good here, but we don't want to use `click.echo` for communication with the user here since that'll mess up the output if they're piping it somewhere.
- `meltano cloud config env set <secret name 1>`
- `meltano cloud config env set <secret name 2> --value`
- `meltano cloud config env list` -> lists the set secrets
- `meltano cloud config env delete <secret name 2>`
- `meltano cloud config env list` -> lists the remaining set secret