### PR TITLE
docs: Sync sidebar order with index page link-lists, remove broken /index links

### DIFF
--- a/docs/docs/concepts/index.mdx
+++ b/docs/docs/concepts/index.mdx
@@ -8,7 +8,7 @@ toc: false
 :::info
 
   <p><strong>Contributions are welcome!</strong></p>
-  <p>If there's a document you want to see that's not here, we welcome contributions to add it! Submit a <a href="/https://github.com/meltano/meltano/tree/main/docs">pull request</a> with your doc and the Meltano team will help you polish it for release. You may also <a href="/https://github.com/meltano/meltano/issues/new">submit an issue</a> to help us gauge interest in new docs.</p>
+  <p>If there's a document you want to see that's not here, we welcome contributions to add it! Submit a <a href="https://github.com/meltano/meltano/tree/main/docs">pull request</a> with your doc and the Meltano team will help you polish it for release. You may also <a href="https://github.com/meltano/meltano/issues/new">submit an issue</a> to help us gauge interest in new docs.</p>
 :::
 
 ## Index

--- a/docs/docs/concepts/index.mdx
+++ b/docs/docs/concepts/index.mdx
@@ -8,17 +8,17 @@ toc: false
 :::info
 
   <p><strong>Contributions are welcome!</strong></p>
-  <p>If there's a document you want to see that's not here, we welcome contributions to add it! Submit a <a href="https://github.com/meltano/meltano/tree/main/docs">pull request</a> with your doc and the Meltano team will help you polish it for release. You may also <a href="https://github.com/meltano/meltano/issues/new">submit an issue</a> to help us gauge interest in new docs.</p>
+  <p>If there's a document you want to see that's not here, we welcome contributions to add it! Submit a <a href="/https://github.com/meltano/meltano/tree/main/docs">pull request</a> with your doc and the Meltano team will help you polish it for release. You may also <a href="/https://github.com/meltano/meltano/issues/new">submit an issue</a> to help us gauge interest in new docs.</p>
 :::
 
 ## Index
 
 <ul>
-<li><a href="concepts/project">Projects</a></li>
-<li><a href="concepts/plugins">Plugins</a></li>
-<li><a href="concepts/state_backends">State Backends</a></li>
-<li><a href="concepts/environments">Environments</a></li>
-<li><a href="concepts/python_virtual_environments">Python Virtual Environments</a></li>
-<li><a href="concepts/elt">ELT vs ETL</a></li>
+<li><a href="/concepts/project">Projects</a></li>
+<li><a href="/concepts/plugins">Plugins</a></li>
+<li><a href="/concepts/state_backends">State Backends</a></li>
+<li><a href="/concepts/environments">Environments</a></li>
+<li><a href="/concepts/python_virtual_environments">Python Virtual Environments</a></li>
+<li><a href="/concepts/elt">ELT vs ETL</a></li>
 
 </ul>

--- a/docs/docs/concepts/index.mdx
+++ b/docs/docs/concepts/index.mdx
@@ -14,11 +14,11 @@ toc: false
 ## Index
 
 <ul>
-<li><a href="/concepts/elt">ELT vs ETL</a></li>
-<li><a href="/concepts/environments">Environments</a></li>
-<li><a href="/concepts/index">Meltano Concepts</a></li>
-<li><a href="/concepts/plugins">Plugins</a></li>
-<li><a href="/concepts/project">Projects</a></li>
-<li><a href="/concepts/python_virtual_environments">Python Virtual Environments</a></li>
-<li><a href="/concepts/state_backends">State Backends</a></li>
+<li><a href="concepts/project">Projects</a></li>
+<li><a href="concepts/plugins">Plugins</a></li>
+<li><a href="concepts/state_backends">State Backends</a></li>
+<li><a href="concepts/environments">Environments</a></li>
+<li><a href="concepts/python_virtual_environments">Python Virtual Environments</a></li>
+<li><a href="concepts/elt">ELT vs ETL</a></li>
+
 </ul>

--- a/docs/docs/contribute/index.mdx
+++ b/docs/docs/contribute/index.mdx
@@ -52,7 +52,6 @@ so that the team and community are aware of your plan and can help you figure ou
 The following guides have information to help get you up and running and ready to contribute.
 
 <ul>
-<li><a href="/contribute/index">Contributor Guide</a></li>
 <li><a href="/contribute/prerequisites">Prerequisites</a></li>
 <li><a href="/contribute/merge">Pull Request Process</a></li>
 <li><a href="/contribute/api">API Development</a></li>

--- a/docs/docs/guide/index.mdx
+++ b/docs/docs/guide/index.mdx
@@ -14,21 +14,22 @@ toc: false
 ## Index
 
 <ul>
-<li><a href="/guide/advanced-topics">Advanced Topics</a></li>
-<li><a href="/guide/analysis">Analyze Data</a></li>
-<li><a href="/guide/configuration">Manage Configuration</a></li>
-<li><a href="/guide/containerization">Run in Containers</a></li>
-<li><a href="/guide/debugging-custom-extractor">Debug a Custom Extractor</a></li>
-<li><a href="/guide/index">Meltano Guide</a></li>
 <li><a href="/guide/installation-guide">In-depth Installation</a></li>
