### PR TITLE
chore: Remove cyclic imports in `meltano.cli`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -577,6 +577,7 @@ select = [
   "PT",  # flake8-pytest-style
   "RSE", # flake8-raise
   "SIM", # flake8-simplify
+  "TID", # flake8-tidy-imports
   "UP",  # pyupgrade
   "W",   # pycodestyle (warning)
 ]
@@ -600,3 +601,7 @@ required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
+[tool.ruff.flake8-tidy-imports.banned-api]
+"meltano.cli.cli.command".msg = "Use `click.command` and `cloud.add_command` instead"
+"meltano.cli.cli.group".msg = "Use `click.group` and `cloud.add_command` instead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -603,5 +603,5 @@ required-imports = ["from __future__ import annotations"]
 convention = "google"
 
 [tool.ruff.flake8-tidy-imports.banned-api]
-"meltano.cli.cli.command".msg = "Use `click.command` and `cloud.add_command` instead"
-"meltano.cli.cli.group".msg = "Use `click.group` and `cloud.add_command` instead"
+"meltano.cli.cli.command".msg = "Use `click.command` and `meltano.cli.cli.add_command` instead"
+"meltano.cli.cli.group".msg = "Use `click.group` and `meltano.cli.cli.add_command` instead"

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -7,18 +7,8 @@ import os
 import sys
 import typing as t
 
