### PR TITLE
fix: Use hyphens consistently for CLI options

### DIFF
--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -576,22 +576,22 @@ The new project directory will contain:
 - stubs for `.gitignore`, `README.md`, and `requirements.txt` for you to edit (or delete) as appropriate, and
 - empty `extract`, `load`, `transform`, `notebook`, and `orchestrate` directories for you to use (or delete) as you please.
 
-[Anonymous usage statistics](/reference/settings#send-anonymous-usage-stats) are enabled by default, unless the `--no_usage_stats` flag is provided, the `MELTANO_SEND_ANONYMOUS_USAGE_STATS` environment variable is disabled, or you set `send_anonymous_usage_stats: false` in your `meltano.yml`.
+[Anonymous usage statistics](/reference/settings#send-anonymous-usage-stats) are enabled by default, unless the `--no-usage-stats` flag is provided, the `MELTANO_SEND_ANONYMOUS_USAGE_STATS` environment variable is disabled, or you set `send_anonymous_usage_stats: false` in your `meltano.yml`.
 
 ### How to use
 
 ```bash
 # Format
-meltano init [project_directory] [--no_usage_stats] [--force]
+meltano init [project_directory] [--no-usage-stats] [--force]
 ```
 
-#### Parameters
+#### Positional Arguments
 
 - **project_directory** - This determines the directory path to create the project at. Can be `.` to create a project in the current directory.
 
 #### Options
 
-- **no_usage_stats** - This flag disables the [`send_anonymous_usage_stats` setting](/reference/settings#send-anonymous-usage-stats).
+- **no-usage-stats** - This flag disables the [`send_anonymous_usage_stats` setting](/reference/settings#send-anonymous-usage-stats).
 - **force** - This flag overwrites any existing `meltano.yml` in the project directory.
 
 #### Examples
@@ -608,12 +608,12 @@ meltano init
 meltano init demo-project
 # - OR don't share anything with the Meltano team
 #   about this specific project:
-meltano init demo-project --no_usage_stats
+meltano init demo-project --no-usage-stats
 # - OR don't share anything with the Meltano team
 #   about any project I initialize ever:
 SHELLRC=~/.$(basename $SHELL)rc # ~/.bashrc, ~/.zshrc, etc
 echo "export MELTANO_SEND_ANONYMOUS_USAGE_STATS=0" >> $SHELLRC
-meltano init demo-project # --no_usage_stats is implied
+meltano init demo-project # --no-usage-stats is implied
 
 # Initialize a new Meltano project in the current working directory
 meltano init .

--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -33,7 +33,7 @@ These are settings specific to [your Meltano project](/concepts/project).
 ### <a name="send_anonymous_usage_stats"></a>`send_anonymous_usage_stats`
 
 - [Environment variable](../guide/configuration#configuring-settings): `MELTANO_SEND_ANONYMOUS_USAGE_STATS`
-- [`meltano init`](../reference/command-line-interface#init) CLI option: `--no_usage_stats` (implies value `false`)
+- [`meltano init`](../reference/command-line-interface#init) CLI option: `--no-usage-stats` (implies value `false`)
 - Default: `true`
 
 Meltano is open source software thats free for anyone to use. The best thing a user could do to give back to the community, aside from contributing code or reporting issues, is contribute anonymous usage stats to allow the maintainers to understand how features are being utilized ultimately helping the community build a better product.
@@ -54,7 +54,7 @@ Also refer to the Meltano data team handbook page for our ["Philosophy of Teleme
 
 With all that said, if you'd still prefer to use Meltano _without_ sending the maintainers this kind of data, you're able to disable tracking entirely using one of these methods:
 
-- When creating a new project, pass `--no_usage_stats` to [`meltano init`](/reference/command-line-interface#init)
+- When creating a new project, pass `--no-usage-stats` to [`meltano init`](/reference/command-line-interface#init)
 - In an existing project, set the `send_anonymous_usage_stats` setting to `false`
 - To disable tracking in all projects in one go, set the `MELTANO_SEND_ANONYMOUS_USAGE_STATS` environment variable to `false`
 
@@ -65,7 +65,7 @@ meltano config meltano set send_anonymous_usage_stats false
 
 export MELTANO_SEND_ANONYMOUS_USAGE_STATS=false
 
-meltano init --no_usage_stats demo-project
+meltano init --no-usage-stats demo-project
 ```
 
 #### Anonymization Standards

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -47,6 +47,11 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
     cls=NoWindowsGlobbingGroup,
     invoke_without_command=True,
     no_args_is_help=True,
+    # For backwards compatibility, accept CLI options that use underscores
+    # instead of hyphens.
+    # https://github.com/pallets/click/issues/1123#issuecomment-589989721
+    # NOTE: This CLI option normalization applies to all subcommands.
+    context_settings={"token_normalize_func": lambda x: x.replace("_", "-")},
 )
 @click.option("--log-level", type=click.Choice(LEVELS.keys()))
 @click.option(

--- a/src/meltano/cli/initialize.py
+++ b/src/meltano/cli/initialize.py
@@ -26,7 +26,7 @@ path_type = click.Path(file_okay=False, path_type=Path)
 @click.pass_context
 @click.argument("project_directory", required=False, type=path_type)
 @click.option(
-    "--no_usage_stats",
+    "--no-usage-stats",
     help="Do not send anonymous usage stats.",
     is_flag=True,
 )

--- a/src/meltano/cli/upgrade.py
+++ b/src/meltano/cli/upgrade.py
@@ -43,7 +43,7 @@ def upgrade(ctx, project):
     short_help="Upgrade Meltano and your entire project to the latest version.",
 )
 @click.option(
-    "--pip_url",
+    "--pip-url",
     type=str,
     envvar="MELTANO_UPGRADE_PIP_URL",
     help="Meltano pip URL.",
@@ -114,7 +114,7 @@ def all(ctx, pip_url, force, skip_package):
 
 @upgrade.command(cls=InstrumentedCmd, short_help="Upgrade the Meltano package only.")
 @click.option(
-    "--pip_url",
+    "--pip-url",
     type=str,
     envvar="MELTANO_UPGRADE_PIP_URL",
     help="Meltano pip URL.",

--- a/tests/meltano/cli/test_initialize.py
+++ b/tests/meltano/cli/test_initialize.py
@@ -18,7 +18,7 @@ class TestCliInit:
             Project.find()
 
         # Create a project with the CLI
-        cli_runner.invoke(cli, ["init", "test_project", "--no_usage_stats"])
+        cli_runner.invoke(cli, ["init", "test_project", "--no-usage-stats"])
 
         pushd("test_project")
         project = Project.find()
@@ -71,7 +71,7 @@ class TestCliInit:
         project_dir.mkdir()
         assert project_dir.exists()
 
-        result = cli_runner.invoke(cli, ["init", "test_project", "--no_usage_stats"])
+        result = cli_runner.invoke(cli, ["init", "test_project", "--no_usage-stats"])
         assert "Creating project files...\n  test_project/" in result.output
         assert "cd test_project" in result.output
 


### PR DESCRIPTION
This is not a breaking change. All old CLI options will still work thanks to the normalization the CLI now does to the CLI option names.

Closes #2253