### PR TITLE
Prototype of stopping after N rows loaded from taps

### DIFF
--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import os
 import asyncio
 import logging
+import os
 import typing as t
 from contextlib import asynccontextmanager, closing
 
@@ -41,23 +41,25 @@ logger = structlog.getLogger(__name__)
 
 TAP_ROW_LIMITED = False
 try:
-    TAP_ROW_LIMIT = int(os.environ.get('TAP_ROW_LIMIT'))
+    TAP_ROW_LIMIT = int(os.environ.get("TAP_ROW_LIMIT"))
     TAP_ROW_LIMITED = True
-except (ValueError, TypeError) as error:
+except (ValueError, TypeError):
     TAP_ROW_LIMITED = False
 
 
-class GotEnoughRowsException ( Exception):
+class GotEnoughRowsException(Exception):
     pass
+
 
 class RowLimitHandler:
     def __init__(self, row_limit):
         self.linecount = 0
         self.row_limit = row_limit
+
     def writeline(self, line):
         self.linecount += 1
         if self.linecount > self.row_limit:
-            raise GotEnoughRowsException()
+            raise GotEnoughRowsException
 
 
 class BlockSetHasNoStateError(Exception):
@@ -784,7 +786,9 @@ class ELBExecutionManager:
             logger.warning("Intermediate block in sequence failed.")
             await self._stop_all_blocks(start_idx)
 
-            if not isinstance(output_futures_failed.exception(), GotEnoughRowsException):
+            if not isinstance(
+                output_futures_failed.exception(), GotEnoughRowsException
+            ):
                 raise RunnerError(
                     (
                         "Unexpected completion sequence in ExtractLoadBlock set. "


### PR DESCRIPTION
This is a sketch for how i introduced ability to limit rows from taps for the purposes of testing.

Warning: This code has not been executed. I have working code based on an older revision that i tested. So, i know the approach works with code very similar to this. I cleaned up the code to fit into latest meltano main, so that it would be easier to see the essence of the changes.

If this overall path is of interest, i could do more work-- i really would like thoughts about the overall approach before I do that. I dont know the meltano code well at all, so this might be a totally wrong way to do it.

Other notes that might be helpful:

-  i first tried a similar approach in the singer runner code, until i realized that was not the code used for meltano run
-  This uses an environment var to set the row limit. A much better solution of course would be to allow a property on the project and/or taps, so the row limit can be different for each tap. But (a) I dont know enough to approach that, and (b) for us this is sufficient
-  I am worried about whether this code would work in environments with concurrency more than just one. I did not do any testing along those lines.
