### PR TITLE
docs: refresh getting started guide

### DIFF
--- a/docs/src/_getting-started/part1.md
+++ b/docs/src/_getting-started/part1.md
@@ -101,7 +101,7 @@ Now that you have your very own Meltano project, it's time to add [plugins](/con
 1.  Add the GitHub extractor
 
 ```bash
-$ meltano add extractor tap-github --variant=meltanolabs
+meltano add extractor tap-github --variant=meltanolabs
 ```
 <br />
 
@@ -132,7 +132,6 @@ extractors:
     variant: meltanolabs
     pip_url: git+https://github.com/MeltanoLabs/tap-github.git
 ```
-
 
 1.  Test that the installation was successful by calling [`meltano invoke`](/reference/command-line-interface#invoke):
 
@@ -174,29 +173,29 @@ The GitHub tap requires [configuration](/guide/configuration) before it can star
 1. The simplest way to configure a new plugin in Meltano is using the mode `interactive`:
 
 ```bash
-$ meltano config tap-github set --interactive
+meltano config tap-github set --interactive
 ```
 
-2. Follow the prompts to step through all available settings, the ones you'll need to fill out are repositories, start_date and your private_token.
+2. Follow the prompts to step through all available settings, the ones you'll need to fill out are repositories (formatted like `["sbalnojan/meltano-lightdash"]`), start_date, and your auth_token.
 <br>
 <div class="termy">
 
 ```console
 $ meltano config tap-github set --interactive
-Configuring Extractor 'tap-github'
+Configuring Extractor 'tap-github' Interactively
 [...]
 Settings
- 1. user_agent:                                                                                                                                                                                   [...]
- 3. auth_token: GitHub token to authenticate ...
-[...]
+ 1. additional_auth_tokens:                                                       [...]
+ 2. auth_token: GitHub token to authenticate ...
+ [...]
  8. repositories: An array of strings containing the github repos to be ...
-[...]
+ [...]
  11. start_date:
  [...]
-To learn more about extractor 'tap-github' and its settings, visit https://hub.meltano.com/extractors/tap-github
+To learn more about extractor 'tap-github' and its settings, visit https://hub.meltano.com/extractors/tap-github--meltanolabs
 
-Loop through all settings (all), select a setting by number (1 - 11), or exit (e)? [all]:
-$ 3
+Loop through all settings (all), select a setting by number (1 - 16), or exit (e)? [all]:
+$ 2
 [...]Description:
 GitHub token to authenticate with.
 New value:
