### PR TITLE
docs: Fix cloud install git URL

### DIFF
--- a/docs/docs/cloud/onboarding.md
+++ b/docs/docs/cloud/onboarding.md
@@ -60,7 +60,7 @@ jobs:
 To install from scratch using [pipx](https://pypa.github.io/pipx/installation/#install-pipx):
 
 ```console
-pipx install 'git+https://github.com/meltano/meltano.git@cloud#subdirectory=src/cloud-cli'
+pipx install 'git+https://github.com/meltano/meltano.git@cloud'
 ```
 
 To upgrade to the latest version:


### PR DESCRIPTION
Should this pip url be updated? I tried to install it and it failed. Also it looks like that subdirectory no longer exists on the cloud branch.