### PR TITLE
chore: Use Python 3.11 in flakeheaven pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,7 @@ repos:
         exclude: ^(src/meltano/migrations/)
         args:
           - "--max-local-variables=8"
+        language_version: python3.11
         additional_dependencies:
           - flake8==4.0.1
           - flake8-bandit==3.0.0


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/bin/flakeheaven", line 8, in <module>
    sys.exit(entrypoint())
             ^^^^^^^^^^^^
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flakeheaven/_cli.py", line 40, in entrypoint
    exit_code, msg = main(argv)
                     ^^^^^^^^^^
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flakeheaven/_cli.py", line 32, in main
    return COMMANDS[command_name](argv=argv[1:])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flakeheaven/commands/_lint.py", line 12, in lint_command
    app.run(argv)
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flake8/main/application.py", line 375, in run
    self._run(argv)
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flake8/main/application.py", line 363, in _run
    self.initialize(argv)
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flake8/main/application.py", line 343, in initialize
    self.find_plugins(config_finder)
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flakeheaven/_patched/_app.py", line 229, in find_plugins
    self.check_plugins = FlakeHeavenCheckers(local_plugins.extension)  # this line is changed
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flakeheaven/_patched/_plugins.py", line 65, in __init__
    self.manager = FlakeHeavenPluginManager(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flakeheaven/_patched/_plugins.py", line 47, in __init__
    self._load_entrypoint_plugins()
  File "/pc/clone/QA2wLehjTUKCmC6lV2EtgQ/py_env-python3/lib/python3.12/site-packages/flake8/plugins/manager.py", line 261, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'EntryPoints' object has no attribute 'get'
```


Related:

* https://github.com/meltano/meltano/issues/7383
* https://github.com/pre-commit-ci/runner-image/commit/c70df4d8372ab5db26d775216849e66b779c9800
* https://github.com/flakeheaven/flakeheaven/issues/132#issuecomment-1752011839 (where maintainer suggests using Ruff instead 🤣)