### PR TITLE
fix: `--from-ref` for a plugin definition missing a `variant`

### DIFF
--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -305,7 +305,7 @@ def add_plugin(  # noqa: C901
         plugin_attrs = plugin_definition.canonical()
 
         plugin_name = plugin_attrs.pop("name")
-        variant = plugin_attrs.pop("variant")
+        variant = plugin_attrs.pop("variant", variant)
 
     try:
         plugin = add_service.add(


### PR DESCRIPTION
When working on #8378, I found that trying to add from a plugin definition YAML file throws an ambiguous error when `variant` is missing - it seems to be required when publishing to Meltano Hub, but not by Meltano itself for a custom plugin.

During local development of a plugin, I'd imagine a user would initially want to supply a minimal definition (at least on par with what is prompted for in the `--custom` flow, which doesn't include `variant` currently) and build it up as they go, so this helps towards that. See the [example plugin definition](https://deploy-preview-8378--meltano.netlify.app/tutorials/custom-extractor#1-use-the-meltano-add-command) from #8378 for more context.