### PR TITLE
chore: Replace use of flakeheaven with Ruff for flake8-return

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,9 +99,7 @@ repos:
           - flake8-docstrings==1.6.0
           - flake8-eradicate==1.4.0
           - flake8-polyfill==1.0.2
-          - flake8-print==5.0.0
           - flake8-quotes==3.3.1
-          - flake8_return==1.2.0
           - flake8-rst-docstrings==0.2.7
           - flake8-string-format==0.3.0
           - flake8-typing-as-t==0.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,6 +101,7 @@ repos:
           - flake8-polyfill==1.0.2
           - flake8-print==5.0.0
           - flake8-quotes==3.3.1
+          - flake8_return==1.2.0
           - flake8-rst-docstrings==0.2.7
           - flake8-string-format==0.3.0
           - flake8-typing-as-t==0.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -604,6 +604,7 @@ select = [
   "ISC", # flake8-implicit-str-concat
   "N",   # pep8-naming
   "PT",  # flake8-pytest-style
+  "RET", # flake8-return
   "RSE", # flake8-raise
   "S",   # flake8-bandit
   "SIM", # flake8-simplify

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
 
 def _load_yaml_from_ref(_ctx, _param, value: str | None) -> dict:
     if not value:
-        return
+        return None
 
     try:
         url = urlparse(value)

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
     from meltano.core.tracking import Tracker
 
 
-def _load_yaml_from_ref(_ctx, _param, value: str | None) -> dict:
+def _load_yaml_from_ref(_ctx, _param, value: str | None) -> dict | None:
     if not value:
         return None
 
@@ -79,7 +79,7 @@ def _load_yaml_from_ref(_ctx, _param, value: str | None) -> dict:
     "--from-ref",
     "plugin_yaml",
     callback=_load_yaml_from_ref,
-    help="Reference a plugin defintion to add from.",
+    help="Reference a plugin definition to add from.",
 )
 @click.option(
     "--python",

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -331,6 +331,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
 
         elif action.lower() == "e":
             return InteractionStatus.EXIT
+        return None  # RET503
 
     def configure_all(self):
         """Configure all settings."""

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -331,7 +331,7 @@ class InteractiveConfig:  # noqa: WPS230, WPS214
 
         elif action.lower() == "e":
             return InteractionStatus.EXIT
-        return None  # RET503
+        return None
 
     def configure_all(self):
         """Configure all settings."""

--- a/src/meltano/cli/select.py
+++ b/src/meltano/cli/select.py
@@ -21,12 +21,14 @@ if t.TYPE_CHECKING:
 
 def selection_color(selection):
     """Return the appropriate colour for given SelectionType."""
+    ret_val = None
     if selection is SelectionType.SELECTED:
-        return "bright_green"
+        ret_val = "bright_green"
     elif selection is SelectionType.AUTOMATIC:
-        return "bright_white"
+        ret_val = "bright_white"
     elif selection is SelectionType.EXCLUDED:
-        return "red"
+        ret_val = "red"
+    return ret_val  # RET503, RET505
 
 
 def selection_mark(selection):

--- a/src/meltano/cli/select.py
+++ b/src/meltano/cli/select.py
@@ -21,14 +21,13 @@ if t.TYPE_CHECKING:
 
 def selection_color(selection):
     """Return the appropriate colour for given SelectionType."""
-    ret_val = None
     if selection is SelectionType.SELECTED:
-        ret_val = "bright_green"
-    elif selection is SelectionType.AUTOMATIC:
-        ret_val = "bright_white"
-    elif selection is SelectionType.EXCLUDED:
-        ret_val = "red"
-    return ret_val  # RET503, RET505
+        return "bright_green"
+    if selection is SelectionType.AUTOMATIC:
+        return "bright_white"
+    if selection is SelectionType.EXCLUDED:
+        return "red"
+    return None
 
 
 def selection_mark(selection):

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -235,7 +235,7 @@ def merge_state(
     }
     if not reduce(xor, (bool(x) for x in mutually_exclusive_options.values())):
         raise MutuallyExclusiveOptionsError(*mutually_exclusive_options)
-    elif input_file:  # noqa: RET506
+    if input_file:
         with open(input_file) as state_f:
             state_service.add_state(
                 state_id,
@@ -282,7 +282,7 @@ def set_state(
     }
     if not reduce(xor, (bool(x) for x in mutually_exclusive_options.values())):
         raise MutuallyExclusiveOptionsError(*mutually_exclusive_options)
-    elif input_file:  # noqa: RET506
+    if input_file:
         with open(input_file) as state_f:
             state_service.set_state(state_id, state_f.read())
     elif state:

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -235,7 +235,7 @@ def merge_state(
     }
     if not reduce(xor, (bool(x) for x in mutually_exclusive_options.values())):
         raise MutuallyExclusiveOptionsError(*mutually_exclusive_options)
-    elif input_file:
+    elif input_file:  # noqa: RET506
         with open(input_file) as state_f:
             state_service.add_state(
                 state_id,
@@ -282,7 +282,7 @@ def set_state(
     }
     if not reduce(xor, (bool(x) for x in mutually_exclusive_options.values())):
         raise MutuallyExclusiveOptionsError(*mutually_exclusive_options)
-    elif input_file:
+    elif input_file:  # noqa: RET506
         with open(input_file) as state_f:
             state_service.set_state(state_id, state_f.read())
     elif state:

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -64,7 +64,7 @@ class CommandLineRunner(ValidationsRunner):
         handle = await self.invoker.invoke_async(command=name)
         with propagate_stop_signals(handle):
             exit_code = await handle.wait()
-        return exit_code
+        return exit_code  # noqa: RET504
 
 
 @click.command(

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -63,8 +63,7 @@ class CommandLineRunner(ValidationsRunner):
         write_sep_line(f"{self.plugin_name}:{name}", "=", bold=True)
         handle = await self.invoker.invoke_async(command=name)
         with propagate_stop_signals(handle):
-            exit_code = await handle.wait()
-        return exit_code  # noqa: RET504
+            return await handle.wait()
 
 
 @click.command(
@@ -88,7 +87,7 @@ class CommandLineRunner(ValidationsRunner):
 def test(
     project: Project,
     all_tests: bool,
-    plugin_tests: tuple[str] = (),
+    plugin_tests: tuple[str, ...] = (),
 ):
     """
     Run validations using plugins' tests.

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -737,12 +737,13 @@ class ELBExecutionManager:
                     stream_buffer_size=self.stream_buffer_size,
                 )
             raise output_futures_failed.exception()  # noqa: RSE102
-        else:  # noqa: RET506
-            # If all the output handlers completed without raising an
-            # exception, we still need to wait for all the underlying block
-            # processes to complete. Note that since all output handlers
-            # completed we DO NOT need to wait for any output futures!
-            done = await self.elb.process_wait(None, start_idx)
+
+        # If all the output handlers completed without raising an
+        # exception, we still need to wait for all the underlying block
+        # processes to complete. Note that since all output handlers
+        # completed we DO NOT need to wait for any output futures!
+        done = await self.elb.process_wait(None, start_idx)
+
         if self.elb.tail.process_future.done():
             logger.debug("tail consumer completed first")
             self._consumer_code = self.elb.tail.process_future.result()

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -94,7 +94,7 @@ class ELBContext:  # noqa: WPS230
         Returns:
             The run directory for the current job.
         """
-        if self.job:
+        if self.job:  # noqa: RET503
             return self.project.job_dir(self.job.job_name, str(self.job.run_id))
 
 
@@ -278,7 +278,7 @@ class ELBContextBuilder:  # noqa: WPS214
         Returns:
             The run directory for the current job.
         """
-        if self._job:
+        if self._job:  # noqa: RET503
             return self.project.job_dir(self._job.job_name, str(self._job.run_id))
 
     def context(self) -> ELBContext:
@@ -377,7 +377,7 @@ class ExtractLoadBlocks(BlockSet):  # noqa: WPS214
         Returns:
             The index of the block furthest from the start that has exited and required input.
         """  # noqa: E501
-        for idx, block in reversed(list(enumerate(self.blocks))):
+        for idx, block in reversed(list(enumerate(self.blocks))):  # noqa: RET503
             if block.requires_input and block.proxy_stderr.done():
                 return idx
 
@@ -390,7 +390,7 @@ class ExtractLoadBlocks(BlockSet):  # noqa: WPS214
         Returns:
             True if all upstream blocks are done, False otherwise.
         """
-        for idx, block in enumerate(self.blocks):
+        for idx, block in enumerate(self.blocks):  # noqa: RET503
             if idx >= index:
                 return True
             if block.process_future.done():
@@ -737,7 +737,7 @@ class ELBExecutionManager:
                     stream_buffer_size=self.stream_buffer_size,
                 )
             raise output_futures_failed.exception()  # noqa: RSE102
-        else:
+        else:  # noqa: RET506
             # If all the output handlers completed without raising an
             # exception, we still need to wait for all the underlying block
             # processes to complete. Note that since all output handlers

--- a/src/meltano/core/block/future_utils.py
+++ b/src/meltano/core/block/future_utils.py
@@ -26,15 +26,13 @@ def first_failed_future(exception_future: Task, done: set[Task]) -> Task | None:
     Returns:
         The first future that failed.
     """
-    ret = None  # RET503
     if exception_future in done:
         futures_done, _ = exception_future.result()
-        futures_failed = [
+        if futures_failed := [
             future for future in futures_done if future.exception() is not None
-        ]
-        if futures_failed:
-            ret = futures_failed.pop()
-    return ret
+        ]:
+            return futures_failed.pop()
+    return None
 
 
 def handle_producer_line_length_limit_error(

--- a/src/meltano/core/block/future_utils.py
+++ b/src/meltano/core/block/future_utils.py
@@ -26,9 +26,9 @@ def first_failed_future(exception_future: Task, done: set[Task]) -> Task | None:
     Returns:
         The first future that failed.
     """
-    if exception_future in done:
+    if exception_future in done:  # noqa: RET503
         futures_done, _ = exception_future.result()
-        if futures_failed := [
+        if futures_failed := [  # noqa: RET503
             future for future in futures_done if future.exception() is not None
         ]:
             return futures_failed.pop()

--- a/src/meltano/core/block/future_utils.py
+++ b/src/meltano/core/block/future_utils.py
@@ -26,12 +26,15 @@ def first_failed_future(exception_future: Task, done: set[Task]) -> Task | None:
     Returns:
         The first future that failed.
     """
-    if exception_future in done:  # noqa: RET503
+    ret = None  # RET503
+    if exception_future in done:
         futures_done, _ = exception_future.result()
-        if futures_failed := [  # noqa: RET503
+        futures_failed = [
             future for future in futures_done if future.exception() is not None
-        ]:
-            return futures_failed.pop()
+        ]
+        if futures_failed:
+            ret = futures_failed.pop()
+    return ret
 
 
 def handle_producer_line_length_limit_error(

--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -297,8 +297,8 @@ class BlockParser:  # noqa: D101
                         f"Expected unique mappings name not the mapper plugin "  # noqa: EM102
                         f"name: {plugin.name}.",
                     )
-                else:  # noqa: RET506
-                    blocks.append(builder.make_block(plugin))
+                blocks.append(builder.make_block(plugin))
+
             elif plugin.type == PluginType.LOADERS:
                 self.log.debug("blocks", offset=offset, idx=next_block)
                 blocks.append(builder.make_block(plugin))

--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -297,7 +297,7 @@ class BlockParser:  # noqa: D101
                         f"Expected unique mappings name not the mapper plugin "  # noqa: EM102
                         f"name: {plugin.name}.",
                     )
-                else:
+                else:  # noqa: RET506
                     blocks.append(builder.make_block(plugin))
             elif plugin.type == PluginType.LOADERS:
                 self.log.debug("blocks", offset=offset, idx=next_block)

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -144,7 +144,7 @@ class ELTContext:  # noqa: WPS230
         Returns:
             The job dir, if a Job is provided, else None.
         """
-        if self.job:
+        if self.job:  # noqa: RET503
             return self.project.job_dir(self.job.job_name, str(self.job.run_id))
 
     def invoker_for(self, plugin_type: PluginType) -> PluginInvoker:

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -86,7 +86,7 @@ class AsyncSubprocessError(Exception):
         """Return the output of the process to stderr."""
         if not self._stderr:  # noqa: DAR201
             return None
-        elif not isinstance(self._stderr, str):
+        elif not isinstance(self._stderr, str):  # noqa: RET505
             stream = await self._stderr.read()
             self._stderr = stream.decode("utf-8")
 

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -86,7 +86,7 @@ class AsyncSubprocessError(Exception):
         """Return the output of the process to stderr."""
         if not self._stderr:  # noqa: DAR201
             return None
-        elif not isinstance(self._stderr, str):  # noqa: RET505
+        if not isinstance(self._stderr, str):
             stream = await self._stderr.read()
             self._stderr = stream.decode("utf-8")
 
@@ -112,7 +112,7 @@ class EmptyMeltanoFileException(MeltanoError):
 
 
 class MeltanoConfigurationError(MeltanoError):
-    """Exception for when Meltano is inproperly configured."""
+    """Exception for when Meltano is improperly configured."""
 
 
 class ProjectNotFound(Error):

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -270,7 +270,7 @@ class Manifest:  # noqa: WPS214
         """
         if key != "env":
             return NotImplemented  # type: ignore
-        data[key] = self.sanitize_env_vars(
+        data[key] = self.sanitize_env_vars(  # noqa: RET503
             {
                 **expand_env_vars(
                     data[key],

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -234,7 +234,7 @@ class Manifest:  # noqa: WPS214
     def sanitize_env_vars(self, env: t.Mapping[str, str]) -> dict[str, str]:
         """Sanitize environment variables.
 
-        Sanitization is perfomed by:
+        Sanitization is performed by:
         - Replacing the project root as an absolute path in values with
             '${MELTANO_PROJECT_ROOT}'
 

--- a/src/meltano/core/plugin/singer/mapper.py
+++ b/src/meltano/core/plugin/singer/mapper.py
@@ -71,6 +71,6 @@ class SingerMapper(SingerPlugin):
 
     @staticmethod
     def _get_mapping_config(extra_config: dict) -> dict | None:
-        for mapping in extra_config.get("_mappings", []):
+        for mapping in extra_config.get("_mappings", []):  # noqa: RET503
             if mapping.get("name") == extra_config.get("_mapping_name"):
                 return mapping["config"]

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -161,7 +161,7 @@ class PluginInstallService:  # noqa: WPS214
         """
         if self._parallelism is None:
             return cpu_count()
-        elif self._parallelism < 1:
+        elif self._parallelism < 1:  # noqa: RET505
             return sys.maxsize
         return self._parallelism
 

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -161,7 +161,7 @@ class PluginInstallService:  # noqa: WPS214
         """
         if self._parallelism is None:
             return cpu_count()
-        elif self._parallelism < 1:  # noqa: RET505
+        if self._parallelism < 1:
             return sys.maxsize
         return self._parallelism
 

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -183,7 +183,7 @@ class ProjectFiles:  # noqa: WPS214
                 f"file {existing_key_file_path}.",
             )
             raise Exception("Duplicate plugin name found.")  # noqa: EM101
-        else:
+        else:  # noqa: RET506
             self._plugin_file_map.update({key: str(include_path)})
 
     def _index_file(  # noqa: WPS210

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -183,8 +183,8 @@ class ProjectFiles:  # noqa: WPS214
                 f"file {existing_key_file_path}.",
             )
             raise Exception("Duplicate plugin name found.")  # noqa: EM101
-        else:  # noqa: RET506
-            self._plugin_file_map.update({key: str(include_path)})
+
+        self._plugin_file_map.update({key: str(include_path)})
 
     def _index_file(  # noqa: WPS210
         self,

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -242,7 +242,7 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
                 )
             ):
                 return self.ensure_parent(plugin)
-            elif plugin.type == PluginType.MAPPERS:
+            elif plugin.type == PluginType.MAPPERS:  # noqa: RET505
                 mapping = self._find_mapping(plugin_name, plugin)
                 if mapping:
                     return mapping
@@ -252,7 +252,7 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
 
     def _find_mapping(self, plugin_name: str, plugin: ProjectPlugin) -> ProjectPlugin:
         mapping_name = plugin.extra_config.get("_mapping_name")
-        if mapping_name == plugin_name:
+        if mapping_name == plugin_name:  # noqa: RET503
             all_mappings = self.find_plugins_by_mapping_name(mapping_name)
             if len(all_mappings) > 1:
                 raise AmbiguousMappingName(mapping_name)

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -242,7 +242,8 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
                 )
             ):
                 return self.ensure_parent(plugin)
-            elif plugin.type == PluginType.MAPPERS:  # noqa: RET505
+
+            if plugin.type == PluginType.MAPPERS:
                 mapping = self._find_mapping(plugin_name, plugin)
                 if mapping:
                     return mapping

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -142,7 +142,7 @@ class SingerRunner(Runner):
 
                 failed_future = output_futures_failed.pop()
                 raise failed_future.exception()  # noqa: RSE102
-            else:
+            else:  # noqa: RET506
                 # If all of the output handlers completed without raising an
                 # exception, we still need to wait for the tap or target to
                 # complete.
@@ -195,7 +195,7 @@ class SingerRunner(Runner):
                 "Extractor and loader failed",  # noqa: EM101
                 {PluginType.EXTRACTORS: tap_code, PluginType.LOADERS: target_code},
             )
-        elif tap_code:
+        elif tap_code:  # noqa: RET506
             raise RunnerError("Extractor failed", {PluginType.EXTRACTORS: tap_code})  # noqa: EM101
         elif target_code:
             raise RunnerError("Loader failed", {PluginType.LOADERS: target_code})  # noqa: EM101
@@ -221,7 +221,7 @@ class SingerRunner(Runner):
         async with tap.prepared(self.context.session), target.prepared(
             self.context.session,
         ):
-            await self.invoke(
+            await self.invoke(  # noqa: RET503
                 tap,
                 target,
                 extractor_log=extractor_log,

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -142,14 +142,14 @@ class SingerRunner(Runner):
 
                 failed_future = output_futures_failed.pop()
                 raise failed_future.exception()  # noqa: RSE102
-            else:  # noqa: RET506
-                # If all of the output handlers completed without raising an
-                # exception, we still need to wait for the tap or target to
-                # complete.
-                done, _ = await asyncio.wait(
-                    [tap_process_future, target_process_future],
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
+
+            # If all of the output handlers completed without raising an
+            # exception, we still need to wait for the tap or target to
+            # complete.
+            done, _ = await asyncio.wait(
+                [tap_process_future, target_process_future],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
 
         if target_process_future in done:
             target_code = target_process_future.result()
@@ -195,9 +195,9 @@ class SingerRunner(Runner):
                 "Extractor and loader failed",  # noqa: EM101
                 {PluginType.EXTRACTORS: tap_code, PluginType.LOADERS: target_code},
             )
-        elif tap_code:  # noqa: RET506
+        if tap_code:
             raise RunnerError("Extractor failed", {PluginType.EXTRACTORS: tap_code})  # noqa: EM101
-        elif target_code:
+        if target_code:
             raise RunnerError("Loader failed", {PluginType.LOADERS: target_code})  # noqa: EM101
 
     def dry_run(self, tap: PluginInvoker, target: PluginInvoker):

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -451,9 +451,9 @@ class SettingDefinition(NameEq, Canonical):
         if isinstance(value, str):
             if self.kind == SettingKind.BOOLEAN:
                 return utils.truthy(value)
-            elif self.kind == SettingKind.INTEGER:  # noqa: RET505
+            if self.kind == SettingKind.INTEGER:
                 return int(value)
-            elif self.kind == SettingKind.OBJECT:
+            if self.kind == SettingKind.OBJECT:
                 value = dict(
                     self._parse_value(value, "object", Mapping),  # type: ignore
                 )

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -451,7 +451,7 @@ class SettingDefinition(NameEq, Canonical):
         if isinstance(value, str):
             if self.kind == SettingKind.BOOLEAN:
                 return utils.truthy(value)
-            elif self.kind == SettingKind.INTEGER:
+            elif self.kind == SettingKind.INTEGER:  # noqa: RET505
                 return int(value)
             elif self.kind == SettingKind.OBJECT:
                 value = dict(

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -623,7 +623,7 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
         except StopIteration as err:
             raise SettingMissingError(name) from err
 
-    # TODO: The `for_writing` parameter is unsued, but referenced elsewhere.
+    # TODO: The `for_writing` parameter is unused, but referenced elsewhere.
     # Callers should be updated to not use it, and then it should be removed.
     def setting_env_vars(
         self,

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -154,7 +154,7 @@ class SettingsService(metaclass=ABCMeta):  # noqa: WPS214
     @property
     def inherited_settings_service(self):
         """Return settings service to inherit configuration from."""
-        return None  # noqa: DAR201
+        return None  # noqa: DAR201, RET501
 
     @property
     @abstractmethod

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -1274,7 +1274,7 @@ class AutoStoreManager(SettingsStoreManager):
         if setting_def and setting_def.is_redacted:
             if self.ensure_supported(store=SettingValueStore.DOTENV):
                 return SettingValueStore.DOTENV
-            elif self.ensure_supported(store=SettingValueStore.DB):
+            elif self.ensure_supported(store=SettingValueStore.DB):  # noqa: RET505
                 return SettingValueStore.DB
             # ensure secrets don't leak into other stores
             return None
@@ -1293,7 +1293,7 @@ class AutoStoreManager(SettingsStoreManager):
             if self.ensure_supported(store=SettingValueStore.MELTANO_YML):
                 return SettingValueStore.MELTANO_YML
             # fall back to dotenv
-            elif self.ensure_supported(store=SettingValueStore.DOTENV):
+            elif self.ensure_supported(store=SettingValueStore.DOTENV):  # noqa: RET505
                 return SettingValueStore.DOTENV
             # fall back to meltano system db
             elif self.ensure_supported(store=SettingValueStore.DB):
@@ -1308,7 +1308,7 @@ class AutoStoreManager(SettingsStoreManager):
         if self.ensure_supported(store=SettingValueStore.MELTANO_YML):
             return SettingValueStore.MELTANO_YML
         # fall back to dotenv
-        elif self.ensure_supported(store=SettingValueStore.DOTENV):
+        elif self.ensure_supported(store=SettingValueStore.DOTENV):  # noqa: RET505
             return SettingValueStore.DOTENV
         # fall back to meltano system db
         elif self.ensure_supported(store=SettingValueStore.DB):

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -83,16 +83,16 @@ def cast_setting_value(
     metadata: dict[str, t.Any],
     setting_def: SettingDefinition | None,
 ) -> tuple[t.Any, dict[str, t.Any]]:
-    """Cast a setting value according to its setting defition.
+    """Cast a setting value according to its setting definition.
 
     Args:
         value: The setting value to be cast.
         metadata: The metadata of the setting value.
-        setting_def: The setting defition.
+        setting_def: The setting definition.
 
     Returns:
         A tuple with the setting value, and its metadata. If the
-        setting defition was `None`, or the value was not changed by
+        setting definition was `None`, or the value was not changed by
         the cast, the pair returned is the same `value` and `metadata`
         objects provided. Otherwise, the cast value is returned along
         with a new dictionary which is a shallow copy of the provided
@@ -108,10 +108,10 @@ def cast_setting_value(
 class SettingValueStore(str, Enum):
     """Setting Value Store.
 
-    Note: The declaration order of stores determins store precedence when using
+    Note: The declaration order of stores determines store precedence when using
         the Auto store manager. This is because the `.readables()` and
         `.writables()` methods return ordered lists that the Auto store manager
-        iterates over when retrieveing setting values.
+        iterates over when retrieving setting values.
     """
 
     CONFIG_OVERRIDE = "config_override"
@@ -1274,7 +1274,7 @@ class AutoStoreManager(SettingsStoreManager):
         if setting_def and setting_def.is_redacted:
             if self.ensure_supported(store=SettingValueStore.DOTENV):
                 return SettingValueStore.DOTENV
-            elif self.ensure_supported(store=SettingValueStore.DB):  # noqa: RET505
+            if self.ensure_supported(store=SettingValueStore.DB):
                 return SettingValueStore.DB
             # ensure secrets don't leak into other stores
             return None
@@ -1293,10 +1293,10 @@ class AutoStoreManager(SettingsStoreManager):
             if self.ensure_supported(store=SettingValueStore.MELTANO_YML):
                 return SettingValueStore.MELTANO_YML
             # fall back to dotenv
-            elif self.ensure_supported(store=SettingValueStore.DOTENV):  # noqa: RET505
+            if self.ensure_supported(store=SettingValueStore.DOTENV):
                 return SettingValueStore.DOTENV
             # fall back to meltano system db
-            elif self.ensure_supported(store=SettingValueStore.DB):
+            if self.ensure_supported(store=SettingValueStore.DB):
                 return SettingValueStore.DB
             return None
 
@@ -1308,10 +1308,10 @@ class AutoStoreManager(SettingsStoreManager):
         if self.ensure_supported(store=SettingValueStore.MELTANO_YML):
             return SettingValueStore.MELTANO_YML
         # fall back to dotenv
-        elif self.ensure_supported(store=SettingValueStore.DOTENV):  # noqa: RET505
+        if self.ensure_supported(store=SettingValueStore.DOTENV):
             return SettingValueStore.DOTENV
         # fall back to meltano system db
-        elif self.ensure_supported(store=SettingValueStore.DB):
+        if self.ensure_supported(store=SettingValueStore.DB):
             return SettingValueStore.DB
         return None
 
@@ -1329,7 +1329,7 @@ class AutoStoreManager(SettingsStoreManager):
             setting_def: SettingDefinition. If none is passed, one will be
                 discovered using `self.find_setting(name)`.
             cast_value: Whether to cast the value according to `setting_def`.
-            kwargs: Additional keword arguments to pass to `manager.get()`.
+            kwargs: Additional keyword arguments to pass to `manager.get()`.
 
         Returns:
             A tuple containing the got value and accompanying metadata dictionary.

--- a/src/meltano/core/sqlalchemy.py
+++ b/src/meltano/core/sqlalchemy.py
@@ -76,7 +76,7 @@ class GUID(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value is None:
             return value
-        elif dialect.name == "postgresql":
+        elif dialect.name == "postgresql":  # noqa: RET505
             return str(value)
         if not isinstance(value, uuid.UUID):
             value = uuid.UUID(value)

--- a/src/meltano/core/sqlalchemy.py
+++ b/src/meltano/core/sqlalchemy.py
@@ -76,7 +76,7 @@ class GUID(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value is None:
             return value
-        elif dialect.name == "postgresql":  # noqa: RET505
+        if dialect.name == "postgresql":
             return str(value)
         if not isinstance(value, uuid.UUID):
             value = uuid.UUID(value)

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -79,7 +79,7 @@ class StateService:  # noqa: WPS214
                 started_at=now,
                 ended_at=now,
             )
-        elif isinstance(job, Job):  # noqa: RET505
+        if isinstance(job, Job):
             return job
         raise TypeError("job must be of type Job or of type str")  # noqa: EM101
 

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -79,7 +79,7 @@ class StateService:  # noqa: WPS214
                 started_at=now,
                 ended_at=now,
             )
-        elif isinstance(job, Job):
+        elif isinstance(job, Job):  # noqa: RET505
             return job
         raise TypeError("job must be of type Job or of type str")  # noqa: EM101
 

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -378,7 +378,7 @@ class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):  # noqa
         Returns:
             None
         """
-        return None
+        return None  # noqa: RET501
 
     @property
     def state_dir(self) -> str:

--- a/src/meltano/core/state_store/s3.py
+++ b/src/meltano/core/state_store/s3.py
@@ -112,11 +112,11 @@ class S3StateStoreManager(CloudStateStoreManager):
                     aws_secret_access_key=self.aws_secret_access_key,
                 )
                 return session.client("s3", endpoint_url=self.endpoint_url)
-            elif self.aws_secret_access_key:  # noqa: RET505
+            if self.aws_secret_access_key:
                 raise InvalidStateBackendConfigurationException(
                     "AWS secret access key configured, but not AWS access key ID.",  # noqa: EM101
                 )
-            elif self.aws_access_key_id:
+            if self.aws_access_key_id:
                 raise InvalidStateBackendConfigurationException(
                     "AWS access key ID configured, but no AWS secret access key.",  # noqa: EM101
                 )

--- a/src/meltano/core/state_store/s3.py
+++ b/src/meltano/core/state_store/s3.py
@@ -112,7 +112,7 @@ class S3StateStoreManager(CloudStateStoreManager):
                     aws_secret_access_key=self.aws_secret_access_key,
                 )
                 return session.client("s3", endpoint_url=self.endpoint_url)
-            elif self.aws_secret_access_key:
+            elif self.aws_secret_access_key:  # noqa: RET505
                 raise InvalidStateBackendConfigurationException(
                     "AWS secret access key configured, but not AWS access key ID.",  # noqa: EM101
                 )

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -535,7 +535,7 @@ def expand_env_vars(
             )
             if if_missing == EnvVarMissingBehavior.raise_exception:
                 raise EnvironmentVariableNotSetError(var) from ex
-            elif if_missing == EnvVarMissingBehavior.ignore:
+            elif if_missing == EnvVarMissingBehavior.ignore:  # noqa: RET506
                 return f"${{{var}}}"
             return ""
         if not val:
@@ -688,7 +688,7 @@ def strtobool(val: str) -> bool:
     val = val.lower()
     if val in {"y", "yes", "t", "true", "on", "1"}:
         return True
-    elif val in {"n", "no", "f", "false", "off", "0"}:
+    elif val in {"n", "no", "f", "false", "off", "0"}:  # noqa: RET505
         return False
 
     raise ValueError(f"invalid truth value {val!r}")  # noqa: EM102
@@ -827,7 +827,7 @@ def remove_suffix(string: str, suffix: str) -> str:
     """
     if sys.version_info >= (3, 9):
         return string.removesuffix(suffix)
-    elif string.endswith(suffix):
+    elif string.endswith(suffix):  # noqa: RET505
         return string[: -len(suffix)]
     return string
 

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -259,7 +259,7 @@ def to_env_var(*xs: str) -> str:
 def flatten(d: dict, reducer: str | t.Callable = "tuple", **kwargs):
     """Flatten a dictionary with `dot` and `env_var` reducers.
 
-    Wrapper arround `flatten_dict.flatten`.
+    Wrapper around `flatten_dict.flatten`.
 
     Args:
         d: the dict to flatten
@@ -535,7 +535,7 @@ def expand_env_vars(
             )
             if if_missing == EnvVarMissingBehavior.raise_exception:
                 raise EnvironmentVariableNotSetError(var) from ex
-            elif if_missing == EnvVarMissingBehavior.ignore:  # noqa: RET506
+            if if_missing == EnvVarMissingBehavior.ignore:
                 return f"${{{var}}}"
             return ""
         if not val:
@@ -688,7 +688,7 @@ def strtobool(val: str) -> bool:
     val = val.lower()
     if val in {"y", "yes", "t", "true", "on", "1"}:
         return True
-    elif val in {"n", "no", "f", "false", "off", "0"}:  # noqa: RET505
+    if val in {"n", "no", "f", "false", "off", "0"}:
         return False
 
     raise ValueError(f"invalid truth value {val!r}")  # noqa: EM102
@@ -827,7 +827,7 @@ def remove_suffix(string: str, suffix: str) -> str:
     """
     if sys.version_info >= (3, 9):
         return string.removesuffix(suffix)
-    elif string.endswith(suffix):  # noqa: RET505
+    if string.endswith(suffix):
         return string[: -len(suffix)]
     return string
 
@@ -878,7 +878,7 @@ def sanitize_filename(filename: str) -> str:
         filename: The name of the file to sanitize - not the full path.
 
     Returns:
-        The provided filename after a series of santitization steps. It will
+        The provided filename after a series of sanitization steps. It will
         only contain ASCII characters. If necessary on Windows, the filename
         will be prefixed by an underscore to avoid conflict with reserved
         Windows file names.

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -93,7 +93,7 @@ class VirtualEnv:
         """
         if self._system in {"Linux", "Darwin"}:
             return self.root / "lib"
-        elif self._system == "Windows":  # noqa: RET505
+        if self._system == "Windows":
             return self.root / "Lib"
         raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
 
@@ -109,7 +109,7 @@ class VirtualEnv:
         """
         if self._system in {"Linux", "Darwin"}:
             return self.root / "bin"
-        elif self._system == "Windows":  # noqa: RET505
+        if self._system == "Windows":
             return self.root / "Scripts"
         raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
 
@@ -129,7 +129,7 @@ class VirtualEnv:
                 / f"python{'.'.join(str(x) for x in self.python_version_tuple[:2])}"
                 / "site-packages"
             )
-        elif self._system == "Windows":  # noqa: RET505
+        if self._system == "Windows":
             return self.lib_dir / "site-packages"
         raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
 

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -93,7 +93,7 @@ class VirtualEnv:
         """
         if self._system in {"Linux", "Darwin"}:
             return self.root / "lib"
-        elif self._system == "Windows":
+        elif self._system == "Windows":  # noqa: RET505
             return self.root / "Lib"
         raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
 
@@ -109,7 +109,7 @@ class VirtualEnv:
         """
         if self._system in {"Linux", "Darwin"}:
             return self.root / "bin"
-        elif self._system == "Windows":
+        elif self._system == "Windows":  # noqa: RET505
             return self.root / "Scripts"
         raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
 
@@ -129,7 +129,7 @@ class VirtualEnv:
                 / f"python{'.'.join(str(x) for x in self.python_version_tuple[:2])}"
                 / "site-packages"
             )
-        elif self._system == "Windows":
+        elif self._system == "Windows":  # noqa: RET505
             return self.lib_dir / "site-packages"
         raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
 

--- a/tests/meltano/cli/test_elt.py
+++ b/tests/meltano/cli/test_elt.py
@@ -56,7 +56,7 @@ class LogEntry:
         Returns:
             True if a matching log line is found, else False
         """
-        for line in lines:
+        for line in lines:  # noqa: RET503
             matches = (
                 line.get("name") == self.name
                 and line.get("cmd_type") == self.cmd_type

--- a/tests/meltano/cli/test_elt.py
+++ b/tests/meltano/cli/test_elt.py
@@ -204,7 +204,7 @@ class TestWindowsELT:
         args = ["elt", tap.name, target.name]
         result = cli_runner.invoke(cli, args)
         assert result.exit_code == 1
-        # Didn't use `exception_logged()` as `result.stderr` doensn't contain
+        # Didn't use `exception_logged()` as `result.stderr` doesn't contain
         # the error for some reason
         assert (
             "ELT command not supported on Windows. Please use the run command "

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -148,7 +148,7 @@ class EventMatcher:
         Returns:
             True if the event was found, False otherwise.
         """
-        for line in self.seen_events:
+        for line in self.seen_events:  # noqa: RET503
             matches = line["event"] == event
             if matches:
                 return True

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -45,7 +45,7 @@ class FakeTraceback:  # pragma: no cover
 
     @property
     def tb_next(self):
-        if len(self._frames) > 1:
+        if len(self._frames) > 1:  # noqa: RET503
             return FakeTraceback(self._frames[1:], self._line_nums[1:])
 
 


### PR DESCRIPTION
Related:

- Closes #8457 
- https://github.com/meltano/meltano/issues/7383

```
ruff check --select=RET --add-noqa src tests
```

Question: Which RET error code should we consider, and which one should we put on the ignore list? For eg: RET505 to RET508 are the return type we consider more pythonic.

https://pypi.org/project/flake8-return/

<img width="788" alt="flake8_return" src="https://github.com/meltano/meltano/assets/83767876/31cfe30d-eafa-41b8-9f1d-0c5ef1256a30">
