### PR TITLE
fix: Create hierarchical structure for remembering org project and deployment defaults

### DIFF
--- a/src/cloud-cli/meltano/cloud/api/auth/auth.py
+++ b/src/cloud-cli/meltano/cloud/api/auth/auth.py
@@ -197,12 +197,11 @@ class MeltanoCloudAuth:  # noqa: WPS214
 
     @asynccontextmanager
     async def _get_user_info_response(self) -> t.AsyncIterator[aiohttp.ClientResponse]:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                urljoin(self.base_url, "oauth2/userInfo"),
-                headers=self.get_access_token_header(),
-            ) as response:
-                yield response
+        async with aiohttp.ClientSession() as session, session.get(
+            urljoin(self.base_url, "oauth2/userInfo"),
+            headers=self.get_access_token_header(),
+        ) as response:
+            yield response
 
     async def get_user_info_response(self) -> aiohttp.ClientResponse:
         """Get user info.

--- a/src/cloud-cli/meltano/cloud/api/config.py
+++ b/src/cloud-cli/meltano/cloud/api/config.py
@@ -117,6 +117,7 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
             default_project_id: The ID of the default Meltano Cloud project.
             default_deployment_name: The name of the default Meltano Cloud
                 deployment.
+            organizations_defaults: Default org settings.
         """
         self.auth_callback_port = auth_callback_port
         self.base_url = base_url
@@ -252,7 +253,11 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
 
     @property
     def internal_organization_default(self) -> CloudConfigOrg:
