### PR TITLE
docs: Restore `python` settings docs

### DIFF
--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -104,6 +104,22 @@ meltano add <type> <name> --no-install
 meltano add extractor tap-spotify --no-install
 ```
 
+By default, plugins that use Python use the version of Python that was used to run Meltano. This behavior can be overridden using the `python` attribute, which can be set [for all plugins](/reference/settings#project-python), or on a [per-plugin basis](/reference/settings#plugin-python).
+
+When adding a new plugin, the Python version can be specified using the `--python` option:
+
+```bash
+meltano add <type> <name> --python <Python executable name or path>
+```
+
+For example, to add `tap-github` using Python 3.12 (assuming `python3.12` is installed and on your `$PATH`):
+
+```bash
+meltano add extractor tap-github --python python3.12
+```
+
+Then regardless of the Python version used when the plugin is installed, `tap-gitlab` and any plugin which inherits from it will use Python 3.12.
+
 #### Parameters
 
 - `--custom`: Add a [custom plugin](/concepts/plugins#custom-plugins). The command will prompt you for the package's [base plugin description](/concepts/plugins#project-plugins) metadata.

--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -26,9 +26,33 @@ For plugin settings, refer to the specific plugin's documentation
 or use [`meltano config <plugin> list`](/reference/command-line-interface#config)
 to list all available settings with their names, environment variables, and current values.
 
+### <a name="plugin-python"></a>`python`
+
+The python version to use for this plugin, specified as a path, or as the name of an executable to find within a directory in `$PATH`.
+
+If not specified, [the top-level `python` setting will be used](#project-python), or if it is not set, the python executable that was used to run Meltano will be used (within a separate virtual environment).
+
+This setting only applies when creating new virtual environments. If you've already created a virtual environment and you'd like to use a new Python version for it, you'll need to delete it from within `.meltano/`, then run `meltano install` for that plugin again.
+
+This setting only applies to base plugins, which have their own virtual environment. Inherited plugins necessarily use the same virtual environment (and thus, the Python version) as their base plugin.
+
 ## Your Meltano project
 
 These are settings specific to [your Meltano project](/concepts/project).
+
+### <a name="project-python"></a>`python`
+
+- [Environment variable](../guide/configuration#configuring-settings): `MELTANO_PYTHON`
+
+The python version to use for plugins, specified as a path, or as the name of an executable to find within a directory in `$PATH`.
+
+If not specified, the python executable that was used to run Meltano will be used (within a separate virtual environment).
+
+[This can be overridden on a per-plugin basis by setting the `python` property for the plugin.](#plugin-python)
+
+This setting only applies when creating new virtual environments. If you've already created a virtual environment and you'd like to use a new Python version for it, you'll need to delete it from within `.meltano/`, then run `meltano install` for that plugin again.
+
+This setting only applies to base plugins, which have their own virtual environment. Inherited plugins necessarily use the same virtual environment (and thus, the Python version) as their base plugin.
 
 ### <a name="send_anonymous_usage_stats"></a>`send_anonymous_usage_stats`
 


### PR DESCRIPTION
They were accidentally removed in https://github.com/meltano/meltano/pull/8064
