### PR TITLE
docs: Document other supported ways of configuring an S3 endpoint URL

### DIFF
--- a/docs/docs/concepts/state_backends.md
+++ b/docs/docs/concepts/state_backends.md
@@ -90,6 +90,19 @@ If these environment variables are not set, it will use the credentials stored i
 
 If AWS credentials are not found via any of the methods described above, Meltano will not be able to authenticate to S3 and state operations will fail.
 
+#### Endpoint URL
+
+Meltano supports service-specific endpoint URLs via:
+
+* The `endpoint_url` setting in the shared AWS config file.
+* The `AWS_ENDPOINT_URL` environment variable.
+* The `AWS_ENDPOINT_URL_S3` environment variable.
+* The Meltano [`state_backend.s3.endpoint_url`](/reference/settings#state_backends3endpoint_url) setting.
+
+The `AWS_IGNORE_CONFIGURED_ENDPOINT_URLS` environment variable won't have any effect if `state_backend.s3.endpoint_url` is not null.
+
+For reference, read the [AWS documentation on service-specific endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html).
+
 ### Google Cloud Storage
 
 To store state remotely in Google Cloud Storage, set the `state_backend.uri` setting to `gs://<your bucket name>/<prefix for state JSON blobs>`.

--- a/docs/docs/concepts/state_backends.md
+++ b/docs/docs/concepts/state_backends.md
@@ -99,7 +99,9 @@ Meltano supports service-specific endpoint URLs via:
 * The `AWS_ENDPOINT_URL_S3` environment variable.
 * The Meltano [`state_backend.s3.endpoint_url`](/reference/settings#state_backends3endpoint_url) setting.
 
+:::info
 The `AWS_IGNORE_CONFIGURED_ENDPOINT_URLS` environment variable won't have any effect if `state_backend.s3.endpoint_url` is not null.
+:::
 
 For reference, read the [AWS documentation on service-specific endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html).
 


### PR DESCRIPTION
This was added in boto3 `1.28.0`: https://github.com/boto/boto3/pull/2746#issuecomment-1626113796

---

* Slack: https://meltano.slack.com/archives/C01TCRBBJD7/p1696576079456299?thread_ts=1696524007.166329&cid=C01TCRBBJD7
* Linen: https://www.linen.dev/s/meltano/t/15962804/hello-there-i-m-facing-once-again-this-strange-issue-with-me#f3932192-1714-46fa-a48f-2444ad28375f