### PR TITLE
feat: Support state backend and setting add-ons

### DIFF
--- a/docs/docs/guide/custom-state-backend.md
+++ b/docs/docs/guide/custom-state-backend.md
@@ -1,0 +1,103 @@
+---
+title: Custom State Backends
+description: Learn how to create a custom state backend for Meltano.
+layout: doc
+sidebar_position: 20
+---
+
+To create a custom state backend for Meltano, you need to implement the `StateStoreManager` interface and any settings required to configure the backend.
+
+```python
+# my_state_manager/backend.py
+from urllib.parse import urlparse
+
+from meltano.core.error import MeltanoError
+from meltano.core.setting_definition import SettingDefinition, SettingKind
+from meltano.core.state_store.base import MeltanoState, StateStoreManager
+
+
+USERNAME = SettingDefinition(
+    key="username",
+    label="Username",
+    kind=SettingKind.STRING,
+    description="The username to use when connecting to the custom state manager",
+)
+
+PASSWORD = SettingDefinition(
+    key="password",
+    label="Password",
+    kind=SettingKind.STRING,
+    sensitive=True,
+    description="The password to use when connecting to the custom state manager",
+)
+
+
+class MyStateManagerError(MeltanoError):
+    pass
+
+
+class MyStateManager(StateStoreManager):
+    """My Custom State Manager"""
+
+    label: str = "My Custom State Manager"
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        username: str | None = None,
+        password: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.uri = uri
+
+        # Parse the URI to extract the connection details
+        # Expecting `msm://<host>/<database>`, e.g. `msm://localhost/meltano`
+        parsed = urlparse(uri)
+        self.host = parsed.hostname
+        self.database = parsed.path.lstrip("/")
+
+        self.username = username or parsed.username
+
+        if not self.username:
+            raise MyStateManagerError("Username is required")
+
+        self.password = password or parsed.password
+
+        if not self.password:
+            raise MyStateManagerError("Password is required")
+
+
+    def set(self, state: MeltanoState) -> None:
+        # Implement the logic to store the state in your custom backend
+
+    def get(self) -> MeltanoState | None:
+        # Implement the logic to retrieve the state from your custom backend
+
+    def clear(self) -> None:
+        # Implement the logic to clear the state from your custom backend
+
+    def get_state_ids(self) -> list[str]:
+        # Implement the logic to retrieve the list of state IDs from your custom backend
+```
+
+To let Meltano know about your custom state manager, you need to add the following configuration to your `pyproject.toml`:
+
+```toml
+[project.entry-points."meltano.settings"]
+my_state_manager_username = "my_state_manager.backend:USERNAME"
+my_state_manager_password = "my_state_manager.backend:PASSWORD"
+
+[project.entry-points."meltano.state_backends"]
+# These keys should match the expected scheme for URIs of
+# the given type. E.g., filesystem state backends have a
+# file://<path>/<to>/<state directory> URI
+msm = "my_state_manager.backend:MyStateManager"
+```
+
+You can now use your custom state manager by installing it alongside Meltano:
+
+```bash
+uv tool install --with git+https://github.com/your-username/my-state-manager.git meltano
+```

--- a/docs/docs/guide/index.mdx
+++ b/docs/docs/guide/index.mdx
@@ -30,6 +30,7 @@ toc: false
 <li><a href="/guide/v2-migration">Meltano 2.0 Migration Guide</a></li>
 <li><a href="/guide/v3-migration">Meltano 3.0 Migration Guide</a></li>
 <li><a href="/guide/debugging-custom-extractor">Debug a Custom Extractor</a></li>
+<li><a href="/guide/custom-state-backend">Custom State Backends</a></li>
 <li><a href="/guide/migrate-an-existing-dbt-project">Migrate an Existing dbt Project</a></li>
 <li><a href="/guide/troubleshooting">Troubleshooting</a></li>
 </ul>

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -206,7 +206,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ['yaml', 'json', 'bash'],
+        additionalLanguages: ['yaml', 'json', 'bash', 'toml'],
       },
       docs: {
         sidebar: {

--- a/poetry.lock
+++ b/poetry.lock
@@ -4388,4 +4388,4 @@ s3 = ["boto3"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14"
-content-hash = "2cc23807d10d0cbde8c7d7d31c4e2bd4a87bbb19dca78e3c038471cda4305253"
+content-hash = "c351195b6ac329d2e482cab811d50bc73dd4db2c6ad818056bbe46041f59e589"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,12 @@ meltano = "meltano.cli:main"
 s3_aws_access_key_id = "meltano.core.state_store.s3:AWS_ACCESS_KEY_ID"
 s3_aws_secret_access_key = "meltano.core.state_store.s3:AWS_SECRET_ACCESS_KEY"
 s3_endpoint_url = "meltano.core.state_store.s3:ENDPOINT_URL"
+# Azure state backend settings
+azure_connection_string = "meltano.core.state_store.azure:CONNECTION_STRING"
+azure_storage_account_url = "meltano.core.state_store.azure:STORAGE_ACCOUNT_URL"
 
 [tool.poetry.plugins."meltano.state_backends"]
+azure = "meltano.core.state_store.azure:AZStorageStateStoreManager"
 s3 = "meltano.core.state_store.s3:S3StateStoreManager"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ croniter = "^6.0.0"
 fasteners = "^0.19"
 flatten-dict = "^0"
 google-cloud-storage = {version = ">=1.31.0", optional = true}
+importlib-metadata = { version = ">=5", python = "<3.12" }
 jinja2 = "^3.1.4"
 jsonschema = "^4.23"
 packaging = "^24.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,11 @@ azure_storage_account_url = "meltano.core.state_store.azure:STORAGE_ACCOUNT_URL"
 google_application_credentials = "meltano.core.state_store.google:APPLICATION_CREDENTIALS"
 
 [tool.poetry.plugins."meltano.state_backends"]
+# These keys should match the expected scheme for URIs of
+# the given type. E.g., filesystem state backends have a
+# file://<path>/<to>/<state directory> URI
 azure = "meltano.core.state_store.azure:AZStorageStateStoreManager"
+file = "meltano.core.state_store.filesystem:LocalFilesystemStateStoreManager"
 gs = "meltano.core.state_store.google:GCSStateStoreManager"
 s3 = "meltano.core.state_store.s3:S3StateStoreManager"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,12 @@ s3_endpoint_url = "meltano.core.state_store.s3:ENDPOINT_URL"
 # Azure state backend settings
 azure_connection_string = "meltano.core.state_store.azure:CONNECTION_STRING"
 azure_storage_account_url = "meltano.core.state_store.azure:STORAGE_ACCOUNT_URL"
+# Google Cloud Storage state backend settings
+google_application_credentials = "meltano.core.state_store.google:APPLICATION_CREDENTIALS"
 
 [tool.poetry.plugins."meltano.state_backends"]
 azure = "meltano.core.state_store.azure:AZStorageStateStoreManager"
+gs = "meltano.core.state_store.google:GCSStateStoreManager"
 s3 = "meltano.core.state_store.s3:S3StateStoreManager"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,15 @@ types-requests = "^2.31.0"
 [tool.poetry.scripts]
 meltano = "meltano.cli:main"
 
+[tool.poetry.plugins."meltano.settings"]
+# AWS S3 state backend settings
+s3_aws_access_key_id = "meltano.core.state_store.s3:AWS_ACCESS_KEY_ID"
+s3_aws_secret_access_key = "meltano.core.state_store.s3:AWS_SECRET_ACCESS_KEY"
+s3_endpoint_url = "meltano.core.state_store.s3:ENDPOINT_URL"
+
+[tool.poetry.plugins."meltano.state_backends"]
+s3 = "meltano.core.state_store.s3:S3StateStoreManager"
+
 [tool.pytest.ini_options]
 addopts = [
   "--cov=meltano",

--- a/src/meltano/core/behavior/addon.py
+++ b/src/meltano/core/behavior/addon.py
@@ -1,0 +1,55 @@
+"""Meltano add-ons installable as packaging plugins."""
+
+from __future__ import annotations
+
+import sys
+import typing as t
+from functools import cached_property
+
+if sys.version_info < (3, 12):
+    from importlib_metadata import EntryPoints, entry_points
+else:
+    from importlib.metadata import EntryPoints, entry_points
+
+T = t.TypeVar("T")
+
+
+class MeltanoAddon(t.Generic[T]):
+    """A Meltano add-on with packaging plugins."""
+
+    def __init__(self, entry_point_group: str):
+        """Create a new Meltano add-on.
+
+        Args:
+            entry_point_group: The entry point group for the feature.
+        """
+        self.entry_point_group = entry_point_group
+
+    @cached_property
+    def installed(self) -> EntryPoints:
+        """List installed add-ons.
+
+        Returns:
+            List of available add-ons.
+        """
+        return entry_points(group=self.entry_point_group)
+
+    def get_all(self) -> t.Generator[T, None, None]:
+        """Get all add-ons.
+
+        Returns:
+            All add-ons.
+        """
+        for ep in self.installed:
+            yield ep.load()
+
+    def get(self, name: str) -> T:
+        """Get an add-on by name.
+
+        Args:
+            name: The name of the add-on.
+
+        Returns:
+            The add-on object.
+        """
+        return self.installed[name].load()

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -9,11 +9,11 @@ from contextlib import asynccontextmanager, closing
 
 import structlog
 
+from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.db import project_engine
 from meltano.core.elt_context import PluginContext
 from meltano.core.job import Job, JobFinder
 from meltano.core.job.stale_job_failer import fail_stale_jobs
-from meltano.core.job_state import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.logging import JobLoggingService, OutputLogger
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.settings_service import PluginSettingsService

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -68,12 +68,6 @@ settings:
   env_specific: true
   description: Number of seconds that a Meltano should wait if trying to access or modify state for a state ID that is locked
 
-## GCS state backend
-- name: state_backend.gcs.application_credentials
-  sensitive: true
-  env_specific: true
-  description: Path to the credential file to use in authenticating to Google Cloud Storage
-
 # CLI
 - name: cli.log_level
   kind: options

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -77,19 +77,6 @@ settings:
   env_specific: true
   description: URL for the Azure Blob Storage account
 
-## AWS S3 state backend
-- name: state_backend.s3.aws_access_key_id
-  sensitive: true
-  env_specific: true
-  description: AWS access key ID
-- name: state_backend.s3.aws_secret_access_key
-  sensitive: true
-  env_specific: true
-  description: AWS secret access key
-- name: state_backend.s3.endpoint_url
-  env_specific: true
-  description: URL for the AWS S3 or S3-compatible storage service
-
 ## GCS state backend
 - name: state_backend.gcs.application_credentials
   sensitive: true

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -68,15 +68,6 @@ settings:
   env_specific: true
   description: Number of seconds that a Meltano should wait if trying to access or modify state for a state ID that is locked
 
-## Azure state backend
-- name: state_backend.azure.connection_string
-  sensitive: true
-  env_specific: true
-  description: Connection string for the Azure Blob Storage account
-- name: state_backend.azure.storage_account_url
-  env_specific: true
-  description: URL for the Azure Blob Storage account
-
 ## GCS state backend
 - name: state_backend.gcs.application_credentials
   sensitive: true

--- a/src/meltano/core/constants.py
+++ b/src/meltano/core/constants.py
@@ -1,0 +1,5 @@
+"""Constants used by Meltano."""
+
+from __future__ import annotations
+
+STATE_ID_COMPONENT_DELIMITER = ":"

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -7,7 +7,7 @@ import typing as t
 
 from meltano.core.behavior import NameEq
 from meltano.core.behavior.canonical import Canonical
-from meltano.core.job_state import STATE_ID_COMPONENT_DELIMITER
+from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.base import PluginRef
 from meltano.core.setting_definition import SettingDefinition

--- a/src/meltano/core/job_state.py
+++ b/src/meltano/core/job_state.py
@@ -13,7 +13,6 @@ from meltano.core.sqlalchemy import StateType  # noqa: TC001
 from meltano.core.utils import merge
 
 SINGER_STATE_KEY = "singer_state"
-STATE_ID_COMPONENT_DELIMITER = ":"
 
 
 class JobState(SystemModel):

--- a/src/meltano/core/migration_service.py
+++ b/src/meltano/core/migration_service.py
@@ -7,14 +7,12 @@ import typing as t
 
 import click
 import structlog
-from alembic import command
-from alembic.config import Config
-from alembic.runtime.migration import MigrationContext
-from alembic.script import ScriptDirectory
 
 from meltano.migrations import LOCK_PATH, MIGRATION_DIR
 
 if t.TYPE_CHECKING:
+    from alembic.runtime.migration import MigrationContext
+    from alembic.script import ScriptDirectory
     from sqlalchemy.engine import Engine
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -75,6 +73,11 @@ class MigrationService:
         Raises:
             MigrationError: If the upgrade fails.
         """
+        from alembic import command
+        from alembic.config import Config
+        from alembic.runtime.migration import MigrationContext
+        from alembic.script import ScriptDirectory
+
         with self.engine.begin() as conn:
             cfg = Config()
 

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -13,7 +13,7 @@ from structlog.stdlib import get_logger
 from meltano.core.behavior import NameEq
 from meltano.core.behavior.canonical import Canonical
 from meltano.core.behavior.hookable import HookObject
-from meltano.core.job_state import STATE_ID_COMPONENT_DELIMITER
+from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.plugin.command import Command
 from meltano.core.plugin.requirements import PluginRequirement
 from meltano.core.setting_definition import SettingDefinition, SettingKind, YAMLEnum

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -12,7 +12,6 @@ from structlog.stdlib import get_logger
 
 from meltano.core.behavior.addon import MeltanoAddon
 from meltano.core.db import project_engine
-from meltano.core.state_store.azure import AZStorageStateStoreManager
 from meltano.core.state_store.base import MeltanoState, StateStoreManager
 from meltano.core.state_store.db import DBStateStoreManager
 from meltano.core.state_store.filesystem import (
@@ -39,7 +38,6 @@ else:
     from importlib_metadata import EntryPoints, entry_points
 
 __all__ = [
-    "AZStorageStateStoreManager",
     "BuiltinStateBackendEnum",
     "DBStateStoreManager",
     "GCSStateStoreManager",
@@ -61,7 +59,6 @@ class BuiltinStateBackendEnum(StrEnum):
     # the given type. E.g., filesystem state backends have a
     # file://<path>/<to>/<state directory> URI
     LOCAL_FILESYSTEM = "file"
-    AZURE = "azure"
     GCS = "gs"
 
 
@@ -101,7 +98,6 @@ class StateBackend:
         return {
             BuiltinStateBackendEnum.SYSTEMDB: DBStateStoreManager,
             BuiltinStateBackendEnum.LOCAL_FILESYSTEM: LocalFilesystemStateStoreManager,
-            BuiltinStateBackendEnum.AZURE: AZStorageStateStoreManager,
             BuiltinStateBackendEnum.GCS: GCSStateStoreManager,
         }
 

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -14,10 +14,6 @@ from meltano.core.behavior.addon import MeltanoAddon
 from meltano.core.db import project_engine
 from meltano.core.state_store.base import MeltanoState, StateStoreManager
 from meltano.core.state_store.db import DBStateStoreManager
-from meltano.core.state_store.filesystem import (
-    LocalFilesystemStateStoreManager,
-    WindowsFilesystemStateStoreManager,
-)
 
 if sys.version_info < (3, 11):
     from backports.strenum import StrEnum
@@ -39,7 +35,6 @@ else:
 __all__ = [
     "BuiltinStateBackendEnum",
     "DBStateStoreManager",
-    "LocalFilesystemStateStoreManager",
     "MeltanoState",
     "StateBackend",
     "StateStoreManager",
@@ -53,10 +48,6 @@ class BuiltinStateBackendEnum(StrEnum):
     """State backend."""
 
     SYSTEMDB = "systemdb"
-    # These strings should match the expected scheme for URIs of
-    # the given type. E.g., filesystem state backends have a
-    # file://<path>/<to>/<state directory> URI
-    LOCAL_FILESYSTEM = "file"
 
 
 class StateBackend:
@@ -94,7 +85,6 @@ class StateBackend:
         """
         return {
             BuiltinStateBackendEnum.SYSTEMDB: DBStateStoreManager,
-            BuiltinStateBackendEnum.LOCAL_FILESYSTEM: LocalFilesystemStateStoreManager,
         }
 
     @property
@@ -165,10 +155,5 @@ def state_store_manager_from_project_settings(
     )
     settings = (setting_def.name for setting_def in setting_defs)
     backend = StateBackend(scheme).manager
-    if (
-        scheme == BuiltinStateBackendEnum.LOCAL_FILESYSTEM
-        and "Windows" in platform.system()
-    ):
-        backend = WindowsFilesystemStateStoreManager
     kwargs = {name.split(".")[-1]: settings_service.get(name) for name in settings}
     return backend(**kwargs)

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -20,7 +20,6 @@ from meltano.core.state_store.filesystem import (
     WindowsFilesystemStateStoreManager,
 )
 from meltano.core.state_store.google import GCSStateStoreManager
-from meltano.core.state_store.s3 import S3StateStoreManager
 
 if sys.version_info < (3, 11):
     from backports.strenum import StrEnum
@@ -46,7 +45,6 @@ __all__ = [
     "GCSStateStoreManager",
     "LocalFilesystemStateStoreManager",
     "MeltanoState",
-    "S3StateStoreManager",
     "StateBackend",
     "StateStoreManager",
     "state_store_manager_from_project_settings",
@@ -64,7 +62,6 @@ class BuiltinStateBackendEnum(StrEnum):
     # file://<path>/<to>/<state directory> URI
     LOCAL_FILESYSTEM = "file"
     AZURE = "azure"
-    S3 = "s3"
     GCS = "gs"
 
 
@@ -104,7 +101,6 @@ class StateBackend:
         return {
             BuiltinStateBackendEnum.SYSTEMDB: DBStateStoreManager,
             BuiltinStateBackendEnum.LOCAL_FILESYSTEM: LocalFilesystemStateStoreManager,
-            BuiltinStateBackendEnum.S3: S3StateStoreManager,
             BuiltinStateBackendEnum.AZURE: AZStorageStateStoreManager,
             BuiltinStateBackendEnum.GCS: GCSStateStoreManager,
         }

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -18,7 +18,6 @@ from meltano.core.state_store.filesystem import (
     LocalFilesystemStateStoreManager,
     WindowsFilesystemStateStoreManager,
 )
-from meltano.core.state_store.google import GCSStateStoreManager
 
 if sys.version_info < (3, 11):
     from backports.strenum import StrEnum
@@ -40,7 +39,6 @@ else:
 __all__ = [
     "BuiltinStateBackendEnum",
     "DBStateStoreManager",
-    "GCSStateStoreManager",
     "LocalFilesystemStateStoreManager",
     "MeltanoState",
     "StateBackend",
@@ -59,7 +57,6 @@ class BuiltinStateBackendEnum(StrEnum):
     # the given type. E.g., filesystem state backends have a
     # file://<path>/<to>/<state directory> URI
     LOCAL_FILESYSTEM = "file"
-    GCS = "gs"
 
 
 class StateBackend:
@@ -98,7 +95,6 @@ class StateBackend:
         return {
             BuiltinStateBackendEnum.SYSTEMDB: DBStateStoreManager,
             BuiltinStateBackendEnum.LOCAL_FILESYSTEM: LocalFilesystemStateStoreManager,
-            BuiltinStateBackendEnum.GCS: GCSStateStoreManager,
         }
 
     @property

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -72,7 +72,10 @@ class StateBackend:
         Returns:
             List of available state backends.
         """
-        return list(BuiltinStateBackendEnum) + [ep.name for ep in cls.addon.installed]
+        return [
+            *(x.value for x in BuiltinStateBackendEnum),
+            *(ep.name for ep in cls.addon.installed)
+        ]
 
     @property
     def _builtin_managers(

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -74,7 +74,7 @@ class StateBackend:
         """
         return [
             *(x.value for x in BuiltinStateBackendEnum),
-            *(ep.name for ep in cls.addon.installed)
+            *(ep.name for ep in cls.addon.installed),
         ]
 
     @property

--- a/src/meltano/core/state_store/azure.py
+++ b/src/meltano/core/state_store/azure.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from functools import cached_property
 
 from meltano.core.error import MeltanoError
+from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.state_store.filesystem import (
     CloudStateStoreManager,
 )
@@ -45,6 +46,24 @@ def requires_azure() -> Generator[None, None, None]:
     if not AZURE_INSTALLED:
         raise MissingAzureError
     yield
+
+
+CONNECTION_STRING = SettingDefinition(
+    name="state_backend.azure.connection_string",
+    label="Connection String",
+    description="Connection string for the Azure Blob Storage account",
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
+
+STORAGE_ACCOUNT_URL = SettingDefinition(
+    name="state_backend.azure.storage_account_url",
+    label="Storage Account URL",
+    description="URL for the Azure Blob Storage account",
+    kind=SettingKind.STRING,
+    env_specific=True,
+)
 
 
 class AZStorageStateStoreManager(CloudStateStoreManager):

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import glob
 import os
+import platform
 import re
 import shutil
 import typing as t
@@ -371,7 +372,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
             self.delete(self.get_state_path(state_id))
 
 
-class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
+class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
     """State backend for local filesystem."""
 
     label: str = "Local Filesystem"
@@ -486,7 +487,7 @@ class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
         shutil.rmtree(self.get_state_dir(state_id))
 
 
-class WindowsFilesystemStateStoreManager(LocalFilesystemStateStoreManager):
+class _WindowsFilesystemStateStoreManager(_LocalFilesystemStateStoreManager):
     """State backend for local Windows filesystem."""
 
     label: str = "Local Windows Filesystem"
@@ -543,6 +544,14 @@ class WindowsFilesystemStateStoreManager(LocalFilesystemStateStoreManager):
             if pattern_re is None or pattern_re.match(state_id):
                 state_ids.add(state_id)
         return state_ids
+
+
+LocalFilesystemStateStoreManager: type[BaseFilesystemStateStoreManager]
+
+if "Windows" in platform.system():
+    LocalFilesystemStateStoreManager = _WindowsFilesystemStateStoreManager
+else:
+    LocalFilesystemStateStoreManager = _LocalFilesystemStateStoreManager
 
 
 class CloudStateStoreManager(BaseFilesystemStateStoreManager):

--- a/src/meltano/core/state_store/google.py
+++ b/src/meltano/core/state_store/google.py
@@ -6,6 +6,7 @@ import typing as t
 from contextlib import contextmanager
 from functools import cached_property
 
+from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.state_store.filesystem import CloudStateStoreManager
 
 if t.TYPE_CHECKING:
@@ -44,6 +45,18 @@ def requires_gcs() -> Generator[None, None, None]:
     if not GOOGLE_INSTALLED:
         raise MissingGoogleError
     yield
+
+
+APPLICATION_CREDENTIALS = SettingDefinition(
+    name="state_backend.gcs.application_credentials",
+    label="Application Credentials",
+    description=(
+        "Path to the credential file to use in authenticating to Google Cloud Storage"
+    ),
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
 
 
 class GCSStateStoreManager(CloudStateStoreManager):

--- a/src/meltano/core/state_store/s3.py
+++ b/src/meltano/core/state_store/s3.py
@@ -6,6 +6,7 @@ import typing as t
 from contextlib import contextmanager
 from functools import cached_property
 
+from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.state_store.filesystem import (
     CloudStateStoreManager,
     InvalidStateBackendConfigurationException,
@@ -47,6 +48,33 @@ def requires_boto3() -> Generator[None, None, None]:
     if not BOTO_INSTALLED:
         raise MissingBoto3Error
     yield
+
+
+AWS_ACCESS_KEY_ID = SettingDefinition(
+    name="state_backend.s3.aws_access_key_id",
+    label="AWS Access Key ID",
+    description="AWS Access Key ID",
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
+
+AWS_SECRET_ACCESS_KEY = SettingDefinition(
+    name="state_backend.s3.aws_secret_access_key",
+    label="AWS Secret Access Key",
+    description="AWS Secret Access Key",
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
+
+ENDPOINT_URL = SettingDefinition(
+    name="state_backend.s3.endpoint_url",
+    label="Endpoint URL",
+    description="URL for the AWS S3 or S3-compatible storage service",
+    kind=SettingKind.STRING,
+    env_specific=True,
+)
 
 
 class S3StateStoreManager(CloudStateStoreManager):

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -17,7 +17,6 @@ from meltano.core.error import MeltanoError
 from meltano.core.plugin_install_service import PluginInstallReason, install_plugins
 from meltano.core.project_plugins_service import PluginType
 from meltano.core.state_service import StateService
-from meltano.core.state_store.filesystem import CloudStateStoreManager
 
 if t.TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -193,6 +192,8 @@ class UpgradeService:
 
         See: https://github.com/meltano/meltano/issues/7938
         """
+        from meltano.core.state_store.filesystem import CloudStateStoreManager
+
         state_service = StateService(project=self.project)
         manager = state_service.state_store_manager
         if isinstance(manager, CloudStateStoreManager):

--- a/tests/fixtures/custom_addon.py
+++ b/tests/fixtures/custom_addon.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class MyAddon:
+    """Dummy plugin."""

--- a/tests/fixtures/state_backends.py
+++ b/tests/fixtures/state_backends.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from meltano.core.state_store import StateStoreManager
+
+
+class DummyStateStoreManager(StateStoreManager):
+    label: str = "Dummy state store manager"
+
+    def __init__(self, **kwargs): ...
+
+    def set(self, state): ...
+
+    def get(self, state_id): ...
+
+    def clear(self, state_id): ...
+
+    def get_state_ids(self, pattern=None):  # noqa: ARG002
+        return ()  # pragma: no cover
+
+    def acquire_lock(self, state_id): ...

--- a/tests/meltano/core/behavior/test_addon.py
+++ b/tests/meltano/core/behavior/test_addon.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import sys
+import typing as t
+
+from fixtures.custom_addon import MyAddon
+from meltano.core.behavior.addon import MeltanoAddon
+
+if sys.version_info >= (3, 12):
+    from importlib.metadata import EntryPoint, EntryPoints
+else:
+    from importlib_metadata import EntryPoint, EntryPoints
+
+if t.TYPE_CHECKING:
+    import pytest
+
+
+def test_entry_point_group():
+    """Test that the entry point group is set correctly."""
+    addon = MeltanoAddon("meltano.custom_feature")
+
+    assert addon.entry_point_group == "meltano.custom_feature"
+    assert not addon.installed
+
+
+def test_entry_points(monkeypatch: pytest.MonkeyPatch):
+    """Test that the entry points are loaded correctly."""
+    addon: MeltanoAddon[object] = MeltanoAddon("meltano.custom_feature")
+
+    entry_points = EntryPoints(
+        (
+            EntryPoint(
+                value="fixtures.custom_addon:MyAddon",
+                name="custom",
+                group="meltano.custom_feature",
+            ),
+        ),
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(addon, "installed", entry_points)
+        my_addon = addon.get("custom")
+        assert my_addon is MyAddon
+
+        addons = list(addon.get_all())
+        assert addons == [MyAddon]

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -21,9 +21,9 @@ from meltano.core.block.extract_load import (
 )
 from meltano.core.block.ioblock import IOBlock
 from meltano.core.block.singer import SingerBlock
+from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.environment import Environment
 from meltano.core.job import Job, Payload, State
-from meltano.core.job_state import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.logging import OutputLogger
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_invoker import PluginInvoker

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -28,12 +28,12 @@ from botocore.stub import Stubber
 from google.cloud.storage import Blob, Bucket
 
 from meltano.core.state_store import (
-    AZStorageStateStoreManager,
     GCSStateStoreManager,
     LocalFilesystemStateStoreManager,
     MeltanoState,
     WindowsFilesystemStateStoreManager,
 )
+from meltano.core.state_store.azure import AZStorageStateStoreManager
 from meltano.core.state_store.s3 import S3StateStoreManager
 
 if t.TYPE_CHECKING:

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -28,12 +28,12 @@ from botocore.stub import Stubber
 from google.cloud.storage import Blob, Bucket
 
 from meltano.core.state_store import (
-    GCSStateStoreManager,
     LocalFilesystemStateStoreManager,
     MeltanoState,
     WindowsFilesystemStateStoreManager,
 )
 from meltano.core.state_store.azure import AZStorageStateStoreManager
+from meltano.core.state_store.google import GCSStateStoreManager
 from meltano.core.state_store.s3 import S3StateStoreManager
 
 if t.TYPE_CHECKING:

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -32,9 +32,9 @@ from meltano.core.state_store import (
     GCSStateStoreManager,
     LocalFilesystemStateStoreManager,
     MeltanoState,
-    S3StateStoreManager,
     WindowsFilesystemStateStoreManager,
 )
+from meltano.core.state_store.s3 import S3StateStoreManager
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterator
@@ -409,7 +409,7 @@ class TestS3StateStoreManager:
     @contextmanager
     def stubber(self) -> Iterator[Stubber]:
         with patch(
-            "meltano.core.state_store.S3StateStoreManager.client",
+            "meltano.core.state_store.s3.S3StateStoreManager.client",
             new_callable=PropertyMock,
         ) as mock_client:
             mock_client.return_value = client("s3")

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -15,7 +15,6 @@ from azure.storage.blob._shared.authentication import (
 from fixtures.state_backends import DummyStateStoreManager
 from meltano.core.error import MeltanoError
 from meltano.core.state_store import (
-    AZStorageStateStoreManager,
     BuiltinStateBackendEnum,
     DBStateStoreManager,
     GCSStateStoreManager,
@@ -24,6 +23,7 @@ from meltano.core.state_store import (
     StateBackend,
     state_store_manager_from_project_settings,
 )
+from meltano.core.state_store.azure import AZStorageStateStoreManager
 from meltano.core.state_store.s3 import S3StateStoreManager
 
 if t.TYPE_CHECKING:

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -21,10 +21,10 @@ from meltano.core.state_store import (
     GCSStateStoreManager,
     LocalFilesystemStateStoreManager,
     MeltanoState,
-    S3StateStoreManager,
     StateBackend,
     state_store_manager_from_project_settings,
 )
+from meltano.core.state_store.s3 import S3StateStoreManager
 
 if t.TYPE_CHECKING:
     from pathlib import Path

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import sys
 import typing as t
 
 import moto
@@ -11,9 +12,11 @@ from azure.storage.blob._shared.authentication import (
     SharedKeyCredentialPolicy,
 )
 
+from fixtures.state_backends import DummyStateStoreManager
 from meltano.core.error import MeltanoError
 from meltano.core.state_store import (
     AZStorageStateStoreManager,
+    BuiltinStateBackendEnum,
     DBStateStoreManager,
     GCSStateStoreManager,
     LocalFilesystemStateStoreManager,
@@ -28,10 +31,42 @@ if t.TYPE_CHECKING:
 
     from meltano.core.project import Project
 
+if sys.version_info >= (3, 12):
+    from importlib.metadata import EntryPoint, EntryPoints
+else:
+    from importlib_metadata import EntryPoint, EntryPoints
+
+
+def test_unknown_state_backend_scheme(project: Project):
+    project.settings.set(["state_backend", "uri"], "unknown://")
+    with pytest.raises(ValueError, match="No state backend found for scheme"):
+        state_store_manager_from_project_settings(project.settings)
+
+
+def test_pluggable_state_backend(project: Project, monkeypatch: pytest.MonkeyPatch):
+    project.settings.set(["state_backend", "uri"], "custom://")
+
+    entry_points = EntryPoints(
+        (
+            EntryPoint(
+                value="fixtures.state_backends:DummyStateStoreManager",
+                name="custom",
+                group="meltano.state_backends",
+            ),
+        ),
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(StateBackend.addon, "installed", entry_points)
+        assert "custom" in StateBackend.backends()
+
+        state_store = state_store_manager_from_project_settings(project.settings)
+        assert isinstance(state_store, DummyStateStoreManager)
+
 
 class TestSystemDBStateBackend:
     def test_manager_from_settings(self, project: Project) -> None:
-        project.settings.set(["state_backend", "uri"], StateBackend.SYSTEMDB)
+        project.settings.set(["state_backend", "uri"], BuiltinStateBackendEnum.SYSTEMDB)
         project.settings.set(["state_backend", "lock_timeout_seconds"], 10)
         db_state_store = state_store_manager_from_project_settings(project.settings)
         assert isinstance(db_state_store, DBStateStoreManager)

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -17,13 +17,13 @@ from meltano.core.error import MeltanoError
 from meltano.core.state_store import (
     BuiltinStateBackendEnum,
     DBStateStoreManager,
-    GCSStateStoreManager,
     LocalFilesystemStateStoreManager,
     MeltanoState,
     StateBackend,
     state_store_manager_from_project_settings,
 )
 from meltano.core.state_store.azure import AZStorageStateStoreManager
+from meltano.core.state_store.google import GCSStateStoreManager
 from meltano.core.state_store.s3 import S3StateStoreManager
 
 if t.TYPE_CHECKING:

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -17,12 +17,12 @@ from meltano.core.error import MeltanoError
 from meltano.core.state_store import (
     BuiltinStateBackendEnum,
     DBStateStoreManager,
-    LocalFilesystemStateStoreManager,
     MeltanoState,
     StateBackend,
     state_store_manager_from_project_settings,
 )
 from meltano.core.state_store.azure import AZStorageStateStoreManager
+from meltano.core.state_store.filesystem import _LocalFilesystemStateStoreManager
 from meltano.core.state_store.google import GCSStateStoreManager
 from meltano.core.state_store.s3 import S3StateStoreManager
 
@@ -84,7 +84,7 @@ class TestLocalFilesystemStateBackend:
     def test_manager_from_settings(self, project: Project, state_path: str) -> None:
         project.settings.set(["state_backend", "uri"], f"file://{state_path}")
         file_state_store = state_store_manager_from_project_settings(project.settings)
-        assert isinstance(file_state_store, LocalFilesystemStateStoreManager)
+        assert isinstance(file_state_store, _LocalFilesystemStateStoreManager)
         assert file_state_store.state_dir == state_path
 
 

--- a/tests/meltano/core/test_environment_service.py
+++ b/tests/meltano/core/test_environment_service.py
@@ -4,6 +4,7 @@ import platform
 
 import pytest
 
+from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.environment import (
     Environment,
     EnvironmentNameContainsStateIdDelimiterError,
@@ -12,7 +13,6 @@ from meltano.core.environment_service import (
     EnvironmentAlreadyExistsError,
     EnvironmentService,
 )
-from meltano.core.job_state import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.utils import NotFound
 
 

--- a/tests/meltano/core/test_project_add_service.py
+++ b/tests/meltano/core/test_project_add_service.py
@@ -5,7 +5,7 @@ import typing as t
 import mock
 import pytest
 
-from meltano.core.job_state import STATE_ID_COMPONENT_DELIMITER
+from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.plugin import PluginType, Variant
 from meltano.core.plugin.base import PluginRefNameContainsStateIdDelimiterError
 from meltano.core.plugin.project_plugin import ProjectPlugin


### PR DESCRIPTION
Packaging example from Meltano's builtin state backends:

```toml
[project.entry-points."meltano.settings"]
# AWS S3 state backend settings
s3_aws_access_key_id = "meltano.core.state_store.s3:AWS_ACCESS_KEY_ID"
s3_aws_secret_access_key = "meltano.core.state_store.s3:AWS_SECRET_ACCESS_KEY"
s3_endpoint_url = "meltano.core.state_store.s3:ENDPOINT_URL"```

[project.entry-points."meltano.state_backends"]
# These keys should match the expected scheme for URIs of
# the given type. E.g., filesystem state backends have a
# file://<path>/<to>/<state directory> URI
s3 = "meltano.core.state_store.s3:S3StateStoreManager"
```

## Documentation

- [Custom State Backends](https://deploy-preview-8367--meltano.netlify.app/guide/custom-state-backend/)

## Related

* https://github.com/meltano/meltano/discussions/8276
* https://github.com/meltano/meltano/issues/2414
* https://github.com/edgarrmondragon/meltano-rocksdb-state-backend/
* https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/
