### PR TITLE
fix: Redirect tap's stderr to /dev/null during a configuration test

### DIFF
--- a/src/meltano/core/plugin_test_service.py
+++ b/src/meltano/core/plugin_test_service.py
@@ -72,7 +72,7 @@ class ExtractorTestService(PluginTestService):
         try:
             process = await self.plugin_invoker.invoke_async(
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
+                stderr=asyncio.subprocess.DEVNULL,
             )
         except Exception as exc:
             return False, str(exc)


### PR DESCRIPTION
## Motivation

Closes https://github.com/meltano/meltano/issues/8223