### PR TITLE
refactor: Remove dependencies on default_project_id and default_deployment_name

### DIFF
--- a/src/cloud-cli/meltano/cloud/api/config.py
+++ b/src/cloud-cli/meltano/cloud/api/config.py
@@ -95,7 +95,6 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
         id_token: str | None = None,
         access_token: str | None = None,
         config_path: os.PathLike | str | None = None,
-        default_project_id: str | None = None,
         organizations_defaults: dict[str, CloudConfigOrg] | None = None,
     ):
         """Initialize a MeltanoCloudConfig instance.
@@ -113,7 +112,6 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
             id_token: ID token for use in authentication.
             access_token: Access token for use in authentication.
             config_path: Path to the config file to use.
-            default_project_id: The ID of the default Meltano Cloud project.
             organizations_defaults: Default org settings.
         """
         self.auth_callback_port = auth_callback_port
@@ -125,7 +123,6 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
         self.config_path = (
             Path(config_path).resolve() if config_path else self.user_config_path()
         )
-        self.default_project_id = default_project_id
         self.organizations_defaults = organizations_defaults
 
     def __getattribute__(self, name: str) -> str | None:
@@ -203,8 +200,11 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
             MeltanoCloudProjectAmbiguityError: when ID token includes more
                 than one project ID.
         """
-        if self.default_project_id:
-            return self.default_project_id
+        org_default_project_id = self.internal_organization_default.get(
+            "default_project_id",
+        )
+        if org_default_project_id:
+            return org_default_project_id
         if len(self.internal_project_ids) > 1:
             raise MeltanoCloudProjectAmbiguityError
         try:
@@ -221,7 +221,6 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
         Args:
             project_id: The Meltano Cloud project ID that should be used.
         """
-        self.default_project_id = project_id
         self.internal_organization_default["default_project_id"] = project_id
         self.write_to_file()
 
@@ -321,6 +320,7 @@ class MeltanoCloudConfig:  # noqa: WPS214 WPS230
 
         Deprecated keys:
         - default_deployment_name
+        - default_project_id
 
         Args:
             config_path: Path to the config file.

--- a/src/cloud-cli/meltano/cloud/cli/deployment.py
+++ b/src/cloud-cli/meltano/cloud/cli/deployment.py
@@ -88,7 +88,8 @@ class DeploymentsCloudClient(MeltanoCloudClient):
         return {
             **deployment,  # type: ignore[misc]
             "default": (
-                self.config.default_deployment_name == deployment["deployment_name"]
+                self.config.internal_project_default["default_deployment_name"]
+                == deployment["deployment_name"]
             ),
         }
 
@@ -169,7 +170,8 @@ class DeploymentsCloudClient(MeltanoCloudClient):
             {
                 **deployment,  # type: ignore[misc]
                 "default": (
-                    self.config.default_deployment_name == deployment["deployment_name"]
+                    self.config.internal_project_default["default_deployment_name"]
+                    == deployment["deployment_name"]
                 ),
             },
         )
