### PR TITLE
docs: add the Matatika GitHub Analytics project to the example projects page

### DIFF
--- a/docs/src/_tutorials/example-projects.md
+++ b/docs/src/_tutorials/example-projects.md
@@ -26,7 +26,7 @@ The following Meltano projects are designed to illustrate a solution to one prob
 - **[Data Stack 4 Fun & Nonprofits](https://github.com/andrewcstewart/ds4fnp)** - A larger setup accompanied by a tutorial series setting up Meltano, Gitpod, dbt and superset.
 - **[Meltano Getting Started Project](https://github.com/meltano/demo-project)** - If you follow the getting started doc part, this will be the resulting Meltano project.
 - **[Advanced dbt orchestration with Meltano + Airflow](https://github.com/pnadolny13/meltano_example_implementations/tree/main/meltano_projects/dbt_orchestration)** - A self-contained Meltano project using Airflow to orchestrate a variation of the dbt jaffle shop project using tap-csv along with an experimental Airflow DAG generator that translates each dbt model into a Airflow task in your DAG, for finer grain control. There also is a [video demonstrating this dbt & Airflow project in action](https://www.youtube.com/watch?v=pNGJ96HOioM&t=919s).
-
+- **[Matatika GitHub Analytics](https://github.com/Matatika/github-analytics)** - A Meltano project for GitHub built to run out of the box with the Matatika utility plugin allowing users to have a UI, an orchestrator and some insights into their data. You can see the project in action in [this video](https://www.youtube.com/watch?v=p67VBQaJAX0). This project also works as a stand alone Meltano project.
 
 ### 3. Sandbox projects
 


### PR DESCRIPTION
Added the Matatika GitHub Analytics project to the example projects docs page.