### PR TITLE
fix: State from interrupted pipelines or using the `--merge-state` flag no longer causes crashes

### DIFF
--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -81,7 +81,8 @@ class BookmarkWriter:
                 json.dumps(job.payload),
                 job.payload_flags,
             )
-        except Exception:
+        except Exception:  # pragma: no cover
+            logger.debug("Failed to persist state", exc_info=True)
             logger.warning(
                 "Unable to persist state, or received state is invalid, "
                 "incremental state has not been updated",

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -316,7 +316,8 @@ class BaseFilesystemStateStoreManager(StateStoreManager):  # noqa: WPS214
                             state.state_id,
                             current_state_reader,
                         )
-                        state_to_write = current_state.merge_partial(state)
+                        current_state.merge_partial(state)
+                        state_to_write = current_state
                 except Exception as e:
                     if self.is_file_not_found_error(e):
                         state_to_write = state


### PR DESCRIPTION
Related:

* Closes https://github.com/meltano/meltano/issues/8541