### PR TITLE
fix: install schedule elt style and mappings

### DIFF
--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import typing as t
 
 import click
+import structlog
 
 from meltano.cli.params import pass_project
 from meltano.cli.utils import CliError, PartialInstrumentedCmd, install_plugins
+from meltano.core.block.parser import BlockParser
 from meltano.core.plugin import PluginType
 from meltano.core.schedule_service import ScheduleService
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
@@ -15,6 +17,8 @@ from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
     from meltano.core.tracking import Tracker
+
+logger = structlog.getLogger(__name__)
 
 
 @click.command(cls=PartialInstrumentedCmd, short_help="Install project dependencies.")
@@ -106,13 +110,24 @@ def install(  # noqa: C901
         raise CliError("Failed to install plugin(s)")
     tracker.track_command_event(CliEvent.completed)
 
-
 def _get_schedule_plugins(project: Project, schedule_name: str):
     schedule_service = ScheduleService(project)
     schedule_obj = schedule_service.find_schedule(schedule_name)
-    task_sets = schedule_service.task_sets_service.get(schedule_obj.job)
-    schedule_plugins = []
-    for plugin_command in task_sets.flat_args:
-        plugin_name = plugin_command.split(":")[0]
-        schedule_plugins.append(project.plugins.find_plugin(plugin_name))
+    schedule_plugins = set()
+    if schedule_obj.elt_schedule:
+        for plugin_name in schedule_obj.elt_args[:2]:
+            schedule_plugins.add(
+                project.plugins.find_plugin(plugin_name)
+            )
+    else:
+        task_sets = schedule_service.task_sets_service.get(schedule_obj.job)
+        for blocks in task_sets.flat_args_per_set:
+            parser = BlockParser(logger, project, blocks)
+            for plugin in parser.plugins:
+                if plugin.type == PluginType.MAPPERS:
+                    schedule_plugins.add(
+                        project.plugins.find_plugin(plugin.info.get("name"))
+                    )
+                else:
+                    schedule_plugins.add(plugin)
     return schedule_plugins

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -126,6 +126,6 @@ def _get_schedule_plugins(project: Project, schedule_name: str):
                 schedule_plugins.add(
                     project.plugins.find_plugin(plugin.info.get("name"))
                     if plugin.type == PluginType.MAPPERS
-                    else plugin
+                    else plugin,
                 )
     return schedule_plugins

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -123,10 +123,9 @@ def _get_schedule_plugins(project: Project, schedule_name: str):
         for blocks in task_sets.flat_args_per_set:
             parser = BlockParser(logger, project, blocks)
             for plugin in parser.plugins:
-                if plugin.type == PluginType.MAPPERS:
-                    schedule_plugins.add(
-                        project.plugins.find_plugin(plugin.info.get("name")),
-                    )
-                else:
-                    schedule_plugins.add(plugin)
+                schedule_plugins.add(
+                    project.plugins.find_plugin(plugin.info.get("name"))
+                    if plugin.type == PluginType.MAPPERS
+                    else plugin
+                )
     return schedule_plugins

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -116,7 +116,7 @@ def _get_schedule_plugins(project: Project, schedule_name: str):
     schedule_obj = schedule_service.find_schedule(schedule_name)
     schedule_plugins = set()
     if schedule_obj.elt_schedule:
-        for plugin_name in schedule_obj.elt_args[:2]:
+        for plugin_name in (schedule_obj.extractor, schedule_obj.loader):
             schedule_plugins.add(project.plugins.find_plugin(plugin_name))
     else:
         task_sets = schedule_service.task_sets_service.get(schedule_obj.job)

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -110,15 +110,14 @@ def install(  # noqa: C901
         raise CliError("Failed to install plugin(s)")
     tracker.track_command_event(CliEvent.completed)
 
+
 def _get_schedule_plugins(project: Project, schedule_name: str):
     schedule_service = ScheduleService(project)
     schedule_obj = schedule_service.find_schedule(schedule_name)
     schedule_plugins = set()
     if schedule_obj.elt_schedule:
         for plugin_name in schedule_obj.elt_args[:2]:
-            schedule_plugins.add(
-                project.plugins.find_plugin(plugin_name)
-            )
+            schedule_plugins.add(project.plugins.find_plugin(plugin_name))
     else:
         task_sets = schedule_service.task_sets_service.get(schedule_obj.job)
         for blocks in task_sets.flat_args_per_set:
@@ -126,7 +125,7 @@ def _get_schedule_plugins(project: Project, schedule_name: str):
             for plugin in parser.plugins:
                 if plugin.type == PluginType.MAPPERS:
                     schedule_plugins.add(
-                        project.plugins.find_plugin(plugin.info.get("name"))
+                        project.plugins.find_plugin(plugin.info.get("name")),
                     )
                 else:
                     schedule_plugins.add(plugin)

--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -138,6 +138,11 @@ class BlockParser:  # noqa: D101
 
     @property
     def plugins(self) -> list[ProjectPlugin]:
+        """Return the list of plugins in the block.
+
+        Returns:
+            A list of ProjectPlugin.
+        """
         return self._plugins
 
     def _expand_jobs(self, blocks: list[str], task_sets: TaskSetsService) -> list[str]:

--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -136,6 +136,10 @@ class BlockParser:  # noqa: D101
 
             self.log.debug("found plugin in cli invocation", plugin_name=plugin.name)
 
+    @property
+    def plugins(self) -> list[ProjectPlugin]:
+        return self._plugins
+
     def _expand_jobs(self, blocks: list[str], task_sets: TaskSetsService) -> list[str]:
         """Expand any jobs present in a list of blocks into their raw block names.
 

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -5,8 +5,8 @@ import shutil
 
 import mock
 import pytest
-from asserts import assert_cli_runner
 
+from asserts import assert_cli_runner
 from meltano.cli import cli
 from meltano.core.plugin import PluginType
 from meltano.core.project_add_service import PluginAlreadyAddedException
@@ -256,9 +256,13 @@ class TestCliInstall:
             install_plugin_mock.return_value = True
             schedule_service.task_sets_service = task_sets_service
             from meltano.core.task_sets import TaskSets
+
             mapping = mapper.extra_config.get("_mappings")[0].get("name")
             task_sets_service.add(
-                TaskSets(job_schedule.job, [tap_gitlab.name, mapping, target.name, dbt.name]),
+                TaskSets(
+                    job_schedule.job,
+                    [tap_gitlab.name, mapping, target.name, dbt.name],
+                ),
             )
             result = cli_runner.invoke(
                 cli,
@@ -269,18 +273,14 @@ class TestCliInstall:
             install_plugin_mock.assert_called_once()
             assert install_plugin_mock.mock_calls[0].args[0] == project
 
-            plugins_installed = [plugin.name for plugin in install_plugin_mock.mock_calls[0].args[1]]
-            plugins_expected = [
-                tap_gitlab.name,
-                mapper.name,
-                target.name,
-                dbt.name
+            plugins_installed = [
+                plugin.name for plugin in install_plugin_mock.mock_calls[0].args[1]
             ]
+            plugins_expected = [tap_gitlab.name, mapper.name, target.name, dbt.name]
             assert sorted(plugins_installed) == sorted(plugins_expected)
-            assert install_plugin_mock.mock_calls[0].kwargs["parallelism"] == None
-            assert install_plugin_mock.mock_calls[0].kwargs["clean"] == False
-            assert install_plugin_mock.mock_calls[0].kwargs["force"] == False
-
+            assert install_plugin_mock.mock_calls[0].kwargs["parallelism"] is None
+            assert install_plugin_mock.mock_calls[0].kwargs["clean"] is False
+            assert install_plugin_mock.mock_calls[0].kwargs["force"] is False
 
     def test_install_schedule_elt(
         self,
@@ -298,7 +298,6 @@ class TestCliInstall:
         ), mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             schedule_service.task_sets_service = task_sets_service
-            from meltano.core.task_sets import TaskSets
 
             result = cli_runner.invoke(
                 cli,
@@ -309,15 +308,18 @@ class TestCliInstall:
             install_plugin_mock.assert_called_once()
             assert install_plugin_mock.mock_calls[0].args[0] == project
 
-            plugins_installed = [plugin.name for plugin in install_plugin_mock.mock_calls[0].args[1]]
+            plugins_installed = [
+                plugin.name for plugin in install_plugin_mock.mock_calls[0].args[1]
+            ]
             plugins_expected = [
                 tap.name,
                 target.name,
             ]
             assert sorted(plugins_installed) == sorted(plugins_expected)
-            assert install_plugin_mock.mock_calls[0].kwargs["parallelism"] == None
-            assert install_plugin_mock.mock_calls[0].kwargs["clean"] == False
-            assert install_plugin_mock.mock_calls[0].kwargs["force"] == False
+            assert install_plugin_mock.mock_calls[0].kwargs["parallelism"] is None
+            assert install_plugin_mock.mock_calls[0].kwargs["clean"] is False
+            assert install_plugin_mock.mock_calls[0].kwargs["force"] is False
+
 
 # un_engine_uri forces us to create a new project, we must do this before the
 # project fixture creates the project see


### PR DESCRIPTION
Closes https://github.com/meltano/meltano/issues/7643

The `install --schedule=x` command had a couple bugs that this PR fixes:
1. it was only handling the schedule syntax that uses job names and not the elt style syntax
2. in a job definition the user defines a mapping not the mapper plugin itself. The original implementation was looking up a plugin using the mapping name instead of the parent mapper.
  - I also refactored this `_get_schedule_plugins` method to more closely mimic the logic used for parsing `meltano run` commands by bring in the `BlockParser`.
  - Previously the `BlockParser`'s only public method was `find_blocks` that returns and invoker. Instead of re-implmenting the block parsing logic I just wanted to piggy back off of whats already there so I chose to make a public `plugins` property to make the post processed plugin list public. I didnt think this would have any negative consequences and it allows me to reuse the code we already have.

@WillDaSilva let me know if you see anything wrong with the implementation from 2 where I add the plugins property.