### PR TITLE
refactor: Fixed some log serialization issues with `meltano.core.proj…ec_plugins_service.DefinitionSource` and `meltano.core.plugin.project_plugin.ProjectPlugin`

### DIFF
--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -256,7 +256,7 @@ class BlockParser:  # noqa: D101
 
         self.log.debug(
             "head of set is extractor as expected",
-            block=self._plugins[offset],
+            block=self._plugins[offset].name,
         )
 
         blocks.append(builder.make_block(self._plugins[offset]))

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -537,7 +537,7 @@ class ProjectPluginsService:  # noqa: WPS214, WPS230 (too many methods, attribut
             "Found plugin parent",
             plugin=plugin.name,
             parent=parent.name,
-            source=source,
+            source=source.name,
         )
         return parent
 


### PR DESCRIPTION
Some serialization libraries seem to have problems encoding these objects. I'm sure there are others but these are the ones I found during a simple `meltano run` using [`fluent-logger`](https://pypi.org/project/fluent-logger/).

This also makes the logged value slightly _prettier_. So we get for example, `block=tap-github` instead of `block=<meltano.core.plugin.project_plugin.ProjectPlugin object at ...`.