### PR TITLE
refactor: Use `cloud.add_command` to register Cloud CLI commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -601,7 +601,7 @@ select = [
 ]
 
 [tool.ruff.per-file-ignores]
-"__init__.py" = [
+"src/meltano/**/__init__.py" = [
   "F401", # Permit unused imports in `__init__.py` files
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -598,6 +598,7 @@ select = [
   "ISC", # flake8-implicit-str-concat
   "UP",  # pyupgrade
   "W",   # pycodestyle (warning)
+  "TID", # flake8-tidy-imports
 ]
 
 [tool.ruff.per-file-ignores]
@@ -620,3 +621,7 @@ required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
+[tool.ruff.flake8-tidy-imports.banned-api]
+"meltano.cloud.cli.base.cloud.command".msg = "Use `click.command` and `cloud.add_command` instead"
+"meltano.cloud.cli.base.cloud.group".msg = "Use `click.group` and `cloud.add_command` instead"

--- a/src/cloud-cli/meltano/cloud/__init__.py
+++ b/src/cloud-cli/meltano/cloud/__init__.py
@@ -1,5 +1,3 @@
 """Meltano Cloud."""
 
 from __future__ import annotations
-
-from meltano.cloud.cli import login

--- a/src/cloud-cli/meltano/cloud/api/auth/__init__.py
+++ b/src/cloud-cli/meltano/cloud/api/auth/__init__.py
@@ -3,3 +3,5 @@
 from __future__ import annotations
 
 from .auth import MeltanoCloudAuth, MeltanoCloudAuthError
+
+__all__ = ["MeltanoCloudAuth", "MeltanoCloudAuthError"]

--- a/src/cloud-cli/meltano/cloud/cli/__init__.py
+++ b/src/cloud-cli/meltano/cloud/cli/__init__.py
@@ -6,10 +6,17 @@ import click
 from structlog import get_logger
 
 from meltano.cloud.api import MeltanoCloudError
-from meltano.cloud.cli import config, history, logs, run, schedule
+from meltano.cloud.cli import config, history, login, logs, run, schedule
 from meltano.cloud.cli.base import cloud
 
 logger = get_logger()
+
+cloud.add_command(config.config)
+cloud.add_command(history.history)
+cloud.add_command(login.login)
+cloud.add_command(logs.logs)
+cloud.add_command(run.run)
+cloud.add_command(schedule.schedule_group)
 
 
 def main() -> int:

--- a/src/cloud-cli/meltano/cloud/cli/config.py
+++ b/src/cloud-cli/meltano/cloud/cli/config.py
@@ -7,7 +7,7 @@ import typing as t
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.cli.base import cloud, pass_context, run_async
+from meltano.cloud.cli.base import pass_context, run_async
 
 if t.TYPE_CHECKING:
     from meltano.cloud.cli.base import MeltanoCloudCLIContext
@@ -15,7 +15,7 @@ if t.TYPE_CHECKING:
 MAX_PAGE_SIZE = 250
 
 
-@cloud.group("config")
+@click.group("config")
 def config() -> None:
     """Configure Meltano Cloud project settings and secrets."""
 

--- a/src/cloud-cli/meltano/cloud/cli/history.py
+++ b/src/cloud-cli/meltano/cloud/cli/history.py
@@ -11,7 +11,7 @@ import click
 import tabulate
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.cli.base import cloud, pass_context
+from meltano.cloud.cli.base import pass_context
 
 if t.TYPE_CHECKING:
     from meltano.cloud.api.config import MeltanoCloudConfig
@@ -103,6 +103,7 @@ def _format_history_table(history: list[CloudExecution], table_format: str) -> s
 
     Args:
         history: The history to format.
+        table_format: The table format to use.
 
     Returns:
         The formatted history.
@@ -121,7 +122,7 @@ def _format_history_table(history: list[CloudExecution], table_format: str) -> s
     )
 
 
-@cloud.command()
+@click.command()
 @click.option(
     "--filter",
     "schedule_filter",

--- a/src/cloud-cli/meltano/cloud/cli/login.py
+++ b/src/cloud-cli/meltano/cloud/cli/login.py
@@ -7,14 +7,13 @@ import typing as t
 
 import click
 
-from meltano.cloud.cli import cloud
 from meltano.cloud.cli.base import pass_context
 
 if t.TYPE_CHECKING:
     from meltano.cloud.cli.base import MeltanoCloudCLIContext
 
 
-@cloud.command
+@click.command
 @pass_context
 def login(context: MeltanoCloudCLIContext) -> None:
     """Log in to Meltano Cloud."""
@@ -23,7 +22,7 @@ def login(context: MeltanoCloudCLIContext) -> None:
     click.secho(f"Logged in as {user_info['preferred_username']}", fg="green")
 
 
-@cloud.command
+@click.command
 @pass_context
 def logout(context: MeltanoCloudCLIContext) -> None:
     """Log out of Meltano Cloud."""

--- a/src/cloud-cli/meltano/cloud/cli/logs.py
+++ b/src/cloud-cli/meltano/cloud/cli/logs.py
@@ -9,14 +9,14 @@ import typing as t
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.cli.base import cloud, pass_context
+from meltano.cloud.cli.base import pass_context
 
 if t.TYPE_CHECKING:
     from meltano.cloud.api.config import MeltanoCloudConfig
     from meltano.cloud.cli.base import MeltanoCloudCLIContext
 
 
-@cloud.group()
+@click.group()
 def logs() -> None:
     """Meltano Cloud `logs` command."""
 

--- a/src/cloud-cli/meltano/cloud/cli/run.py
+++ b/src/cloud-cli/meltano/cloud/cli/run.py
@@ -8,7 +8,7 @@ import typing as t
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient
-from meltano.cloud.cli.base import cloud, pass_context
+from meltano.cloud.cli.base import pass_context
 
 if t.TYPE_CHECKING:
     from meltano.cloud.api.config import MeltanoCloudConfig
@@ -37,7 +37,7 @@ async def run_project(
         )
 
 
-@cloud.command()
+@click.command()
 @click.argument("job_or_schedule")
 @click.option(
     "--deployment",

--- a/src/cloud-cli/meltano/cloud/cli/schedule.py
+++ b/src/cloud-cli/meltano/cloud/cli/schedule.py
@@ -9,7 +9,7 @@ from http import HTTPStatus
 import click
 
 from meltano.cloud.api.client import MeltanoCloudClient, MeltanoCloudError
-from meltano.cloud.cli.base import cloud, pass_context, shared_option
+from meltano.cloud.cli.base import pass_context, shared_option
 
 if t.TYPE_CHECKING:
     from meltano.cloud.api.config import MeltanoCloudConfig
@@ -100,7 +100,7 @@ schedule_option = shared_option(
 )
 
 
-@cloud.group(name="schedule")
+@click.group(name="schedule")
 @deployment_option
 @schedule_option
 def schedule_group() -> None:

--- a/tests/fixtures/docker/__init__.py
+++ b/tests/fixtures/docker/__init__.py
@@ -8,6 +8,13 @@ import pytest
 
 from .snowplow import SnowplowMicro, snowplow, snowplow_optional, snowplow_session
 
+__all__ = [
+    "SnowplowMicro",
+    "snowplow",
+    "snowplow_optional",
+    "snowplow_session",
+]
+
 
 # Originally defined by `pytest-docker`. Overridden to provide a custom location.
 @pytest.fixture(scope="session")


### PR DESCRIPTION
As discussed in Slack with @WillDaSilva
