### PR TITLE
ci: Bump Docker and CodeQL actions to their latest major series to use Node 20

### DIFF
--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -31,10 +31,10 @@ runs:
   using: 'composite'
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Prepare the tags
       id: prepare-tags
@@ -43,7 +43,7 @@ runs:
         echo "tags=$(echo "${{ inputs.tags }}" | sed "s/^/${{ inputs.registry }}\/meltano\/meltano:/" | tr '\n' ',')" >> $GITHUB_OUTPUT
 
     - name: Build the image for all supported architectures
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: docker/meltano
         build-args: |
@@ -60,7 +60,7 @@ runs:
         push: false
 
     - name: Load the amd64 image for scanning
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: docker/meltano
         build-args: |
@@ -87,7 +87,7 @@ runs:
         severity-cutoff: "critical"
 
     - name: Upload Anchore scan SARIF report
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.anchore-scan.outputs.sarif }}
         category: python-${{ inputs.python-version }}
@@ -105,7 +105,7 @@ runs:
         [ "$NUM_ISSUES" = '0' ] # Error if there are any alerts that are neither fixed nor dismissed
 
     - name: Login to the registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
@@ -113,7 +113,7 @@ runs:
 
     - name: Push the scanned image to the registry
       if: ${{ inputs.push == 'true' }}
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: docker/meltano
         build-args: |


### PR DESCRIPTION
* github/codeql-action:

  > The only difference between CodeQL Action v2 and v3 is the version of Node.js on which they run. CodeQL Action v3 runs on Node 20, while CodeQL Action v2 runs on Node 16.

  https://github.com/github/codeql-action?tab=readme-ov-file#supported-versions-of-the-codeql-action

The others have a similar changelog.