### PR TITLE
fix: Interactive config now indicates that you're typing a redacted value

### DIFF
--- a/docs/docs/getting-started/part1.mdx
+++ b/docs/docs/getting-started/part1.mdx
@@ -221,7 +221,7 @@ Loop through all settings (all), select a setting by number (1 - 16), or exit (e
 $ 2
 [...]Description:
 GitHub token to authenticate with.
-New value:
+New value (redacted):
 $
 Repeat for confirmation:
 $

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -240,7 +240,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
         if config_metadata["setting"].kind != SettingKind.OPTIONS:
             return (
                 click.prompt(
-                    "New value",
+                    "New value (redacted)",
                     default="",
                     show_default=False,
                     hide_input=True,


### PR DESCRIPTION
Closes #8299