### PR TITLE
refactor: Replace deprecated `locale.getdefaultlocale` with `locale.getlocale`

### DIFF
--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -138,7 +138,7 @@ class Tracker:  # noqa: WPS214, WPS230 - too many (public) methods
                 app_id="meltano",
                 emitters=emitters,
             )
-            self.snowplow_tracker.subject.set_lang(locale.getdefaultlocale()[0])
+            self.snowplow_tracker.subject.set_lang(locale.getlocale()[0])
             self.snowplow_tracker.subject.set_timezone(self.timezone_name)
             self.setup_exit_event()
         else:


### PR DESCRIPTION
Closes #7962