### PR TITLE
test: Fix running tests in an environment with `NO_COLOR=1`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,12 @@ def concurrency():
     }
 
 
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+
 class MockAdapter(BaseAdapter):
     RETURN_500 = {
         "/extractors/this-returns-500--original": {"error": "Server error"},


### PR DESCRIPTION
Previously, running `NO_COLOR=1 poetry run pytest tests/meltano/cli/test_cli.py` would fail.
