### PR TITLE
docs: Added YAML docs examples of global and per-plugin `python` executable option

### DIFF
--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -190,6 +190,8 @@ Then regardless of the Python version used when the plugin is installed, `tap-gi
 
 - `--force-install`: Ignore the required Python version declared by the plugins.
 
+- `--python`: The Python version to use for the plugin. See [the setting documentation](/reference/settings#python) for more information.
+
 ### Using `add` with Environments
 
 The `add` command does not run relative to a [Meltano Environment](https://docs.meltano.com/concepts/environments). The `--environment` flag and [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored if set.

--- a/docs/docs/reference/settings.mdx
+++ b/docs/docs/reference/settings.mdx
@@ -31,13 +31,27 @@ to list all available settings with their names, environment variables, and curr
 
 ### <a name="plugin-python"></a>`python`
 
-The python version to use for this plugin, specified as a path, or as the name of an executable to find within a directory in `$PATH`.
+The python version to use for this plugin, specified as a path, or as the name of an executable to find within a directory in `$PATH`. You can set it at the time you add a plugin using [`meltano add --python <python>`](/reference/command-line-interface#add).
 
 If not specified, [the top-level `python` setting will be used](#project-python), or if it is not set, the python executable that was used to run Meltano will be used (within a separate virtual environment).
 
 This setting only applies when creating new virtual environments. If you've already created a virtual environment and you'd like to use a new Python version for it, you'll need to delete it from within `.meltano/`, then run `meltano install` for that plugin again.
 
 This setting only applies to base plugins, which have their own virtual environment. Inherited plugins necessarily use the same virtual environment (and thus, the Python version) as their base plugin.
+
+Example:
+
+```yaml
+plugins:
+  extractors:
+  - name: tap-gitlab
+    variant: meltanolabs
+    python: /path/to/python3.10
+  loaders:
+  - name: target-postgres
+    variant: meltanolabs
+    python: python3.10 # if it's in your $PATH
+```
 
 ## Your Meltano project
 
@@ -56,6 +70,15 @@ If not specified, the python executable that was used to run Meltano will be use
 This setting only applies when creating new virtual environments. If you've already created a virtual environment and you'd like to use a new Python version for it, you'll need to delete it from within `.meltano/`, then run `meltano install` for that plugin again.
 
 This setting only applies to base plugins, which have their own virtual environment. Inherited plugins necessarily use the same virtual environment (and thus, the Python version) as their base plugin.
+
+Example:
+
+```yaml
+python: /path/to/python3.10 # or just python3.10 if it's in your $PATH
+plugins:
+  extractors: ...
+  loaders: ...
+```
 
 ### <a name="send_anonymous_usage_stats"></a>`send_anonymous_usage_stats`
 


### PR DESCRIPTION
Related:

* https://github.com/meltano/meltano/issues/8374
* https://github.com/meltano/meltano/issues/8543

Updated docs links:

* https://deploy-preview-8544--meltano.netlify.app/reference/settings#python
* https://deploy-preview-8544--meltano.netlify.app/reference/settings#python-1
* https://deploy-preview-8544--meltano.netlify.app/reference/command-line-interface#how-to-use