### PR TITLE
docs: Update schedule interval with single quotes

### DIFF
--- a/docs/src/_cloud/onboarding.md
+++ b/docs/src/_cloud/onboarding.md
@@ -40,7 +40,7 @@ If you don't yet have an existing schedule, you can get started quickly by copy-
 schedules:
 - name: daily-refresh
   job: daily-refresh-job
-  interval: @daily  # Can be @daily, @hourly, etc., or a cron-based interval
+  interval: '@daily'  # Can be @daily, @hourly, etc., or a cron-based interval
 jobs:
 - name: daily-refresh-job
   tasks:


### PR DESCRIPTION
`meltano compile` will fail if the schedule contains `@` and is not single quoted. This is a reserved variable in yaml and requires being quoted. 
`meltano schedule add` already adds the schedule in `meltano.yml` with single quotes.  