### PR TITLE
fix: Fix Cloud-cli tests if env variables are set.

### DIFF
--- a/src/cloud-cli/tests/conftest.py
+++ b/src/cloud-cli/tests/conftest.py
@@ -17,7 +17,6 @@ def unset_env_vars(monkeypatch: pytest.MonkeyPatch):
 
     MeltanoCloudConfig __getattribute__ overrides the config value on get
     to env vars if set. This causes tests to fail unless you unset the env variables.
-
     """
     monkeypatch.delenv("MELTANO_CLOUD_BASE_URL", raising=False)
     monkeypatch.delenv("MELTANO_CLOUD_BASE_AUTH_URL", raising=False)

--- a/src/cloud-cli/tests/conftest.py
+++ b/src/cloud-cli/tests/conftest.py
@@ -11,6 +11,20 @@ from pytest_structlog import StructuredLogCapture
 from meltano.cloud.api.config import MeltanoCloudConfig
 
 
+@pytest.fixture(autouse=True)
+def unset_env_vars(monkeypatch: pytest.MonkeyPatch):
+    """Unsets possible env variables set during development while using Meltano Cloud.
+
+    MeltanoCloudConfig __getattribute__ overrides the config value on get
+    to env vars if set. This causes tests to fail unless you unset the env variables.
+
+    """
+    monkeypatch.delenv("MELTANO_CLOUD_BASE_URL", raising=False)
+    monkeypatch.delenv("MELTANO_CLOUD_BASE_AUTH_URL", raising=False)
+    monkeypatch.delenv("MELTANO_CLOUD_APP_CLIENT_ID", raising=False)
+    monkeypatch.delenv("MELTANO_CLOUD_TENANT_RESOURCE_KEY", raising=False)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def config_path(tmpdir_factory: pytest.TempdirFactory) -> Path:
     """Return the path to the test configuration file."""


### PR DESCRIPTION
Cloud-cli tests would fail with Nox due to environment variables being set. 

Closes: https://github.com/meltano/meltano/issues/7841