### PR TITLE
ci: Group minor and patch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,10 @@ updates:
     reviewers: [meltano/engineering]
     labels: [deps]
     groups:
-      default:
+      development-dependencies:
+        dependency-type: development
+      runtime-dependencies:
+        dependency-type: production
         update-types:
         - "minor"
         - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       timezone: "UTC"
     reviewers: [meltano/engineering]
     labels: [deps]
+    groups:
+      default:
+        update-types:
+        - "minor"
+        - "patch"
     commit-message:
       prefix: "ci: "
   - package-ecosystem: github-actions
@@ -18,6 +23,11 @@ updates:
       timezone: "UTC"
     reviewers: [meltano/engineering]
     labels: [deps]
+    groups:
+      default:
+        update-types:
+        - "minor"
+        - "patch"
     commit-message:
       prefix: "ci: "
   - package-ecosystem: pip
@@ -29,6 +39,11 @@ updates:
       timezone: "UTC"
     reviewers: [meltano/engineering]
     labels: [deps]
+    groups:
+      default:
+        update-types:
+        - "minor"
+        - "patch"
     commit-message:
       prefix: "chore(deps): "
       prefix-development: "chore(deps-dev): "


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

This should reduce the number of Dependabot PRs we have to deal with, while still ensuring our CI passes for all of the dependency updates.