### PR TITLE
fix: Redact sensitive values in `config list` output

### DIFF
--- a/docs/src/_reference/command-line-interface.md
+++ b/docs/src/_reference/command-line-interface.md
@@ -360,6 +360,15 @@ meltano config <plugin> set --interactive --extras
 meltano config <plugin> set --interactive --store=dotenv
 ```
 
+### Sensitive configuration
+Values for sensitive settings (defined as `kind: password`) are redacted in the output of the following commands:
+
+```bash
+meltano config <plugin> list
+meltano config set <name> <value>
+meltano config <plugin> set --interactive
+```
+
 ## `discover`
 
 Lists the available [discoverable plugins](/concepts/plugins#discoverable-plugins) and their [variants](/concepts/plugins#variants).

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -284,7 +284,11 @@ def list_settings(ctx, extras: bool):
         else:
             label = f"{get_label(config_metadata)}"
 
-        current_value = click.style(f"{value!r}", fg="green")
+        current_value = click.style(
+            f"{value!r}",
+            fg="yellow" if value is not None and setting_def.is_redacted else "green",
+        )
+
         click.echo(f" current value: {current_value}", nl=False)
 
         unexpanded_value = config_metadata.get("unexpanded_value")

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -284,9 +284,11 @@ def list_settings(ctx, extras: bool):
         else:
             label = f"{get_label(config_metadata)}"
 
+        redacted_with_value = value is not None and setting_def.is_redacted
+
         current_value = click.style(
-            f"{value!r}",
-            fg="yellow" if value is not None and setting_def.is_redacted else "green",
+            value if redacted_with_value else f"{value!r}",
+            fg="yellow" if redacted_with_value else "green",
         )
 
         click.echo(f" current value: {current_value}", nl=False)

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -235,7 +235,12 @@ def list_settings(ctx, extras: bool):
     # regular and extra settings, since we show custom extras.
     load_extras = True if extras else None
 
-    full_config = settings.config_with_metadata(session=session, extras=load_extras)
+    full_config = settings.config_with_metadata(
+        session=session,
+        extras=load_extras,
+        redacted=True,
+    )
+
     for name, config_metadata in full_config.items():
         value = config_metadata["value"]
         source = config_metadata["source"]

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -190,7 +190,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
 
         if unexpanded_value:
             current_value = value_for_display(unexpanded_value)
-            details.add_row(Text("Current Expanded Value"), Text(f"{expanded_value}"))
+            details.add_row(Text("Current expanded value"), Text(f"{expanded_value}"))
         else:
             current_value = expanded_value
 
@@ -198,7 +198,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         value_color = "yellow" if redacted_with_value else "green"
 
         details.add_row(
-            Text(f"Current Value ({label})"),
+            Text(f"Current value ({label})"),
             Text.from_markup(f"[{value_color}]{current_value}[/{value_color}]"),
         )
 

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -37,7 +37,6 @@ if t.TYPE_CHECKING:
 PLUGIN_COLOR = "magenta"
 ENVIRONMENT_COLOR = "orange1"
 SETTING_COLOR = "blue1"
-VALUE_COLOR = "green"
 
 HOME_SCREEN_TEMPLATE = """[bold underline]Configuring [{{ plugin_color }}]{{ plugin_name.capitalize() | safe }}[/{{ plugin_color }}] {% if environment_name %}in Environment[{{ environment_color }}]{{ environment_name }}[/{{ environment_color }}] {% endif %}Interactively[/bold underline]
 
@@ -179,19 +178,28 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
             label = f"inherited from '{self.settings.plugin.parent.name}'"
         else:
             label = f"from {source.label}"
-        expanded_value = value if value is not None else "(empty string)"
-        unexpanded_value = config_metadata.get("unexpanded_value")
-        if unexpanded_value:
-            current_value = (
-                unexpanded_value if unexpanded_value is not None else "(empty string)"
-            )
 
+        def value_is_defined(v=value):
+            return v is not None
+
+        def value_for_display(v=value):
+            return v if value_is_defined(v) else "(empty string)"
+
+        expanded_value = value_for_display()
+        unexpanded_value = config_metadata.get("unexpanded_value")
+
+        if unexpanded_value:
+            current_value = value_for_display(unexpanded_value)
             details.add_row(Text("Current Expanded Value"), Text(f"{expanded_value}"))
         else:
-            current_value = value if value is not None else "(empty string)"
+            current_value = expanded_value
+
+        redacted_with_value = setting_def.is_redacted and value_is_defined()
+        value_color = "yellow" if redacted_with_value else "green"
+
         details.add_row(
             Text(f"Current Value ({label})"),
-            Text.from_markup(f"[{VALUE_COLOR}]{current_value}[/{VALUE_COLOR}]"),
+            Text.from_markup(f"[{value_color}]{current_value}[/{value_color}]"),
         )
 
         if setting_def.kind:
@@ -406,14 +414,18 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         name = metadata["name"]
         store = metadata["store"]
         is_redacted = metadata["setting"] and metadata["setting"].is_redacted
-        if is_redacted:
-            value = REDACTED_VALUE
+
         click.secho(
             (
                 f"{settings.label.capitalize()} setting '{name}' was set in "
-                f"{store.label}: {value!r}"
+                f"{store.label}: "
             ),
-            fg=VALUE_COLOR,
+            fg="green",
+            nl=False,
+        )
+        click.secho(
+            f"{REDACTED_VALUE if is_redacted else value!r}",
+            fg="yellow" if is_redacted else "green",
         )
 
         current_value, source = settings.get_with_source(name, session=self.session)

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -424,16 +424,16 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
             nl=False,
         )
         click.secho(
-            f"{REDACTED_VALUE if is_redacted else value!r}",
+            REDACTED_VALUE if is_redacted else f"{value!r}",
             fg="yellow" if is_redacted else "green",
         )
 
         current_value, source = settings.get_with_source(name, session=self.session)
         if source != store:
-            if is_redacted:
-                current_value = REDACTED_VALUE
+            current_value = REDACTED_VALUE if is_redacted else f"{value!r}"
+
             click.secho(
-                f"Current value is still: {current_value!r} (from {source.label})",
+                f"Current value is still: {current_value} (from {source.label})",
                 fg="yellow",
             )
 


### PR DESCRIPTION
Fix to redact values for sensitive settings (of `kind` `password` or `oauth`) in `config list`. Also minor refactor to display the redacted value in yellow across `config` commands.

`config list`

![image](https://github.com/meltano/meltano/assets/60552974/0190f45b-44e2-4e37-a1f9-f05d32a3ed7c)

`config set`

![image](https://github.com/meltano/meltano/assets/60552974/53f943b8-e65c-4d80-bb3d-4eace23578ed)

`config set --interactive`

![image](https://github.com/meltano/meltano/assets/60552974/00243b1f-8692-431c-a450-f472472a7713)

---

Closes #6858