### PR TITLE
perf: Make authenticated requests without an explicit check for login

### DIFF
--- a/src/cloud-cli/meltano/cloud/api/auth/auth.py
+++ b/src/cloud-cli/meltano/cloud/api/auth/auth.py
@@ -229,9 +229,16 @@ class MeltanoCloudAuth:  # noqa: WPS214
             True if logged in, else False
         """
         return bool(
-            self.config.access_token
-            and self.config.id_token
+            self.has_auth_tokens()
             # Perform this check at the end to avoid
             # spamming our servers if logout fails
             and (await self.get_user_info_response()).ok,
         )
+
+    def has_auth_tokens(self) -> bool:
+        """Check if this instance has cached access and ID tokens.
+
+        Returns:
+            True if it has both tokens, else False
+        """
+        return bool(self.config.access_token and self.config.id_token)

--- a/src/cloud-cli/meltano/cloud/api/auth/auth.py
+++ b/src/cloud-cli/meltano/cloud/api/auth/auth.py
@@ -197,12 +197,11 @@ class MeltanoCloudAuth:  # noqa: WPS214
 
     @asynccontextmanager
     async def _get_user_info_response(self) -> t.AsyncIterator[aiohttp.ClientResponse]:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                urljoin(self.base_url, "oauth2/userInfo"),
-                headers=self.get_access_token_header(),
-            ) as response:
-                yield response
+        async with aiohttp.ClientSession() as session, session.get(
+            urljoin(self.base_url, "oauth2/userInfo"),
+            headers=self.get_access_token_header(),
+        ) as response:
+            yield response
 
     async def get_user_info_response(self) -> aiohttp.ClientResponse:
         """Get user info.

--- a/src/cloud-cli/meltano/cloud/api/client.py
+++ b/src/cloud-cli/meltano/cloud/api/client.py
@@ -60,7 +60,6 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
         self.auth = MeltanoCloudAuth(self.config)
         self.api_url = self.config.base_url
         self.version = version
-        # Tracks nesting depth of authenticated contexts
         self._within_authenticated: bool = False
 
     async def __aenter__(self) -> Self:

--- a/src/cloud-cli/meltano/cloud/api/client.py
+++ b/src/cloud-cli/meltano/cloud/api/client.py
@@ -60,6 +60,8 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
         self.auth = MeltanoCloudAuth(self.config)
         self.api_url = self.config.base_url
         self.version = version
+        # Tracks nesting depth of authenticated contexts
+        self._within_authenticated: bool = False
 
     async def __aenter__(self) -> Self:
         """Enter the client context.
@@ -131,13 +133,21 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
     async def authenticated(self) -> t.AsyncIterator[None]:
         """Provide context for API calls which require authentication.
 
+        Authorization and ID tokens may be out-of-date. In this case, requests made
+        within the context which get a 403 response will cause re-authentication, and
+        the request will be remade.
+
+        Note: Will not work correctly if nested.
+
         Yields:
             None
         """
-        if not await self.auth.logged_in():
+        if not self.auth.has_auth_tokens():
             await self.auth.login()
+        self._within_authenticated = True
         with self.headers(self.auth.get_auth_header()):
             yield
+        self._within_authenticated = False
 
     @staticmethod
     def clean_params(params: dict) -> dict:
@@ -175,6 +185,24 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
         """
         url = urljoin(base_url if base_url else self.api_url, path)
         logger.debug("Making Cloud CLI HTTP request", method=method, url=url)
+        async with self.session.request(method, url, **kwargs) as response:
+            if not (
+                response.status == HTTPStatus.FORBIDDEN and self._within_authenticated
+            ):
+                try:
+                    response.raise_for_status()
+                except ClientResponseError as e:
+                    raise MeltanoCloudError(response) from e
+                yield response
+                return
+
+        logger.debug(
+            "Authentication failed with a 403, retrying after login",
+            method=method,
+            url=url,
+        )
+        await self.auth.login()
+        self.session.headers.update(self.auth.get_auth_header())
         async with self.session.request(method, url, **kwargs) as response:
             try:
                 response.raise_for_status()

--- a/src/cloud-cli/meltano/cloud/api/client.py
+++ b/src/cloud-cli/meltano/cloud/api/client.py
@@ -136,7 +136,7 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
         within the context which get a 403 response will cause re-authentication, and
         the request will be remade.
 
-        Note: Will not work correctly if nested.
+        This context manager is not reentrant.
 
         Yields:
             None
@@ -185,9 +185,7 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
         url = urljoin(base_url if base_url else self.api_url, path)
         logger.debug("Making Cloud CLI HTTP request", method=method, url=url)
         async with self.session.request(method, url, **kwargs) as response:
