### PR TITLE
fix: Hide 'Login successful' message when login failed

### DIFF
--- a/src/cloud-cli/meltano/cloud/api/auth/callback.jinja2
+++ b/src/cloud-cli/meltano/cloud/api/auth/callback.jinja2
@@ -7,7 +7,7 @@
         display: block;
       }
 
-      #successs-message {
+      #success-message {
         display: none;
       }
 


### PR DESCRIPTION
When `meltano cloud login` failed, it would open a webpage with the following:
```
Logged in. You may close this window.

Login failed. You may close this window.
```

This fix makes it only show:
```
Login failed. You may close this window.
```