### PR TITLE
fix: Ensure elt/run log file is closed

### DIFF
--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -173,7 +173,7 @@ class Out:  # noqa: WPS230
             ),
             foreign_pre_chain=LEVELED_TIMESTAMPED_PRE_CHAIN,
         )
-        handler = logging.FileHandler(self.file)
+        handler = logging.FileHandler(self.file, delay=True)
         handler.setFormatter(formatter)
         return handler
 


### PR DESCRIPTION
Fixes this warning:

```
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/meltano/meltano-cloud/src/meltano/core/logging/output_logger.py:217: ResourceWarning: unclosed file <_io.TextIOWrapper name='/project/.meltano/logs/elt/prodtap-getpocket-to-target-jsonl/12701452-91c4-4b2b-928c-943cc1e271fa/elt.log' mode='a' encoding='UTF-8'>
  logger.removeHandler(self.redirect_log_handler)
```

https://docs.python.org/3/library/logging.handlers.html#logging.FileHandler