### PR TITLE
fix: python code formatting in Custom Extractor docs

### DIFF
--- a/docs/src/_tutorials/custom-extractor.md
+++ b/docs/src/_tutorials/custom-extractor.md
@@ -153,37 +153,23 @@ from typing import List
 
 from singer_sdk import Tap, Stream
 
-from singer_sdk import typing as th # JSON schema typing helpers
+from singer_sdk import typing as th  # JSON schema typing helpers
 
-from tap_jsonplaceholder.streams import (
-
-jsonplaceholderStream,
-
-CommentsStream
-
-)
+from tap_jsonplaceholder.streams import jsonplaceholderStream, CommentsStream
 
 
-STREAM_TYPES = [
-
-CommentsStream
-
-]
+STREAM_TYPES = [CommentsStream]
 
 
 class Tapjsonplaceholder(Tap):
+    """jsonplaceholder tap class."""
 
-"""jsonplaceholder tap class."""
+    name = "tap-jsonplaceholder"
 
-name = "tap-jsonplaceholder"
+    def discover_streams(self) -> List[Stream]:
+        """Return a list of discovered streams."""
 
-
-
-def discover_streams(self) -> List[Stream]:
-
-"""Return a list of discovered streams."""
-
-return [stream_class(tap=self) for stream_class in STREAM_TYPES]
+        return [stream_class(tap=self) for stream_class in STREAM_TYPES]
 
 ```
 


### PR DESCRIPTION
fixes code formatting of 
https://docs.meltano.com/tutorials/custom-extractor#4-configure-the-custom-extractor-to-consume-data-from-the-source

related slack comments - https://meltano.slack.com/archives/CMN8HELB0/p1685892315328349