### PR TITLE
chore: Revert "chore: Release v2.21.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,45 +3,6 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
 
-## v2.21.0 (2023-08-17)
-
-### ✨ New
-
-- [#7992](https://github.com/meltano/meltano/issues/7992) Add support for mappers in the invoke command
-- [#7997](https://github.com/meltano/meltano/issues/7997) Add `el` command as an alias of `elt` and depecrate both `elt` and the `--transform` option
-- [#7989](https://github.com/meltano/meltano/issues/7989) Add `meltano hub ping` command
-- [#7984](https://github.com/meltano/meltano/issues/7984) Add `meltano config --unsafe` flag -- _**Thanks @ReubenFrankel!**_
-- [#7932](https://github.com/meltano/meltano/issues/7932) Add "did you mean" CLI command name suggestions
-
-### 🐛 Fixes
-
-- [#8031](https://github.com/meltano/meltano/issues/8031) Redact DB password from logs
-- [#8015](https://github.com/meltano/meltano/issues/8015) Display a better error message when database URI is null
-- [#7982](https://github.com/meltano/meltano/issues/7982) Use hyphens consistently for CLI options
-- [#7947](https://github.com/meltano/meltano/issues/7947) Support PEP 440 direct references in `pip_url`
-
-### ⚙️ Under the Hood
-
-- [#7964](https://github.com/meltano/meltano/issues/7964) Replace deprecated `locale.getdefaultlocale` with `locale.getlocale` -- _**Thanks @AmirAflak!**_
-
-### 📚 Documentation Improvements
-
-- [#8011](https://github.com/meltano/meltano/issues/8011) Add JSON Schema information -- _**Thanks @anden-akkio!**_
-- [#7991](https://github.com/meltano/meltano/issues/7991) Fix cloud install git URL
-- [#7975](https://github.com/meltano/meltano/issues/7975) Link `mssql` additional compoment to system database explanation
-- [#7979](https://github.com/meltano/meltano/issues/7979) Correct `repo_ext` to `ext_repo` for plugin definition syntax -- _**Thanks @ReubenFrankel!**_
-- [#7953](https://github.com/meltano/meltano/issues/7953) Update tagline in readme
-- [#7951](https://github.com/meltano/meltano/issues/7951) Update changelog
-- [#7950](https://github.com/meltano/meltano/issues/7950) Fix logging example -- _**Thanks @aminebeh!**_
-- [#7948](https://github.com/meltano/meltano/issues/7948) Update docusaurus.config.js -- _**Thanks @gridig!**_
-- [#7945](https://github.com/meltano/meltano/issues/7945) Douwe fixes
-- [#7944](https://github.com/meltano/meltano/issues/7944) Quick doc fixes
-- [#7936](https://github.com/meltano/meltano/issues/7936) Migrate Meltano docs to Docusaurus
-- [#7902](https://github.com/meltano/meltano/issues/7902) Rm ELT messaging, move things around
-- [#7931](https://github.com/meltano/meltano/issues/7931) Cloud docs ssh key validate tip
-- [#7930](https://github.com/meltano/meltano/issues/7930) Meltano cloud to meltano-cloud
-- [#7926](https://github.com/meltano/meltano/issues/7926) Fix state backend env vars in examples
-
 ## v2.20.0 (2023-07-19)
 
 ### ✨ New

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meltano"
-version = "2.21.0"
+version = "2.20.0"
 description = "Meltano is your CLI for ELT+: Open Source, Flexible, and Scalable. Move, transform, and test your data with confidence using a streamlined data engineering workflow you’ll love."
 authors = ["Meltano <hello@meltano.com>"]
 license = "MIT"
@@ -480,7 +480,7 @@ skip_covered = true
 [tool.commitizen]
 name = "cz_version_bump"
 tag_format = "v$major.$minor.$patch$prerelease"
-version = "2.21.0"
+version = "2.20.0"
 version_files = [
   "pyproject.toml:^version =",
   "src/meltano/__init__.py:^__version__ =",

--- a/src/meltano/__init__.py
+++ b/src/meltano/__init__.py
@@ -4,4 +4,4 @@
 from __future__ import annotations
 
 # Managed by commitizen
-__version__ = "2.21.0"
+__version__ = "2.20.0"

--- a/src/webapp/package.json
+++ b/src/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meltano-webapp",
-  "version": "2.21.0",
+  "version": "2.20.0",
   "private": true,
   "scripts": {
     "dev": "npm run serve",


### PR DESCRIPTION
Reverts meltano/meltano#8036

This release failed to publish due to UI build errors. We may end up skipping it, in favour of releasing `v3` next:
- https://github.com/meltano/meltano/pull/8047

The associated release draft release has been deleted, as has the `v2.21.0` tag.