### PR TITLE
docs: add cloud deployment hints for common errors

### DIFF
--- a/docs/src/_cloud/cloud-cli.md
+++ b/docs/src/_cloud/cloud-cli.md
@@ -66,7 +66,7 @@ The above example creates a new deployment named `my-dev-deployment` for the Mel
 
 <div class="notification is-info">
   <p>If your deployment is failing you can try running <a href="/reference/command-line-interface#compile">`meltano compile`</a> to confirm that your configuration files are valid.
-  Also double check that you have schedules configured, otherwise the deployment will throw and error.</p>
+  Also double check that you have schedules configured, otherwise the deployment will throw an error.</p>
 </div>
 
 List deployments:

--- a/docs/src/_cloud/cloud-cli.md
+++ b/docs/src/_cloud/cloud-cli.md
@@ -64,6 +64,11 @@ meltano-cloud deployment create --name 'my-dev-deployment' --environment 'dev' -
 
 The above example creates a new deployment named `my-dev-deployment` for the Meltano environment named `dev`, using the `develop` branch of the project's git repository. Note that the Meltano environment name must match what is in `meltano.yml`.
 
+<div class="notification is-info">
+  <p>If your deployment is failing you can try running <a href="/reference/command-line-interface#compile">`meltano compile`</a> to confirm that your configuration files are valid.
+  Also double check that you have schedules configured, otherwise the deployment will throw and error.</p>
+</div>
+
 List deployments:
 
 ```sh

--- a/docs/src/_cloud/onboarding.md
+++ b/docs/src/_cloud/onboarding.md
@@ -120,7 +120,7 @@ meltano-cloud deployment create --name production --environment prod --git-rev m
 
 <div class="notification is-info">
   <p>If your deployment is failing you can try running <a href="/reference/command-line-interface#compile">`meltano compile`</a> to confirm that your configuration files are valid.
-  Also double check that you have schedules configured, otherwise the deployment will throw and error.</p>
+  Also double check that you have schedules configured, otherwise the deployment will throw an error.</p>
 </div>
 
 To confirm that your deployment was created, you can view all of your Meltano Cloud deployments by running:

--- a/docs/src/_cloud/onboarding.md
+++ b/docs/src/_cloud/onboarding.md
@@ -118,6 +118,11 @@ For example, if you wanted to deploy the `prod` Meltano Environment as defined i
 meltano-cloud deployment create --name production --environment prod --git-rev main
 ```
 
+<div class="notification is-info">
+  <p>If your deployment is failing you can try running <a href="/reference/command-line-interface#compile">`meltano compile`</a> to confirm that your configuration files are valid.
+  Also double check that you have schedules configured, otherwise the deployment will throw and error.</p>
+</div>
+
 To confirm that your deployment was created, you can view all of your Meltano Cloud deployments by running:
 ```console
 meltano-cloud deployment list


### PR DESCRIPTION
I've seen a bunch of slack threads with cloud users who are struggling to get their deployment to work and its almost always an issue with their config or the fact that they were missing schedules and the deployment requires it.

Theres a couple issues already for improving the error messages but it doesnt hurt to give a few hints in the docs as well.

- https://github.com/meltano/infra/issues/1197
- https://github.com/meltano/infra/issues/1360
- etc.

Feel free to suggest other wording, I just wanted to open the PR with some content to start.