-            if not (
-                response.status == HTTPStatus.FORBIDDEN and self._within_authenticated
-            ):
+            if response.status != HTTPStatus.FORBIDDEN or not self._within_authenticated:
                 try:
                     response.raise_for_status()
                 except ClientResponseError as e:

--- a/src/cloud-cli/meltano/cloud/api/client.py
+++ b/src/cloud-cli/meltano/cloud/api/client.py
@@ -185,7 +185,10 @@ class MeltanoCloudClient:  # noqa: WPS214, WPS230
         url = urljoin(base_url if base_url else self.api_url, path)
         logger.debug("Making Cloud CLI HTTP request", method=method, url=url)
         async with self.session.request(method, url, **kwargs) as response:
-            if response.status != HTTPStatus.FORBIDDEN or not self._within_authenticated:
+            if (
+                response.status != HTTPStatus.FORBIDDEN
+                or not self._within_authenticated
+            ):
                 try:
                     response.raise_for_status()
                 except ClientResponseError as e:

--- a/src/cloud-cli/meltano/cloud/cli/logs.py
+++ b/src/cloud-cli/meltano/cloud/cli/logs.py
@@ -40,9 +40,8 @@ class LogsClient(MeltanoCloudClient):
             f"/{self.config.internal_project_id}/{execution_id}"
         )
 
