### PR TITLE
fix: Print a clearer message when `meltano.yml` is empty

### DIFF
--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -105,8 +105,8 @@ class EmptyMeltanoFileException(MeltanoError):
 
     def __init__(self) -> None:
         """Instantiate the error."""
-        reason = "Your meltano.yml file is empty."
-        instruction = "Please update your meltano file with a valid configuration."
+        reason = "Your meltano.yml file is empty"
+        instruction = "Please update your meltano file with a valid configuration"
         super().__init__(reason, instruction)
 
 

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -100,8 +100,12 @@ class PluginInstallWarning(Exception):
     """Exception for when a plugin optional optional step fails to install."""
 
 
-class EmptyMeltanoFileException(Exception):
+class EmptyMeltanoFileException(MeltanoError):
     """Exception for empty meltano.yml file."""
+    def __init__(self, *args, **kwargs) -> None:
+        reason = "Your meltano.yml file is empty."
+        instruction = "Please update your meltano file with a valid configuration."
+        super().__init__(reason, instruction, *args, **kwargs)
 
 
 class MeltanoConfigurationError(MeltanoError):

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -102,6 +102,7 @@ class PluginInstallWarning(Exception):
 
 class EmptyMeltanoFileException(MeltanoError):
     """Exception for empty meltano.yml file."""
+
     def __init__(self, *args, **kwargs) -> None:
         reason = "Your meltano.yml file is empty."
         instruction = "Please update your meltano file with a valid configuration."

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -103,10 +103,11 @@ class PluginInstallWarning(Exception):
 class EmptyMeltanoFileException(MeltanoError):
     """Exception for empty meltano.yml file."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self) -> None:
+        """Instantiate the error."""
         reason = "Your meltano.yml file is empty."
         instruction = "Please update your meltano file with a valid configuration."
-        super().__init__(reason, instruction, *args, **kwargs)
+        super().__init__(reason, instruction)
 
 
 class MeltanoConfigurationError(MeltanoError):


### PR DESCRIPTION
fixes #7635 
