### PR TITLE
docs: Add example of database URI for SQL Server 

### DIFF
--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -179,11 +179,19 @@ Some systems may come with an older version by default. You can run <code>sqlite
 #### How to use
 
 ```bash
+PostgreSQL
 meltano config meltano set database_uri postgresql+psycopg://<username>:<password>@<host>:<port>/<database>
 
 export MELTANO_DATABASE_URI=postgresql+psycopg://<username>:<password>@<host>:<port>/<database>
 
 meltano run --database-uri=postgresql+psycopg://<username>:<password>@<host>:<port>/<database> ...
+
+SQL SERVER (MSSQL)
+meltano config meltano set database_uri mssql+pymssql://<username>:<password>@<host>:<port>/<database>
+
+export MELTANO_DATABASE_URI=mssql+pymssql://<username>:<password>@<host>:<port>/<database>
+
+meltano run --database-uri=mssql+pymssql://<username>:<password>@<host>:<port>/<database> ...
 ```
 
 :::info

--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -179,14 +179,14 @@ Some systems may come with an older version by default. You can run <code>sqlite
 #### How to use
 
 ```bash
-PostgreSQL
+# PostgreSQL
 meltano config meltano set database_uri postgresql+psycopg://<username>:<password>@<host>:<port>/<database>
 
 export MELTANO_DATABASE_URI=postgresql+psycopg://<username>:<password>@<host>:<port>/<database>
 
 meltano run --database-uri=postgresql+psycopg://<username>:<password>@<host>:<port>/<database> ...
 
-SQL Server (MSSQL)
+# SQL Server (MSSQL)
 meltano config meltano set database_uri mssql+pymssql://<username>:<password>@<host>:<port>/<database>
 
 export MELTANO_DATABASE_URI=mssql+pymssql://<username>:<password>@<host>:<port>/<database>

--- a/docs/docs/reference/settings.md
+++ b/docs/docs/reference/settings.md
@@ -186,7 +186,7 @@ export MELTANO_DATABASE_URI=postgresql+psycopg://<username>:<password>@<host>:<p
 
 meltano run --database-uri=postgresql+psycopg://<username>:<password>@<host>:<port>/<database> ...
 
-SQL SERVER (MSSQL)
+SQL Server (MSSQL)
 meltano config meltano set database_uri mssql+pymssql://<username>:<password>@<host>:<port>/<database>
 
 export MELTANO_DATABASE_URI=mssql+pymssql://<username>:<password>@<host>:<port>/<database>


### PR DESCRIPTION
added an example for sql server users to the docs alongside the postgresql example