### PR TITLE
fix: Use clear error message for `meltano cloud project use` with no projects

### DIFF
--- a/src/cloud-cli/meltano/cloud/cli/project.py
+++ b/src/cloud-cli/meltano/cloud/cli/project.py
@@ -242,6 +242,11 @@ class ProjectChoicesQuestionaryOption(click.Option):
             ),
             {"project_name": None},
         )["project_name"]
+        if not context.projects:
+            raise click.ClickException(
+                "No Meltano Cloud projects available to use. Please create a "
+                "project before running 'meltano cloud project use'.",
+            )
         return questionary.select(
             message="",
             qmark="Use Meltano Cloud project",


### PR DESCRIPTION
Closes #7770 