-        async with self.authenticated():
-            async with self._raw_request("GET", url) as response:
-                yield response
+        async with self.authenticated(), self._raw_request("GET", url) as response:
+            yield response
 
     async def _get_logs_page(
         self,

--- a/src/cloud-cli/tests/api/test_cloud_client.py
+++ b/src/cloud-cli/tests/api/test_cloud_client.py
@@ -100,11 +100,10 @@ class TestMeltanoCloudClient:
         pattern = re.compile(f"^{path}(\\?.*)?$")
         httpserver.clear()
         httpserver.expect_request(pattern).respond_with_handler(handle_request)
-        async with MeltanoCloudClient(config) as client:
-            async with client.authenticated():
-                async with client._raw_request("GET", "/fakeRequest") as response:
-                    assert response.status == HTTPStatus.OK
-                login_mock.assert_awaited_once()
+        async with MeltanoCloudClient(config) as client, client.authenticated():
+            async with client._raw_request("GET", "/fakeRequest") as response:
+                assert response.status == HTTPStatus.OK
+            login_mock.assert_awaited_once()
 
     @pytest.mark.asyncio()
     async def test_authenticated_context_failure_on_retry(
@@ -117,13 +116,12 @@ class TestMeltanoCloudClient:
         pattern = re.compile(f"^{path}(\\?.*)?$")
         httpserver.clear()
         httpserver.expect_request(pattern).respond_with_data(status=403)
-        async with MeltanoCloudClient(config) as client:
-            async with client.authenticated():
-                with pytest.raises(MeltanoCloudError) as excinfo:
-                    async with client._raw_request(  # noqa: WPS328
-                        "GET",
-                        "/fakeRequest",
-                    ):
-                        pass
-                assert excinfo.value.response.status == 403
-                login_mock.assert_awaited_once()
+        async with MeltanoCloudClient(config) as client, client.authenticated():
+            with pytest.raises(MeltanoCloudError) as excinfo:
+                async with client._raw_request(  # noqa: WPS328
+                    "GET",
+                    "/fakeRequest",
+                ):
+                    pass
+            assert excinfo.value.response.status == 403
+            login_mock.assert_awaited_once()

--- a/src/cloud-cli/tests/api/test_cloud_client.py
+++ b/src/cloud-cli/tests/api/test_cloud_client.py
@@ -2,18 +2,128 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import re
+import typing as t
+from http import HTTPStatus
 
+import mock
 import pytest
+from mock import AsyncMock, MagicMock
+from werkzeug import Response
 
+from meltano.cloud.api.client import MeltanoCloudClient, MeltanoCloudError
 from meltano.cloud.api.config import MeltanoCloudConfig
+
+if t.TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 class TestMeltanoCloudClient:
     """Test the Meltano Cloud API client."""
 
     @pytest.fixture()
-    def config(self, tmp_path: Path):
-        path = tmp_path / "meltano-cloud.json"
-        path.touch()
-        return MeltanoCloudConfig(config_path=path)
+    def login_mock(self, config: MeltanoCloudConfig):
+        def set_auth_tokens():
+            config.id_token = "fake_id_token"  # noqa: S105
+            config.access_token = "fake_access_token"  # noqa: S105
+
+        with mock.patch("meltano.cloud.api.auth.MeltanoCloudAuth.login") as login_mock:
+            login_mock.return_value = None
+            login_mock.side_effect = set_auth_tokens
+            yield login_mock
+
+    @pytest.mark.asyncio()
+    async def test_authenticated_context(
+        self,
+        config: MeltanoCloudConfig,
+        login_mock: MagicMock | AsyncMock,
+    ):
+        config.id_token = None
+        config.access_token = None
+        async with MeltanoCloudClient(config) as client:
+            assert not client.auth.has_auth_tokens()
+
+            # Expect login to get called if no auth tokens have been cached
+            async with client.authenticated():
+                login_mock.assert_awaited_once()
+                assert client.auth.has_auth_tokens()
+                assert (
+                    client._session.headers["Authorization"] == "Bearer fake_id_token"
+                )
+            assert "Authorization" not in client._session.headers
+
+            # Expect login to not get called if auth tokens have been cached
+            login_mock.reset_mock()
+            async with client.authenticated():
+                login_mock.assert_not_called()
+                assert client.auth.has_auth_tokens()
+                assert (
+                    client._session.headers["Authorization"] == "Bearer fake_id_token"
+                )
+            assert "Authorization" not in client._session.headers
+
+    @pytest.mark.asyncio()
+    async def test_no_login_on_403(
+        self,
+        config: MeltanoCloudConfig,
+        login_mock: MagicMock | AsyncMock,
+        httpserver: HTTPServer,
+    ):
+        # Expect 403 response to cause an error if outside of an authenticated context
+        path = "/fakeRequest"
+        pattern = re.compile(f"^{path}(\\?.*)?$")
+        httpserver.clear()
+        httpserver.expect_oneshot_request(pattern).respond_with_data(status=403)
+        async with MeltanoCloudClient(config) as client:
+            with pytest.raises(MeltanoCloudError) as excinfo:
+                async with client._raw_request("GET", "/fakeRequest"):  # noqa: WPS328
+                    pass
+            assert excinfo.value.response.status == 403
+            login_mock.assert_not_called()
+
+    @pytest.mark.asyncio()
+    async def test_authenticated_context_login_on_403(
+        self,
+        config: MeltanoCloudConfig,
+        login_mock: MagicMock | AsyncMock,
+        httpserver: HTTPServer,
+    ):
+        handled = False
+
+        def handle_request(_):
+            nonlocal handled
+            status = HTTPStatus.OK if handled else HTTPStatus.FORBIDDEN
+            handled = True
+            return Response(status=status)
+
+        path = "/fakeRequest"
+        pattern = re.compile(f"^{path}(\\?.*)?$")
+        httpserver.clear()
+        httpserver.expect_request(pattern).respond_with_handler(handle_request)
+        async with MeltanoCloudClient(config) as client:
+            async with client.authenticated():
+                async with client._raw_request("GET", "/fakeRequest") as response:
+                    assert response.status == HTTPStatus.OK
+                login_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_authenticated_context_failure_on_retry(
+        self,
+        config: MeltanoCloudConfig,
+        login_mock: MagicMock | AsyncMock,
+        httpserver: HTTPServer,
+    ):
+        path = "/fakeRequest"
+        pattern = re.compile(f"^{path}(\\?.*)?$")
+        httpserver.clear()
+        httpserver.expect_request(pattern).respond_with_data(status=403)
+        async with MeltanoCloudClient(config) as client:
+            async with client.authenticated():
+                with pytest.raises(MeltanoCloudError) as excinfo:
+                    async with client._raw_request(  # noqa: WPS328
+                        "GET",
+                        "/fakeRequest",
+                    ):
+                        pass
+                assert excinfo.value.response.status == 403
+                login_mock.assert_awaited_once()

--- a/src/cloud-cli/tests/cli/conftest.py
+++ b/src/cloud-cli/tests/cli/conftest.py
@@ -11,18 +11,6 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture()
-def tenant_resource_key():
-    """Return a fake tenant resource key."""
-    return "meltano-cloud-test"
-
-
-@pytest.fixture()
-def internal_project_id():
-    """Return a fake Cloud/internal project ID."""
-    return "pytest-123"
-
-
-@pytest.fixture()
 def client(config: MeltanoCloudConfig) -> MeltanoCloudClient:
     """Return a MeltanoCloudClient instance with fake credentials."""
     return MeltanoCloudClient(config=config)

--- a/src/cloud-cli/tests/conftest.py
+++ b/src/cloud-cli/tests/conftest.py
@@ -104,3 +104,15 @@ def config(
     )
     config.write_to_file()
     return config
+
+
+@pytest.fixture()
+def tenant_resource_key():
+    """Return a fake tenant resource key."""
+    return "meltano-cloud-test"
+
+
+@pytest.fixture()
+def internal_project_id():
+    """Return a fake Cloud/internal project ID."""
+    return "pytest-123"


### PR DESCRIPTION
When you have an access and id token, requests are made with the assumption that the tokens aren't out of date. On 403, login is triggered and the request is retried automatically.

closes: https://github.com/meltano/meltano/issues/7730
