### PR TITLE
feat(cli): Add `meltano config --unsafe` flag

### DIFF
--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -256,6 +256,23 @@ meltano config <plugin> set <name> "@\$a"
 meltano config <plugin> set <name> '@$a'
 ```
 
+#### Sensitive values
+By default, values for sensitive settings are redacted from the output of `meltano config` commands and replaced with `(redacted)`. If this behaviour is not desirable, you can expose them with the `--unsafe` flag instead. The default behaviour can be reaffirmed with the counterpart `--safe` flag (although functionally, this has no effect).
+
+:::caution
+  <p>The exception to this rule is <code>meltano config &lt;plugin&gt;</code> which will <b>always output unredacted values</b>, and is intended for debugging purposes only</p>
+:::
+
+```bash
+# `--safe` is the effective default, whether the flag is present or not
+meltano config --safe <plugin> list
+meltano config <plugin> list
+
+meltano config --unsafe <plugin> list
+meltano config --unsafe <plugin> set <sensitive-name> <sensitive-value>
+meltano config --unsafe <plugin> set --interactive
+```
+
 #### Nested properties
 
 Nested properties can be set (and unset) by specifying a list of property names:

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -80,7 +80,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         self.environment_service = EnvironmentService(self.project)
         self.max_width = max_width or 75  # noqa: WPS432
         self.console = Console()
-        self.unsafe: bool = ctx.obj["unsafe"]
+        self.safe: bool = ctx.obj["safe"]
 
     @property
     def configurable_settings(self):
@@ -88,7 +88,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         return self.settings.config_with_metadata(
             session=self.session,
             extras=self.extras,
-            redacted=not self.unsafe,
+            redacted=self.safe,
         )
 
     @property
@@ -196,7 +196,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
             current_value = expanded_value
 
         redacted_with_value = (
-            not self.unsafe and setting_def.is_redacted and value_is_defined()
+            self.safe and setting_def.is_redacted and value_is_defined()
         )
         value_color = "yellow" if redacted_with_value else "green"
 
@@ -417,7 +417,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         name = metadata["name"]
         store = metadata["store"]
         setting = metadata["setting"]
-        is_redacted = not self.unsafe and setting and setting.is_redacted
+        is_redacted = self.safe and setting and setting.is_redacted
 
         click.secho(
             (

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -80,6 +80,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         self.environment_service = EnvironmentService(self.project)
         self.max_width = max_width or 75  # noqa: WPS432
         self.console = Console()
+        self.unsafe: bool = ctx.obj["unsafe"]
 
     @property
     def configurable_settings(self):
@@ -87,7 +88,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         return self.settings.config_with_metadata(
             session=self.session,
             extras=self.extras,
-            redacted=True,
+            redacted=not self.unsafe,
         )
 
     @property
@@ -194,7 +195,9 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         else:
             current_value = expanded_value
 
-        redacted_with_value = setting_def.is_redacted and value_is_defined()
+        redacted_with_value = (
+            not self.unsafe and setting_def.is_redacted and value_is_defined()
+        )
         value_color = "yellow" if redacted_with_value else "green"
 
         details.add_row(
@@ -413,7 +416,8 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
 
         name = metadata["name"]
         store = metadata["store"]
-        is_redacted = metadata["setting"] and metadata["setting"].is_redacted
+        setting = metadata["setting"]
+        is_redacted = not self.unsafe and setting and setting.is_redacted
 
         click.secho(
             (

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -119,6 +119,32 @@ class TestCliConfig:
             "TAP_MOCK_SECURE variable in `.env`)"
         ) in result.stdout
 
+    @pytest.mark.usefixtures("project")
+    def test_config_list_unsafe(
+        self,
+        cli_runner,
+        tap,
+        session,
+        plugin_settings_service_factory,
+    ):
+        value = "thisisatest"
+
+        plugin_settings_service = plugin_settings_service_factory(tap)
+        plugin_settings_service.set(
+            "secure",
+            value,
+            store=SettingValueStore.DOTENV,
+            session=session,
+        )
+
+        result = cli_runner.invoke(cli, ["config", "--unsafe", tap.name, "list"])
+        assert_cli_runner(result)
+
+        assert (
+            f"secure [env: TAP_MOCK_SECURE] current value: '{value}' (from the "
+            "TAP_MOCK_SECURE variable in `.env`)"
+        ) in result.stdout
+
 
 class TestCliConfigSet:
     @pytest.mark.usefixtures("project")
@@ -132,6 +158,20 @@ class TestCliConfigSet:
         assert (
             f"Extractor '{tap.name}' setting 'secure' was set in `.env`: "
             + REDACTED_VALUE
+        ) in result.stdout
+
+    @pytest.mark.usefixtures("project")
+    def test_config_set_unsafe(self, cli_runner, tap):
+        value = "thisisatest"
+
+        result = cli_runner.invoke(
+            cli,
+            ["config", "--unsafe", tap.name, "set", "secure", value],
+        )
+        assert_cli_runner(result)
+
+        assert (
+            f"Extractor '{tap.name}' setting 'secure' was set in `.env`: '{value}'"
         ) in result.stdout
 
     @pytest.mark.usefixtures("tap")


### PR DESCRIPTION
Essentially bypasses behaviour changes made in #7878 to expose sensitive setting values with `--unsafe`, as per [this request on Slack](https://meltano.slack.com/archives/CKHP6G5V4/p1690300061219669) by @visch.