### PR TITLE
fix: Support intervals in cron regex pattern on meltano.schema.json

### DIFF
--- a/src/meltano/schemas/meltano.schema.json
+++ b/src/meltano/schemas/meltano.schema.json
@@ -988,7 +988,7 @@
             "@weekly",
             "0 0 * * *"
           ],
-          "pattern": "^((@(hourly|daily|weekly|monthly|yearly|once))|((((\d+,)+\d+|(\d+|\*)(\/|-)\d+|\d+|\*) ?){5,6}))$"
+          "pattern": "^((@(hourly|daily|weekly|monthly|yearly|once))|((((\\d+,)+\\d+|(\\d+|\\*)(\\/|-)\\d+|\\d+|\\*) ?){5,6}))$"
         },
         "transform": {
           "type": "string",

--- a/src/meltano/schemas/meltano.schema.json
+++ b/src/meltano/schemas/meltano.schema.json
@@ -988,7 +988,7 @@
             "@weekly",
             "0 0 * * *"
           ],
-          "pattern": "^((@(hourly|daily|weekly|monthly|yearly|once))|((((\\d+,)+\\d+|(\\d+(\\/|-)\\d+)|\\d+|\\*) ?){5,6}))$"
+          "pattern": "^((@(hourly|daily|weekly|monthly|yearly|once))|((((\d+,)+\d+|(\d+|\*)(\/|-)\d+|\d+|\*) ?){5,6}))$"
         },
         "transform": {
           "type": "string",


### PR DESCRIPTION
Proposing an updated regex pattern to correctly validate cron expressions including those with intervals (e.g., `0 */3 * * *`).

**Issue:** The existing regex fails to match valid interval-based cron expressions.
VS Code Extension: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
![image](https://github.com/meltano/meltano/assets/982190/0d0cba85-0f51-4abe-8ccc-535007b98ae5)


**Current Regex Test:** [Fails Validation](https://regex101.com/r/ZKE58l/1)

**Proposed Regex Update:** [Passes Validation](https://regex101.com/r/ZKE58l/2)
