### PR TITLE
docs: Change "meltano cloud" to "meltano-cloud" during Beta

### DIFF
--- a/docs/src/_cloud/cloud-cli.md
+++ b/docs/src/_cloud/cloud-cli.md
@@ -10,6 +10,7 @@ weight: 3
   <p>While in Beta, functionality is not guaranteed and subject to change. <br> If you're interested in using Meltano Cloud please join our <a href="https://meltano.com/cloud/">waitlist</a>.</p>
 </div>
 
+
 ## `login`
 
 Logging into Meltano Cloud via the CLI stores a token locally which is used by the CLI to take actions that require authentication.
@@ -18,7 +19,7 @@ Logging in will open a browser tab where you may be asked to authenticate yourse
 
 ```sh
 # Login to Meltano Cloud
-meltano cloud login
+meltano-cloud login
 ```
 
 ## `logout`
@@ -27,7 +28,7 @@ Logging out of Meltano Cloud invalidates your login token, and deletes the local
 
 ```sh
 # Logout from Meltano Cloud
-meltano cloud logout
+meltano-cloud logout
 ```
 
 ## `project`
@@ -37,7 +38,7 @@ The `project` command provides an interface for Meltano Cloud projects.
 The `list` subcommand shows all of the projects you have access to, and can use with other commands:
 
 ```sh
-meltano cloud project list
+meltano-cloud project list
 ╭───────────┬───────────────────────────────┬──────────────────────────────────────────────────────────╮
 │  Default  │ Name                          │ Git Repository                                           │
 ├───────────┼───────────────────────────────┼──────────────────────────────────────────────────────────┤
@@ -46,17 +47,17 @@ meltano cloud project list
 ╰───────────┴───────────────────────────────┴──────────────────────────────────────────────────────────╯
 ```
 
-When you run the `login` command, if you only have a single project, it will be set as the default project to use for future commands. Otherwise, you will need to run `meltano cloud project use` to specify which Meltano Cloud project the other `meltano cloud` commands should operate on.
+When you run the `login` command, if you only have a single project, it will be set as the default project to use for future commands. Otherwise, you will need to run `meltano-cloud project use` to specify which Meltano Cloud project the other `meltano-cloud` commands should operate on.
 
-When `meltano cloud project use` is not provided any argument, it will list the available projects, and have you select one interactively using the arrow keys. To select a project as the default non-interactively, use the `--name` argument:
+When `meltano-cloud project use` is not provided any argument, it will list the available projects, and have you select one interactively using the arrow keys. To select a project as the default non-interactively, use the `--name` argument:
 
 ```sh
-meltano cloud project use --name 'Meltano Squared'
+meltano-cloud project use --name 'Meltano Squared'
 Set 'Meltano Squared' as the default Meltano Cloud project for future commands
 ```
 
 ```sh
-meltano cloud project list
+meltano-cloud project list
 ╭───────────┬───────────────────────────────┬──────────────────────────────────────────────────────────╮
 │  Default  │ Name                          │ Git Repository                                           │
 ├───────────┼───────────────────────────────┼──────────────────────────────────────────────────────────┤
@@ -65,14 +66,14 @@ meltano cloud project list
 ╰───────────┴───────────────────────────────┴──────────────────────────────────────────────────────────╯
 ```
 
-When specifying a project to use as the default for future command, its name must be exactly as shown when running `meltano cloud project list`. If there are spaces or special characters in the name, then it must be quoted.
+When specifying a project to use as the default for future command, its name must be exactly as shown when running `meltano-cloud project list`. If there are spaces or special characters in the name, then it must be quoted.
 
 ## `history`
 
 Display the history of executions for a project.
 
 ```sh
-$ meltano cloud history --limit 3
+$ meltano-cloud history --limit 3
 ╭──────────────────────────────────┬─────────────────┬──────────────┬─────────────────────┬──────────┬────────────╮
 │ Execution ID                     │ Schedule Name   │ Deployment   │ Executed At (UTC)   │ Result   │ Duration   │
 ├──────────────────────────────────┼─────────────────┼──────────────┼─────────────────────┼──────────┼────────────┤
@@ -82,20 +83,20 @@ $ meltano cloud history --limit 3
 ╰──────────────────────────────────┴─────────────────┴──────────────┴─────────────────────┴──────────┴────────────╯
 
 # Display the last 12 hours of executions
-$ meltano cloud history --lookback 12h
+$ meltano-cloud history --lookback 12h
 
 # Display the last week of executions
-$ meltano cloud history --lookback 1w
+$ meltano-cloud history --lookback 1w
 
 # Display the last hour and a half of executions
-$ meltano cloud history --lookback 1h30m
+$ meltano-cloud history --lookback 1h30m
 ```
 
 ## `logs`
 
 ```sh
 # Print logs for an execution
-meltano cloud logs print --execution-id <execution_id>
+meltano-cloud logs print --execution-id <execution_id>
 ```
 
 ## `schedule`
