### PR TITLE
docs: Fix `sidebar_class_name: hidden` in content

### DIFF
--- a/docs/docs/reference/plugin-definition-syntax.md
+++ b/docs/docs/reference/plugin-definition-syntax.md
@@ -455,7 +455,7 @@ Optional. Use to hide a setting.
 ```yaml
 settings:
 - name: setting_name
-  sidebar_class_name: hidden
+  hidden: true
 ```
 
 ### `settings[*].kind`
@@ -478,7 +478,7 @@ settings:
 
 :::caution
 
-  <p><code>kind: hidden</code> is deprecated in favour of <a href="#settingshidden"><code>sidebar_class_name: hidden</code></a>.</p>
+  <p><code>kind: hidden</code> is deprecated in favour of <a href="#settingshidden"><code>hidden</code></a>.</p>
 :::
 
 ### `settings[*].label`


### PR DESCRIPTION
Looks like a bad find and replace from [this commit](https://github.com/meltano/meltano/pull/7936/commits/f7d65b7ac4c84117d07d08fac01def06f4e35143).

I just noticed this today, so not sure if there are any other similar occurrences.  