-        """Get the current tenant resource key defaults for projects and deployments"""
+        """Get the current tenant resource key defaults for projects and deployments.
+
+        Returns:
+            The current tenant resource key default project and list of projects
+        """
         if (
             self.organizations_defaults
             and self.tenant_resource_key in self.organizations_defaults
@@ -266,7 +271,11 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
 
     @internal_organization_default.setter
     def internal_organization_default(self, org_default: CloudConfigOrg) -> None:
-        """Sets the internal organization defaults and updates the config file"""
+        """Set the internal organization defaults and updates the config file.
+
+        Args:
+            org_default: the new default organization settings
+        """
         if not self.organizations_defaults:
             self.organizations_defaults = {}
 
@@ -275,7 +284,11 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
 
     @property
     def internal_project_default(self) -> CloudConfigProject:
-        """Get the current org projects default settings"""
+        """Get the current org projects default settings.
+
+        Returns:
+            The current project deployment defaults
+        """
         org_default = self.internal_organization_default
         if self.internal_project_id in org_default:
             return self.internal_organization_default[self.internal_project_id]
@@ -286,7 +299,11 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
 
     @internal_project_default.setter
     def internal_project_default(self, project_default: CloudConfigProject) -> None:
-        """Set the current org projects default settings and update config file"""
+        """Set the current org projects default settings and update config file.
+
+        Args:
+            project_default: the new default project settings
+        """
         org_default = self.internal_organization_default
         org_default["projects"][self.internal_project_id] = project_default
         self.internal_organization_default = org_default

--- a/src/cloud-cli/meltano/cloud/api/config.py
+++ b/src/cloud-cli/meltano/cloud/api/config.py
@@ -226,10 +226,9 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
             project_id: The Meltano Cloud project ID that should be used.
         """
         self.default_project_id = project_id
-        self.internal_organization_default = {
-            **self.internal_organization_default,
-            "default_project_id": project_id,
-        }
+        org_default = self.internal_organization_default
+        org_default["default_project_id"] = project_id
+        self.internal_organization_default = org_default
 
     @property
     def tenant_resource_key(self) -> str:
@@ -290,8 +289,8 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
             The current project deployment defaults
         """
         org_default = self.internal_organization_default
-        if self.internal_project_id in org_default:
-            return self.internal_organization_default[self.internal_project_id]
+        if self.internal_project_id in org_default["projects"]:
+            return org_default["projects"][self.internal_project_id]
 
         new_project_config = CloudConfigProject(default_deployment_name=None)
         self.internal_project_default = new_project_config

--- a/src/cloud-cli/meltano/cloud/api/config.py
+++ b/src/cloud-cli/meltano/cloud/api/config.py
@@ -226,9 +226,8 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
             project_id: The Meltano Cloud project ID that should be used.
         """
         self.default_project_id = project_id
-        org_default = self.internal_organization_default
-        org_default["default_project_id"] = project_id
-        self.internal_organization_default = org_default
+        self.internal_organization_default["default_project_id"] = project_id
+        self.write_to_file()
 
     @property
     def tenant_resource_key(self) -> str:
@@ -263,10 +262,10 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
         ):
             return self.organizations_defaults[self.tenant_resource_key]
 
-        new_org_default = CloudConfigOrg(default_project_id=None, projects={})
+        new_org_defaults = CloudConfigOrg(default_project_id=None, projects_defaults={})
 
-        self.internal_organization_default = new_org_default
-        return new_org_default
+        self.internal_organization_default = new_org_defaults
+        return new_org_defaults
 
     @internal_organization_default.setter
     def internal_organization_default(self, org_default: CloudConfigOrg) -> None:
@@ -289,8 +288,8 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
             The current project deployment defaults
         """
         org_default = self.internal_organization_default
-        if self.internal_project_id in org_default["projects"]:
-            return org_default["projects"][self.internal_project_id]
+        if self.internal_project_id in org_default["projects_defaults"]:
+            return org_default["projects_defaults"][self.internal_project_id]
 
         new_project_config = CloudConfigProject(default_deployment_name=None)
         self.internal_project_default = new_project_config
@@ -304,7 +303,7 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
             project_default: the new default project settings
         """
         org_default = self.internal_organization_default
-        org_default["projects"][self.internal_project_id] = project_default
+        org_default["projects_defaults"][self.internal_project_id] = project_default
         self.internal_organization_default = org_default
 
     @staticmethod

--- a/src/cloud-cli/meltano/cloud/api/types.py
+++ b/src/cloud-cli/meltano/cloud/api/types.py
@@ -74,4 +74,4 @@ class CloudConfigOrg(TypedDict):
     """Meltano cloud config org for storing default projects and deployments."""
 
     default_project_id: str | None
-    projects: dict[str, CloudConfigProject]
+    projects_defaults: dict[str, CloudConfigProject]

--- a/src/cloud-cli/meltano/cloud/api/types.py
+++ b/src/cloud-cli/meltano/cloud/api/types.py
@@ -65,13 +65,13 @@ class CloudDeployment(TypedDict):
 
 
 class CloudConfigProject(TypedDict):
-    """Meltano cloud config project settings for default deployments"""
+    """Meltano cloud config project settings for default deployments."""
 
     default_deployment_name: str | None
 
 
 class CloudConfigOrg(TypedDict):
-    """Meltano cloud config organization for storing default projects and deployments"""
+    """Meltano cloud config org for storing default projects and deployments."""
 
     default_project_id: str | None
     projects: dict[str, CloudConfigProject]

--- a/src/cloud-cli/meltano/cloud/api/types.py
+++ b/src/cloud-cli/meltano/cloud/api/types.py
@@ -62,3 +62,16 @@ class CloudDeployment(TypedDict):
 
     # Added client-side:
     default: bool
+
+
+class CloudConfigProject(TypedDict):
+    """Meltano cloud config project settings for default deployments"""
+
+    default_deployment_name: str | None
+
+
+class CloudConfigOrg(TypedDict):
+    """Meltano cloud config organization for storing default projects and deployments"""
+
+    default_project_id: str | None
+    projects: dict[str, CloudConfigProject]

--- a/src/cloud-cli/meltano/cloud/cli/deployment.py
+++ b/src/cloud-cli/meltano/cloud/cli/deployment.py
@@ -17,6 +17,7 @@ from slugify import slugify
 from yaspin import yaspin  # type: ignore
 
 from meltano.cloud.api.client import MeltanoCloudClient, MeltanoCloudError
+from meltano.cloud.api.config import CloudConfigProject
 from meltano.cloud.api.types import CloudDeployment
 from meltano.cloud.cli.base import (
     LimitedResult,
@@ -334,6 +335,11 @@ async def use_deployment(  # noqa: D103
                 "Meltano Cloud deployment matches name.",
             )
     context.config.default_deployment_name = deployment_name
+
+    context.config.internal_project_default = CloudConfigProject(
+        default_deployment_name=deployment_name,
+    )
+
     context.config.write_to_file()
     click.secho(
         (

--- a/src/cloud-cli/meltano/cloud/cli/deployment.py
+++ b/src/cloud-cli/meltano/cloud/cli/deployment.py
@@ -88,7 +88,8 @@ class DeploymentsCloudClient(MeltanoCloudClient):
         return {
             **deployment,  # type: ignore[misc]
             "default": (
-                self.config.default_deployment_name == deployment["deployment_name"]
+                self.config.internal_project_default["default_deployment_name"]
+                == deployment["deployment_name"]
             ),
         }
 
@@ -169,7 +170,8 @@ class DeploymentsCloudClient(MeltanoCloudClient):
             {
                 **deployment,  # type: ignore[misc]
                 "default": (
-                    self.config.default_deployment_name == deployment["deployment_name"]
+                    self.config.internal_project_default["default_deployment_name"]
+                    == deployment["deployment_name"]
                 ),
             },
         )
@@ -218,7 +220,8 @@ async def _get_deployments(
     results.items = [
         {
             **x,  # type: ignore[misc]
-            "default": x["deployment_name"] == config.default_deployment_name,
+            "default": x["deployment_name"]
+            == config.internal_project_default["default_deployment_name"],
         }
         for x in results.items
     ]
@@ -356,8 +359,6 @@ def _set_project_default_deployment(
         context: The Cloud CLI context.
         deployment_name: The name of the deployment to set as the default.
     """
-    # TODO: Remove dependency on this default_deployment_name
-    context.config.default_deployment_name = deployment_name
     context.config.internal_project_default = CloudConfigProject(
         default_deployment_name=deployment_name,
     )

--- a/src/cloud-cli/meltano/cloud/cli/logs.py
+++ b/src/cloud-cli/meltano/cloud/cli/logs.py
@@ -40,9 +40,8 @@ class LogsClient(MeltanoCloudClient):
             f"/{self.config.internal_project_id}/{execution_id}"
         )
 
