### PR TITLE
ci: Update FOSSA CLI version used in dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FOSSA_CLI_VERSION: '3.6.7'
+  FOSSA_CLI_VERSION: '3.8.3'
 
 permissions:
   contents: read


### PR DESCRIPTION
Required update to fix https://github.com/meltano/meltano/actions/runs/5392972707/jobs/9792050788