### PR TITLE
feat: Autouse set default deployment if first deployment created for project

### DIFF
--- a/src/cloud-cli/meltano/cloud/cli/deployment.py
+++ b/src/cloud-cli/meltano/cloud/cli/deployment.py
@@ -294,7 +294,8 @@ class DeploymentChoicesQuestionaryOption(click.Option):
         """
         if platform.system() == "Windows":
             asyncio.set_event_loop_policy(
-                asyncio.WindowsSelectorEventLoopPolicy(),  # type: ignore[attr-defined]
+                # type: ignore[attr-defined]
+                asyncio.WindowsSelectorEventLoopPolicy(),
             )
 
         context: MeltanoCloudCLIContext = ctx.obj
@@ -334,12 +335,8 @@ async def use_deployment(  # noqa: D103
                 f"Unable to use deployment named {deployment_name!r} - no available "
                 "Meltano Cloud deployment matches name.",
             )
-    context.config.default_deployment_name = deployment_name
 
-    context.config.internal_project_default = CloudConfigProject(
-        default_deployment_name=deployment_name,
-    )
-
+    _set_project_default_deployment(context, deployment_name)
     context.config.write_to_file()
     click.secho(
         (
@@ -347,6 +344,23 @@ async def use_deployment(  # noqa: D103
             "deployment for future commands"
         ),
         fg="green",
+    )
+
+
+def _set_project_default_deployment(
+    context: MeltanoCloudCLIContext,
+    deployment_name: str,
+) -> None:
+    """Set the default deployment in the config for future commands.
+
+    Args:
+        context: The Cloud CLI context.
+        deployment_name: The name of the deployment to set as the default.
+    """
+    # TODO: Remove dependency on this default_deployment_name
+    context.config.default_deployment_name = deployment_name
+    context.config.internal_project_default = CloudConfigProject(
+        default_deployment_name=deployment_name,
     )
 
 
@@ -397,12 +411,38 @@ async def create_deployment(
                 git_rev=git_rev,
             )
         if deployment is None:
-            click.secho("Deployment already exists, and was not updated.", fg="yellow")
-        else:
             click.secho(
-                f"Created deployment {deployment['deployment_name']!r}",
-                fg="green",
+                "Deployment already exists, and was not updated.",
+                fg="yellow",
             )
+            return
+
+        new_deployment_name = deployment["deployment_name"]
+        deployments = await client.get_deployments(page_size=2)
+
+        if isinstance(deployments, dict) and deployments["results"]:
+            results = deployments["results"]
+            if isinstance(results, list) and len(results) == 1:
+                _set_project_default_deployment(context, new_deployment_name)
+                click.secho(
+                    (
+                        "Created first deployment. "
+                        f"Set {new_deployment_name!r} as the "
+                        "default Meltano Cloud deployment for future commands"
+                    ),
+                    fg="green",
+                )
+
+                return
+
+        click.secho(
+            (
+                f'Created deployment "{new_deployment_name}". '
+                "To use as default run "
+                f'"meltano cloud deployment use --name {new_deployment_name}."'
+            ),
+            fg="green",
+        )
 
 
 @deployment_group.command(

--- a/src/cloud-cli/meltano/cloud/cli/deployment.py
+++ b/src/cloud-cli/meltano/cloud/cli/deployment.py
@@ -298,8 +298,7 @@ class DeploymentChoicesQuestionaryOption(click.Option):
             )
 
         context: MeltanoCloudCLIContext = ctx.obj
-        context.deployments = asyncio.run(
-            _get_deployments(context.config)).items
+        context.deployments = asyncio.run(_get_deployments(context.config)).items
         return questionary.select(
             message="",
             qmark="Use Meltano Cloud deployment",

--- a/src/cloud-cli/tests/cli/test_deployment.py
+++ b/src/cloud-cli/tests/cli/test_deployment.py
@@ -112,8 +112,7 @@ class TestDeploymentCommand:
         )
         result = CliRunner(mix_stderr=False).invoke(
             cli,
-            ("--config-path", config.config_path,
-             "deployment", "list", "--limit", "2"),
+            ("--config-path", config.config_path, "deployment", "list", "--limit", "2"),
         )
         assert result.exit_code == 0, result.output
         assert result.stdout == (
@@ -208,8 +207,7 @@ class TestDeploymentCommand:
             "for future commands\n"
         )
         assert (
-            json.loads(Path(config.config_path).read_text())[
-                "default_deployment_name"]
+            json.loads(Path(config.config_path).read_text())["default_deployment_name"]
             == "ultra-production"
         )
         default_org_settings = json.loads(Path(config.config_path).read_text())[
@@ -259,8 +257,7 @@ class TestDeploymentCommand:
             "Set 'legacy' as the default Meltano Cloud deployment for future commands\n"
         ) in result.stdout
         assert (
-            json.loads(Path(config.config_path).read_text())[
-                "default_deployment_name"]
+            json.loads(Path(config.config_path).read_text())["default_deployment_name"]
             == "legacy"
         )
         default_org_settings = json.loads(Path(config.config_path).read_text())[

--- a/src/cloud-cli/tests/cli/test_deployment.py
+++ b/src/cloud-cli/tests/cli/test_deployment.py
@@ -273,7 +273,7 @@ class TestDeploymentCommand:
         )
 
     @pytest.mark.parametrize("prepared_request", ({"method": "POST"},), indirect=True)
-    def test_create_new_deployment(
+    def test_create_first_new_deployment(
         self,
         config: MeltanoCloudConfig,
         path: str,
@@ -290,6 +290,13 @@ class TestDeploymentCommand:
             f"{path}/ultra-production",
             "POST",
         ).respond_with_json(prepared_request)
+        httpserver.expect_oneshot_request(
+            f"/deployments/v1/{config.tenant_resource_key}/{config.internal_project_id}",
+            "GET",
+            query_string="page_size=2",
+        ).respond_with_json(
+            {"results": [deployments[0]], "pagination": None},
+        )
         requests_mock.post(prepared_request["url"], json=deployments[0])  # noqa: S113
         result = CliRunner().invoke(
             cli,
@@ -308,7 +315,60 @@ class TestDeploymentCommand:
         )
         assert result.exit_code == 0, result.output
         assert "Creating deployment - this may take several minutes..." in result.output
-        assert "Created deployment 'ultra-production'\n" in result.output
+        assert (
+            "Created first deployment. "
+            "Set 'ultra-production' as the "
+            "default Meltano Cloud deployment for future commands"
+        ) in result.output
+
+    @pytest.mark.parametrize("prepared_request", ({"method": "POST"},), indirect=True)
+    def test_create_second_new_deployment(
+        self,
+        config: MeltanoCloudConfig,
+        path: str,
+        httpserver: HTTPServer,
+        deployments: list[CloudDeployment],
+        prepared_request,
+        requests_mock: RequestsMocker,
+    ):
+        httpserver.expect_oneshot_request(
+            f"{path}/ultra-production",
+            "GET",
+        ).respond_with_response(Response(status=HTTPStatus.NOT_FOUND))
+        httpserver.expect_oneshot_request(
+            f"{path}/ultra-production",
+            "POST",
+        ).respond_with_json(prepared_request)
+        httpserver.expect_oneshot_request(
+            f"/deployments/v1/{config.tenant_resource_key}/{config.internal_project_id}",
+            "GET",
+            query_string="page_size=2",
+        ).respond_with_json(
+            {"results": [deployments[0], deployments[1]], "pagination": None},
+        )
+        requests_mock.post(prepared_request["url"], json=deployments[0])  # noqa: S113
+        result = CliRunner().invoke(
+            cli,
+            (
+                "--config-path",
+                config.config_path,
+                "deployment",
+                "create",
+                "--name",
+                "ultra-production",
+                "--environment",
+                "Ultra Production",
+                "--git-rev",
+                "Main",
+            ),
+        )
+        assert result.exit_code == 0, result.output
+        assert "Creating deployment - this may take several minutes..." in result.output
+        assert (
+            'Created deployment "ultra-production". '
+            "To use as default run "
+            '"meltano cloud deployment use --name ultra-production."'
+        ) in result.output
 
     @pytest.mark.parametrize("prepared_request", ({"method": "POST"},), indirect=True)
     def test_update_existing_deployment(


### PR DESCRIPTION
Automatically set the projects default deployment name if it is the first deployment being created for that default project.

This PR still uses the previous "default_deployment_name" and "internal_project_id" which has some amount of references still dependent on them. 

My plan is to get the logic in first, then slowly start to do a refactor on all the dependencies for default_deployment_name and internal_project_id to use the new organizations_defaults structure proposed in https://github.com/meltano/meltano/pull/7847