### PR TITLE
docs: Add tabs for all remaining env/cli/config settings

### DIFF
--- a/docs/docs/concepts/environments.md
+++ b/docs/docs/concepts/environments.md
@@ -5,6 +5,10 @@ layout: doc
 sidebar_position: 3
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+
 As part of Meltano's vision to enable data teams to operate with best practices, **Environments** allows
 you to define custom layers of configuration within your project. That way, You can run the same commands against multiple environments,
 by passing a single environment variable or CLI option.
@@ -109,14 +113,23 @@ The full ID when a suffix is present is `<environment_name>:<tap_name>-to-<targe
 
 To use an environment, you can pass the option `--environment=<ENV>` to the CLI command, or set the `MELTANO_ENVIRONMENT=<ENV>` variable.
 
-```shell
-# Using the CLI option
-meltano --environment=dev run tap-github target-sqlite
+<Tabs className="meltano-tabs" queryString="meltano-tabs">
+  <TabItem className="meltano-tab-content" value="command" label="command" default>
 
-# Using env vars
+```bash
+meltano --environment=dev run tap-github target-sqlite
+```
+
+  </TabItem>
+  <TabItem className="meltano-tab-content" value="env" label="env" default>
+
+```bash
 export MELTANO_ENVIRONMENT=dev
 meltano run tap-github target-sqlite
 ```
+
+  </TabItem>
+</Tabs>
 
 Once activated, Plugins and other processes invoked by Meltano can access the current environment via the `MELTANO_ENVIRONMENT` environment variable available in every Plugins execution environment.
 If no environment is active, the `MELTANO_ENVIRONMENT` is populated with an empty string.

--- a/docs/docs/guide/production.md
+++ b/docs/docs/guide/production.md
@@ -5,6 +5,9 @@ layout: doc
 sidebar_position: 9
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 Once you've [set up a Meltano project](/concepts/project) and
 [run some pipelines](/guide/integration) on your local machine,
 it'll be time to repeat this trick in production!
@@ -198,21 +201,43 @@ Specifically, you will want to configure Airflow to:
   instead of the `SequentialExecutor` default by setting the `core.executor` setting
   (or `AIRFLOW__CORE__EXECUTOR` environment variable) to `LocalExecutor`:
 
+  <Tabs className="meltano-tabs" queryString="meltano-tabs">
+    <TabItem className="meltano-tab-content" value="meltano config" label="meltano config" default>
+
   ```bash
   meltano config airflow set core.executor LocalExecutor
+  ```
 
+    </TabItem>
+    <TabItem className="meltano-tab-content" value="env" label="env" default>
+
+  ```bash
   export AIRFLOW__CORE__EXECUTOR=LocalExecutor
   ```
+
+    </TabItem>
+  </Tabs>
 
 - [use a PostgreSQL metadata database](https://airflow.apache.org/docs/apache-airflow/1.10.14/best-practices.html#database-backend)
   instead of the SQLite default ([sounds familiar?](#storing-metadata)) by setting the `core.sql_alchemy_conn` setting
   (or `AIRFLOW__CORE__SQL_ALCHEMY_CONN` environment variable) to a [`postgresql://` URI](https://docs.sqlalchemy.org/en/13/core/engines.html#postgresql):
 
+  <Tabs className="meltano-tabs" queryString="meltano-tabs">
+    <TabItem className="meltano-tab-content" value="meltano config" label="meltano config" default>
+
   ```bash
   meltano config airflow set core.sql_alchemy_conn postgresql://<username>:<password>@<host>:<port>/<database>
+  ```
 
+    </TabItem>
+    <TabItem className="meltano-tab-content" value="env" label="env" default>
+
+  ```bash
   export AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql://<username>:<password>@<host>:<port>/<database>
   ```
+
+    </TabItem>
+  </Tabs>
 
   For this to work, the [`psycopg2` package](https://pypi.org/project/psycopg2/) will
   also need to be installed alongside [`apache-airflow`](https://pypi.org/project/apache-airflow/),

--- a/docs/docs/guide/troubleshooting.md
+++ b/docs/docs/guide/troubleshooting.md
@@ -8,6 +8,9 @@ redirect_from:
 sidebar_position: 25
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 If you have a question about Meltano, are having trouble getting it to work, or have any kind of feedback, you can:
 
 <div class="columns is-multiline is-centered">
@@ -51,11 +54,29 @@ When you are trying to troubleshoot an issue the Meltano logs should be your fir
 
 If you have a failure using Meltano's execution commands (`invoke`, `elt`, `run`, or `test`) or you're experienced general unexpected behavior, you can learn more about what’s happening behind the scenes by setting Meltano’s [`cli.log_level` setting](/reference/settings#clilog_level) to debug, using the `MELTANO_CLI_LOG_LEVEL` environment variable or the `--log-level` CLI option:
 
+<Tabs className="meltano-tabs" queryString="meltano-tabs">
+  <TabItem className="meltano-tab-content" value="meltano config" label="meltano config" default>
+
+```bash
+meltano config meltano set cli log_level debug
+```
+
+  </TabItem>
+  <TabItem className="meltano-tab-content" value="env" label="env" default>
+
 ```bash
 export MELTANO_CLI_LOG_LEVEL=debug
+```
 
+  </TabItem>
+  <TabItem className="meltano-tab-content" value="command" label="command" default>
+
+```bash
 meltano --log-level=debug <command> ...
 ```
+
+  </TabItem>
+</Tabs>
 
 In debug mode, Meltano will log additional information about the environment and arguments used to invoke your components (Singer taps and targets, dbt, Airflow, etc.), including the paths to the generated config, catalog, state files, etc. for you to review.
 


### PR DESCRIPTION
#### Tabs Part 3! 🤓 

I think I hunted down the last remaining pages where options were provided for a combination of:

- `meltano config`
- `meltano --some-switch=xyz`
- `export MELTANO_`

I have split these from a single code block out into tabs, similar to recent updates #8201, #7765