### PR TITLE
chore: Use `increase` Dependabot version strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
     reviewers: [meltano/engineering]
     labels: [deps]
   - package-ecosystem: pip
+    versioning-strategy: increase
     directory: "/"
     schedule:
       interval: daily


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy

Meltano is an application, not a library, so there is little benefit in widening the allowed dependency version ranges. Letting it grow wide makes it difficult to test, so we should keep it as narrow as we can while still ensuring compatibility with all of our other libraries, and with our supported Python versions.