### PR TITLE
chore: Fix commitizen config for Meltano docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -485,7 +485,8 @@ version_files = [
   "pyproject.toml:^version =",
   "src/meltano/__init__.py:^__version__ =",
   'src/webapp/package.json:^  "version":',
-  'docs/package.json:^  "version":',
+  # TODO: uncomment the following line for Meltano v3.0.0
+  # 'docs/package.json:^  "version":',
 ]
 
 [tool.mypy]


### PR DESCRIPTION
The line for commitizen to update the version in the docs has been commented out because the docs are at version 3.0.0, which causes problems for commitizen, as it is expecting to find 2.20.0

https://github.com/meltano/meltano/actions/runs/5860595390/job/15889013855