### PR TITLE
docs: Add JSON Schema information

### DIFF
--- a/docs/docs/concepts/project.md
+++ b/docs/docs/concepts/project.md
@@ -25,7 +25,7 @@ You can initialize a new Meltano project using [`meltano init`](/reference/comma
 At a minimum, a Meltano project must contain a project file named `meltano.yml`,
 which contains your project configuration and tells Meltano that a particular directory is a Meltano project.
 
-The only required property is `version`, which currently always holds the value `1`.
+The only required property is `version`, which currently always holds the value `1`. You can find a formal JSON Schema for the specification on [SchemaStore.org](https://schemastore.org) or directly in the main repository [here](https://raw.githubusercontent.com/meltano/meltano/main/src/meltano/schemas/meltano.schema.json), which can be useful for code generation by many tools like [datamodel-code-generator](https://github.com/koxudaxi/datamodel-code-generator) or [swagger-codegen](https://github.com/swagger-api/swagger-codegen).
 
 ### Configuration
 


### PR DESCRIPTION
Adds information about JSON Schema for `meltano.yml` and how to use it for things like generating Pydantic types and such. This process is useful for embedded ETL circumstances where you're modifying `meltano.yml` at runtime and want to validate the format of each write to fail fast, like we are at [Akkio](https://akkio.com). Another potential use case for even non-embedded use cases is to add an automated test that validates your `meltano.yml`, which prevents you from pushing a broken file to higher environments or even production. 

Attempted to follow PR guidelines at https://docs.meltano.com/contribute/merge, including semver PR name.