### PR TITLE
fix: Terminal output from plugin installation is now safely decoded

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -325,6 +325,7 @@ class VenvService:  # noqa: WPS214
         async def extract_stderr(proc: Process):
             return (await t.cast(asyncio.StreamReader, proc.stdout).read()).decode(
                 "unicode_escape",
+                errors="replace",
             )
 
         try:
@@ -441,7 +442,7 @@ class VenvService:  # noqa: WPS214
             if not proc.stdout:
                 return None
 
-            return (await proc.stdout.read()).decode("unicode_escape")
+            return (await proc.stdout.read()).decode("unicode_escape", errors="replace")
 
         try:
             return await exec_async(


### PR DESCRIPTION
Related:

* Similar issue to https://github.com/meltano/meltano/issues/8377
* Similar solution to https://github.com/meltano/meltano/pull/8399
* `bytes.decode()` docs: https://docs.python.org/3.12/library/stdtypes.html#bytes.decode
* Slack: https://meltano.slack.com/archives/C069CQNHDNF/p1709745908279289