-<li><a href="/guide/integration">Replicate Data</a></li>
-<li><a href="/guide/logging">Logging and Monitoring</a></li>
-<li><a href="/guide/mappers">Inline Data Mapping</a></li>
-<li><a href="/guide/migrate-an-existing-dbt-project">Migrate an Existing dbt Project</a></li>
-<li><a href="/guide/orchestration">Orchestrate Data</a></li>
 <li><a href="/guide/plugin-management">General Usage</a></li>
-<li><a href="/guide/production">Deployment in Production</a></li>
+<li><a href="/guide/configuration">Manage Configuration</a></li>
+<li><a href="/guide/integration">Replicate Data</a></li>
+<li><a href="/guide/complete_tutorial">Complete ELT Walkthrough</a></li>
+<li><a href="/guide/mappers">Inline Data Mapping</a></li>
 <li><a href="/guide/transformation">Transform Data</a></li>
-<li><a href="/guide/troubleshooting">Troubleshooting</a></li>
+<li><a href="/guide/orchestration">Orchestrate Data</a></li>
+<li><a href="/guide/analysis">Analyze Data</a></li>
+<li><a href="/guide/containerization">Run in Containers</a></li>
+<li><a href="/guide/production">Deployment in Production</a></li>
+<li><a href="/guide/advanced-topics">Advanced Topics</a></li>
+<li><a href="/guide/logging">Logging and Monitoring</a></li>
 <li><a href="/guide/v2-migration">Meltano 2.0 Migration Guide</a></li>
+<li><a href="/guide/v3-migration">Meltano 3.0 Migration Guide</a></li>
+<li><a href="/guide/debugging-custom-extractor">Debug a Custom Extractor</a></li>
+<li><a href="/guide/migrate-an-existing-dbt-project">Migrate an Existing dbt Project</a></li>
+<li><a href="/guide/troubleshooting">Troubleshooting</a></li>
 </ul>

--- a/docs/docs/reference/index.mdx
+++ b/docs/docs/reference/index.mdx
@@ -15,9 +15,8 @@ toc: false
 
 <ul>
 <li><a href="/reference/command-line-interface">Command Line</a></li>
-<li><a href="/reference/glossary">Glossary</a></li>
-<li><a href="/reference/index">Meltano Reference</a></li>
-<li><a href="/reference/plugin-definition-syntax">Plugin Definition Syntax</a></li>
 <li><a href="/reference/settings">Settings</a></li>
+<li><a href="/reference/plugin-definition-syntax">Plugin Definition Syntax</a></li>
+<li><a href="/reference/glossary">Glossary</a></li>
 <li><a href="/reference/ui">Meltano UI and REST API Server (Deprecated)</a></li>
 </ul>

--- a/docs/docs/tutorials/index.mdx
+++ b/docs/docs/tutorials/index.mdx
@@ -15,9 +15,8 @@ Here you will find a series of step-by-step tutorials where we help walk you thr
 
 <ul>
 <li><a href="/tutorials/custom-extractor">Create a Custom Extractor</a></li>
+<li><a href="/tutorials/jupyter">How to use Jupyter with Meltano</a></li>
 <li><a href="/tutorials/datahub">How to use DataHub with Meltano</a></li>
 <li><a href="/tutorials/example-projects">Example Meltano Projects</a></li>
-<li><a href="/tutorials/index">Tutorials</a></li>
-<li><a href="/tutorials/jupyter">How to use Jupyter with Meltano</a></li>
-<li><a href="/tutorials/video-tutorials">Video Tutorials &amp; Demos</a></li>
+<li><a href="/tutorials/video-tutorials">Video Tutorials & Demos</a></li>
 </ul>


### PR DESCRIPTION
After investigating #8206, I found more links to /index pages that don't work:

https://docs.meltano.com/contribute/#contribution-guides (link text: "Contributor Guide")
https://docs.meltano.com/reference/#index (link text: "Meltano Reference")
https://docs.meltano.com/guide/#index (link text: "Meltano Guide")
https://docs.meltano.com/tutorials/ (link text: "Tutorials")

I also went through and reordered the index page link-lists, taking the `sidebar_position` as the key for ordering those lists, or pushing them to the end of the list if that property is not set.

I notice there is only one page without `sidebar_class_name: hidden` in the "Contribute" section, this is the "Custom Errors" page, so the sidebar looks like:

```
Contribute
    Custom Errors
```

Would it be good to have a few more of those pages visible on the sidebar, e.g. "Prerequisites" - by removing `sidebar_class_name: hidden`?

```md
---
title: Prerequisites
description: Meltano is open source software built by a growing team and a community of contributors.
layout: doc
sidebar_position: 2
sidebar_class_name: hidden
---
```

Alternatively all pages under "Contribute" could be hidden.