### PR TITLE
docs: Redirect Meltano Cloud docs to Arch docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,3 +20,9 @@
   to = "https://docs.meltano.com/guide/troubleshooting/:splat"
   status = 301
   force = true
+
+[[redirects]]
+  from = "https://docs.meltano.com/cloud/*"
+  to = "https://docs.arch.dev/"
+  status = 301
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,7 +22,7 @@
   force = true
 
 [[redirects]]
-  from = "https://docs.meltano.com/cloud/*"
+  from = "/cloud/*"
   to = "https://docs.arch.dev/"
   status = 301
   force = true


### PR DESCRIPTION
Another PR will remove the Cloud docs, and clean up other outdated mentions of Meltano Cloud.