@@ -216,16 +215,13 @@ This will add the configuration to your [`meltano.yml` project file](/concepts/p
           config:
             start_date: '2022-01-01'
             repositories:
-              - sbalnojan/meltano-lightdash
+            - sbalnojan/meltano-lightdash
   ```
 
 It will also add your secret auth token to the file `.env`:
   ```yml
   TAP_GITHUB_AUTH_TOKEN='ghp_XXX' # your token!
   ```
-
-
-
 
 3. Double check the config by running [`meltano config tap-github`](/reference/command-line-interface#config):
 
@@ -267,7 +263,8 @@ meltano select tap-github --list --all
 
 ```console
 $ meltano select tap-github --list
-2022-09-19T10:59:43.554214Z [info     ] Environment 'dev' is active
+2023-05-17T20:07:24.085827Z [info     ] The default environment 'dev' will be ignored for 'meltano select'. To configure a specific environment, please use the option '--environment=environment name'.
+
 Legend:
         selected
         excluded
@@ -305,14 +302,6 @@ This will add the [selection rules](/concepts/plugins#select-extra) to your [`me
   default_environment: dev
   environments:
   - name: dev
-    config:
-      plugins:
-        extractors:
-        - name: tap-github
-          select:
-          - commits.url
-          - commits.sha
-          - commits.commit_timestamp
   - name: staging
   - name: prod
   project_id: YOUR_ID
@@ -325,6 +314,11 @@ This will add the [selection rules](/concepts/plugins#select-extra) to your [`me
         start_date: '2022-01-01'
         repositories:
         - sbalnojan/meltano-lightdash
+      select:
+      - commits.url
+      - commits.sha
+      - commits.commit_timestamp
+
   ```
 
 
@@ -337,12 +331,12 @@ meltano select tap-github --list
 ## Add a dummy loader to dump the data into JSON
 To test that the extraction process works, we add a JSON target.
 
-1. Add the JSON target using ```meltano add loader target-jsonl```.
+1. Add the JSON target using ```meltano add loader target-jsonl --variant=andyh1203```.
 <br>
 <div class="termy">
 
 ```console
-$ meltano add loader target-jsonl</span>
+$ meltano add loader target-jsonl --variant=andyh1203</span>
 Added loader 'target-jsonl' to your Meltano project
 Variant:        andyh1203 (default)
 Repository:     https://github.com/andyh1203/target-jsonl
@@ -364,7 +358,7 @@ Now that [your Meltano project](#create-your-meltano-project), [extractor](#add-
 There's just one step here: run your newly added extractor and jsonl loader in a pipeline using [`meltano run`](/reference/command-line-interface#run):
 
 ```bash
-$ meltano run tap-github target-jsonl
+meltano run tap-github target-jsonl
 ```
 <br>
 <div class="termy">
@@ -390,7 +384,7 @@ You can verify that it worked by looking inside the newly created file called ``
 
 ```console
 $ cat output/commits.jsonl
-{"sha": "409bdd601e0531833665f538bccecd0f69e101c0", "url": "https://api.github.com/repos/sbalnojan/meltano-lightdash/commits/409bdd601e0531833665f538bccecd0f69e101c0"}
+{"sha": "409bdd601e0531833665f538bccecd0f69e101c0", "node_id": "C_kwDOH_twHNoAKDQwOWJkZDYwMWUwNTMxODMzNjY1ZjUzOGJjY2VjZDBmNjllMTAxYzA", "url": "https://api.github.com/repos/sbalnojan/meltano-lightdash/commits/409bdd601e0531833665f538bccecd0f69e101c0", "commit_timestamp": "2022-09-14T12:41:21Z"}
 ```
 
 </div>

--- a/docs/src/_getting-started/part1.md
+++ b/docs/src/_getting-started/part1.md
@@ -21,7 +21,7 @@ We'll assume you have [Meltano installed](/getting-started/installation) already
 
 ```console
 $ meltano --version
-meltano, version 2.6.0
+meltano, version 2.19.0
 </div>
 <br />
 This tutorial is written using meltano >= v2.0.0.

--- a/docs/src/_getting-started/part2.md
+++ b/docs/src/_getting-started/part2.md
@@ -20,7 +20,7 @@ In  [part 1](/getting-started/part1), we extracted data from GitHub and are now 
 We're going to load our data into a dockerized PostgreSQL database running on your laptop. View the [docker docs](https://docs.docker.com/get-docker/) if you don't yet have docker installed. To launch a local PostgreSQL container, you just need to run:
 
 ```bash
-$ docker run -p 5432:5432 -e POSTGRES_USER=meltano -e POSTGRES_PASSWORD=password -d postgres
+docker run --name meltano_postgres -p 5432:5432 -e POSTGRES_USER=meltano -e POSTGRES_PASSWORD=password -d postgres
 ```
 <br />
 <div class="termy">
@@ -155,11 +155,13 @@ You can use `meltano config target-postgres` to check the configuration, includi
 ```console
 $ meltano config target-postgres
 {
-&ensp;&ensp;&ensp;&ensp;"host": "localhost",
-&ensp;&ensp;&ensp;&ensp;"user": "meltano",
-&ensp;&ensp;&ensp;&ensp;"password": "password",
+&ensp;&ensp;&ensp;&ensp;"add_record_metadata": true,
 &ensp;&ensp;&ensp;&ensp;"database": "postgres",
-&ensp;&ensp;&ensp;&ensp;"add_record_metadata": true
+&ensp;&ensp;&ensp;&ensp;"dialect+driver": "postgresql+psycopg2",
+&ensp;&ensp;&ensp;&ensp;"host": "localhost",
+&ensp;&ensp;&ensp;&ensp;"password": "password",
+&ensp;&ensp;&ensp;&ensp;"port": 5432,
+&ensp;&ensp;&ensp;&ensp;"user": "meltano"
 }
 ```
 </div>
@@ -190,6 +192,7 @@ $ meltano run tap-github target-postgres
 </div>
 <br />
 If everything was configured correctly, you should now see your data flow from your source into your destination!
+The postgres database should now have a schema `tap_github` with the table `commits` containing your data.
 
 ## Next Steps
 

--- a/docs/src/_getting-started/part3.md
+++ b/docs/src/_getting-started/part3.md
@@ -29,6 +29,7 @@ This will add the following line to your project file:
 ```yaml
       extractors:
       - name: tap-github
+        [...]
         select:
         - commits.url # <== technically not necessary anymore, but no need to delete
         - commits.sha # <== technically not necessary anymore, but no need to delete
@@ -36,14 +37,14 @@ This will add the following line to your project file:
         - commits.* # <== new data.
 ```
 
-You can test that the new data is extracted by using `meltano invoke`:
+To refresh your database tables after the configuration changes you can run `meltano run --full-refresh tap-github target-postgres`:
 
 <div class="termy">
 ```console
-$ meltano invoke tap-github
+$ meltano run --full-refresh tap-github target-postgres
 2022-09-22T07:36:52.985090Z [info     ] Environment 'dev' is active
 {"type": "STATE", "value":  [...]}
-INFO Starting sync of repository: sbalnojan/meltano-example-el
+INFO Starting sync of repository: sbalnojan/meltano-lightdash
 ---> 100%
 {"type": "SCHEMA", "stream": "commits", [...]
 
@@ -51,57 +52,53 @@ INFO METRIC: {"type": "timer", "metric":  [...]
 
 {"type": "RECORD", "stream": "commits", "record": {"sha": "c771a832720c0f87b3ce53ac12bdcbf742df4e3d", "commit": {"author": {"name": "Horst", "email":
 [...]
-"sbalnojan/meltano-example-el"}, "time_extracted": "2022-09-22T07:37:06.289545Z"}
+"sbalnojan/meltano-lightdash"}, "time_extracted": "2022-09-22T07:37:06.289545Z"}
 
 ...[many more records]...
 
-{"type": "STATE", "value": {"bookmarks": {"sbalnojan/meltano-example-el": {"commits": {"since": "2022-09-22T07:37:06.289545Z"}}}}}
+{"type": "STATE", "value": {"bookmarks": {"sbalnojan/meltano-lightdash": {"commits": {"since": "2022-09-22T07:37:06.289545Z"}}}}}
 ´´´
 </div>
 
 Next, we add the dbt plugin to transform this data.
 
-## Install and configure the postgres specific dbt transformer
-dbt uses different [adapters](https://docs.getdbt.com/docs/supported-data-platforms) depending on the database/warehouse/platform you use. Meltano transformers match this pattern; in this case our transformer is `dbt-postgres`. As usual, you can use the `meltano add` command to add it to your project.
+## Install the postgres specific dbt utility
+dbt uses different [adapters](https://docs.getdbt.com/docs/supported-data-platforms) depending on the database/warehouse/platform you use. Meltano dbt utilities match this pattern; in this case our adapter is `dbt-postgres`. As usual, you can use the `meltano add` command to add it to your project.
 
 <div class="termy">
 
 ```console
-$ meltano add transformer dbt-postgres
-2022-09-22T11:32:35.601357Z [info     ] Environment 'dev' is active
-Added transformer 'dbt-postgres' to your Meltano project
+$ meltano add utility dbt-postgres
+AAdded utility 'dbt-postgres' to your Meltano project
 Variant:        dbt-labs (default)
 Repository:     https://github.com/dbt-labs/dbt-core
-Documentation:  https://docs.meltano.com/guide/transformation
+Documentation:  https://hub.meltano.com/utilities/dbt-postgres--dbt-labs
 
-Adding required file bundle 'files-dbt-postgres' to your Meltano project...
-Variant:        meltano (default)
-Repository:     https://github.com/meltano/files-dbt-postgres
-Documentation:  https://hub.meltano.com/files/files-dbt-postgres
+Installing utility 'dbt-postgres'...
+Installed utility 'dbt-postgres'
 
-Installing transformer 'dbt-postgres'...
----> 100%
-Installing file bundle 'files-dbt-postgres'..
----> 100%
-Installed file bundle 'files-dbt-postgres'
+To learn more about utility 'dbt-postgres', visit https://hub.meltano.com/utilities/dbt-postgres--dbt-labs
+```
 
-Adding 'files-dbt-postgres' files to project...
-Created transform/.gitignore (files-dbt-postgres)
-Created transform/dbt_project (files-dbt-postgres).yml
-Created transform/models/.gitkeep (files-dbt-postgres)
-Created transform/profiles/postgres/profiles (files-dbt-postgres).yml
+</div>
 
-Installed transformer 'dbt-postgres'
-Installed 2/2 plugins
+## Initialize dbt
 
-To learn more about transformer 'dbt-postgres', visit https://docs.meltano.com/guide/transformation
-To learn more about file bundle 'files-dbt-postgres', visit https://hub.meltano.com/files/files-dbt-postgres
+Next you can run the `initialize` command to have the transformer utility populate the project scaffold for dbt.
+
+<div class="termy">
+
+```console
+$ meltano invoke dbt-postgres:initialize
+2022-09-22T07:36:52.985090Z [info     ] Environment 'dev' is active
+creating dbt profiles directory path=PosixPath('/[...]/my-meltano-project/transform/profiles/postgres')
+dbt initialized                dbt_ext_type=postgres dbt_profiles_dir=PosixPath('/[...]/my-meltano-project/transform/profiles/postgres') dbt_project_dir=PosixPath('/[...]/my-meltano-project/transform')
 ```
 
 </div>
 
 <br />
-As you can see, this adds both the transformer as well as a [file bundle](/concepts/plugins#file-bundles) to your project. You can verify that this worked by viewing the newly populated directory `transform`.
+You can verify that this worked by viewing that the `transform` directory is newly populated with dbt configuration files.
 
 ## Configure dbt
 Configure the dbt-postgres transformer to use the same configuration as our target-postgres loader using `meltano config`:
@@ -123,6 +120,22 @@ $ meltano config dbt-postgres set schema analytics
 ```
 </div>
 
+<br />
+The result of your configuration will look like this in your meltano.yml, remember that sensitive configurations are in your .env file:
+
+
+```yaml
+  utilities:
+  - name: dbt-postgres
+    [...]
+    config:
+      host: localhost
+      port: 5432
+      user: meltano
+      dbname: postgres
+      schema: analytics
+```
+
 ## Add our source data to dbt
 The EL pipeline run already added our source data into the schema `tap_github` as table `commits`. dbt will need to know where to locate this data. Let's add that to our dbt project:
 
@@ -130,7 +143,7 @@ The EL pipeline run already added our source data into the schema `tap_github` a
 mkdir transform/models/tap_github
 ```
 
-Add a file called `source.yml` into this directory with the following content:
+Add a file called `transform/models/tap_github/source.yml` into this directory with the following content:
 
 ```yaml
 config-version: 2
@@ -155,37 +168,49 @@ Add a file called `authors.sql` to the folder `transform/models/tap_github` with
   )
 }}
 
+with base as (
+    select *
+    from {{ source('tap_github', 'commits') }} {% endraw %}
+)
+select distinct (commit -> 'author' -> 'name') as authors
+from base
 
-with base as (select *
-from {{ source('tap_github', 'commits') }}) {% endraw %}
-
-select distinct (commit -> 'author' -> 'name') as authors from base
 ```
 
 This model is configured to creating a table via the `materialized='table'` configuration. The keyword `source` is used in dbt to reference the source we just created. The actual model selects the distinct author names from the commits which are wrapped into a JSON blob.
 
 ## Run the transformation process
-To create the actual table, we run the dbt model via `meltano invoke dbt-postgres:run`:
+To create the actual table, we run the dbt model via `meltano invoke dbt-postgres:run`. Note this relies on previously running `meltano run --full-refresh tap-github target-postgres` to postgres your database `commits` table:
 
 <div class="termy">
 
 ```console
 $ meltano invoke dbt-postgres:run
 2022-09-22T12:30:31.842691Z [info     ] Environment 'dev' is active
-12:31:01  Running with dbt=1.1.2
-12:31:02  Found 1 model, 0 tests, 0 snapshots, 0 analyses, 167 macros, 0 operations, 0 seed files, 1 source, 0 exposures, 0 metrics
-12:31:02
-12:31:03  Concurrency: 2 threads (target='dev')
-12:31:03
-12:31:03  1 of 1 START table model analytics.authors ..................................... [RUN]
----> 100%
-12:31:03  1 of 1 OK created table model analytics.authors ................................ [SELECT 2 in 0.59s]
-12:31:03
-12:31:03  Finished running 1 table model in 1.56s.
-12:31:03
-12:31:03  Completed successfully
-12:31:04
-12:31:04  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
+Extension executing `dbt clean`...
+[...]
+20:45:09  Finished cleaning all paths.
+
+
+Extension executing `dbt deps`...
+20:45:12  Running with dbt=1.3.4
+20:45:12  Warning: No packages were found in packages.yml
+
+
+Extension executing `dbt run`...
+20:45:15  Running with dbt=1.3.4
+20:45:15  Found 1 model, 0 tests, 0 snapshots, 0 analyses, 289 macros, 0 operations, 0 seed files, 1 source, 0 exposures, 0 metrics
+20:45:15
+20:45:15  Concurrency: 2 threads (target='dev')
+20:45:15
+20:45:15  1 of 1 START sql table model analytics.auhtors ................................. [RUN]
+20:45:15  1 of 1 OK created sql table model analytics.auhtors ............................ [SELECT 1 in 0.14s]
+20:45:15
+20:45:15  Finished running 1 table model in 0 hours 0 minutes and 0.31 seconds (0.31s).
+20:45:15
+20:45:15  Completed successfully
+20:45:15
+20:45:15  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
 #
 ```
 
@@ -198,7 +223,7 @@ You can check the data inside the database using your favourite SQL editor. Ther
 To check that everything works together as a pipeline, we clean out once more and run the whole ELT pipeline. Drop the tap_github.commits and the analytics.authors tables by running
 
 ```bash
-docker exec meltano_postgres psql -U meltano -c 'DROP TABLE tap_github.commits; DROP TABLE analytics.authors;'
+docker exec meltano_postgres psql -d postgres -U meltano -c 'DROP TABLE tap_github.commits; DROP TABLE analytics.authors;'
 ```
 
 Run the final pipeline alltogether using the parameter `--full-refresh` to ignore the stored state:
@@ -209,7 +234,7 @@ Run the final pipeline alltogether using the parameter `--full-refresh` to ignor
 $ meltano run --full-refresh tap-github target-postgres dbt-postgres:run
 [warning  ] Performing full refresh, ignoring state left behind by any previous runs.
 
- [info     ] INFO Starting sync of repository: sbalnojan/meltano-example-el
+ [info     ] INFO Starting sync of repository: sbalnojan/meltano-lightdash
  <font color="red">[...]</font>
 [info     ] INFO METRIC: {"type": "timer", "metric": "http_request_duration",[...]
 


### PR DESCRIPTION
I re-read through the getting started guide after someone reported seeing issues in slack https://meltano.slack.com/archives/C01TCRBBJD7/p1684327364192699 and I noticed its quite out dated especially when it comes to the dbt parts.

I've noticed that more and more people are reporting issues with dbt and airflow when using the original transformer/orchestrator plugin types but once they switch to utilities their problems are resolved. Ideally we'd get all our docs cleaned up to improve the onboarding experience.

- removed `$` from the commands because they were inconsistent and made it hard to copy and paste
- refresh some outputs and configs since the plugins have changed over time
- the tutorial starts by using `sbalnojan/meltano-lightdash` as the repo then switched to `sbalnojan/meltano-example-el`. I think this was a bug because there was no text telling the user to switch their configs.
- dbt utility instead of transformer
- the first dbt invoke command threw an error because it never told the user to run a tap/target sync after updating the selection critieria to "*". The commit column didnt exist for me.
- The docker command to start postgres needs to assign a name so later we can use it in the `exec` commands. Previously the postgres container was getting a randomly generated name.
- Also for the docker commands to drop tables we didnt provide a database name so I was getting errors like "table not found"
- Add an sample of the data for the mapper section to clarify what its doing.


TODO:
- the numbers arent rendering properly in the current version or my version but I couldnt get them to increment properly