### PR TITLE
docs: Update Cloud "Getting Started" guide to include the lock command

### DIFF
--- a/docs/docs/cloud/getting_started.md
+++ b/docs/docs/cloud/getting_started.md
@@ -30,6 +30,8 @@ Meltano Cloud connects to an existing Meltano project in your GitHub repository,
 
    ```bash
    meltano init <INSERT_YOUR_PROJECT_NAME>
+   cd <INSERT_YOUR_PROJECT_NAME>
+   meltano lock --update --all
    ```
 
    Commit your changes back to the GitHub repository.

--- a/docs/docs/cloud/getting_started.md
+++ b/docs/docs/cloud/getting_started.md
@@ -31,10 +31,7 @@ Meltano Cloud connects to an existing Meltano project in your GitHub repository,
    ```bash
    meltano init <INSERT_YOUR_PROJECT_NAME>
    cd <INSERT_YOUR_PROJECT_NAME>
-   meltano lock --update --all
    ```
-
-   Commit your changes back to the GitHub repository.
 
 4. Add Sample Plugins and Schedules
 
@@ -65,6 +62,15 @@ Meltano Cloud connects to an existing Meltano project in your GitHub repository,
      job: sample_job
    ```
 
-5. Next follow the [Onboarding Guide](/cloud/onboarding/) to configure your GitHub repository with Meltano Cloud.
+5. Lock your new plugins and commit the changes
+
+   ```bash
+   meltano lock --update --all
+   ```
+
+   Commit your changes back to the GitHub repository.
+
+
+6. Next follow the [Onboarding Guide](/cloud/onboarding/) to configure your GitHub repository with Meltano Cloud.
 
 Once your Meltano Cloud project is set up you can explore the Meltano Core [getting started guide](/getting-started/part1) to learn how to customize your project.


### PR DESCRIPTION
Prior to the v3 release you could paste plugin configs into your project and it would compile properly. Now lock files are required so after following these onboarding steps https://docs.meltano.com/cloud/getting_started#new-to-meltano I got:

```Extractor 'tap-smoke-test' is not known to Meltano. Try running `meltano lock --update --all` to ensure your plugins are up to date.```

To handle that I added a few more commands to the lock before committing changes back to github.