### PR TITLE
docs: Fixed a broken link to custom plugin definitions in the project concept page

### DIFF
--- a/docs/docs/concepts/plugins.mdx
+++ b/docs/docs/concepts/plugins.mdx
@@ -82,7 +82,7 @@ To learn how to add a non-default variant of a discoverable plugin to your proje
 If you'd like to use a package in your project whose [base plugin description](#project-plugins) isn't [discoverable](#discoverable-plugins) yet,
 you'll need to collect and provide this metadata yourself.
 
-To learn how to add a custom plugin to your project using a [custom plugin definition](project#custom-plugin-definitions), refer to the [Plugin Management guide](/guide/plugin-management#custom-plugins).
+To learn how to add a custom plugin to your project using a [custom plugin definition](/concepts/project#custom-plugin-definitions), refer to the [Plugin Management guide](/guide/plugin-management#custom-plugins).
 
 :::caution
 


### PR DESCRIPTION
Fixes https://github.com/meltano/meltano/issues/8448
