### PR TITLE
chore: Run `pytest` in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,7 +434,7 @@ pycodestyle = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=meltano --cov=tests --doctest-modules --order-scope=module -ra"
+addopts = "--cov=meltano --cov=tests --doctest-modules --order-scope=module -ra -n auto --dist=loadfile"
 asyncio_mode = "auto"
 log_cli = 1
 log_cli_format = "%(message)s"


### PR DESCRIPTION
In https://github.com/meltano/meltano/commit/d046f706bf70a8fa114778375706e751fc80de20 the flags required to run Pytest in parallel were mistakenly removed. This PR re-adds them.