### PR TITLE
fix(cli): Added `run_id` and `job_name` properties to `meltano run` log messages

### DIFF
--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -609,6 +609,9 @@ class ExtractLoadBlocks(BlockSet):  # noqa: WPS214
                 producer=block.producer,
                 string_id=block.string_id,
                 cmd_type="elb",
+                run_id=str(self.context.job.run_id)
+                if self.context.job
+                else "stateless",
             )
             if logger.isEnabledFor(logging.DEBUG):
                 block.stdout_link(

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -609,9 +609,7 @@ class ExtractLoadBlocks(BlockSet):  # noqa: WPS214
                 producer=block.producer,
                 string_id=block.string_id,
                 cmd_type="elb",
-                run_id=str(self.context.job.run_id)
-                if self.context.job
-                else "stateless",
+                run_id=str(self.context.job.run_id) if self.context.job else None,
             )
             if logger.isEnabledFor(logging.DEBUG):
                 block.stdout_link(

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -610,6 +610,7 @@ class ExtractLoadBlocks(BlockSet):  # noqa: WPS214
                 string_id=block.string_id,
                 cmd_type="elb",
                 run_id=str(self.context.job.run_id) if self.context.job else None,
+                job_name=self.context.job.job_name if self.context.job else None,
             )
             if logger.isEnabledFor(logging.DEBUG):
                 block.stdout_link(


### PR DESCRIPTION
Quick win after a Slack thread: https://meltano.slack.com/archives/C069CQNHDNF/p1710435376837949