### PR TITLE
fix(cli): Do not perform destructive state ops when answering 'no' in prompt

### DIFF
--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -47,9 +47,9 @@ class MutuallyExclusiveOptionsError(Exception):
 def _prompt_for_confirmation(prompt):
     """Wrap destructive CLI commands which should prompt the user for confirmation."""
 
-    def _prompt_callback(ctx, param, value):  # noqa: ARG001
-        if not value:
-            click.confirm(prompt)
+    def _prompt_callback(ctx: click.Context, param, value: bool):  # noqa: ARG001
+        if not value and not click.confirm(prompt):
+            ctx.exit(1)
 
     return click.option(
         "--force",

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -269,3 +269,18 @@ class TestCliState:
                 assert_cli_runner(result)
                 job_state = state_service.get_state(state_id)
                 assert (not job_state) or (not job_state.get("singer_state"))
+
+    def test_clear_prompt(self, state_service, cli_runner, state_ids):
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            for state_id in state_ids:
+                result = cli_runner.invoke(cli, ["state", "clear", state_id], input="n")
+                assert result.exit_code == 1
+
+                job_state = state_service.get_state(state_id)
+                assert "singer_state" in job_state
+
+                result = cli_runner.invoke(cli, ["state", "clear", state_id], input="y")
+                assert_cli_runner(result)
+
+                job_state = state_service.get_state(state_id)
+                assert (not job_state) or (not job_state.get("singer_state"))


### PR DESCRIPTION
Closes https://github.com/meltano/meltano/issues/8114