### PR TITLE
fix: Made the output of `meltano select ... list` consistent between different Python versions

### DIFF
--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -295,6 +295,7 @@ class CatalogNode(Enum):
     METADATA = auto()
 
 
+# TODO: Move to `enum.StrEnum` when support for Python 3.8 is dropped
 class SelectionType(str, ReprEnum):
     """A valid stream or property selection type."""
 

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 import fnmatch
 import logging
 import re
+import sys
 import typing as t
 from collections import OrderedDict
 from enum import Enum, auto
 from functools import singledispatch
 
 from meltano.core.behavior.visitor import visit_with
+
+if sys.version_info < (3, 11):
+    ReprEnum = Enum
+else:
+    from enum import ReprEnum
 
 Node = t.Dict[str, t.Any]
 T = t.TypeVar("T", bound="CatalogRule")
@@ -289,7 +295,7 @@ class CatalogNode(Enum):
     METADATA = auto()
 
 
-class SelectionType(str, Enum):
+class SelectionType(str, ReprEnum):
     """A valid stream or property selection type."""
 
     SELECTED = "selected"

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -1093,6 +1093,21 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         assert ListSelectedExecutor.node_selection(node) == selection_type
 
 
+class TestSelectionType:
+    def test_selection_type_addition(self):
+        st = SelectionType
+        assert st.EXCLUDED + st.EXCLUDED == st.EXCLUDED
+        assert st.SELECTED + st.EXCLUDED == st.EXCLUDED
+        assert st.AUTOMATIC + st.EXCLUDED == st.EXCLUDED
+        assert st.SELECTED + st.AUTOMATIC == st.AUTOMATIC
+        assert st.SELECTED + st.SELECTED == st.SELECTED
+
+    def test_selection_type_repr(self):
+        assert f"{SelectionType.EXCLUDED}" == "excluded"
+        assert f"{SelectionType.AUTOMATIC}" == "automatic"
+        assert f"{SelectionType.SELECTED}" == "selected"
+
+
 class TestMetadataExecutor:
     @pytest.fixture()
     def catalog(self, request):


### PR DESCRIPTION
Related:

* Closes https://github.com/meltano/meltano/issues/8526