-from meltano.cli.utils import CliError
-from meltano.core.error import MeltanoError, ProjectReadonly
-from meltano.core.logging import setup_logging
-
-# TODO: Importing the cli.cli module breaks other cli module imports
-# This suggests a cyclic dependency or a poorly structured interface.
-# This should be investigated and resolved to avoid implicit behavior
-# based solely on import order.
-from meltano.cli.cli import cli  # isort:skip
-from meltano.cli import (  # isort:skip # noqa: WPS235
+from meltano.cli import (  # noqa: WPS235
     add,
-    compile,
     config,
     discovery,
     dragon,
@@ -27,9 +17,11 @@ from meltano.cli import (  # isort:skip # noqa: WPS235
     initialize,
     install,
     invoke,
+    job,
     lock,
     remove,
     repl,
+    run,
     schedule,
     schema,
     select,
@@ -37,14 +29,40 @@ from meltano.cli import (  # isort:skip # noqa: WPS235
     ui,
     upgrade,
     user,
-    run,
     validate,
-    job,
 )
+from meltano.cli import compile as compile_module
+from meltano.cli.cli import cli
+from meltano.cli.utils import CliError
+from meltano.core.error import MeltanoError, ProjectReadonly
+from meltano.core.logging import setup_logging
 
 if t.TYPE_CHECKING:
     from meltano.core.tracking.tracker import Tracker
 
+cli.add_command(add.add)
+cli.add_command(compile_module.compile_command)
+cli.add_command(config.config)
+cli.add_command(discovery.discover)
+cli.add_command(dragon.dragon)
+cli.add_command(elt.elt)
+cli.add_command(environment.meltano_environment)
+cli.add_command(initialize.init)
+cli.add_command(install.install)
+cli.add_command(invoke.invoke)
+cli.add_command(lock.lock)
+cli.add_command(remove.remove)
+cli.add_command(repl.repl)
+cli.add_command(schedule.schedule)
+cli.add_command(schema.schema)
+cli.add_command(select.select)
+cli.add_command(state.meltano_state)
+cli.add_command(ui.ui)
+cli.add_command(upgrade.upgrade)
+cli.add_command(user.user)
+cli.add_command(run.run)
+cli.add_command(validate.test)
+cli.add_command(job.job)
 
 # Holds the exit code for error reporting during process exiting. In
 # particular, a function registered by the `atexit` module uses this value.

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -6,7 +6,6 @@ import typing as t
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
     CliError,
@@ -27,7 +26,7 @@ if t.TYPE_CHECKING:
     from meltano.core.tracking import Tracker
 
 
-@cli.command(  # noqa: WPS238
+@click.command(  # noqa: WPS238
     cls=PartialInstrumentedCmd,
     short_help="Add a plugin to your project.",
 )

--- a/src/meltano/cli/compile.py
+++ b/src/meltano/cli/compile.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import CliError, InstrumentedCmd
 from meltano.core.environment import Environment
@@ -21,7 +20,11 @@ if t.TYPE_CHECKING:
     from meltano.core.tracking import Tracker
 
 
-@cli.command(cls=InstrumentedCmd, short_help="Compile a Meltano manifest. (beta)")
+@click.command(
+    "compile",
+    cls=InstrumentedCmd,
+    short_help="Compile a Meltano manifest. (beta)",
+)
 @click.option(
     "--directory",
     default=".meltano/manifests",
@@ -49,7 +52,7 @@ if t.TYPE_CHECKING:
 )
 @click.pass_context
 @pass_project(migrate=True)
-def compile(  # noqa: WPS125
+def compile_command(
     project: Project,
     ctx: click.Context,
     directory: Path,

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import click
 import dotenv
 
-from meltano.cli import cli
 from meltano.cli.interactive import InteractiveConfig
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
@@ -113,7 +112,7 @@ def get_label(metadata) -> str:
         return f"from {source.label}"
 
 
-@cli.group(
+@click.group(
     cls=InstrumentedGroup,
     invoke_without_command=True,
     short_help="Display Meltano or plugin configuration.",

--- a/src/meltano/cli/discovery.py
+++ b/src/meltano/cli/discovery.py
@@ -6,7 +6,6 @@ import typing as t
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import InstrumentedCmd
 from meltano.core.plugin import PluginType
@@ -15,7 +14,7 @@ if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 
-@cli.command(
+@click.command(
     cls=InstrumentedCmd,
     short_help="List the available plugins in Meltano Hub and their variants.",
 )

--- a/src/meltano/cli/dragon.py
+++ b/src/meltano/cli/dragon.py
@@ -14,10 +14,8 @@ from meltano.core.cli_messages import (
     MELTY,
 )
 
-from . import cli
 
-
-@cli.command(short_help="Summon a dragon!")
+@click.command(short_help="Summon a dragon!")
 @click.pass_context
 def dragon(ctx):
     """Summon a dragon."""

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -11,7 +11,6 @@ from contextlib import asynccontextmanager, nullcontext, suppress
 import click
 from structlog import stdlib as structlog_stdlib
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import CliEnvironmentBehavior, CliError, PartialInstrumentedCmd
 from meltano.core.db import project_engine
@@ -43,7 +42,7 @@ DUMPABLES = {
 logger = structlog_stdlib.get_logger(__name__)
 
 
-@cli.command(
+@click.command(
     cls=PartialInstrumentedCmd,
     short_help="Run an ELT pipeline to Extract, Load, and Transform data.",
     environment_behavior=CliEnvironmentBehavior.environment_optional_use_default,

--- a/src/meltano/cli/environment.py
+++ b/src/meltano/cli/environment.py
@@ -6,7 +6,6 @@ import typing as t
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import InstrumentedGroup, PartialInstrumentedCmd
 from meltano.core.environment_service import EnvironmentService
@@ -18,7 +17,11 @@ if t.TYPE_CHECKING:
 ENVIRONMENT_SERVICE_KEY = "environment_service"
 
 
-@cli.group(cls=InstrumentedGroup, name="environment", short_help="Manage environments.")
+@click.group(
+    cls=InstrumentedGroup,
+    name="environment",
+    short_help="Manage environments.",
+)
 @click.pass_context
 @pass_project(migrate=True)
 def meltano_environment(project: Project, ctx: click.Context):

--- a/src/meltano/cli/initialize.py
+++ b/src/meltano/cli/initialize.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import database_uri_option
 from meltano.cli.utils import InstrumentedCmd
 from meltano.core.project_init_service import ProjectInitService
@@ -23,7 +22,7 @@ logger = logging.getLogger(__name__)
 path_type = click.Path(file_okay=False, path_type=Path)
 
 
-@cli.command(cls=InstrumentedCmd, short_help="Create a new Meltano project.")
+@click.command(cls=InstrumentedCmd, short_help="Create a new Meltano project.")
 @click.pass_context
 @click.argument("project_directory", required=False, type=path_type)
 @click.option(

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -6,7 +6,6 @@ import typing as t
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import CliError, PartialInstrumentedCmd, install_plugins
 from meltano.core.plugin import PluginType
@@ -17,7 +16,7 @@ if t.TYPE_CHECKING:
     from meltano.core.tracking import Tracker
 
 
-@cli.command(cls=PartialInstrumentedCmd, short_help="Install project dependencies.")
+@click.command(cls=PartialInstrumentedCmd, short_help="Install project dependencies.")
 @click.argument(
     "plugin_type",
     type=click.Choice(PluginType.cli_arguments()),

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -9,7 +9,6 @@ import typing as t
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
     CliEnvironmentBehavior,
@@ -37,7 +36,7 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@cli.command(
+@click.command(
     cls=PartialInstrumentedCmd,
     context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
     short_help="Invoke a plugin.",

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -8,10 +8,10 @@ import typing as t
 import click
 import structlog
 
-from meltano.cli import CliError, cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
     CliEnvironmentBehavior,
+    CliError,
     InstrumentedGroup,
     PartialInstrumentedCmd,
 )
@@ -93,7 +93,7 @@ def _list_all_jobs(
     tracker.track_command_event(CliEvent.completed)
 
 
-@cli.group(
+@click.group(
     cls=InstrumentedGroup,
     short_help="Manage jobs.",
     environment_behavior=CliEnvironmentBehavior.environment_optional_ignore_default,

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -7,9 +7,8 @@ import typing as t
 import click
 import structlog
 
-from meltano.cli import CliError, cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import PartialInstrumentedCmd
+from meltano.cli.utils import CliError, PartialInstrumentedCmd
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_lock_service import (
     LockfileAlreadyExistsError,
@@ -27,7 +26,7 @@ __all__ = ["lock"]
 logger = structlog.get_logger(__name__)
 
 
-@cli.command(cls=PartialInstrumentedCmd, short_help="Lock plugin definitions.")
+@click.command(cls=PartialInstrumentedCmd, short_help="Lock plugin definitions.")
 @click.option(
     "--all",
     "all_plugins",

--- a/src/meltano/cli/remove.py
+++ b/src/meltano/cli/remove.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import InstrumentedCmd
 from meltano.core.plugin import PluginType
@@ -15,7 +14,7 @@ from meltano.core.plugin_location_remove import (
 from meltano.core.plugin_remove_service import PluginRemoveService
 
 
-@cli.command(cls=InstrumentedCmd, short_help="Remove plugins from your project.")
+@click.command(cls=InstrumentedCmd, short_help="Remove plugins from your project.")
 @click.argument("plugin_type", type=click.Choice(PluginType.cli_arguments()))
 @click.argument("plugin_names", nargs=-1, required=True)
 @pass_project()

--- a/src/meltano/cli/repl.py
+++ b/src/meltano/cli/repl.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import click
 
-from meltano.cli.cli import cli
 from meltano.cli.params import database_uri_option
 from meltano.cli.utils import InstrumentedCmd
 
 
-@cli.command(cls=InstrumentedCmd, hidden=True)
+@click.command(cls=InstrumentedCmd, hidden=True)
 @database_uri_option
 @click.pass_context
 def repl(ctx: click.Context):

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -7,9 +7,8 @@ import typing as t
 import click
 import structlog
 
-from meltano.cli import CliError, cli
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliEnvironmentBehavior, PartialInstrumentedCmd
+from meltano.cli.utils import CliEnvironmentBehavior, CliError, PartialInstrumentedCmd
 from meltano.core.block.blockset import BlockSet
 from meltano.core.block.parser import BlockParser, validate_block_sets
 from meltano.core.block.plugin_command import PluginCommandBlock
@@ -27,7 +26,7 @@ if t.TYPE_CHECKING:
 logger = structlog.getLogger(__name__)
 
 
-@cli.command(
+@click.command(
     cls=PartialInstrumentedCmd,
     short_help="Run a set of plugins in series.",
     environment_behavior=CliEnvironmentBehavior.environment_required,

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -8,7 +8,6 @@ import typing as t
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
     CliEnvironmentBehavior,
@@ -29,7 +28,7 @@ if t.TYPE_CHECKING:
     from meltano.core.task_sets import TaskSets
 
 
-@cli.group(
+@click.group(
     cls=InstrumentedDefaultGroup,
     default="add",
     short_help="Manage pipeline schedules.",

--- a/src/meltano/cli/schema.py
+++ b/src/meltano/cli/schema.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import click
 
+from meltano.cli.params import pass_project
+from meltano.cli.utils import InstrumentedCmd, InstrumentedGroup
 from meltano.core.db import ensure_schema_exists, project_engine
 
-from . import cli
-from .params import pass_project
-from .utils import InstrumentedCmd, InstrumentedGroup
 
-
-@cli.group(cls=InstrumentedGroup, short_help="Manage system DB schema.")
+@click.group(cls=InstrumentedGroup, short_help="Manage system DB schema.")
 def schema():
     """Manage system DB schema."""
 

--- a/src/meltano/cli/select.py
+++ b/src/meltano/cli/select.py
@@ -6,7 +6,6 @@ from contextlib import closing
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import CliEnvironmentBehavior, CliError, InstrumentedCmd
 from meltano.core.db import project_engine
@@ -42,7 +41,7 @@ def selection_mark(selection):
     return f"[{selection:<{colwidth}}]"
 
 
-@cli.command(
+@click.command(
     cls=InstrumentedCmd,
     short_help="Manage extractor selection patterns.",
     environment_behavior=CliEnvironmentBehavior.environment_optional_ignore_default,

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -12,7 +12,6 @@ from operator import xor
 import click
 import structlog
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import CliEnvironmentBehavior, InstrumentedCmd, InstrumentedGroup
 from meltano.core.block.parser import BlockParser
@@ -108,7 +107,7 @@ def state_service_from_state_id(project: Project, state_id: str) -> StateService
     return None
 
 
-@cli.group(
+@click.group(
     cls=InstrumentedGroup,
     name="state",
     short_help="Manage Singer state.",

--- a/src/meltano/cli/ui.py
+++ b/src/meltano/cli/ui.py
@@ -11,7 +11,6 @@ import typing as t
 import click
 
 from meltano.api.workers import APIWorker, UIAvailableWorker
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import CliError, InstrumentedCmd, InstrumentedDefaultGroup
 from meltano.core.project_settings_service import (
@@ -76,7 +75,7 @@ def start_workers(workers):
     return stop_all
 
 
-@cli.group(
+@click.group(
     cls=InstrumentedDefaultGroup,
     default="start",
     default_if_no_args=True,

--- a/src/meltano/cli/upgrade.py
+++ b/src/meltano/cli/upgrade.py
@@ -6,7 +6,6 @@ import os
 
 import click
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import InstrumentedCmd, InstrumentedDefaultGroup
 from meltano.core.db import project_engine
@@ -14,7 +13,7 @@ from meltano.core.meltano_invoker import MeltanoInvoker
 from meltano.core.upgrade_service import UpgradeService
 
 
-@cli.group(
+@click.group(
     cls=InstrumentedDefaultGroup,
     default="all",
     default_if_no_args=True,

--- a/src/meltano/cli/user.py
+++ b/src/meltano/cli/user.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import click
 
 from meltano.api.app import create_app
-
-from . import cli
-from .params import pass_project
-from .utils import InstrumentedCmd, InstrumentedGroup
+from meltano.cli.params import pass_project
+from meltano.cli.utils import InstrumentedCmd, InstrumentedGroup
 
 
-@cli.group(
+@click.group(
     cls=InstrumentedGroup,
     invoke_without_command=True,
     short_help="Manage Meltano user accounts.",

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -10,7 +10,6 @@ import typing as t
 import click
 import structlog
 
-from meltano.cli import cli
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
     CliEnvironmentBehavior,
@@ -68,7 +67,7 @@ class CommandLineRunner(ValidationsRunner):
         return exit_code
 
 
-@cli.command(
+@click.command(
     cls=InstrumentedCmd,
     short_help="Run validations using plugins' tests.",
     environment_behavior=CliEnvironmentBehavior.environment_optional_use_default,

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -450,13 +450,15 @@ class TestCliColors:
         else:
             log_config_path = None
 
-        @cli.command("dummy")
+        @click.command("dummy")
         @click.pass_context
-        def _dummy_command(ctx):
+        def dummy_command(ctx):
             setup_logging(None, "DEBUG", log_config_path)
             logger = get_logger("meltano.cli.dummy")
             logger.info(self.TEST_TEXT)
             click.echo(styled_text)
+
+        cli.add_command(dummy_command)
 
         expected_text = styled_text if cli_colors_expected else self.TEST_TEXT
 

--- a/tests/meltano/cli/test_elt.py
+++ b/tests/meltano/cli/test_elt.py
@@ -9,7 +9,8 @@ import structlog
 from mock import AsyncMock, mock
 
 from asserts import assert_cli_runner
-from meltano.cli import CliError, cli
+from meltano.cli import cli
+from meltano.cli.utils import CliError
 from meltano.core.job import Job, State
 from meltano.core.logging.formatters import LEVELED_TIMESTAMPED_PRE_CHAIN
 from meltano.core.plugin import PluginType

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 from click.testing import CliRunner
 
-from meltano.cli import CliError, cli
+from meltano.cli import cli
+from meltano.cli.utils import CliError
 from meltano.core.hub import MeltanoHubService
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_lock_service import PluginLock


### PR DESCRIPTION
This approach of using `click.command` with `cli.add_command` is currently used by the Cloud CLI. This PR applies this approach to the rest of Meltano in order to simplify the imports in the `meltano.cli` module. Now there are no more cyclic dependencies, and we can let isort (Ruff) handle the imports.