-        async with self.authenticated():
-            async with self._raw_request("GET", url) as response:
-                yield response
+        async with self.authenticated(), self._raw_request("GET", url) as response:
+            yield response
 
     async def _get_logs_page(
         self,

--- a/src/cloud-cli/meltano/cloud/cli/project.py
+++ b/src/cloud-cli/meltano/cloud/cli/project.py
@@ -210,7 +210,8 @@ class ProjectChoicesQuestionaryOption(click.Option):
             (
                 x
                 for x in context.projects
-                if x["project_id"] == context.config.default_project_id
+                if x["project_id"]
+                == context.config.internal_organization_default["default_project_id"]
             ),
             {"project_name": None},
         )["project_name"]

--- a/src/cloud-cli/meltano/cloud/cli/run.py
+++ b/src/cloud-cli/meltano/cloud/cli/run.py
@@ -51,7 +51,9 @@ async def run(
 ) -> None:
     """Run a Meltano project in Meltano Cloud."""
     deployment = (
-        deployment if deployment is not None else context.config.default_deployment_name
+        deployment
+        if deployment is not None
+        else context.config.internal_project_default["default_deployment_name"]
     )
     if deployment is None:
         raise click.UsageError(

--- a/src/cloud-cli/meltano/cloud/cli/schedule.py
+++ b/src/cloud-cli/meltano/cloud/cli/schedule.py
@@ -158,7 +158,7 @@ async def _set_enabled_state(
     deployment_name = (
         deployment_name
         if deployment_name is not None
-        else config.default_deployment_name
+        else config.internal_project_default["default_deployment_name"]
     )
     if deployment_name is None:
         raise click.UsageError(

--- a/src/cloud-cli/tests/cli/test_deployment.py
+++ b/src/cloud-cli/tests/cli/test_deployment.py
@@ -215,7 +215,7 @@ class TestDeploymentCommand:
         ][config.tenant_resource_key]
         default_project_id = default_org_settings["default_project_id"]
         assert (
-            default_org_settings["projects"][default_project_id][
+            default_org_settings["projects_defaults"][default_project_id][
                 "default_deployment_name"
             ]
             == "ultra-production"
@@ -266,7 +266,7 @@ class TestDeploymentCommand:
         default_project_id = default_org_settings["default_project_id"]
 
         assert (
-            default_org_settings["projects"][default_project_id][
+            default_org_settings["projects_defaults"][default_project_id][
                 "default_deployment_name"
             ]
             == "legacy"

--- a/src/cloud-cli/tests/cli/test_deployment.py
+++ b/src/cloud-cli/tests/cli/test_deployment.py
@@ -210,6 +210,16 @@ class TestDeploymentCommand:
             json.loads(Path(config.config_path).read_text())["default_deployment_name"]
             == "ultra-production"
         )
+        default_org_settings = json.loads(Path(config.config_path).read_text())[
+            "organizations_defaults"
+        ][config.tenant_resource_key]
+        default_project_id = default_org_settings["default_project_id"]
+        assert (
+            default_org_settings["projects"][default_project_id][
+                "default_deployment_name"
+            ]
+            == "ultra-production"
+        )
 
     @pytest.mark.xfail(
         platform.system() == "Windows",
@@ -248,6 +258,17 @@ class TestDeploymentCommand:
         ) in result.stdout
         assert (
             json.loads(Path(config.config_path).read_text())["default_deployment_name"]
+            == "legacy"
+        )
+        default_org_settings = json.loads(Path(config.config_path).read_text())[
+            "organizations_defaults"
+        ][config.tenant_resource_key]
+        default_project_id = default_org_settings["default_project_id"]
+
+        assert (
+            default_org_settings["projects"][default_project_id][
+                "default_deployment_name"
+            ]
             == "legacy"
         )
 

--- a/src/cloud-cli/tests/cli/test_project.py
+++ b/src/cloud-cli/tests/cli/test_project.py
@@ -214,6 +214,12 @@ class TestProjectCommand:
             json.loads(Path(config.config_path).read_text())["default_project_id"]
             == "01GWQ7520WNMQT0PQ6KHCC4EE1"
         )
+        assert (
+            json.loads(Path(config.config_path).read_text())["organizations_defaults"][
+                config.tenant_resource_key
+            ]["default_project_id"]
+            == "01GWQ7520WNMQT0PQ6KHCC4EE1"
+        )
 
     @pytest.mark.xfail(
         platform.system() == "Windows",
@@ -253,6 +259,12 @@ class TestProjectCommand:
         ) in result.stdout
         assert (
             json.loads(Path(config.config_path).read_text())["default_project_id"]
+            == "01GWQ788M7TVP9HFVRGQ34BG17"
+        )
+        assert (
+            json.loads(Path(config.config_path).read_text())["organizations_defaults"][
+                config.tenant_resource_key
+            ]["default_project_id"]
             == "01GWQ788M7TVP9HFVRGQ34BG17"
         )
 
@@ -311,6 +323,12 @@ class TestProjectCommand:
             json.loads(Path(config.config_path).read_text())["default_project_id"]
             == "01GWQREZ7G0526JZS9JY5H3BH9"
         )
+        assert (
+            json.loads(Path(config.config_path).read_text())["organizations_defaults"][
+                config.tenant_resource_key
+            ]["default_project_id"]
+            == "01GWQREZ7G0526JZS9JY5H3BH9"
+        )
 
     def test_project_use_by_id(self, config: MeltanoCloudConfig):
         result = CliRunner().invoke(
@@ -331,6 +349,12 @@ class TestProjectCommand:
         )
         assert (
             json.loads(Path(config.config_path).read_text())["default_project_id"]
+            == "01GWQ7520WNMQT0PQ6KHCC4EE1"
+        )
+        assert (
+            json.loads(Path(config.config_path).read_text())["organizations_defaults"][
+                config.tenant_resource_key
+            ]["default_project_id"]
             == "01GWQ7520WNMQT0PQ6KHCC4EE1"
         )
 

--- a/src/cloud-cli/tests/cli/test_project.py
+++ b/src/cloud-cli/tests/cli/test_project.py
@@ -211,10 +211,6 @@ class TestProjectCommand:
             "future commands\n"
         )
         assert (
-            json.loads(Path(config.config_path).read_text())["default_project_id"]
-            == "01GWQ7520WNMQT0PQ6KHCC4EE1"
-        )
-        assert (
             json.loads(Path(config.config_path).read_text())["organizations_defaults"][
                 config.tenant_resource_key
             ]["default_project_id"]
@@ -257,10 +253,6 @@ class TestProjectCommand:
             "Set 'Stranger in a Strange Org' as the default Meltano Cloud "
             "project for future commands\n"
         ) in result.stdout
-        assert (
-            json.loads(Path(config.config_path).read_text())["default_project_id"]
-            == "01GWQ788M7TVP9HFVRGQ34BG17"
-        )
         assert (
             json.loads(Path(config.config_path).read_text())["organizations_defaults"][
                 config.tenant_resource_key
@@ -320,10 +312,6 @@ class TestProjectCommand:
             "project for future commands\n"
         )
         assert (
-            json.loads(Path(config.config_path).read_text())["default_project_id"]
-            == "01GWQREZ7G0526JZS9JY5H3BH9"
-        )
-        assert (
             json.loads(Path(config.config_path).read_text())["organizations_defaults"][
                 config.tenant_resource_key
             ]["default_project_id"]
@@ -346,10 +334,6 @@ class TestProjectCommand:
         assert result.output == (
             "Set the project with ID '01GWQ7520WNMQT0PQ6KHCC4EE1' as the "
             "default Meltano Cloud project for future commands\n"
-        )
-        assert (
-            json.loads(Path(config.config_path).read_text())["default_project_id"]
-            == "01GWQ7520WNMQT0PQ6KHCC4EE1"
         )
         assert (
             json.loads(Path(config.config_path).read_text())["organizations_defaults"][

--- a/src/cloud-cli/tests/cli/test_run.py
+++ b/src/cloud-cli/tests/cli/test_run.py
@@ -6,6 +6,7 @@ import typing as t
 
 from click.testing import CliRunner
 
+from meltano.cloud.api.types import CloudConfigOrg, CloudConfigProject
 from meltano.cloud.cli import cloud as cli
 
 if t.TYPE_CHECKING:
@@ -63,7 +64,16 @@ class TestCloudRun:
             f"{tenant_resource_key}/{internal_project_id}/"
             f"{deployment}/{job_or_schedule}"
         )
-        config.default_deployment_name = deployment
+        config.organizations_defaults = {
+            config.tenant_resource_key: CloudConfigOrg(
+                default_project_id=None,
+                projects_defaults={
+                    config.internal_project_id: CloudConfigProject(
+                        default_deployment_name=deployment,
+                    ),
+                },
+            ),
+        }
         config.write_to_file()
         httpserver.expect_oneshot_request(path).respond_with_data(
             b"Running a Meltano project in Meltano Cloud",
@@ -89,7 +99,16 @@ class TestCloudRun:
             f"{tenant_resource_key}/{internal_project_id}/"
             f"{deployment}/{job_or_schedule}"
         )
-        config.default_deployment_name = None
+        config.organizations_defaults = {
+            config.tenant_resource_key: CloudConfigOrg(
+                default_project_id=None,
+                projects_defaults={
+                    config.internal_project_id: CloudConfigProject(
+                        default_deployment_name=None,
+                    ),
+                },
+            ),
+        }
         config.write_to_file()
         httpserver.expect_oneshot_request(path).respond_with_data(
             b"Running a Meltano project in Meltano Cloud",

--- a/src/cloud-cli/tests/cli/test_schedules.py
+++ b/src/cloud-cli/tests/cli/test_schedules.py
@@ -10,6 +10,7 @@ import pytest
 from click.testing import CliRunner
 from freezegun import freeze_time
 
+from meltano.cloud.api.types import CloudConfigOrg, CloudConfigProject
 from meltano.cloud.cli import cloud as cli
 
 if t.TYPE_CHECKING:
@@ -60,7 +61,17 @@ class TestScheduleCommand:
             f"/schedules/v1/{tenant_resource_key}/{internal_project_id}"
             "/test-deployment/daily/enabled"
         )
-        config.default_deployment_name = "test-deployment"
+        config.organizations_defaults = {
+            config.tenant_resource_key: CloudConfigOrg(
+                default_project_id=None,
+                projects_defaults={
+                    config.internal_project_id: CloudConfigProject(
+                        default_deployment_name="test-deployment",
+                    ),
+                },
+            ),
+        }
+
         config.write_to_file()
         runner = CliRunner()
         for cmd in ("enable", "disable"):
@@ -89,7 +100,16 @@ class TestScheduleCommand:
             f"/schedules/v1/{tenant_resource_key}/{internal_project_id}"
             "/test-deployment/daily/enabled"
         )
-        config.default_deployment_name = None
+        config.organizations_defaults = {
+            config.tenant_resource_key: CloudConfigOrg(
+                default_project_id=None,
+                projects_defaults={
+                    config.internal_project_id: CloudConfigProject(
+                        default_deployment_name=None,
+                    ),
+                },
+            ),
+        }
         config.write_to_file()
         runner = CliRunner()
         for cmd in ("enable", "disable"):


### PR DESCRIPTION
Relates to https://github.com/meltano/meltano/issues/7839

We currently assume that the user's default projects and deployments are within the same organization. However, when users switch between organizations, their previous default settings persist, which can be inconsistent and confusing

@BraedonLeonard proposed a solution for creating a hierarchical structure within the config.json in order to better remember the different default settings between orgs and projects. 

Pull Request is intended to present my current approach based on Braedon's suggestion.

In this PR, the focus is solely on the creation of the new 'organizations' default object within the config. It does not yet modify any other components that depend on it. My plan is to gradually phase out the use of older dependent methods, replacing them with referencing the fields within the new object.

![Screenshot 2023-06-26 at 2 08 12 PM](https://github.com/meltano/meltano/assets/14004680/5f4cc05a-586d-49ee-8035-a433be981516)
