### PR TITLE
docs: Fix `mappers.md` sample command

### DIFF
--- a/docs/src/_guide/mappers.md
+++ b/docs/src/_guide/mappers.md
@@ -152,7 +152,7 @@ plugins
             ip_address: __NULL__
 ```
 
-After running `meltano run tap-csv hash_email target-sqlite` the result would be:
+After running `meltano run tap-csv lower target-sqlite` the result would be:
 
 | count_t |           email            | first_name | id | last_name  |        __loaded_at         |
 |---------|----------------------------|------------|----|------------|----------------------------|


### PR DESCRIPTION
The sample command was wrong relative to the yaml provided.