### PR TITLE
docs: Remove references to --include-related

### DIFF
--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -628,8 +628,6 @@ Installs dependencies of your project based on the **meltano.yml** file.
 Optionally, provide a plugin type argument to only (re)install plugins of a certain type.
 Additionally, plugin names can be provided to only (re)install those specific plugins.
 
-Use `--include-related` to automatically install transforms related to installed extractor plugins.
-
 Subsequent calls to `meltano install` will upgrade a plugin to its latest version, if any. To completely uninstall and reinstall a plugin, use `--clean`.
 
 Meltano installs plugins in parallel. The number of plugins to install in parallel defaults to the number of CPUs on the machine, but can be controlled with `--parallelism`. Use `--parallelism=1` to disable the feature and install them one at a time.
@@ -667,8 +665,6 @@ meltano install
 meltano install extractors
 meltano install extractor tap-gitlab
 meltano install extractors tap-gitlab tap-adwords
-
-meltano install --include-related
 
 meltano install --parallelism=16
 meltano install --clean


### PR DESCRIPTION
I believe `--include-related` is deprecated in 2.0.0 as mentioned in #5957. I am currently on 2.5.0 version

```sh
$ meltano --no-environment install --help
2023-04-18T05:33:22.577125Z [info     ] No environment is active
Usage: meltano install [OPTIONS] [[extractor|loader|transform|orchestrator|tra
                       nsformer|file|utility|mapper|mapping|extractors|loaders
                       |transforms|orchestrators|transformers|files|utilities|
                       mappers|mappings]] [PLUGIN_NAME]...

      Install all the dependencies of your project based on the meltano.yml
      file.

      Read more at https://docs.meltano.com/reference/command-line-interface#install
          

Options:
  --clean                    Completely reinstall a plugin rather than simply
                             upgrading if necessary.
  -p, --parallelism INTEGER  Limit the number of plugins to install in
                             parallel. Defaults to the number of cores.
  --database-uri TEXT        System database URI.
  --help                     Show this message and exit.
```