### PR TITLE
chore: Enable mypy warnings for unused configurations and "ignores"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -492,6 +492,8 @@ files = "src"
 plugins = [
   "sqlalchemy.ext.mypy.plugin",
 ]
+warn_unused_configs = true
+warn_unused_ignores = true
 
 # The following whitelist is used to allow for incremental adoption
 # of MyPy. Modules should be removed from this whitelist as and when

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -63,7 +63,7 @@ MANIFEST_SCHEMA_PATH = (
     Path(package_root_path).parent / "schemas" / "meltano.schema.json"
 )
 
-Trie: TypeAlias = t.Dict[str, "Trie"]  # type: ignore
+Trie: TypeAlias = t.Dict[str, "Trie"]
 PluginsByType: TypeAlias = t.Mapping[str, t.List[t.Mapping[str, t.Any]]]
 PluginsByNameByType: TypeAlias = t.Mapping[str, t.Mapping[str, t.Mapping[str, t.Any]]]
 

--- a/src/meltano/core/state_store/azure.py
+++ b/src/meltano/core/state_store/azure.py
@@ -15,7 +15,7 @@ from meltano.core.state_store.filesystem import BaseFilesystemStateStoreManager
 try:
     from azure.storage.blob import BlobServiceClient  # type: ignore
 except ImportError:
-    BlobServiceClient = None  # type: ignore
+    BlobServiceClient = None
 
 
 class MissingAzureError(Exception):
@@ -95,7 +95,7 @@ class AZStorageStateStoreManager(BaseFilesystemStateStoreManager):
         with requires_azure():
             if self.connection_string:
                 return BlobServiceClient.from_connection_string(self.connection_string)
-            return BlobServiceClient()  # type: ignore
+            return BlobServiceClient()
 
     @property
     def state_dir(self) -> str:

--- a/src/meltano/core/state_store/google.py
+++ b/src/meltano/core/state_store/google.py
@@ -15,7 +15,7 @@ from meltano.core.state_store.filesystem import BaseFilesystemStateStoreManager
 try:
     import google  # type: ignore
 except ImportError:
-    google = None  # type: ignore
+    google = None
 
 
 class MissingGoogleError(Exception):


### PR DESCRIPTION
Enables mypy errors for unused configurations and `type: ignore` comments:

- [`warn_unused_configs`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_unused_configs)
- [`warn_unused_ignores`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_unused_ignores)

See https://github.com/meltano/meltano/pull/7912#pullrequestreview-1535009956
