### PR TITLE
feat: Use the default deployment by default

### DIFF
--- a/src/cloud-cli/meltano/cloud/cli/run.py
+++ b/src/cloud-cli/meltano/cloud/cli/run.py
@@ -51,9 +51,7 @@ async def run(
 ) -> None:
     """Run a Meltano project in Meltano Cloud."""
     deployment = (
-        deployment
-        if deployment is not None
-        else context.config.default_deployment_name
+        deployment if deployment is not None else context.config.default_deployment_name
     )
     if deployment is None:
         raise click.UsageError(

--- a/src/cloud-cli/meltano/cloud/cli/run.py
+++ b/src/cloud-cli/meltano/cloud/cli/run.py
@@ -40,7 +40,6 @@ async def run_project(
 @click.argument("job_or_schedule")
 @click.option(
     "--deployment",
-    required=True,
     help="The name of the Meltano Cloud deployment to run in.",
 )
 @pass_context
@@ -48,9 +47,18 @@ async def run_project(
 async def run(
     context: MeltanoCloudCLIContext,
     job_or_schedule: str,
-    deployment: str,
+    deployment: str | None = None,
 ) -> None:
     """Run a Meltano project in Meltano Cloud."""
+    if deployment is None:
+        if context.config.default_deployment_name is not None:
+            deployment = context.config.default_deployment_name
+        else:
+            raise click.UsageError(
+                "A deployment name is required. Please specify "
+                "one with the '--deployment' option, or specify a default"
+                "deployment by running 'meltano cloud deployment use'.",
+            )
     click.echo("Running a Meltano project in Meltano Cloud.")
 
     result = await run_project(

--- a/src/cloud-cli/meltano/cloud/cli/run.py
+++ b/src/cloud-cli/meltano/cloud/cli/run.py
@@ -50,15 +50,17 @@ async def run(
     deployment: str | None = None,
 ) -> None:
     """Run a Meltano project in Meltano Cloud."""
+    deployment = (
+        deployment
+        if deployment is not None
+        else context.config.default_deployment_name
+    )
     if deployment is None:
-        if context.config.default_deployment_name is not None:
-            deployment = context.config.default_deployment_name
-        else:
-            raise click.UsageError(
-                "A deployment name is required. Please specify "
-                "one with the '--deployment' option, or specify a default"
-                "deployment by running 'meltano cloud deployment use'.",
-            )
+        raise click.UsageError(
+            "A deployment name is required. Please specify "
+            "one with the '--deployment' option, or specify a default"
+            "deployment by running 'meltano cloud deployment use'.",
+        )
     click.echo("Running a Meltano project in Meltano Cloud.")
 
     result = await run_project(

--- a/src/cloud-cli/meltano/cloud/cli/schedule.py
+++ b/src/cloud-cli/meltano/cloud/cli/schedule.py
@@ -150,15 +150,17 @@ async def _set_enabled_state(
 ):
     if schedule_name is None:
         raise click.UsageError("Missing option '--schedule'")
+    deployment_name = (
+        deployment_name
+        if deployment_name is not None
+        else config.default_deployment_name
+    )
     if deployment_name is None:
-        if config.default_deployment_name is not None:
-            deployment_name = config.default_deployment_name
-        else:
-            raise click.UsageError(
-                "A deployment name is required. Please specify "
-                "one with the '--deployment' option, or specify a default"
-                "deployment by running 'meltano cloud deployment use'.",
-            )
+        raise click.UsageError(
+            "A deployment name is required. Please specify "
+            "one with the '--deployment' option, or specify a default"
+            "deployment by running 'meltano cloud deployment use'.",
+        )
     async with SchedulesCloudClient(config=config) as client:
         await client.set_schedule_enabled(
             deployment_name=deployment_name,

--- a/src/cloud-cli/meltano/cloud/cli/schedule.py
+++ b/src/cloud-cli/meltano/cloud/cli/schedule.py
@@ -151,7 +151,14 @@ async def _set_enabled_state(
     if schedule_name is None:
         raise click.UsageError("Missing option '--schedule'")
     if deployment_name is None:
-        raise click.UsageError("Missing option '--deployment'")
+        if config.default_deployment_name is not None:
+            deployment_name = config.default_deployment_name
+        else:
+            raise click.UsageError(
+                "A deployment name is required. Please specify "
+                "one with the '--deployment' option, or specify a default"
+                "deployment by running 'meltano cloud deployment use'.",
+            )
     async with SchedulesCloudClient(config=config) as client:
         await client.set_schedule_enabled(
             deployment_name=deployment_name,

--- a/src/cloud-cli/tests/cli/test_run.py
+++ b/src/cloud-cli/tests/cli/test_run.py
@@ -48,3 +48,29 @@ class TestCloudRun:
         )
         assert result.exit_code == 0
         assert "Running a Meltano project in Meltano Cloud" in result.output
+
+    def test_run_ok_with_default_deployment(
+        self,
+        tenant_resource_key: str,
+        internal_project_id: str,
+        config: MeltanoCloudConfig,
+        httpserver: HTTPServer,
+    ):
+        deployment = "default-sandbox"
+        job_or_schedule = "daily"
+        path = (
+            f"/run/v1/external/"
+            f"{tenant_resource_key}/{internal_project_id}/"
+            f"{deployment}/{job_or_schedule}"
+        )
+        config.default_deployment_name = deployment
+        config.write_to_file()
+        httpserver.expect_oneshot_request(path).respond_with_data(
+            b"Running a Meltano project in Meltano Cloud",
+        )
+        result = CliRunner().invoke(
+            cli,
+            ["--config-path", config.config_path, "run", job_or_schedule],
+        )
+        assert result.exit_code == 0
+        assert "Running a Meltano project in Meltano Cloud" in result.output

--- a/src/cloud-cli/tests/cli/test_run.py
+++ b/src/cloud-cli/tests/cli/test_run.py
@@ -74,3 +74,29 @@ class TestCloudRun:
         )
         assert result.exit_code == 0
         assert "Running a Meltano project in Meltano Cloud" in result.output
+
+    def test_run_fails_when_missing_deployment(
+        self,
+        tenant_resource_key: str,
+        internal_project_id: str,
+        config: MeltanoCloudConfig,
+        httpserver: HTTPServer,
+    ):
+        deployment = "default-sandbox"
+        job_or_schedule = "daily"
+        path = (
+            f"/run/v1/external/"
+            f"{tenant_resource_key}/{internal_project_id}/"
+            f"{deployment}/{job_or_schedule}"
+        )
+        config.default_deployment_name = None
+        config.write_to_file()
+        httpserver.expect_oneshot_request(path).respond_with_data(
+            b"Running a Meltano project in Meltano Cloud",
+        )
+        result = CliRunner().invoke(
+            cli,
+            ["--config-path", config.config_path, "run", job_or_schedule],
+        )
+        assert result.exit_code == 2
+        assert "A deployment name is required." in result.output

--- a/src/cloud-cli/tests/cli/test_schedules.py
+++ b/src/cloud-cli/tests/cli/test_schedules.py
@@ -49,6 +49,35 @@ class TestScheduleCommand:
                 assert result.exit_code == 0, result.output
                 assert not result.output
 
+    def test_schedule_enable_with_default_deployment(
+        self,
+        tenant_resource_key: str,
+        internal_project_id: str,
+        config: MeltanoCloudConfig,
+        httpserver: HTTPServer,
+    ):
+        path = (
+            f"/schedules/v1/{tenant_resource_key}/{internal_project_id}"
+            "/test-deployment/daily/enabled"
+        )
+        config.default_deployment_name = "test-deployment"
+        config.write_to_file()
+        runner = CliRunner()
+        for cmd in ("enable", "disable"):
+            httpserver.expect_oneshot_request(path).respond_with_data(status=204)
+            result = runner.invoke(
+                cli,
+                (
+                    "--config-path",
+                    config.config_path,
+                    "schedule",
+                    cmd,
+                    "--schedule=daily",
+                ),
+            )
+            assert result.exit_code == 0, result.output
+            assert not result.output
+
     @pytest.fixture()
     def schedules(self) -> list[CloudProjectSchedule]:
         return [


### PR DESCRIPTION
This PR makes it so that the following commands no longer require the `--deployment` option when a default deployment is configured:
- `meltano cloud run <job or schedule name>`
- `meltano schedule enable --schedule <schedule name>`

Note that this does not affect all Cloud CLI commands with a `--deployment` option. It wouldn't be appropriate to use the selected deployment for `meltano cloud history`, for instance, since that filters results, rather than controls what you're acting on.

Closes #7721