### PR TITLE
test: Fix Hub fixture unnecessarily creating a project for each test class

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,12 +198,12 @@ class MockAdapter(BaseAdapter):
         return response
 
 
-@pytest.fixture(scope="class", autouse=True)
-def mount_meltano_hub_mock_adapter(project: Project, discovery) -> None:
-    project.hub_service.session.mount(
-        project.hub_service.hub_api_url,
-        MockAdapter(project.hub_service.hub_api_url, discovery),
-    )
+@pytest.fixture(scope="class")
+def hub_mock_adapter(discovery) -> t.Callable[[str], MockAdapter]:
+    def _get_adapter(api_url: str) -> MockAdapter:
+        return MockAdapter(api_url, discovery)
+
+    return _get_adapter
 
 
 @pytest.fixture(scope="class")

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -20,6 +20,7 @@ if t.TYPE_CHECKING:
 
 class TestLock:
     @pytest.mark.order(0)
+    @pytest.mark.usefixtures("project")
     @pytest.mark.parametrize(
         "args",
         (


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

The `autouse` fixture was causing a project to be created for every test class, even if the class made no use of the fixture.

This change also shaves off some time from the full pytest run, but doesn't fix all flakiness (see https://github.com/meltano/meltano/pull/8640#issuecomment-2235513353).

## Related Issues

* Closes #XXXX
