### PR TITLE
fix: Display a better error message when database URI is null

### DIFF
--- a/tests/meltano/core/test_db_connection.py
+++ b/tests/meltano/core/test_db_connection.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import typing as t
+
 import pytest
+import yaml
 from mock import Mock
 from sqlalchemy.exc import OperationalError
 
-from meltano.core.db import connect
+from meltano.core.db import NullConnectionStringError, connect, project_engine
+from meltano.core.project import Project
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestConnectionRetries:
@@ -31,3 +38,25 @@ class TestConnectionRetries:
 
         connect(engine=engine_mock, max_retries=3, retry_timeout=0.1)
         assert engine_mock.connect.call_count == 2
+
+
+class TestProjectEngine:
+    def test_project_engine(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ):
+        with tmp_path.joinpath("meltano.yml").open("w") as meltano_yml:
+            yaml.dump(
+                {
+                    "project_id": "test",
+                    "send_anonymous_usage_stat": False,
+                    "database_uri": "$DATABASE",
+                },
+                meltano_yml,
+            )
+        monkeypatch.delenv("MELTANO_DATABASE_URI")
+
+        project = Project(tmp_path)
+        with pytest.raises(NullConnectionStringError):
+            project_engine(project)


### PR DESCRIPTION
Related:

* Closes https://github.com/meltano/meltano/issues/8014