### PR TITLE
docs: Correct `repo_ext` to `ext_repo` for plugin definition syntax

### DIFF
--- a/docs/docs/reference/plugin-definition-syntax.md
+++ b/docs/docs/reference/plugin-definition-syntax.md
@@ -66,12 +66,12 @@ wrapping another application this should point the applications repository, not 
 repo: https://github.com/apache/airflow
 ```
 
-## `repo_ext`
+## `ext_repo`
 
-The URL of the plugins extensions repository itself (in GitHub, GitLab, etc.).
+The URL of the plugin's extension repository itself (in GitHub, GitLab, etc.).
 
 ```yaml
-repo_ext: https://github.com/meltano/airflow-ext
+ext_repo: https://github.com/meltano/airflow-ext
 ```
 
 ## `executable`


### PR DESCRIPTION
Minor docs fix to change `repo_ext` to `ext_repo`. There are [no references to `repo_ext` in Meltano Hub](https://github.com/search?type=code&q=repo%3Ameltano%2Fhub+repo_ext).