### PR TITLE
fix: Print `Plugin definition is already locked` to stdout instead of stderr

### DIFF
--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -371,7 +371,6 @@ def add_plugin(  # noqa: C901
         click.secho(
             f"Plugin definition is already locked at {exc.path}.",
             fg="yellow",
-            err=True,
         )
         click.echo(
             "You can remove the file manually to avoid using a stale definition.",


### PR DESCRIPTION
This also addresses some flaky coverage, since sometimes the tests that touch lock files run without an existing lockfile so the code path in `except LockfileAlreadyExistsError as exc:` is never called.