### PR TITLE
chore: Enable SQLAlchemy `future` flags

### DIFF
--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -115,7 +115,7 @@ def meltano_state(project: Project, ctx: click.Context):
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#state
     """
     _, sessionmaker = project_engine(project)
-    session = sessionmaker()
+    session = sessionmaker(future=True)
     ctx.obj[STATE_SERVICE_KEY] = StateService(project, session)  # noqa: WPS204
 
 

--- a/src/meltano/core/db.py
+++ b/src/meltano/core/db.py
@@ -58,7 +58,7 @@ def project_engine(
     engine_uri = project.settings.get("database_uri")
     logging.debug(f"Creating engine '{project}@{engine_uri}'")
 
-    engine = create_engine(engine_uri, poolclass=NullPool)
+    engine = create_engine(engine_uri, poolclass=NullPool, future=True)
 
     # Connect to the database to ensure it is available.
     connect(
@@ -70,7 +70,7 @@ def project_engine(
     check_database_compatibility(engine)
     init_hook(engine)
 
-    engine_session = (engine, sessionmaker(bind=engine))
+    engine_session = (engine, sessionmaker(bind=engine, future=True))
 
     if default:
         # register the default engine

--- a/src/meltano/migrations/versions/53e97221d99f_add_run_id_to_job.py
+++ b/src/meltano/migrations/versions/53e97221d99f_add_run_id_to_job.py
@@ -20,7 +20,7 @@ down_revision = "6ef30ab7b8e5"
 branch_labels = None
 depends_on = None
 
-Session = sa.orm.sessionmaker()
+Session = sa.orm.sessionmaker(future=True)
 
 
 def upgrade():

--- a/tests/fixtures/db/__init__.py
+++ b/tests/fixtures/db/__init__.py
@@ -51,8 +51,8 @@ def vacuum_db(engine_sessionmaker):
 
 @pytest.fixture(scope="class")
 def engine_sessionmaker(engine_uri):
-    engine = create_engine(engine_uri, poolclass=NullPool)
-    return (engine, sessionmaker(bind=engine))
+    engine = create_engine(engine_uri, poolclass=NullPool, future=True)
+    return (engine, sessionmaker(bind=engine, future=True))
 
 
 @pytest.fixture()

--- a/tests/fixtures/db/mssql.py
+++ b/tests/fixtures/db/mssql.py
@@ -71,6 +71,7 @@ def engine_uri(worker_id: str):
         master_engine_uri,
         isolation_level="AUTOCOMMIT",
         poolclass=NullPool,
+        future=True,
     )
     recreate_database(engine, database)
 

--- a/tests/fixtures/db/postgresql.py
+++ b/tests/fixtures/db/postgresql.py
@@ -32,6 +32,7 @@ def engine_uri(worker_id: str):
         engine_uri,
         isolation_level="AUTOCOMMIT",
         poolclass=NullPool,
+        future=True,
     )
     recreate_database(engine, database)
 


### PR DESCRIPTION
- [Migration to 2.0 Step Four - Use the `future` flag on Engine](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-four-use-the-future-flag-on-engine)
- [Migration to 2.0 Step Five - Use the `future` flag on Session](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-five-use-the-future-flag-on-session)