@@ -218,7 +220,8 @@ async def _get_deployments(
     results.items = [
         {
             **x,  # type: ignore[misc]
-            "default": x["deployment_name"] == config.default_deployment_name,
+            "default": x["deployment_name"]
+            == config.internal_project_default["default_deployment_name"],
         }
         for x in results.items
     ]
@@ -294,7 +297,8 @@ class DeploymentChoicesQuestionaryOption(click.Option):
         """
         if platform.system() == "Windows":
             asyncio.set_event_loop_policy(
-                asyncio.WindowsSelectorEventLoopPolicy(),  # type: ignore[attr-defined]
+                # type: ignore[attr-defined]
+                asyncio.WindowsSelectorEventLoopPolicy(),
             )
 
         context: MeltanoCloudCLIContext = ctx.obj
@@ -356,8 +360,6 @@ def _set_project_default_deployment(
         context: The Cloud CLI context.
         deployment_name: The name of the deployment to set as the default.
     """
-    # TODO: Remove dependency on this default_deployment_name
-    context.config.default_deployment_name = deployment_name
     context.config.internal_project_default = CloudConfigProject(
         default_deployment_name=deployment_name,
     )

--- a/src/cloud-cli/meltano/cloud/cli/deployment.py
+++ b/src/cloud-cli/meltano/cloud/cli/deployment.py
@@ -296,9 +296,8 @@ class DeploymentChoicesQuestionaryOption(click.Option):
             The name of the deployment to be used as the default for future commands.
         """
         if platform.system() == "Windows":
-            asyncio.set_event_loop_policy(
-                # type: ignore[attr-defined]
-                asyncio.WindowsSelectorEventLoopPolicy(),
+            asyncio.set_event_loop_policy( 
+                asyncio.WindowsSelectorEventLoopPolicy(),  # type: ignore[attr-defined]
             )
 
         context: MeltanoCloudCLIContext = ctx.obj

--- a/src/cloud-cli/meltano/cloud/cli/deployment.py
+++ b/src/cloud-cli/meltano/cloud/cli/deployment.py
@@ -296,7 +296,7 @@ class DeploymentChoicesQuestionaryOption(click.Option):
             The name of the deployment to be used as the default for future commands.
         """
         if platform.system() == "Windows":
-            asyncio.set_event_loop_policy( 
+            asyncio.set_event_loop_policy(
                 asyncio.WindowsSelectorEventLoopPolicy(),  # type: ignore[attr-defined]
             )
 

--- a/src/cloud-cli/meltano/cloud/cli/project.py
+++ b/src/cloud-cli/meltano/cloud/cli/project.py
@@ -199,7 +199,7 @@ class ProjectChoicesQuestionaryOption(click.Option):
             return None
 
         if platform.system() == "Windows":
-            asyncio.set_event_loop_policy(
+            asyncio.set_event_loop_policy( 
                 asyncio.WindowsSelectorEventLoopPolicy(),  # type: ignore[attr-defined]
             )
 
@@ -210,7 +210,8 @@ class ProjectChoicesQuestionaryOption(click.Option):
             (
                 x
                 for x in context.projects
-                if x["project_id"] == context.config.default_project_id
+                if x["project_id"]
+                == context.config.internal_organization_default["default_project_id"]
             ),
             {"project_name": None},
         )["project_name"]

--- a/src/cloud-cli/meltano/cloud/cli/project.py
+++ b/src/cloud-cli/meltano/cloud/cli/project.py
@@ -199,7 +199,7 @@ class ProjectChoicesQuestionaryOption(click.Option):
             return None
 
         if platform.system() == "Windows":
-            asyncio.set_event_loop_policy( 
+            asyncio.set_event_loop_policy(
                 asyncio.WindowsSelectorEventLoopPolicy(),  # type: ignore[attr-defined]
             )
 

--- a/src/cloud-cli/meltano/cloud/cli/run.py
+++ b/src/cloud-cli/meltano/cloud/cli/run.py
@@ -51,7 +51,9 @@ async def run(
 ) -> None:
     """Run a Meltano project in Meltano Cloud."""
     deployment = (
-        deployment if deployment is not None else context.config.default_deployment_name
+        deployment
+        if deployment is not None
+        else context.config.internal_project_default["default_deployment_name"]
     )
     if deployment is None:
         raise click.UsageError(

--- a/src/cloud-cli/meltano/cloud/cli/schedule.py
+++ b/src/cloud-cli/meltano/cloud/cli/schedule.py
@@ -158,7 +158,7 @@ async def _set_enabled_state(
     deployment_name = (
         deployment_name
         if deployment_name is not None
-        else config.default_deployment_name
+        else config.internal_project_default["default_deployment_name"]
     )
     if deployment_name is None:
         raise click.UsageError(

--- a/src/cloud-cli/tests/cli/test_project.py
+++ b/src/cloud-cli/tests/cli/test_project.py
@@ -211,10 +211,6 @@ class TestProjectCommand:
             "future commands\n"
         )
         assert (
-            json.loads(Path(config.config_path).read_text())["default_project_id"]
-            == "01GWQ7520WNMQT0PQ6KHCC4EE1"
-        )
-        assert (
             json.loads(Path(config.config_path).read_text())["organizations_defaults"][
                 config.tenant_resource_key
             ]["default_project_id"]
@@ -257,10 +253,6 @@ class TestProjectCommand:
             "Set 'Stranger in a Strange Org' as the default Meltano Cloud "
             "project for future commands\n"
         ) in result.stdout
-        assert (
-            json.loads(Path(config.config_path).read_text())["default_project_id"]
-            == "01GWQ788M7TVP9HFVRGQ34BG17"
-        )
         assert (
             json.loads(Path(config.config_path).read_text())["organizations_defaults"][
                 config.tenant_resource_key
@@ -320,10 +312,6 @@ class TestProjectCommand:
             "project for future commands\n"
         )
         assert (
-            json.loads(Path(config.config_path).read_text())["default_project_id"]
-            == "01GWQREZ7G0526JZS9JY5H3BH9"
-        )
-        assert (
             json.loads(Path(config.config_path).read_text())["organizations_defaults"][
                 config.tenant_resource_key
             ]["default_project_id"]
@@ -346,10 +334,6 @@ class TestProjectCommand:
         assert result.output == (
             "Set the project with ID '01GWQ7520WNMQT0PQ6KHCC4EE1' as the "
             "default Meltano Cloud project for future commands\n"
-        )
-        assert (
-            json.loads(Path(config.config_path).read_text())["default_project_id"]
-            == "01GWQ7520WNMQT0PQ6KHCC4EE1"
         )
         assert (
             json.loads(Path(config.config_path).read_text())["organizations_defaults"][

--- a/src/cloud-cli/tests/cli/test_run.py
+++ b/src/cloud-cli/tests/cli/test_run.py
@@ -6,6 +6,7 @@ import typing as t
 
 from click.testing import CliRunner
 
+from meltano.cloud.api.types import CloudConfigOrg, CloudConfigProject
 from meltano.cloud.cli import cloud as cli
 
 if t.TYPE_CHECKING:
@@ -63,7 +64,16 @@ class TestCloudRun:
             f"{tenant_resource_key}/{internal_project_id}/"
             f"{deployment}/{job_or_schedule}"
         )
-        config.default_deployment_name = deployment
+        config.organizations_defaults = {
+            config.tenant_resource_key: CloudConfigOrg(
+                default_project_id=None,
+                projects_defaults={
+                    config.internal_project_id: CloudConfigProject(
+                        default_deployment_name=deployment,
+                    ),
+                },
+            ),
+        }
         config.write_to_file()
         httpserver.expect_oneshot_request(path).respond_with_data(
             b"Running a Meltano project in Meltano Cloud",
@@ -89,7 +99,16 @@ class TestCloudRun:
             f"{tenant_resource_key}/{internal_project_id}/"
             f"{deployment}/{job_or_schedule}"
         )
-        config.default_deployment_name = None
+        config.organizations_defaults = {
+            config.tenant_resource_key: CloudConfigOrg(
+                default_project_id=None,
+                projects_defaults={
+                    config.internal_project_id: CloudConfigProject(
+                        default_deployment_name=None,
+                    ),
+                },
+            ),
+        }
         config.write_to_file()
         httpserver.expect_oneshot_request(path).respond_with_data(
             b"Running a Meltano project in Meltano Cloud",

--- a/src/cloud-cli/tests/cli/test_schedules.py
+++ b/src/cloud-cli/tests/cli/test_schedules.py
@@ -10,6 +10,7 @@ import pytest
 from click.testing import CliRunner
 from freezegun import freeze_time
 
+from meltano.cloud.api.types import CloudConfigOrg, CloudConfigProject
 from meltano.cloud.cli import cloud as cli
 
 if t.TYPE_CHECKING:
@@ -60,7 +61,17 @@ class TestScheduleCommand:
             f"/schedules/v1/{tenant_resource_key}/{internal_project_id}"
             "/test-deployment/daily/enabled"
         )
-        config.default_deployment_name = "test-deployment"
+        config.organizations_defaults = {
+            config.tenant_resource_key: CloudConfigOrg(
+                default_project_id=None,
+                projects_defaults={
+                    config.internal_project_id: CloudConfigProject(
+                        default_deployment_name="test-deployment",
+                    ),
+                },
+            ),
+        }
+
         config.write_to_file()
         runner = CliRunner()
         for cmd in ("enable", "disable"):
@@ -89,7 +100,16 @@ class TestScheduleCommand:
             f"/schedules/v1/{tenant_resource_key}/{internal_project_id}"
             "/test-deployment/daily/enabled"
         )
-        config.default_deployment_name = None
+        config.organizations_defaults = {
+            config.tenant_resource_key: CloudConfigOrg(
+                default_project_id=None,
+                projects_defaults={
+                    config.internal_project_id: CloudConfigProject(
+                        default_deployment_name=None,
+                    ),
+                },
+            ),
+        }
         config.write_to_file()
         runner = CliRunner()
         for cmd in ("enable", "disable"):


### PR DESCRIPTION
We have modified the config for meltano cloud to be able to better remember different defaults between organizations and projects. This removes the dependencies on the old keys as well as updates all tests and access to them.

Keys removed:
- default_project_id
- default_deployment_name

Closes: #7839
Closes: #7856
Closes: #7771 