### PR TITLE
fix: Removed the `--verbose` option from CLI, which no longer had any effect

### DIFF
--- a/docs/docs/contribute/cli.md
+++ b/docs/docs/contribute/cli.md
@@ -34,7 +34,7 @@ defined as follows for use in `meltano`.
   or task. Sub-commands take the form of parameters, but require additional arguments or options themselves.
 - Arguments are positional parameters that are passed to a command. Arguments do not require additional options or
   arguments - otherwise they would be considered a sub-command.
-- Options (switch, option flags, or flags) are options that alter the behavior (e.g. `--dry-run/--verbose`) or named
+- Options (switch, option flags, or flags) are options that alter the behavior (e.g. `--dry-run`) or named
   input options (e.g. `--tasks=`). They come in two forms. A long form: `--option-name`, and a short form: `-o`.
 
 Given a command like `meltano job set JOB_NAME --tasks=[<task>...]`:

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -58,7 +58,6 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
     type=str,
     help="Path to a python logging yaml config file.",
 )
-@click.option("-v", "--verbose", count=True, help="Not used.")
 @click.option("--environment", help="Meltano environment name.")
 @click.option(
     "--no-environment",

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -76,7 +76,6 @@ def cli(  # noqa: C901,WPS231
     ctx: click.Context,
     log_level: str,
     log_config: str,
-    verbose: int,
     environment: str,
     no_environment: bool,
     cwd: Path | None,

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -94,7 +94,6 @@ def cli(  # noqa: C901,WPS231
     if log_config:
         ProjectSettingsService.config_override["cli.log_config"] = log_config
 
-    ctx.obj["verbosity"] = verbose
     ctx.obj["explicit_no_environment"] = no_environment
 
     no_color = get_no_color_flag()

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -157,7 +157,7 @@ class TestCliInvoke:
     def test_invoke_command_args(self, cli_runner, mock_invoke):
         res = cli_runner.invoke(
             cli,
-            ["invoke", "utility-mock:cmd", "--verbose"],
+            ["invoke", "utility-mock:cmd"],
             env={"ENV_VAR_ARG": "arg"},
         )
 
@@ -166,7 +166,7 @@ class TestCliInvoke:
 
         args = mock_invoke.call_args[0]
         assert args[0].endswith("utility-mock")
-        assert args[1:] == ("--option", "arg", "--verbose")
+        assert args[1:] == ("--option", "arg")
 
     def test_invoke_exit_code(self, cli_runner, tap, plugin_invoker_factory, utility):
         process_mock = Mock()


### PR DESCRIPTION
Changes :

-  Removed --verbose Option from CLI
- Also Removed from the Doc

Closes https://github.com/meltano/meltano/issues/3087