### PR TITLE
chore: Use Python 3.12 in CI

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -55,10 +55,10 @@ jobs:
         pipx install poetry
         poetry --version
 
-    - name: Setup Python 3.10
+    - name: Setup Python 3.12
       uses: actions/setup-python@v5.1.0
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         architecture: x64
         cache: 'poetry'
 
@@ -71,7 +71,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        poetry env use "3.10"
+        poetry env use "3.12"
         poetry install --extras "s3"
 
     - name: Start Postgres Container
@@ -90,5 +90,5 @@ jobs:
 
     - name: Run integration tests
       run: |
-        poetry env use "3.10"
+        poetry env use "3.12"
         poetry run bash integration/validate.sh ${{ matrix.integration_test }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,10 +256,10 @@ jobs:
         pipx install poetry
         poetry --version
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5.1.0
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         architecture: x64
         # Nox uses pip, so we cache with pip
         cache: 'pip'
@@ -311,10 +311,10 @@ jobs:
         pipx install poetry
         poetry --version
 
-    - name: Setup Python 3.10
+    - name: Setup Python 3.12
       uses: actions/setup-python@v5.1.0
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         architecture: x64
         # Nox uses pip, so we cache with pip
         cache: 'pip'

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.1.0
       with:
-        python-version: "3.10"
+        python-version: "3.12"
         architecture: x64
 
     - name: Bump version

--- a/integration/example-library/meltano-run/ending-meltano.yml
+++ b/integration/example-library/meltano-run/ending-meltano.yml
@@ -1,4 +1,6 @@
 version: 1
+env:
+  DBT_CLEAN_PROJECT_FILES_ONLY: 'false'
 default_environment: dev
 project_id: 90f75496-2018-4b3a-97ac-9662e11c0094
 send_anonymous_usage_stats: false
@@ -11,10 +13,10 @@ plugins:
   - name: target-postgres
     variant: transferwise
     pip_url: pipelinewise-target-postgres
-  transformers:
+  utilities:
   - name: dbt-postgres
     variant: dbt-labs
-    pip_url: dbt-core~=1.3.0 dbt-postgres~=1.3.0
+    pip_url: dbt-core dbt-postgres git+https://github.com/meltano/dbt-ext.git@main
 environments:
 - name: dev
   config:
@@ -33,7 +35,7 @@ environments:
           user: postgres
           dbname: warehouse
           default_target_schema: public
-      transformers:
+      utilities:
       - name: dbt-postgres
         config:
           host: localhost

--- a/integration/example-library/meltano-run/index.md
+++ b/integration/example-library/meltano-run/index.md
@@ -63,7 +63,7 @@ meltano run --dry-run gitlab-to-postgres
 The meltano.yml didn't include dbt, so let's install that and get it configured to use our database:
 
 ```shell
-meltano add transformer dbt-postgres
+meltano add utility dbt-postgres
 meltano --environment=dev config dbt-postgres set host localhost
 meltano --environment=dev config dbt-postgres set user postgres
 meltano --environment=dev config dbt-postgres set password postgres
@@ -75,6 +75,7 @@ meltano --environment=dev config dbt-postgres set schema analytics
 ### Prep the `dbt` transform for this demo
 
 ```shell
+meltano invoke dbt-postgres:initialize
 mkdir ./transform/models/tap_gitlab
 touch  ./transform/models/tap_gitlab/source.yml
 ```

--- a/integration/example-library/meltano-run/meltano.yml
+++ b/integration/example-library/meltano-run/meltano.yml
@@ -1,4 +1,6 @@
 version: 1
+env:
+  DBT_CLEAN_PROJECT_FILES_ONLY: 'false'
 default_environment: dev
 project_id: 90f75496-2018-4b3a-97ac-9662e11c0094
 send_anonymous_usage_stats: false

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ except ImportError:
 
 root_path = Path(__file__).parent
 python_versions = ("3.8", "3.9", "3.10", "3.11", "3.12")
-main_python_version = "3.10"
+main_python_version = "3.12"
 pytest_deps = (
     "backoff",
     "colorama",  # colored output in Windows


### PR DESCRIPTION
* Python 3.10 ended active support on 05 Apr 2023
* Python 3.11 ended active support on 01 Apr 2024

https://endoflife.date/python
