### PR TITLE
fix: Clarify no Meltano Cloud project error message

### DIFF
--- a/src/cloud-cli/meltano/cloud/api/config.py
+++ b/src/cloud-cli/meltano/cloud/api/config.py
@@ -72,8 +72,8 @@ class NoMeltanoCloudProjectIDError(Exception):
     def __init__(self) -> None:
         """Initialize exception with message."""
         super().__init__(
-            "Logged in Meltano user has no projects. "
-            "Set one as the default project using the "
+            "No Meltano Cloud projects are available, or no project has been "
+            "selected as the default. Set one as the default using the "
             "`meltano cloud project use` command.",
         )
 


### PR DESCRIPTION
Previously this error message would state that the user has no Meltano Cloud projects even if they did.