### PR TITLE
chore: Drop dependency on `aiohttp`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -48,7 +48,6 @@ pytest_deps = (
     "mock",
     "moto",
     "pytest",
-    "pytest-aiohttp",
     "pytest-asyncio",
     "pytest-cov",
     "pytest-docker",
@@ -98,11 +97,6 @@ def pytest_meltano(session: Session) -> None:
     Args:
         session: Nox session.
     """
-    install_env = {}
-    if session.python == "3.12":
-        # TODO: Remove this once aiohttp has 3.12 wheels
-        install_env["AIOHTTP_NO_EXTENSIONS"] = "1"
-
     backend_db = os.environ.get("PYTEST_BACKEND", "sqlite")
     extras = ["azure", "gcs", "s3"]
 
@@ -116,7 +110,6 @@ def pytest_meltano(session: Session) -> None:
     session.install(
         f".[{','.join(extras)}]",
         *pytest_deps,
-        env=install_env,
     )
     _run_pytest(session)
 
@@ -164,11 +157,6 @@ def mypy(session: Session) -> None:
     Args:
         session: Nox session.
     """
-    install_env = {}
-    if session.python == "3.12":
-        # TODO: Remove this once aiohttp has 3.12 wheels
-        install_env["AIOHTTP_NO_EXTENSIONS"] = "1"
-
     session.install(
         ".[mssql,azure,gcs,s3]",
         "boto3-stubs",
@@ -181,6 +169,5 @@ def mypy(session: Session) -> None:
         "types-PyYAML",
         "types-requests",
         "types-tabulate",
-        env=install_env,
     )
     session.run("mypy", *session.posargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2610,6 +2610,7 @@ files = [
     {file = "psycopg2_binary-2.9.9-cp311-cp311-win32.whl", hash = "sha256:dc4926288b2a3e9fd7b50dc6a1909a13bbdadfc67d93f3374d984e56f885579d"},
     {file = "psycopg2_binary-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:b76bedd166805480ab069612119ea636f5ab8f8771e640ae103e05a4aae3e417"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8532fd6e6e2dc57bcb3bc90b079c60de896d2128c5d9d6f24a63875a95a088cf"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0605eaed3eb239e87df0d5e3c6489daae3f7388d455d0c0b4df899519c6a38d"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f8544b092a29a6ddd72f3556a9fcf249ec412e10ad28be6a0c0d948924f2212"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d423c8d8a3c82d08fe8af900ad5b613ce3632a1249fd6a223941d0735fce493"},
     {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e5afae772c00980525f6d6ecf7cbca55676296b580c0e6abb407f15f3706996"},
@@ -2818,25 +2819,6 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
-
-[[package]]
-name = "pytest-aiohttp"
-version = "1.0.5"
-description = "Pytest plugin for aiohttp support"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pytest-aiohttp-1.0.5.tar.gz", hash = "sha256:880262bc5951e934463b15e3af8bb298f11f7d4d3ebac970aab425aff10a780a"},
-    {file = "pytest_aiohttp-1.0.5-py3-none-any.whl", hash = "sha256:63a5360fd2f34dda4ab8e6baee4c5f5be4cd186a403cabd498fced82ac9c561e"},
-]
-
-[package.dependencies]
-aiohttp = ">=3.8.1"
-pytest = ">=6.1.0"
-pytest-asyncio = ">=0.17.2"
-
-[package.extras]
-testing = ["coverage (==6.2)", "mypy (==0.931)"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -4158,4 +4140,4 @@ s3 = ["boto3"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "681939712403605e18cf8d58413d5553879a8d4ba4d2285074c29b2694a1d6d0"
+content-hash = "051c36e900a2623cecc09e39594b1ae165d78bb076ecdabf62dcb1acf5d9087c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ homepage = "https://meltano.com"
 
 [tool.poetry.dependencies]
 aiodocker = "^0.21.0"
-aiohttp = "^3.8.6"
 alembic = "^1.12.1"
 atomicwrites = "^1.2.1"
 azure-common = {version = "^1.1.28", optional = true}
@@ -112,7 +111,6 @@ moto = "^4.2.7"
 mypy = "^1.6.1"
 pre-commit = "^3.5.0"
 pytest = "^7.4.3"
-pytest-aiohttp = "^1.0.5"
 pytest-asyncio = "^0.21.1"
 pytest-cov = "^4.1.0"
 pytest-docker = "^2.0"


### PR DESCRIPTION
* Only required by the `meltano-cloud` CLI and would force users on Python 3.12 to install with `AIOHTTP_NO_EXTENSIONS=1`
* Also added a missing `psycopg2-binary` wheel to `poetry.lock`
