### PR TITLE
fix(cli): Interval validation for `meltano schedule set`

### DIFF
--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -7,6 +7,7 @@ import sys
 import typing as t
 
 import click
+from croniter import croniter
 
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
@@ -16,7 +17,12 @@ from meltano.cli.utils import (
 )
 from meltano.core.db import project_engine
 from meltano.core.job.stale_job_failer import fail_stale_jobs
-from meltano.core.schedule_service import ScheduleAlreadyExistsError, ScheduleService
+from meltano.core.schedule import CRON_INTERVALS
+from meltano.core.schedule_service import (
+    BadCronError,
+    ScheduleAlreadyExistsError,
+    ScheduleService,
+)
 from meltano.core.task_sets_service import TaskSetsService
 from meltano.core.utils import coerce_datetime
 
@@ -281,6 +287,13 @@ def remove(ctx, name):
     ctx.obj["schedule_service"].remove(name)
 
 
+def validate_interval(interval: str):
+    """Validate the interval for a schedule."""
+    if interval not in CRON_INTERVALS and not croniter.is_valid(interval):
+        raise BadCronError(interval)
+    return interval
+
+
 def _update_job_schedule(
     candidate: Schedule,
     job: str | None,
@@ -307,7 +320,7 @@ def _update_job_schedule(
     if job:
         candidate.job = job
     if interval:
-        candidate.interval = interval
+        candidate.interval = validate_interval(interval)
     return candidate
 
 
@@ -346,7 +359,7 @@ def _update_elt_schedule(
     if transform:
         candidate.transform = transform
     if interval:
-        candidate.interval = interval
+        candidate.interval = validate_interval(interval)
     return candidate
 
 

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -363,9 +363,6 @@ class CronParam(click.ParamType):
 
     def convert(self, value, *_):
         """Validate and con interval."""
-        if value is None:
-            return None
-
         if value not in CRON_INTERVALS and not croniter.is_valid(value):
             raise BadCronError(value)
 

--- a/tests/meltano/cli/test_schedule.py
+++ b/tests/meltano/cli/test_schedule.py
@@ -5,6 +5,7 @@ import pytest
 
 from asserts import assert_cli_runner
 from meltano.cli import cli
+from meltano.core.schedule_service import BadCronError
 from meltano.core.utils import iso8601_datetime
 
 
@@ -212,6 +213,14 @@ class TestCliSchedule:
                 schedule_service.find_schedule(job_schedule.name).cron_interval
                 == "0 * * * *"
             )
+
+            # Should raise exception for invalid cron interval
+            res = cli_runner.invoke(
+                cli,
+                ["schedule", "set", elt_schedule.name, "--interval", "@hourl"],
+            )
+            assert res.exit_code != 0
+            assert isinstance(res.exception, BadCronError)
 
             res = cli_runner.invoke(
                 cli,


### PR DESCRIPTION
1. Used same validations that we use for `meltano schedule add`
https://github.com/meltano/meltano/blob/main/src/meltano/core/schedule_service.py#L216

cc @BraedonLeonard @edgarrmondragon 

Closes #7814