### PR TITLE
chore: Generalize `poetry.lock` check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         # use a local hook to avoid that bug:
         # https://github.com/meltano/meltano/pull/7238#issuecomment-1409434351
         name: check that `poetry.lock` conforms to `pyproject.toml`
-        entry: poetry lock --check
+        entry: sh -c 'find . -type f -name poetry.lock -print0 | xargs -0 -n 1 -P 0 sh -c 'cd "$(dirname "$1")" && echo "$(pwd)/poetry.lock" && poetry lock --check' _ {} \;'
         language: python
         pass_filenames: false
         additional_dependencies:
@@ -27,7 +27,7 @@ repos:
       - id: trailing-whitespace
         exclude: ^src/meltano/core/cli_messages\.py$
       - id: end-of-file-fixer
-        exclude: ^.*/plugins/.*/*.\.lock$
+        exclude: ^.*/plugins/.*/.*\.lock$
       - id: check-yaml
       - id: check-json
       - id: pretty-format-json


### PR DESCRIPTION
This addresses a `TODO` comment in the `cloud` branch for this code, as there it has to check multiple `poetry.lock` files.

Relates to:
- https://github.com/meltano/infra/pull/1424

The `TODO` comment in question:

https://github.com/meltano/meltano/blob/b4c45ba394a417576b87ff3f4a8b774bfdfc6ba0/.pre-commit-config.yaml#L18-L20