### PR TITLE
fix: Values with `$` can now be escaped instead of trying to expand them from environment variables

### DIFF
--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.cicd.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.cicd.json
@@ -41,7 +41,7 @@
   "default_environment": "userdev",
   "env": {
     "AIRFLOW_VAR_OPERATOR_TYPE": "bash",
-    "AIRFLOW__CORE__PLUGINS_FOLDER": "${MELTANO_PROJECT_ROOT}/orchestrate/plugins_local",
+    "AIRFLOW__CORE__PLUGINS_FOLDER": "$MELTANO_PROJECT_ROOT/orchestrate/plugins_local",
     "HUB_METRICS_S3_PATH": "s3://devtest-meltano-bucket-01/hub_metrics/",
     "MELTANO_AUTO_INSTALL": "true",
     "MELTANO_CLI_LOG_CONFIG": "logging.yaml",

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.jigsaw.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.jigsaw.json
@@ -25,7 +25,7 @@
   "env": {
     "AIRFLOW_VAR_MELTANO_ENVIRONMENT": "userdev",
     "AIRFLOW_VAR_OPERATOR_TYPE": "bash",
-    "AIRFLOW__CORE__PLUGINS_FOLDER": "${MELTANO_PROJECT_ROOT}/orchestrate/plugins_local",
+    "AIRFLOW__CORE__PLUGINS_FOLDER": "$MELTANO_PROJECT_ROOT/orchestrate/plugins_local",
     "AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL": "30",
     "HUB_METRICS_S3_PATH": "s3://devtest-meltano-bucket-01/hub_metrics/",
     "MELTANO_AUTO_INSTALL": "true",

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.userdev.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.userdev.json
@@ -25,7 +25,7 @@
   "env": {
     "AIRFLOW_VAR_MELTANO_ENVIRONMENT": "userdev",
     "AIRFLOW_VAR_OPERATOR_TYPE": "bash",
-    "AIRFLOW__CORE__PLUGINS_FOLDER": "${MELTANO_PROJECT_ROOT}/orchestrate/plugins_local",
+    "AIRFLOW__CORE__PLUGINS_FOLDER": "$MELTANO_PROJECT_ROOT/orchestrate/plugins_local",
     "AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL": "30",
     "HUB_METRICS_S3_PATH": "s3://devtest-meltano-bucket-01/hub_metrics/",
     "KMS_DOTENV_PATH": ".env",


### PR DESCRIPTION
Closes https://github.com/meltano/meltano/issues/8637

References:

* Slack: https://meltano.slack.com/archives/C069CQNHDNF/p1721232234084959
* Linen: https://www.linen.dev/s/meltano/t/22723249/searched-the-docs-for-this-but-couldn-t-find-it-if-i-specify#066770b9-ff64-414f-bb7c-06926a1fecdb