### PR TITLE
chore: update run cli output

### DIFF
--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -86,8 +86,8 @@ async def run(
     Run a set of command blocks in series.
 
     Blocks are specified as either:\n
-      * a list of plugin names\n
-      * a job name\n
+      - a list of plugin names\n
+      - a job name\n
     An example of a list of plugin names is: `meltano run some_extractor some_loader some_plugin:some_optional_command`. These would be run in the order they are specified from left to right. A failure in any block will cause the entire run to abort.
 
     Multiple command blocks can be chained together or repeated, and tap/target pairs will automatically be linked:

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -85,9 +85,10 @@ async def run(
     """
     Run a set of command blocks in series.
 
-    Blocks are specified as a list of plugin names, e.g.
-    `meltano run some_extractor some_loader some_plugin:some_optional_command` and are run in the order they are specified
-    from left to right. A failure in any block will cause the entire run to abort.
+    Blocks are specified as either:\n
+      * a list of plugin names\n
+      * a job name\n
+    An example of a list of plugin names is: `meltano run some_extractor some_loader some_plugin:some_optional_command`. These would be run in the order they are specified from left to right. A failure in any block will cause the entire run to abort.
 
     Multiple command blocks can be chained together or repeated, and tap/target pairs will automatically be linked:
 


### PR DESCRIPTION
We didn't mention in the CLI output that you could run jobs in addition to blocks.

<img width="726" alt="Screenshot 2023-06-22 at 1 40 25 PM" src="https://github.com/meltano/meltano/assets/5394188/2e8775a9-1a22-45ea-8dda-2042ae0dc5f3">
