### PR TITLE
chore: Avoid installing `setuptools` and `wheel` in plugin venvs

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -57,9 +57,6 @@ def venv_platform_specs():
         raise Exception(f"Platform {system!r} not supported.") from ex
 
 
-PIP_PACKAGES = ("pip", "setuptools==57.5.0", "wheel")
-
-
 class VirtualEnv:
     """Info about a single virtual environment."""
 
@@ -246,7 +243,7 @@ class VenvService:  # noqa: WPS214
         """
         logger.debug(f"Upgrading pip for '{self.namespace}/{self.name}'")
         try:
-            return await self._pip_install(["--upgrade", *PIP_PACKAGES])
+            return await self._pip_install(["--upgrade", "pip"])
         except AsyncSubprocessError as err:
             raise AsyncSubprocessError(
                 "Failed to upgrade pip to the latest version.",


### PR DESCRIPTION
Relates to:
- https://github.com/meltano/meltano/pull/7022

The above PR was made because `singer-python` was broken, and several plugins depended on it. Because `singer-python` was out of our control, instead of fixing it, we added this hack fix into Meltano itself.

The problem with keeping `setuptools` pinned is that it ensures that an old, possibly vulnerable, version of `setuptools` is installed into every plugin venv.

Meltano v3 seems like a good time to rip this bandaid off. Plugins that rely on this old version of `setuptools` should ensure it's installed themselves, using the ability for modern Python packages to install build-time dependencies.