### PR TITLE
test: Fix test flakiness related to `ProjectSettingsService`

### DIFF
--- a/src/meltano/core/behavior/name_eq.py
+++ b/src/meltano/core/behavior/name_eq.py
@@ -2,8 +2,18 @@ from __future__ import annotations
 
 
 class NameEq:
+    name: str
+
     def __eq__(self, other):
         return self is other or self.name == other.name
 
     def __hash__(self):
         return hash(self.name)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the object.
+
+        Returns:
+            A string representation of the object.
+        """
+        return f"{self.__class__.__name__}({self.name!r})"

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -2097,8 +2097,12 @@ def project_directory(project_init_service):
 
 
 @pytest.fixture(scope="class")
-def project(project_init_service, tmp_path_factory: pytest.TempPathFactory):
-    with cd(tmp_path_factory.mktemp("meltano-project-dir")), project_directory(
+def project(
+    project_init_service,
+    tmp_path_factory: pytest.TempPathFactory,
+    worker_id,
+):
+    with cd(tmp_path_factory.mktemp(worker_id)), project_directory(
         project_init_service,
     ) as project:
         yield project

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -2097,12 +2097,8 @@ def project_directory(project_init_service):
 
 
 @pytest.fixture(scope="class")
-def project(
-    project_init_service,
-    tmp_path_factory: pytest.TempPathFactory,
-    worker_id,
-):
-    with cd(tmp_path_factory.mktemp(worker_id)), project_directory(
+def project(project_init_service, tmp_path_factory: pytest.TempPathFactory):
+    with cd(tmp_path_factory.mktemp("meltano-project-dir")), project_directory(
         project_init_service,
     ) as project:
         yield project

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -28,12 +28,11 @@ def config_override():
         ProjectSettingsService.config_override.pop("project_id")
 
 
-@pytest.fixture()
-def subject(project):
-    return ProjectSettingsService(project)
-
-
 class TestProjectSettingsService:
+    @pytest.fixture()
+    def subject(self, project):
+        return ProjectSettingsService(project)
+
     @pytest.fixture()
     def environment(self):
         return Environment("testing", {})


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

* Adds `__repr__` to all `NameEq` classes to aid debugging.
* Move the `ProjectSettingsService` to the class where it's used to avoid lingering config changes to the project fixture beyond the test class.

## Related Issues

* Closes #XXXX
