### PR TITLE
fix: Handle non-UTF-8 lines in plugin output for logging

### DIFF
--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -197,6 +197,16 @@ class SubprocessOutputWriter(t.Protocol):
 
 async def _write_line_writer(writer: SubprocessOutputWriter, line: bytes):
     # StreamWriters like a subprocess's stdin need special consideration
+    def _decode_log(byte_string):  #8377
+        encodings = ['latin-1']  # list of encoding we need to consider; default is utf-8
+        for enc in encodings:
+            try:
+                return byte_string.decode(enc)
+            except UnicodeDecodeError as e:
+                pass
+        else:
+            return byte_string.decode('utf-8', errors='ignore')
+
     if isinstance(writer, asyncio.StreamWriter):
         try:
             writer.write(line)
@@ -205,7 +215,7 @@ async def _write_line_writer(writer: SubprocessOutputWriter, line: bytes):
             await writer.wait_closed()
             return False
     else:
-        writer.writeline(line.decode())
+        writer.writeline(_decode_log(line))
 
     return True
 

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -197,15 +197,17 @@ class SubprocessOutputWriter(t.Protocol):
 
 async def _write_line_writer(writer: SubprocessOutputWriter, line: bytes):
     # StreamWriters like a subprocess's stdin need special consideration
-    def _decode_log(byte_string):  #8377
-        encodings = ['latin-1']  # list of encoding we need to consider; default is utf-8
+    def _decode_log(byte_string):  # 8377
+        encodings = [
+            "latin-1"
+        ]  # list of encoding we need to consider; default is utf-8
         for enc in encodings:
             try:
                 return byte_string.decode(enc)
-            except UnicodeDecodeError as e:
+            except UnicodeDecodeError:
                 pass
         else:
-            return byte_string.decode('utf-8', errors='ignore')
+            return byte_string.decode("utf-8", errors="ignore")
 
     if isinstance(writer, asyncio.StreamWriter):
         try:


### PR DESCRIPTION
Try to decode the byte text using the list of encoding. For now, it is `latin-1`. If failed, then fall back into `utf-8` with `error=ignore`.

Closes #8377