### PR TITLE
chore: Replace use of flakeheaven with Ruff for pep8-naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,5 +103,4 @@ repos:
           - flake8-rst-docstrings==0.2.7
           - flake8-string-format==0.3.0
           - flake8-typing-as-t==0.0.3
-          - pep8-naming==0.12.1
           - wemake-python-styleguide==0.16.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -579,7 +579,6 @@ exclude = [
 ignore = [
   "ANN101", # Missing type annotation for `self` in method
   "ANN102", # Missing type annotation for `cls` in class method
-  "N815",   # mixedCase variable in class scope (constants, method names)
   "N818",   # Allow Exceptions to have suffix 'Exception' rather than 'Error'
   "PT004",  # Add leading underscore to fixtures that do not return anything
   "UP026",  # Replace `mock` import with `unittest.mock` - remove once Python 3.7 support is dropped
@@ -620,9 +619,6 @@ unfixable = [
 ]
 "tests/**" = [
   "S101", # Allow 'assert' in tests
-]
-"src/meltano/migrations/versions/**" = [
-  "N806", # Allow uppercase variable names
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -579,6 +579,7 @@ exclude = [
 ignore = [
   "ANN101", # Missing type annotation for `self` in method
   "ANN102", # Missing type annotation for `cls` in class method
+  "N815",   # mixedCase variable in class scope (constants, method names)
   "N818",   # Allow Exceptions to have suffix 'Exception' rather than 'Error'
   "PT004",  # Add leading underscore to fixtures that do not return anything
   "UP026",  # Replace `mock` import with `unittest.mock` - remove once Python 3.7 support is dropped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,10 +183,6 @@ statistics = true
 mccabe = [
   "+*",
 ]
-"pep8-naming" = [
-  "+*",
-  "-N818", # Allow Exceptions to have suffix 'Exception' rather than 'Error'
-]
 pycodestyle = [
   "-*", # Covered by Ruff
 ]
@@ -323,9 +319,6 @@ pyflakes = [
   "-D101", # Don't class docstrings in migrations
   "-D103", # Don't require function docstrings in migrations
   "-D400", # Don't require periods in the first lines of dosctrings
-]
-"pep8-naming" = [
-  "-N806", # Allow uppercase variable names
 ]
 "wemake-python-styleguide" = [
   "-WPS102", # Allow module names starting with numbers
@@ -586,6 +579,7 @@ exclude = [
 ignore = [
   "ANN101", # Missing type annotation for `self` in method
   "ANN102", # Missing type annotation for `cls` in class method
+  "N818",   # Allow Exceptions to have suffix 'Exception' rather than 'Error'
   "PT004",  # Add leading underscore to fixtures that do not return anything
   "UP026",  # Replace `mock` import with `unittest.mock` - remove once Python 3.7 support is dropped
   "S310",   # Allow `urllib.open`
@@ -604,6 +598,7 @@ select = [
   "G",   # flake8-logging-format
   "I",   # isort
   "ISC", # flake8-implicit-str-concat
+  "N",   # pep8-naming
   "PT",  # flake8-pytest-style
   "RSE", # flake8-raise
   "S",   # flake8-bandit
@@ -624,6 +619,9 @@ unfixable = [
 ]
 "tests/**" = [
   "S101", # Allow 'assert' in tests
+]
+"src/meltano/migrations/versions/**" = [
+  "N806", # Allow uppercase variable names
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -20,14 +20,14 @@ class AsyncReader(asyncio.StreamReader):
 
 @pytest.mark.asyncio()
 async def test_capture_subprocess_output():
-    INPUT_LINES = [b"LINE\n", b"LINE 2\n", b"\xed\n"]
-    OUTPUT_LINES = []
+    input_lines = [b"LINE\n", b"LINE 2\n", b"\xed\n"]
+    output_lines = []
 
     class LineWriter:
         def writeline(self, line: str):
-            OUTPUT_LINES.append(line)
+            output_lines.append(line)
 
-    reader = AsyncReader(INPUT_LINES)
+    reader = AsyncReader(input_lines)
 
     await capture_subprocess_output(reader, LineWriter())
-    assert ["LINE\n", "LINE 2\n", "�\n"] == OUTPUT_LINES
+    assert ["LINE\n", "LINE 2\n", "�\n"] == output_lines


### PR DESCRIPTION
Closes #8402

 - [ ] squash git commits 