@@ -108,16 +109,16 @@ Currently, updating a schedule requires a redeployment. In the future it will be
 
 ```sh
 # Enable a schedule
-meltano cloud schedule enable --deployment <deployment name> --schedule <schedule name>
+meltano-cloud schedule enable --deployment <deployment name> --schedule <schedule name>
 
 # Disable a schedule
-meltano cloud schedule disable --deployment <deployment name> --schedule <schedule name>
+meltano-cloud schedule disable --deployment <deployment name> --schedule <schedule name>
 ```
 
 Schedules can be listed using the `list` command:
 
 ```sh
-meltano cloud schedule list
+meltano-cloud schedule list
 ╭──────────────┬────────────┬──────────────────────┬──────────────┬───────────╮
 │ Deployment   │ Schedule   │ Interval             │   Runs / Day │ Enabled   │
 ├──────────────┼────────────┼──────────────────────┼──────────────┼───────────┤
@@ -129,7 +130,7 @@ meltano cloud schedule list
 ```
 
 ```sh
-meltano cloud schedule list --deployment prod
+meltano-cloud schedule list --deployment prod
 ╭──────────────┬────────────┬──────────────────────┬──────────────┬───────────╮
 │ Deployment   │ Schedule   │ Interval             │   Runs / Day │ Enabled   │
 ├──────────────┼────────────┼──────────────────────┼──────────────┼───────────┤
@@ -141,7 +142,7 @@ meltano cloud schedule list --deployment prod
 Individual schedules can be more thoroughly described using the `describe` command:
 
 ```sh
-meltano cloud schedule describe --deployment staging --schedule schedule_4 --num-upcoming 5
+meltano-cloud schedule describe --deployment staging --schedule schedule_4 --num-upcoming 5
 Deployment name: prod
 Schedule name:   schedule_4
 Interval:        15,45 */2 * * 1,3,5
@@ -158,7 +159,7 @@ Approximate starting date and time (UTC) of next 5 schedule runs:
 The `--only-upcoming` option can be used to have the command only output the upcoming scheduled run start dates and times:
 
 ```sh
-meltano cloud schedule describe --deployment staging --schedule schedule_4 --num-upcoming 5 --only-upcoming
+meltano-cloud schedule describe --deployment staging --schedule schedule_4 --num-upcoming 5 --only-upcoming
 2023-03-24 20:45
 2023-03-24 22:15
 2023-03-24 22:45

--- a/docs/src/_cloud/encrypting_secrets.md
+++ b/docs/src/_cloud/encrypting_secrets.md
@@ -16,18 +16,18 @@ This document covers information on encrypting secrets in your Meltano `secrets.
 
 ### Encryption Method
 
-Use the `meltano cloud config env set --key <SECRET_NAME> --value <SECRET_VALUE>` CLI command to set configuration secrets.
+Use the `meltano-cloud config env set --key <SECRET_NAME> --value <SECRET_VALUE>` CLI command to set configuration secrets.
 
 Note: The value can be passed in directly or via an environment variable.
-If you have an environment variable set locally called `TEST_SECRET`, the example to set it would be `meltano cloud config env set --key TEST_SECRET --value $TEST_SECRET`.
+If you have an environment variable set locally called `TEST_SECRET`, the example to set it would be `meltano-cloud config env set --key TEST_SECRET --value $TEST_SECRET`.
 
 This will set secrets via the `.env` file at runtime for a job or schedule.
 
 You can list and delete secrets configured as well.
 
 ```
-meltano cloud config env list
-meltano cloud config env delete <SECRET_NAME>
+meltano-cloud config env list
+meltano-cloud config env delete <SECRET_NAME>
 ```
 
 Secrets cannot be decrypted after they are set. If you need to change a secret, you can set the secret again.


### PR DESCRIPTION
This was called out as slightly confusing during a recent onboarding call, since onboarding docs use `meltano-cloud` rather than `meltano cloud`. 

These can be changed back for GA--issue to remind me of that is here: https://github.com/meltano/meltano/issues/7578