### PR TITLE
chore: Bump `check-jsonschema` and `ruamel.yaml`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1026,13 +1026,13 @@ files = [
 
 [[package]]
 name = "check-jsonschema"
-version = "0.27.1"
+version = "0.28.0"
 description = "A jsonschema CLI and pre-commit hook"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "check-jsonschema-0.27.1.tar.gz", hash = "sha256:e640479f16f106b9c6a3d2e47a82105c726ab0cc17e27e05e02e2269f2785e18"},
-    {file = "check_jsonschema-0.27.1-py3-none-any.whl", hash = "sha256:f1f9afaf24a60f1792a1b8f216dc373c762a8db3d7d1c946782d532ce57f94b9"},
+    {file = "check-jsonschema-0.28.0.tar.gz", hash = "sha256:defd6c5e944f07416170df33f218ab048c87129163601eec7b191fa076e91ca5"},
+    {file = "check_jsonschema-0.28.0-py3-none-any.whl", hash = "sha256:6611bb1b0994201a1ba71240bca705d3ebd306f8b45f65f09d8f33f786f9b203"},
 ]
 
 [package.dependencies]
@@ -1041,11 +1041,12 @@ importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""
 jsonschema = ">=4.18.0,<5.0"
 regress = ">=0.4.0"
 requests = "<3.0"
-"ruamel.yaml" = "0.17.33"
+"ruamel.yaml" = "0.18.5"
+tomli = {version = ">=2.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-dev = ["coverage (<8)", "pytest (<8)", "pytest-xdist (<4)", "responses (==0.23.3)"]
-docs = ["furo (==2023.9.10)", "sphinx (<8)", "sphinx-issues (<4)"]
+dev = ["click-type-test (==0.0.7)", "coverage (<8)", "pytest (<9)", "pytest-xdist (<4)", "responses (==0.24.1)"]
+docs = ["furo (==2024.1.29)", "sphinx (<8)", "sphinx-issues (<5)"]
 
 [[package]]
 name = "click"
@@ -3516,20 +3517,20 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.17.33"
+version = "0.18.5"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 optional = false
-python-versions = ">=3"
+python-versions = ">=3.7"
 files = [
-    {file = "ruamel.yaml-0.17.33-py3-none-any.whl", hash = "sha256:2080c7a02b8a30fb3c06727cdf3e254a64055eedf3aa2d17c2b669639c04971b"},
-    {file = "ruamel.yaml-0.17.33.tar.gz", hash = "sha256:5c56aa0bff2afceaa93bffbfc78b450b7dc1e01d5edb80b3a570695286ae62b1"},
+    {file = "ruamel.yaml-0.18.5-py3-none-any.whl", hash = "sha256:a013ac02f99a69cdd6277d9664689eb1acba07069f912823177c5eced21a6ada"},
+    {file = "ruamel.yaml-0.18.5.tar.gz", hash = "sha256:61917e3a35a569c1133a8f772e1226961bf5a1198bea7e23f06a0841dea1ab0e"},
 ]
 
 [package.dependencies]
-"ruamel.yaml.clib" = {version = ">=0.2.7", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.12\""}
+"ruamel.yaml.clib" = {version = ">=0.2.7", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.13\""}
 
 [package.extras]
-docs = ["ryd"]
+docs = ["mercurial (>5.7)", "ryd"]
 jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
 
 [[package]]
@@ -4321,4 +4322,4 @@ s3 = ["boto3"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "518cfe70dad9d44e33ea868198d74ba45868aac06fd01bc3d0a4ed9f0df6b4ad"
+content-hash = "133188ec4fc47d3f8c92e6bffe7e297537d25c03f990f9ccec7b2f4d357bf0fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ azure-core = {version = "^1.30.0", optional = true}
 azure-identity = {version = "^1.15.0", optional = true}
 azure-storage-blob = {version = "^12.19.0", optional = true}
 boto3 = {version = "^1.34.44", optional = true}
-check-jsonschema = "^0.27.0"
+check-jsonschema = "^0.28.0"
 click = "^8.1"
 click-default-group = "^1.2.4"
 click-didyoumean = "^0.3.0"
@@ -75,7 +75,7 @@ pyyaml = "^6.0.1"
 questionary = "^2.0.1"
 requests = "^2.31.0"
 rich = "^13.7.0"
-"ruamel.yaml" = "^0.17.21"
+"ruamel.yaml" = "^0.18.5"
 setuptools = {version = "^69.1.0", python = ">=3.12"}
 smart-open = "^6.4.0"
 snowplow-tracker = "^1.0.1"


### PR DESCRIPTION
dependabot was failing to update because `check-jsonschema` pins `ruamel.yaml` to a patch version: https://github.com/python-jsonschema/check-jsonschema/blob/439860ff767ab8511228920454ae7f920f41cb6c/setup.cfg#L23

My guess is they do that because they want to maximize the stability of the CLI application.