### PR TITLE
chore: Enable Ruff ANN rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,8 +347,6 @@ banned-from = [
 typing = "t"
 
 [tool.ruff.lint.flake8-pytest-style]
-parametrize-names-type = "tuple"
-parametrize-values-row-type = "tuple"
 parametrize-values-type = "tuple"
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,6 +327,8 @@ unfixable = [
   "F401", # Permit unused imports in `__init__.py` files
 ]
 "tests/**" = [
+  "ANN",
+  "D1",
   "S101", # Allow 'assert' in tests
   "INP",  # Don't require __init__.py files in tests directories
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,6 +293,7 @@ select = [
   "EM",   # flake8-errmsg
   "ERA", # flake8-eradicate
   "F",   # pyflakes
+  "FBT", # flake8-boolean-trap
   "G",   # flake8-logging-format
   "I",   # isort
   "ICN", # flake8-import-conventions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,13 +284,14 @@ ignore = [
 ]
 select = [
   "A",   # flake8-builtins
+  "ANN", # flake8-annotations
   "ARG", # flake8-unused-arguments
   "B",   # flake8-bugbear
   "C4",  # flake8-comprehensions
   "COM", # flake8-commas
   "DTZ", # flake8-datetimez
   "E",   # pycodestyle (error)
-  "EM",   # flake8-errmsg
+  "EM",  # flake8-errmsg
   "ERA", # flake8-eradicate
   "F",   # pyflakes
   "FBT", # flake8-boolean-trap
@@ -344,6 +345,8 @@ banned-from = [
 typing = "t"
 
 [tool.ruff.lint.flake8-pytest-style]
+parametrize-names-type = "tuple"
+parametrize-values-row-type = "tuple"
 parametrize-values-type = "tuple"
 
 [tool.ruff.lint.isort]

--- a/scripts/generate_docker_tags.py
+++ b/scripts/generate_docker_tags.py
@@ -19,7 +19,7 @@ import argparse
 from packaging.version import Version
 
 
-def main():
+def main() -> None:
     """Generate docker tags for the given package version."""
     parser = argparse.ArgumentParser()
     parser.add_argument("-r", "--registry", default="docker.io")

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -128,7 +128,13 @@ def main() -> None:
         if ex is None:
             exit_code = 0
         elif isinstance(ex, SystemExit):
-            exit_code = 0 if ex.code is None else ex.code
+            if ex.code is None:
+                exit_code = 0
+            else:
+                try:
+                    exit_code = int(ex.code)
+                except ValueError:
+                    exit_code = 1
         else:
             exit_code = 1
         # Track the exit event now to provide more details via the exception context.

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -92,7 +92,7 @@ def handle_meltano_error(error: MeltanoError) -> t.NoReturn:
     raise CliError(str(error)) from error
 
 
-def _run_cli():
+def _run_cli() -> None:
     """Run the Meltano CLI.
 
     Raises:
@@ -116,7 +116,7 @@ def _run_cli():
         sys.exit(1)
 
 
-def main():
+def main() -> None:
     """Entry point for the meltano CLI."""
     # Mark the current process as executed via the CLI
     os.environ["MELTANO_JOB_TRIGGER"] = os.getenv("MELTANO_JOB_TRIGGER", "cli")

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -115,7 +115,7 @@ def _load_yaml_from_ref(_ctx, _param, value: str | None) -> dict | None:
 @click.pass_context
 @run_async
 async def add(
-    ctx,
+    ctx,  # noqa: ANN001
     project: Project,
     plugin_type: str,
     plugin_name: str,
@@ -125,8 +125,8 @@ async def add(
     as_name: str | None = None,
     plugin_yaml: dict | None = None,
     python: str | None = None,
-    **flags,
-):
+    **flags,  # noqa: ANN003
+) -> None:
     """
     Add a plugin to your project.
 
@@ -213,7 +213,7 @@ async def add(
     tracker.track_command_event(CliEvent.completed)
 
 
-def _print_plugins(plugins):
+def _print_plugins(plugins) -> None:  # noqa: ANN001
     printed_empty_line = False
     for plugin in plugins:
         docs_url = plugin.docs or plugin.repo

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -78,6 +78,7 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
 @click.pass_context
 def cli(
     ctx: click.Context,
+    *,
     log_level: str,
     log_config: str,
     environment: str,

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -36,7 +36,7 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
     typical Meltano commands fail, e.g. `meltano select tap-gitlab tags "*"`.
     """
 
-    def main(self, *args, **kwargs) -> t.Any:
+    def main(self, *args, **kwargs) -> t.Any:  # noqa: ANN002, ANN003, ANN401
         """Invoke the Click CLI with Windows globbing disabled.
 
         Args:
@@ -84,7 +84,7 @@ def cli(
     environment: str,
     no_environment: bool,
     cwd: Path | None,
-):
+) -> None:
     """
     Your CLI for ELT+
 

--- a/src/meltano/cli/compile.py
+++ b/src/meltano/cli/compile.py
@@ -59,7 +59,7 @@ def compile_command(
     directory: Path,
     lint: bool,
     indent: int,
-):
+) -> None:
     """
     Compile a Meltano project into environment-specific manifest files.
 

--- a/src/meltano/cli/compile.py
+++ b/src/meltano/cli/compile.py
@@ -55,6 +55,7 @@ if t.TYPE_CHECKING:
 def compile_command(
     project: Project,
     ctx: click.Context,
+    *,
     directory: Path,
     lint: bool,
     indent: int,

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -147,6 +147,7 @@ def get_label(metadata) -> str:
 def config(
     ctx,
     project: Project,
+    *,
     plugin_type: str,
     plugin_name: str,
     config_format: str,
@@ -242,7 +243,7 @@ def config(
 )
 @click.option("--extras", is_flag=True)
 @click.pass_context
-def list_settings(ctx: click.Context, extras: bool):
+def list_settings(ctx: click.Context, *, extras: bool):
     """List all settings for the specified plugin with their names, environment variables, and current values."""  # noqa: E501
     settings: ProjectSettingsService | PluginSettingsService = ctx.obj["settings"]
     session = ctx.obj["session"]
@@ -381,6 +382,7 @@ def reset(ctx, store):
 @_use_meltano_env
 def set_(
     ctx: click.core.Context,
+    *,
     setting_name: tuple[str, ...],
     value: t.Any,
     store: str,

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -71,7 +71,7 @@ def _get_store_choices() -> list[SettingValueStore]:
     return writables
 
 
-def _use_meltano_env(func):
+def _use_meltano_env(func):  # noqa: ANN001, ANN202
     """Override the 'meltano_yml' choice for a config command's 'store' argument.
 
     If an --environment flag is passed, the decorated command will use
@@ -86,7 +86,7 @@ def _use_meltano_env(func):
     """
 
     @wraps(func)
-    def _wrapper(*args, **kwargs):
+    def _wrapper(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
         store = kwargs.pop("store")
         if store not in {SettingValueStore.MELTANO_YML, SettingValueStore.MELTANO_ENV}:
             return func(*args, **kwargs, store=store)
@@ -101,7 +101,7 @@ def _use_meltano_env(func):
     return _wrapper
 
 
-def get_label(metadata) -> str:
+def get_label(metadata) -> str:  # noqa: ANN001
     """Get the label for an environment variable's source.
 
     Args:
@@ -145,7 +145,7 @@ def get_label(metadata) -> str:
 @pass_project(migrate=True)
 @click.pass_context
 def config(
-    ctx,
+    ctx,  # noqa: ANN001
     project: Project,
     *,
     plugin_type: str,
@@ -153,7 +153,7 @@ def config(
     config_format: str,
     extras: bool,
     safe: bool,
-):
+) -> None:
     """
     Display Meltano or plugin configuration.
 
@@ -243,7 +243,7 @@ def config(
 )
 @click.option("--extras", is_flag=True)
 @click.pass_context
-def list_settings(ctx: click.Context, *, extras: bool):
+def list_settings(ctx: click.Context, *, extras: bool) -> None:
     """List all settings for the specified plugin with their names, environment variables, and current values."""  # noqa: E501
     settings: ProjectSettingsService | PluginSettingsService = ctx.obj["settings"]
     session = ctx.obj["session"]
@@ -343,7 +343,7 @@ def list_settings(ctx: click.Context, *, extras: bool):
 )
 @click.pass_context
 @_use_meltano_env
-def reset(ctx, store):
+def reset(ctx, store) -> None:  # noqa: ANN001
     """Clear the configuration (back to defaults)."""
     store = SettingValueStore(store)
 
@@ -384,11 +384,11 @@ def set_(
     ctx: click.core.Context,
     *,
     setting_name: tuple[str, ...],
-    value: t.Any,
+    value: t.Any,  # noqa: ANN401
     store: str,
     interactive: bool,
     from_file: t.TextIO,
-):
+) -> None:
     """Set the configurations' setting `<name>` to `<value>`."""
     if len(setting_name) == 1:
         setting_name = tuple(setting_name[0].split("."))
@@ -414,10 +414,10 @@ def set_(
 @only_install
 @run_async
 async def test(
-    ctx,
+    ctx,  # noqa: ANN001
     project: Project,
     install_plugins: InstallPlugins,
-):
+) -> None:
     """Test the configuration of a plugin."""
     invoker = ctx.obj["invoker"]
     tracker = ctx.obj["tracker"]
@@ -448,8 +448,8 @@ async def test(
                 (
                     "Plugin configuration is invalid",
                     detail or "Plugin did not emit any output",
-                )
-            )
+                ),
+            ),
         )
 
     click.secho("Plugin configuration is valid", fg="green")
@@ -465,7 +465,7 @@ async def test(
 )
 @click.pass_context
 @_use_meltano_env
-def unset(ctx, setting_name, store):
+def unset(ctx, setting_name, store) -> None:  # noqa: ANN001
     """Unset the configurations' setting called `<name>`."""
     store = SettingValueStore(store)
 

--- a/src/meltano/cli/docs.py
+++ b/src/meltano/cli/docs.py
@@ -11,7 +11,7 @@ from meltano.cli.utils import InstrumentedCmd
     cls=InstrumentedCmd,
     short_help="Open the Meltano docs in your browser.",
 )
-def docs():
+def docs() -> None:
     """Open the Meltano docs in the system browser."""
     click.launch("https://docs.meltano.com/")  # pragma: no cover
     click.secho("Opening the docs...", fg="green")

--- a/src/meltano/cli/dragon.py
+++ b/src/meltano/cli/dragon.py
@@ -17,7 +17,7 @@ from meltano.core.cli_messages import (
 
 
 @click.command(short_help="Summon a dragon!")
-def dragon():
+def dragon() -> None:
     """Summon a dragon."""
     dragon_list = [
         MELTY,

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -134,6 +134,7 @@ class ELOptions:
 async def el(  # WPS408
     project: Project,
     ctx: click.Context,
+    *,
     extractor: str,
     loader: str,
     dry: bool,
@@ -160,23 +161,23 @@ async def el(  # WPS408
     \b\nRead more at https://docs.meltano.com/reference/command-line-interface#el
     """
     await _run_el_command(
-        project,
-        ctx,
-        extractor,
-        loader,
-        None,
-        dry,
-        full_refresh,
-        refresh_catalog,
-        select,
-        exclude,
-        catalog,
-        state,
-        dump,
-        state_id,
-        force,
-        merge_state,
-        install_plugins,
+        project=project,
+        ctx=ctx,
+        extractor=extractor,
+        loader=loader,
+        transform=None,
+        dry=dry,
+        full_refresh=full_refresh,
+        refresh_catalog=refresh_catalog,
+        select=select,
+        exclude=exclude,
+        catalog=catalog,
+        state=state,
+        dump=dump,
+        state_id=state_id,
+        force=force,
+        merge_state=merge_state,
+        install_plugins=install_plugins,
     )
 
 
@@ -208,6 +209,7 @@ async def el(  # WPS408
 async def elt(  # WPS408
     project: Project,
     ctx: click.Context,
+    *,
     extractor: str,
     loader: str,
     transform: str,
@@ -236,29 +238,30 @@ async def elt(  # WPS408
     """
     logger.warning("The `elt` command is deprecated in favor of `el`")
     await _run_el_command(
-        project,
-        ctx,
-        extractor,
-        loader,
-        transform,
-        dry,
-        full_refresh,
-        refresh_catalog,
-        select,
-        exclude,
-        catalog,
-        state,
-        dump,
-        state_id,
-        force,
-        merge_state,
-        install_plugins,
+        project=project,
+        ctx=ctx,
+        extractor=extractor,
+        loader=loader,
+        transform=transform,
+        dry=dry,
+        full_refresh=full_refresh,
+        refresh_catalog=refresh_catalog,
+        select=select,
+        exclude=exclude,
+        catalog=catalog,
+        state=state,
+        dump=dump,
+        state_id=state_id,
+        force=force,
+        merge_state=merge_state,
+        install_plugins=install_plugins,
     )
 
 
 async def _run_el_command(
     project: Project,
     ctx: click.Context,
+    *,
     extractor: str,
     loader: str,
     transform: str | None,
@@ -346,6 +349,7 @@ def _elt_context_builder(
     extractor,
     loader,
     transform,
+    *,
     dry_run=False,
     full_refresh=False,
     refresh_catalog=False,
@@ -366,14 +370,14 @@ def _elt_context_builder(
         .with_extractor(extractor)
         .with_loader(loader)
         .with_transform(transform_name or transform)
-        .with_dry_run(dry_run)
-        .with_only_transform(transform == "only")
-        .with_full_refresh(full_refresh)
-        .with_refresh_catalog(refresh_catalog)
+        .with_dry_run(dry_run=dry_run)
+        .with_only_transform(only_transform=(transform == "only"))
+        .with_full_refresh(full_refresh=full_refresh)
+        .with_refresh_catalog(refresh_catalog=refresh_catalog)
         .with_select_filter(select_filter)
         .with_catalog(catalog)
         .with_state(state)
-        .with_merge_state(merge_state)
+        .with_merge_state(merge_state=merge_state)
     )
 
 
@@ -402,6 +406,7 @@ async def _run_job(
     session,
     context_builder,
     install_plugins: InstallPlugins,
+    *,
     force=False,
 ):
     fail_stale_jobs(session, job.job_name)

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -149,7 +149,7 @@ async def el(  # WPS408
     force: bool,
     merge_state: bool,
     install_plugins: InstallPlugins,
-):
+) -> None:
     """
     Run an EL pipeline to Extract and Load data.
 
@@ -225,7 +225,7 @@ async def elt(  # WPS408
     force: bool,
     merge_state: bool,
     install_plugins: InstallPlugins,
-):
+) -> None:
     """
     Run an ELT pipeline to Extract, Load, and Transform data.
 
@@ -277,7 +277,7 @@ async def _run_el_command(
     force: bool,
     merge_state: bool,
     install_plugins: InstallPlugins,
-):
+) -> None:
     if platform.system() == "Windows":
         raise CliError(
             "ELT command not supported on Windows. Please use the run command "  # noqa: EM101
@@ -342,21 +342,21 @@ async def _run_el_command(
     tracker.track_command_event(CliEvent.completed)
 
 
-def _elt_context_builder(
+def _elt_context_builder(  # noqa: ANN202
     project: Project,
-    job,
-    session,
-    extractor,
-    loader,
-    transform,
+    job,  # noqa: ANN001
+    session,  # noqa: ANN001
+    extractor,  # noqa: ANN001
+    loader,  # noqa: ANN001
+    transform,  # noqa: ANN001
     *,
-    dry_run=False,
-    full_refresh=False,
-    refresh_catalog=False,
-    select_filter=None,
-    catalog=None,
-    state=None,
-    merge_state=False,
+    dry_run=False,  # noqa: ANN001
+    full_refresh=False,  # noqa: ANN001
+    refresh_catalog=False,  # noqa: ANN001
+    select_filter=None,  # noqa: ANN001
+    catalog=None,  # noqa: ANN001
+    state=None,  # noqa: ANN001
+    merge_state=False,  # noqa: ANN001
 ):
     select_filter = select_filter or []
     transform_name = None
@@ -381,7 +381,7 @@ def _elt_context_builder(
     )
 
 
-async def dump_file(context_builder, dumpable):
+async def dump_file(context_builder, dumpable) -> None:  # noqa: ANN001
     """Dump the given dumpable for this pipeline."""
     elt_context = context_builder.context()
 
@@ -400,15 +400,15 @@ async def dump_file(context_builder, dumpable):
 
 
 async def _run_job(
-    tracker,
-    project,
-    job,
-    session,
-    context_builder,
+    tracker,  # noqa: ANN001
+    project,  # noqa: ANN001
+    job,  # noqa: ANN001
+    session,  # noqa: ANN001
+    context_builder,  # noqa: ANN001
     install_plugins: InstallPlugins,
     *,
-    force=False,
-):
+    force=False,  # noqa: ANN001
+) -> None:
     fail_stale_jobs(session, job.job_name)
 
     if not force and (existing := JobFinder(job.job_name).latest_running(session)):
@@ -431,7 +431,7 @@ async def _run_job(
 
 
 @asynccontextmanager
-async def _redirect_output(log, output_logger):
+async def _redirect_output(log, output_logger):  # noqa: ANN001, ANN202
     meltano_stdout = output_logger.out(
         "meltano",
         log.bind(stdio="stdout", cmd_type="elt"),
@@ -456,7 +456,7 @@ async def _run_elt(
     context_builder: ELTContextBuilder,
     output_logger: OutputLogger,
     install_plugins: InstallPlugins,
-):
+) -> None:
     elt_context = context_builder.context()
     plugins = [elt_context.extractor, elt_context.loader]
 
@@ -499,11 +499,11 @@ async def _run_elt(
 
 
 async def _run_extract_load(
-    log,
-    elt_context,
-    output_logger,
-    **kwargs,
-):
+    log,  # noqa: ANN001
+    elt_context,  # noqa: ANN001
+    output_logger,  # noqa: ANN001
+    **kwargs,  # noqa: ANN003
+) -> None:
     extractor = elt_context.extractor.name
     loader = elt_context.loader.name
 
@@ -571,7 +571,7 @@ async def _run_extract_load(
     log.info("Extract & load complete!")
 
 
-async def _run_transform(log, elt_context, output_logger, **kwargs):
+async def _run_transform(log, elt_context, output_logger, **kwargs) -> None:  # noqa: ANN001, ANN003
     stderr_log = logger.bind(
         run_id=str(elt_context.job.run_id),
         state_id=elt_context.job.job_name,
@@ -597,7 +597,7 @@ async def _run_transform(log, elt_context, output_logger, **kwargs):
     log.info("Transformation complete!")
 
 
-def _find_extractor(project: Project, extractor_name: str):
+def _find_extractor(project: Project, extractor_name: str):  # noqa: ANN202
     try:
         return project.plugins.locked_definition_service.find_definition(
             PluginType.EXTRACTORS,
@@ -610,7 +610,7 @@ def _find_extractor(project: Project, extractor_name: str):
         )
 
 
-def _find_transform_for_extractor(
+def _find_transform_for_extractor(  # noqa: ANN202
     project: Project,
     extractor_name: str,
 ):

--- a/src/meltano/cli/environment.py
+++ b/src/meltano/cli/environment.py
@@ -24,7 +24,7 @@ ENVIRONMENT_SERVICE_KEY = "environment_service"
 )
 @click.pass_context
 @pass_project(migrate=True)
-def meltano_environment(project: Project, ctx: click.Context):
+def meltano_environment(project: Project, ctx: click.Context) -> None:
     """
     Manage Environments.
 
@@ -36,7 +36,7 @@ def meltano_environment(project: Project, ctx: click.Context):
 @meltano_environment.command(cls=PartialInstrumentedCmd)
 @click.argument("name")
 @click.pass_context
-def add(ctx: click.Context, name: str):
+def add(ctx: click.Context, name: str) -> None:
     """Add a new environment."""
     tracker = ctx.obj["tracker"]
     environment_service: EnvironmentService = ctx.obj[ENVIRONMENT_SERVICE_KEY]
@@ -52,7 +52,7 @@ def add(ctx: click.Context, name: str):
 @meltano_environment.command(cls=PartialInstrumentedCmd)
 @click.argument("name")
 @click.pass_context
-def remove(ctx: click.Context, name: str):
+def remove(ctx: click.Context, name: str) -> None:
     """Remove an environment."""
     tracker = ctx.obj["tracker"]
     environment_service: EnvironmentService = ctx.obj[ENVIRONMENT_SERVICE_KEY]
@@ -67,7 +67,7 @@ def remove(ctx: click.Context, name: str):
 
 @meltano_environment.command(cls=PartialInstrumentedCmd, name="list")
 @click.pass_context
-def list_environments(ctx: click.Context):
+def list_environments(ctx: click.Context) -> None:
     """List available environments."""
     tracker = ctx.obj["tracker"]
     environment_service: EnvironmentService = ctx.obj[ENVIRONMENT_SERVICE_KEY]

--- a/src/meltano/cli/hub.py
+++ b/src/meltano/cli/hub.py
@@ -19,7 +19,7 @@ if t.TYPE_CHECKING:
     short_help="Interact with Meltano Hub.",
     environment_behavior=CliEnvironmentBehavior.environment_optional_use_default,
 )
-def hub():
+def hub() -> None:
     """
     Interact with Meltano Hub.
     Read more at https://docs.meltano.com/reference/command-line-interface#hub
@@ -31,7 +31,7 @@ def hub():
     short_help="Ping Meltano Hub.",
 )
 @pass_project()
-def ping(project: Project):
+def ping(project: Project) -> None:
     """
     Ping Meltano Hub. This can be useful for checking if a custom Hub URL is reachable.
     Read more at https://docs.meltano.com/reference/command-line-interface#hub

--- a/src/meltano/cli/initialize.py
+++ b/src/meltano/cli/initialize.py
@@ -36,7 +36,7 @@ path_type = click.Path(file_okay=False, path_type=Path)
     is_flag=True,
 )
 @database_uri_option
-def init(ctx, project_directory: Path, *, no_usage_stats: bool, force: bool):
+def init(ctx, project_directory: Path, *, no_usage_stats: bool, force: bool) -> None:  # noqa: ANN001
     """
     Create a new Meltano project.
 

--- a/src/meltano/cli/initialize.py
+++ b/src/meltano/cli/initialize.py
@@ -36,7 +36,7 @@ path_type = click.Path(file_okay=False, path_type=Path)
     is_flag=True,
 )
 @database_uri_option
-def init(ctx, project_directory: Path, no_usage_stats: bool, force: bool):
+def init(ctx, project_directory: Path, *, no_usage_stats: bool, force: bool):
     """
     Create a new Meltano project.
 

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -64,6 +64,7 @@ logger = structlog.getLogger(__name__)
 async def install(
     project: Project,
     ctx: click.Context,
+    *,
     plugin_type: str,
     plugin_name: str,
     clean: bool,

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -71,7 +71,7 @@ async def install(
     parallelism: int,
     force: bool,
     schedule_name: str,
-):
+) -> None:
     """
     Install all the dependencies of your project based on the meltano.yml file.
 
@@ -117,7 +117,7 @@ async def install(
     tracker.track_command_event(CliEvent.completed)
 
 
-def _get_schedule_plugins(project: Project, schedule_name: str):
+def _get_schedule_plugins(project: Project, schedule_name: str):  # noqa: ANN202
     schedule_service = ScheduleService(project)
     schedule_obj = schedule_service.find_schedule(schedule_name)
     schedule_plugins = set()

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -68,7 +68,7 @@ To learn more about configuration options, see the [link=https://docs.meltano.co
 class InteractiveConfig:
     """Manage Config interactively."""
 
-    def __init__(self, ctx, store, *, extras=False, max_width=None):
+    def __init__(self, ctx, store, *, extras=False, max_width=None) -> None:  # noqa: ANN001
         """Initialise InteractiveConfig instance."""
         self.ctx = ctx
         self.store = store
@@ -83,7 +83,7 @@ class InteractiveConfig:
         self.safe: bool = ctx.obj["safe"]
 
     @property
-    def configurable_settings(self):
+    def configurable_settings(self):  # noqa: ANN201
         """Return settings available for interactive configuration."""
         return self.settings.config_with_metadata(
             session=self.session,
@@ -92,7 +92,7 @@ class InteractiveConfig:
         )
 
     @property
-    def setting_choices(self):
+    def setting_choices(self):  # noqa: ANN201
         """Return simplified setting choices, for easy printing."""
         setting_choices = []
         for index, (name, config_metadata) in enumerate(
@@ -109,7 +109,7 @@ class InteractiveConfig:
             return f"{text[: self.max_width - 3]}..."
         return text
 
-    def _print_home_screen(self):
+    def _print_home_screen(self) -> None:
         """Print screen for this interactive."""
         markdown_template = Environment(
             loader=BaseLoader(),
@@ -138,7 +138,7 @@ class InteractiveConfig:
         )
         self.console.print(Panel(Text.from_markup(markdown_text)))
 
-    def _print_setting(self, name, config_metadata, index, last_index):
+    def _print_setting(self, name, config_metadata, index, last_index) -> None:  # noqa: ANN001
         """Print setting."""
         value = config_metadata["value"]
         source = config_metadata["source"]
@@ -183,10 +183,10 @@ class InteractiveConfig:
         else:
             label = f"from {source.label}"
 
-        def value_is_defined(v=value):
+        def value_is_defined(v=value):  # noqa: ANN001, ANN202
             return v is not None
 
-        def value_for_display(v=value):
+        def value_for_display(v=value):  # noqa: ANN001, ANN202
             return v if value_is_defined(v) else "(empty string)"
 
         expanded_value = value_for_display()
@@ -239,7 +239,7 @@ class InteractiveConfig:
         self.console.print(Panel(Group(*pre, details, *post)))
 
     @staticmethod
-    def _value_prompt(config_metadata):
+    def _value_prompt(config_metadata):  # noqa: ANN001, ANN205
         if config_metadata["setting"].kind != SettingKind.OPTIONS:
             return (
                 click.prompt(
@@ -272,7 +272,7 @@ class InteractiveConfig:
         )
         return options_index[chosen_index][1]
 
-    def configure(self, name, index=None, last_index=None, *, show_set_prompt=True):
+    def configure(self, name, index=None, last_index=None, *, show_set_prompt=True):  # noqa: ANN001, ANN201
         """Configure a single setting interactively."""
         config_metadata = next(
             (
@@ -333,7 +333,7 @@ class InteractiveConfig:
             return InteractionStatus.EXIT
         return None
 
-    def configure_all(self):
+    def configure_all(self) -> None:
         """Configure all settings."""
         numeric_choices = [idx for idx, _, _ in self.setting_choices]
         if not numeric_choices:
@@ -396,7 +396,7 @@ class InteractiveConfig:
                     show_set_prompt=False,
                 )
 
-    def set_value(self, setting_name, value, store, *, interactive=False):
+    def set_value(self, setting_name, value, store, *, interactive=False) -> None:  # noqa: ANN001
         """Set value helper function."""
         settings = self.settings
         path = list(setting_name)

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -68,7 +68,7 @@ To learn more about configuration options, see the [link=https://docs.meltano.co
 class InteractiveConfig:
     """Manage Config interactively."""
 
-    def __init__(self, ctx, store, extras=False, max_width=None):
+    def __init__(self, ctx, store, *, extras=False, max_width=None):
         """Initialise InteractiveConfig instance."""
         self.ctx = ctx
         self.store = store
@@ -272,7 +272,7 @@ class InteractiveConfig:
         )
         return options_index[chosen_index][1]
 
-    def configure(self, name, index=None, last_index=None, show_set_prompt=True):
+    def configure(self, name, index=None, last_index=None, *, show_set_prompt=True):
         """Configure a single setting interactively."""
         config_metadata = next(
             (
@@ -396,7 +396,7 @@ class InteractiveConfig:
                     show_set_prompt=False,
                 )
 
-    def set_value(self, setting_name, value, store, interactive=False):
+    def set_value(self, setting_name, value, store, *, interactive=False):
         """Set value helper function."""
         settings = self.settings
         path = list(setting_name)

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -84,6 +84,7 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
 async def invoke(
     project: Project,
     ctx: click.Context,
+    *,
     plugin_type: str,
     dump: str,
     list_commands: bool,
@@ -135,12 +136,12 @@ async def invoke(
     invoker = invoker_factory(project, plugin)
     try:
         exit_code = await _invoke(
-            invoker,
-            plugin_args,
-            session,
-            dump,
-            command_name,
-            containers,
+            invoker=invoker,
+            plugin_args=plugin_args,
+            session=session,
+            dump=dump,
+            command_name=command_name,
+            containers=containers,
             print_var=print_var,
         )
     except Exception as invoke_err:
@@ -155,6 +156,7 @@ async def invoke(
 
 
 async def _invoke(
+    *,
     invoker: PluginInvoker,
     plugin_args: str,
     session: sessionmaker,

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -93,7 +93,7 @@ async def invoke(
     install_plugins: InstallPlugins,
     containers: bool = False,
     print_var: str | None = None,
-):
+) -> None:
     """
     Invoke a plugin's executable with specified arguments.
 
@@ -155,7 +155,7 @@ async def invoke(
     sys.exit(exit_code)
 
 
-async def _invoke(
+async def _invoke(  # noqa: ANN202
     *,
     invoker: PluginInvoker,
     plugin_args: str,
@@ -203,7 +203,7 @@ async def _invoke(
     return exit_code
 
 
-def do_list_commands(plugin):
+def do_list_commands(plugin) -> None:  # noqa: ANN001
     """List the commands supported by plugin."""
     if not plugin.supported_commands:
         click.secho(
@@ -222,7 +222,7 @@ def do_list_commands(plugin):
         click.echo(desc)
 
 
-async def dump_file(invoker: PluginInvoker, file_id: str):
+async def dump_file(invoker: PluginInvoker, file_id: str) -> None:
     """Dump file."""
     try:
         content = await invoker.dump(file_id)

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -100,7 +100,7 @@ def _list_all_jobs(
 )
 @click.pass_context
 @pass_project(migrate=True)
-def job(project, ctx):
+def job(project, ctx) -> None:  # noqa: ANN001
     """
     Manage jobs.
 
@@ -140,7 +140,7 @@ def job(project, ctx):
 )
 @click.argument("job_name", required=False, default=None)
 @click.pass_context
-def list_jobs(ctx, list_format: str, job_name: str):
+def list_jobs(ctx, list_format: str, job_name: str) -> None:  # noqa: ANN001
     """List available jobs."""
     task_sets_service: TaskSetsService = ctx.obj["task_sets_service"]
 
@@ -168,7 +168,7 @@ def list_jobs(ctx, list_format: str, job_name: str):
     help="Tasks that will be run as part of this job.",
 )
 @click.pass_context
-def add(ctx, job_name: str, raw_tasks: str):
+def add(ctx, job_name: str, raw_tasks: str) -> None:  # noqa: ANN001
     """Add tasks to a new job.
 
     Example usage:
@@ -227,7 +227,7 @@ def add(ctx, job_name: str, raw_tasks: str):
     help="Tasks that will be run as part of this job.",
 )
 @click.pass_context
-def set_cmd(ctx, job_name: str, raw_tasks: str):
+def set_cmd(ctx, job_name: str, raw_tasks: str) -> None:  # noqa: ANN001
     """Update the tasks associated with an existing job.
 
     Example usage:
@@ -267,7 +267,7 @@ def set_cmd(ctx, job_name: str, raw_tasks: str):
 @job.command(cls=PartialInstrumentedCmd, name="remove", short_help="Remove a job.")
 @click.argument("job_name", required=True)
 @click.pass_context
-def remove(ctx, job_name: str):
+def remove(ctx, job_name: str) -> None:  # noqa: ANN001
     """Remove a job.
 
     Usage:

--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -51,7 +51,7 @@ def _install_plugins_fn(
     return install_plugins
 
 
-async def _install_plugins_and_exit(*args, **kwargs) -> bool:
+async def _install_plugins_and_exit(*args, **kwargs) -> bool:  # noqa: ANN002, ANN003
     kwargs.pop("reason", None)
     await install_plugins(*args, **kwargs, reason=PluginInstallReason.INSTALL)
     context = click.get_current_context()
@@ -59,7 +59,7 @@ async def _install_plugins_and_exit(*args, **kwargs) -> bool:
     return True  # pragma: no cover
 
 
-def database_uri_option(func):
+def database_uri_option(func):  # noqa: ANN001, ANN201
     """Database URI Click option decorator.
 
     args:
@@ -67,7 +67,7 @@ def database_uri_option(func):
     """
 
     @click.option("--database-uri", help="System database URI.")
-    def decorate(*args, database_uri=None, **kwargs):
+    def decorate(*args, database_uri=None, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
         if database_uri:
             ProjectSettingsService.config_override["database_uri"] = database_uri
 
@@ -123,7 +123,7 @@ class pass_project:  # noqa: N801
 
     __name__ = "project"
 
-    def __init__(self, *, migrate=False):
+    def __init__(self, *, migrate=False) -> None:  # noqa: ANN001
         """Instantiate decorator.
 
         args:
@@ -131,7 +131,7 @@ class pass_project:  # noqa: N801
         """
         self.migrate = migrate
 
-    def __call__(self, func):
+    def __call__(self, func):  # noqa: ANN001, ANN204
         """Return decorated function.
 
         args:
@@ -139,7 +139,7 @@ class pass_project:  # noqa: N801
         """
 
         @database_uri_option
-        def decorate(*args, **kwargs):
+        def decorate(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
             ctx = click.get_current_context()
 
             project = ctx.obj["project"]

--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -123,7 +123,7 @@ class pass_project:  # noqa: N801
 
     __name__ = "project"
 
-    def __init__(self, migrate=False):
+    def __init__(self, *, migrate=False):
         """Instantiate decorator.
 
         args:

--- a/src/meltano/cli/remove.py
+++ b/src/meltano/cli/remove.py
@@ -19,7 +19,7 @@ from meltano.core.plugin_remove_service import PluginRemoveService
 @click.argument("plugin_type", type=click.Choice(PluginType.cli_arguments()))
 @click.argument("plugin_names", nargs=-1, required=True)
 @pass_project()
-def remove(project, plugin_type, plugin_names):
+def remove(project, plugin_type, plugin_names) -> None:  # noqa: ANN001
     """
     Remove plugins from your project.
 
@@ -32,7 +32,7 @@ def remove(project, plugin_type, plugin_names):
     remove_plugins(project, plugins)
 
 
-def remove_plugins(project, plugins):
+def remove_plugins(project, plugins) -> None:  # noqa: ANN001
     """Invoke PluginRemoveService and output CLI removal overview."""
     remove_service = PluginRemoveService(project)
 
@@ -49,7 +49,7 @@ def remove_plugins(project, plugins):
         click.echo()
 
 
-def remove_plugin_status_update(plugin):
+def remove_plugin_status_update(plugin) -> None:  # noqa: ANN001
     """Print remove status message for a plugin."""
     plugin_descriptor = f"{plugin.type.descriptor} '{plugin.name}'"
 
@@ -58,7 +58,7 @@ def remove_plugin_status_update(plugin):
     click.echo()
 
 
-def removal_manager_status_update(removal_manager: PluginLocationRemoveManager):
+def removal_manager_status_update(removal_manager: PluginLocationRemoveManager) -> None:
     """Print remove status message for a plugin location."""
     plugin_descriptor = removal_manager.plugin_descriptor
     location = removal_manager.location

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -35,7 +35,7 @@ class UUIDParamType(click.ParamType):
 
     name = "uuid"
 
-    def convert(self, value, param, ctx):
+    def convert(self, value, param, ctx):  # noqa: ANN001, ANN201
         """Convert an input value to a UUID."""
         try:
             return uuid.UUID(value)
@@ -121,7 +121,7 @@ async def run(
     run_id: uuid.UUID | None,
     blocks: list[str],
     install_plugins: InstallPlugins,
-):
+) -> None:
     """
     Run a set of command blocks in series.
 

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -110,6 +110,7 @@ class UUIDParamType(click.ParamType):
 async def run(
     ctx: click.Context,
     project: Project,
+    *,
     dry_run: bool,
     full_refresh: bool,
     refresh_catalog: bool,
@@ -195,6 +196,7 @@ async def run(
 async def _run_blocks(
     tracker: Tracker,
     parsed_blocks: list[BlockSet | PluginCommandBlock],
+    *,
     dry_run: bool,
 ) -> None:
     for idx, blk in enumerate(parsed_blocks):

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -44,7 +44,7 @@ if t.TYPE_CHECKING:
 )
 @click.pass_context
 @pass_project(migrate=True)
-def schedule(project, ctx):
+def schedule(project, ctx) -> None:  # noqa: ANN001
     """
     Manage pipeline schedules.
 
@@ -63,7 +63,7 @@ def _add_elt(
     transform: str,
     interval: str,
     start_date: datetime.datetime | None,
-):
+) -> None:
     """Add a new legacy elt schedule."""
     project: Project = ctx.obj["project"]
     schedule_service: ScheduleService = ctx.obj["schedule_service"]
@@ -89,7 +89,7 @@ def _add_elt(
         session.close()
 
 
-def _add_job(ctx, name: str, job: str, interval: str):
+def _add_job(ctx, name: str, job: str, interval: str) -> None:  # noqa: ANN001
     """Add a new scheduled job."""
     project: Project = ctx.obj["project"]
     schedule_service: ScheduleService = ctx.obj["schedule_service"]
@@ -133,7 +133,7 @@ def add(
     transform: str,
     interval: str,
     start_date: datetime.datetime | None,
-):
+) -> None:
     """
     Add a new schedule. Schedules can be used to run Meltano jobs or ELT tasks at a specific interval.
 
@@ -281,7 +281,7 @@ def list_schedules(ctx: click.Context, list_format: str) -> None:
 @click.argument("name")
 @click.argument("elt_options", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
-def run(ctx: click.Context, name: str, elt_options: tuple[str]):
+def run(ctx: click.Context, name: str, elt_options: tuple[str]) -> None:
     """Run a schedule."""
     schedule_service: ScheduleService = ctx.obj["schedule_service"]
     process = schedule_service.run(schedule_service.find_schedule(name), *elt_options)
@@ -296,7 +296,7 @@ def run(ctx: click.Context, name: str, elt_options: tuple[str]):
 )
 @click.argument("name", required=True)
 @click.pass_context
-def remove(ctx, name):
+def remove(ctx, name) -> None:  # noqa: ANN001
     """Remove a schedule.
 
     Usage:
@@ -379,7 +379,7 @@ class CronParam(click.ParamType):
 
     name = "cron"
 
-    def convert(self, value, *_):
+    def convert(self, value, *_):  # noqa: ANN001, ANN201
         """Validate and con interval."""
         if value not in CRON_INTERVALS and not croniter.is_valid(value):
             raise BadCronError(value)
@@ -416,7 +416,7 @@ def set_cmd(
     extractor: str | None,
     loader: str | None,
     transform: str | None,
-):
+) -> None:
     """Update a schedule.
 
     Usage:

--- a/src/meltano/cli/schema.py
+++ b/src/meltano/cli/schema.py
@@ -10,7 +10,7 @@ from meltano.core.db import ensure_schema_exists, project_engine
 
 
 @click.group(cls=InstrumentedGroup, short_help="Manage system DB schema.")
-def schema():
+def schema() -> None:
     """Manage system DB schema."""
 
 
@@ -21,7 +21,7 @@ def schema():
 @click.argument("schema")
 @click.argument("roles", nargs=-1, required=True)
 @pass_project()
-def create(project, schema_name, roles):
+def create(project, schema_name, roles) -> None:  # noqa: ANN001
     """Create system DB schema, if not exists."""
     engine, _ = project_engine(project)
     ensure_schema_exists(engine, schema_name, grant_roles=roles)

--- a/src/meltano/cli/select.py
+++ b/src/meltano/cli/select.py
@@ -123,18 +123,20 @@ def update(
     extractor,
     entities_filter,
     attributes_filter,
+    *,
     exclude=False,
     remove=False,
 ):
     """Update select pattern for a specific extractor."""
     select_service = SelectService(project, extractor)
-    select_service.update(entities_filter, attributes_filter, exclude, remove)
+    select_service.update(entities_filter, attributes_filter, exclude, remove=remove)
 
 
 async def show(
     project: Project,
     extractor: str,
     install_plugins: InstallPlugins,
+    *,
     show_all: bool = False,
     refresh: bool = False,
 ) -> None:
@@ -149,7 +151,7 @@ async def show(
     )
 
     with closing(Session()) as session:
-        list_all = await select_service.list_all(session, refresh)
+        list_all = await select_service.list_all(session, refresh=refresh)
 
     # legend
     click.secho("Legend:")

--- a/src/meltano/cli/select.py
+++ b/src/meltano/cli/select.py
@@ -23,7 +23,7 @@ if t.TYPE_CHECKING:
 install, no_install, only_install = get_install_options(include_only_install=True)
 
 
-def selection_color(selection):
+def selection_color(selection) -> str | None:  # noqa: ANN001
     """Return the appropriate colour for given SelectionType."""
     if selection is SelectionType.SELECTED:
         return "bright_green"
@@ -34,7 +34,7 @@ def selection_color(selection):
     return None
 
 
-def selection_mark(selection):
+def selection_mark(selection) -> str:  # noqa: ANN001
     """
     Return the mark to indicate the selection type of an attribute.
 
@@ -90,7 +90,7 @@ async def select(
     attributes_filter: str,
     install_plugins: InstallPlugins,
     **flags: bool,
-):
+) -> None:
     """
     Manage extractor selection patterns.
 
@@ -119,14 +119,14 @@ async def select(
 
 
 def update(
-    project,
-    extractor,
-    entities_filter,
-    attributes_filter,
+    project,  # noqa: ANN001
+    extractor,  # noqa: ANN001
+    entities_filter,  # noqa: ANN001
+    attributes_filter,  # noqa: ANN001
     *,
-    exclude=False,
-    remove=False,
-):
+    exclude=False,  # noqa: ANN001
+    remove=False,  # noqa: ANN001
+) -> None:
     """Update select pattern for a specific extractor."""
     select_service = SelectService(project, extractor)
     select_service.update(entities_filter, attributes_filter, exclude, remove=remove)

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -48,7 +48,7 @@ class MutuallyExclusiveOptionsError(Exception):
 def _prompt_for_confirmation(prompt):
     """Wrap destructive CLI commands which should prompt the user for confirmation."""
 
-    def _prompt_callback(ctx: click.Context, param, value: bool):  # noqa: ARG001
+    def _prompt_callback(ctx: click.Context, param, value: bool):  # noqa: ARG001, FBT001
         if not value and not click.confirm(prompt):
             ctx.exit(1)
 

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -45,10 +45,10 @@ class MutuallyExclusiveOptionsError(Exception):
         return f"Must provide exactly one of: {','.join(self.options)}"
 
 
-def _prompt_for_confirmation(prompt):
+def _prompt_for_confirmation(prompt):  # noqa: ANN001, ANN202
     """Wrap destructive CLI commands which should prompt the user for confirmation."""
 
-    def _prompt_callback(ctx: click.Context, param, value: bool):  # noqa: ARG001, FBT001
+    def _prompt_callback(ctx: click.Context, param, value: bool) -> None:  # noqa: ANN001, ARG001, FBT001
         if not value and not click.confirm(prompt):
             ctx.exit(1)
 
@@ -109,7 +109,7 @@ def state_service_from_state_id(project: Project, state_id: str) -> StateService
 )
 @click.pass_context
 @pass_project(migrate=True)
-def meltano_state(project: Project, ctx: click.Context):
+def meltano_state(project: Project, ctx: click.Context) -> None:
     """
     Manage state.
 
@@ -123,7 +123,7 @@ def meltano_state(project: Project, ctx: click.Context):
 @meltano_state.command(cls=InstrumentedCmd, name="list")
 @click.option("--pattern", type=str, help="Filter state IDs by pattern.")
 @click.pass_context
-def list_state(ctx: click.Context, pattern: str | None):
+def list_state(ctx: click.Context, pattern: str | None) -> None:
     """List all state_ids for this project.
 
     Optionally pass a glob-style pattern to filter state_ids by.
@@ -157,7 +157,7 @@ def copy_state(
     project: Project,
     src_state_id: str,
     dst_state_id: str,
-):
+) -> None:
     """Copy state to another job ID."""
     # Retrieve state for copying
     state_service: StateService = (
@@ -187,7 +187,7 @@ def move_state(
     project: Project,
     src_state_id: str,
     dst_state_id: str,
-):
+) -> None:
     """Move state to another job ID, clearing the original."""
     # Retrieve state for moveing
     state_service: StateService = (
@@ -224,7 +224,7 @@ def merge_state(
     state: str | None,
     input_file: click.Path | None,
     from_state_id: str | None,
-):
+) -> None:
     """Add bookmarks to existing state."""
     state_service: StateService = (
         state_service_from_state_id(project, state_id) or ctx.obj[STATE_SERVICE_KEY]
@@ -272,7 +272,7 @@ def set_state(
     state_id: str,
     state: str | None,
     input_file: click.Path | None,
-):
+) -> None:
     """Set state."""
     state_service: StateService = (
         state_service_from_state_id(project, state_id) or ctx.obj[STATE_SERVICE_KEY]
@@ -298,7 +298,7 @@ def set_state(
 @click.argument("state-id")
 @pass_project(migrate=True)
 @click.pass_context
-def get_state(ctx: click.Context, project: Project, state_id: str):
+def get_state(ctx: click.Context, project: Project, state_id: str) -> None:
     """Get state."""
     state_service: StateService = (
         state_service_from_state_id(project, state_id) or ctx.obj[STATE_SERVICE_KEY]
@@ -312,7 +312,7 @@ def get_state(ctx: click.Context, project: Project, state_id: str):
 @click.argument("state-id")
 @pass_project(migrate=True)
 @click.pass_context
-def clear_state(ctx: click.Context, project: Project, state_id: str):
+def clear_state(ctx: click.Context, project: Project, state_id: str) -> None:
     """Clear state."""
     state_service: StateService = (
         state_service_from_state_id(project, state_id) or ctx.obj[STATE_SERVICE_KEY]

--- a/src/meltano/cli/upgrade.py
+++ b/src/meltano/cli/upgrade.py
@@ -21,7 +21,7 @@ from meltano.core.upgrade_service import UpgradeService
 )
 @pass_project()
 @click.pass_context
-def upgrade(ctx, project):
+def upgrade(ctx, project) -> None:  # noqa: ANN001
     """
     Upgrade Meltano and your entire project to the latest version.
 
@@ -63,7 +63,7 @@ def upgrade(ctx, project):
     help="Skip updating the Meltano package.",
 )
 @click.pass_context
-def all_(ctx, pip_url, force, skip_package):
+def all_(ctx, pip_url, force, skip_package) -> None:  # noqa: ANN001
     """
     Upgrade Meltano and your entire project to the latest version.
 
@@ -128,7 +128,7 @@ def all_(ctx, pip_url, force, skip_package):
     help="Force upgrade.",
 )
 @click.pass_context
-def package(ctx, **kwargs):
+def package(ctx, **kwargs) -> None:  # noqa: ANN001, ANN003
     """Upgrade the Meltano package only."""
     ctx.obj["upgrade_service"].upgrade_package(**kwargs)
 
@@ -138,7 +138,7 @@ def package(ctx, **kwargs):
     short_help="Update files managed by file bundles only.",
 )
 @click.pass_context
-def files(ctx):
+def files(ctx) -> None:  # noqa: ANN001
     """Update files managed by file bundles only."""
     ctx.obj["upgrade_service"].update_files()
 
@@ -148,6 +148,6 @@ def files(ctx):
     short_help="Apply migrations to system database only.",
 )
 @click.pass_context
-def database(ctx):
+def database(ctx) -> None:  # noqa: ANN001
     """Apply migrations to system database only."""
     ctx.obj["upgrade_service"].migrate_database()

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -73,6 +73,7 @@ class CliError(Exception):
 def print_added_plugin(
     plugin: ProjectPlugin,
     reason: PluginAddedReason = PluginAddedReason.USER_REQUEST,
+    *,
     update: bool = False,
 ) -> None:
     """Print added plugin."""
@@ -394,6 +395,7 @@ def add_plugin(
 def add_required_plugins(
     plugins: list[ProjectPlugin],
     add_service: ProjectAddService,
+    *,
     lock: bool = True,
 ):
     """Add any Plugins required by the given Plugin."""
@@ -545,6 +547,7 @@ def check_dependencies_met(
 def activate_environment(
     ctx: click.Context,
     project: Project,
+    *,
     required: bool = False,
 ) -> None:
     """Activate the selected environment.

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -53,13 +53,13 @@ logger = structlog.stdlib.get_logger(__name__)
 class CliError(Exception):
     """CLI Error."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Instantiate custom CLI Error exception."""
         super().__init__(*args, **kwargs)
 
         self.printed = False
 
-    def print(self):
+    def print(self) -> None:
         """Print CLI error."""
         if self.printed:
             return
@@ -118,7 +118,7 @@ def print_added_plugin(
         click.echo(f"Documentation:\t{docs_url}")
 
 
-def _prompt_plugin_namespace(plugin_type, plugin_name):
+def _prompt_plugin_namespace(plugin_type, plugin_name):  # noqa: ANN001, ANN202
     click.secho(
         f"Adding new custom {plugin_type.descriptor} with name '{plugin_name}'...",
         fg="green",
@@ -186,7 +186,7 @@ def _prompt_plugin_executable(pip_url: str | None, plugin_name: str) -> str:
     return click.prompt(click.style("(executable)", fg="blue"), default=package_name)
 
 
-def _prompt_plugin_capabilities(plugin_type):
+def _prompt_plugin_capabilities(plugin_type):  # noqa: ANN001, ANN202
     if plugin_type != PluginType.EXTRACTORS:
         return []
 
@@ -269,18 +269,18 @@ def _prompt_plugin_settings(plugin_type: PluginType) -> list[dict[str, t.Any]]:
     return settings
 
 
-def add_plugin(
+def add_plugin(  # noqa: ANN201
     plugin_type: PluginType,
     plugin_name: str,
     *,
     python: str | None = None,
     add_service: ProjectAddService,
-    variant=None,
-    inherit_from=None,
-    custom=False,
-    update=False,
-    lock=True,
-    plugin_yaml=None,
+    variant=None,  # noqa: ANN001
+    inherit_from=None,  # noqa: ANN001
+    custom=False,  # noqa: ANN001
+    update=False,  # noqa: ANN001
+    lock=True,  # noqa: ANN001
+    plugin_yaml=None,  # noqa: ANN001
 ):
     """Add Plugin to given Project."""
     if custom:
@@ -392,7 +392,7 @@ def add_plugin(
     return plugin
 
 
-def add_required_plugins(
+def add_required_plugins(  # noqa: ANN201
     plugins: list[ProjectPlugin],
     add_service: ProjectAddService,
     *,
@@ -414,7 +414,7 @@ def add_required_plugins(
     return added_plugins
 
 
-def install_status_update(install_state: PluginInstallState):
+def install_status_update(install_state: PluginInstallState) -> None:
     """
     Print the status of plugin installation.
 
@@ -443,13 +443,13 @@ def install_status_update(install_state: PluginInstallState):
 
 
 async def install_plugins(
-    project,
-    plugins,
+    project,  # noqa: ANN001
+    plugins,  # noqa: ANN001
     *,
-    reason=PluginInstallReason.INSTALL,
-    parallelism=None,
-    clean=False,
-    force=False,
+    reason=PluginInstallReason.INSTALL,  # noqa: ANN001
+    parallelism=None,  # noqa: ANN001
+    clean=False,  # noqa: ANN001
+    force=False,  # noqa: ANN001
 ) -> bool:
     """Install the provided plugins and report results to the console."""
     install_service = PluginInstallService(
@@ -492,10 +492,10 @@ async def install_plugins(
 
 
 @contextmanager
-def propagate_stop_signals(proc):
+def propagate_stop_signals(proc):  # noqa: ANN001, ANN201
     """Propagate stop signals to `proc`, then wait for it to terminate."""
 
-    def _handler(sig, _):
+    def _handler(sig, _) -> None:  # noqa: ANN001
         proc.send_signal(sig)
         logger.debug("stopping child process...")
         # unset signal handler, so that even if the child never stops,
@@ -635,9 +635,9 @@ class InstrumentedCmdMixin:
 
     def __init__(
         self,
-        *args,
+        *args,  # noqa: ANN002
         environment_behavior: CliEnvironmentBehavior | None = None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Initialize the `InstrumentedCmdMixin`.
 
@@ -654,7 +654,7 @@ class InstrumentedCmdMixin:
 class InstrumentedGroupMixin(InstrumentedCmdMixin):
     """Shared functionality for all instrumented groups."""
 
-    def invoke(self, ctx: click.Context):
+    def invoke(self, ctx: click.Context) -> None:
         """Update the telemetry context and invoke the group."""
         ctx.ensure_object(dict)
         enact_environment_behavior(self.environment_behavior, ctx)
@@ -680,7 +680,7 @@ class InstrumentedCmd(InstrumentedCmdMixin, click.Command):
     dependent on whether invocation of the command resulted in an Exception.
     """
 
-    def invoke(self, ctx: click.Context):
+    def invoke(self, ctx: click.Context) -> None:
         """Invoke the requested command firing start and events accordingly."""
         ctx.ensure_object(dict)
         enact_environment_behavior(self.environment_behavior, ctx)
@@ -704,7 +704,7 @@ class PartialInstrumentedCmd(InstrumentedCmdMixin, click.Command):
     Only automatically fires a 'start' event.
     """
 
-    def invoke(self, ctx):
+    def invoke(self, ctx) -> None:  # noqa: ANN001
         """Invoke the requested command firing only a start event."""
         ctx.ensure_object(dict)
         enact_environment_behavior(self.environment_behavior, ctx)

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -93,6 +93,7 @@ class CommandLineRunner(ValidationsRunner):
 @run_async
 async def test(
     project: Project,
+    *,
     all_tests: bool,
     install_plugins: InstallPlugins,
     plugin_tests: tuple[str, ...] = (),

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -34,7 +34,7 @@ TEST_LINE_LENGTH = 60
 install, no_install, only_install = get_install_options(include_only_install=True)
 
 
-def write_sep_line(title: str, sepchar: str, **kwargs):
+def write_sep_line(title: str, sepchar: str, **kwargs) -> None:  # noqa: ANN003
     """Write a separator line in the terminal."""
     terminal_width, _ = shutil.get_terminal_size()
     char_count = (
@@ -97,7 +97,7 @@ async def test(
     all_tests: bool,
     install_plugins: InstallPlugins,
     plugin_tests: tuple[str, ...] = (),
-):
+) -> None:
     """
     Run validations using plugins' tests.
 
@@ -137,7 +137,7 @@ async def _run_plugin_tests(
     return {runner.plugin_name: await runner.run_all(session) for runner in runners}
 
 
-def _report_and_exit(results: dict[str, dict[str, int]]):
+def _report_and_exit(results: dict[str, dict[str, int]]) -> None:
     exit_code = 0
     failed_count = 0
     passed_count = 0

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -54,7 +54,7 @@ def write_sep_line(title: str, sepchar: str, **kwargs) -> None:  # noqa: ANN003
 class CommandLineRunner(ValidationsRunner):
     """Validator that runs in the CLI."""
 
-    async def run_test(self, name: str) -> int:
+    async def run_test(self, name: str) -> int:  # type: ignore[override]
         """Run a test command.
 
         Args:

--- a/src/meltano/core/behavior/canonical.py
+++ b/src/meltano/core/behavior/canonical.py
@@ -21,7 +21,7 @@ T = t.TypeVar("T", bound="Canonical")  # (name too short)
 class IdHashBox:
     """Wrapper class that makes the hash of an object its Python ID."""
 
-    def __init__(self, content: t.Any):
+    def __init__(self, content: t.Any):  # noqa: ANN401
         """Initialize the `IdHashBox`.
 
         Parameters:
@@ -38,7 +38,7 @@ class IdHashBox:
         """
         return id(self.content)
 
-    def __eq__(self, other: t.Any) -> bool:
+    def __eq__(self, other: t.Any) -> bool:  # noqa: ANN401
         """Check equality of this instance and some other object.
 
         Parameters:
@@ -63,7 +63,7 @@ class Annotations(t.NamedTuple):
 class AnnotationsMeta(type):
     """Metaclass to intercept and store annotations before calling `__init__`."""
 
-    def __call__(cls, *args: t.Any, **kwargs: t.Any) -> t.Any:
+    def __call__(cls, *args: t.Any, **kwargs: t.Any) -> t.Any:  # noqa: ANN401
         """Create and return an instance of the class this metaclass is applied to.
 
         Args:
@@ -122,7 +122,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         self._defaults = {}
 
     @classmethod
-    def _canonize(cls, val: t.Any) -> t.Any:
+    def _canonize(cls, val: t.Any) -> t.Any:  # noqa: ANN401
         """Call `as_canonical` on `val`, respecting `Canonical` subclasses.
 
         Args:
@@ -138,8 +138,8 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
     @classmethod
     def as_canonical(
         cls: type[T],
-        target: t.Any,
-    ) -> dict | list | CommentedMap | CommentedSeq | t.Any:
+        target: t.Any,  # noqa: ANN401
+    ) -> dict | list | CommentedMap | CommentedSeq | t.Any:  # noqa: ANN401
         """Return a canonical representation of the given instance.
 
         Args:
@@ -177,7 +177,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
 
         return copy.deepcopy(target)
 
-    def canonical(self) -> dict | list | CommentedMap | CommentedSeq | t.Any:
+    def canonical(self) -> dict | list | CommentedMap | CommentedSeq | t.Any:  # noqa: ANN401
         """Return a canonical representation of the current instance.
 
         Returns:
@@ -198,7 +198,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         return type(self)(*args, **{**self.canonical(), **kwargs})
 
     @classmethod
-    def parse(cls: type[T], obj: t.Any) -> T:
+    def parse(cls: type[T], obj: t.Any) -> T:  # noqa: ANN401
         """Parse a 'Canonical' object from a dictionary or return the instance.
 
         Args:
@@ -244,7 +244,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         """
         return self._dict
 
-    def is_attr_set(self, attr):
+    def is_attr_set(self, attr):  # noqa: ANN001, ANN201
         """Return whether specified attribute has a non-default/fallback value set.
 
         Args:
@@ -255,7 +255,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         """
         return self._dict.get(attr) is not None
 
-    def __getattr__(self, attr: str) -> t.Any:
+    def __getattr__(self, attr: str) -> t.Any:  # noqa: ANN401
         """Return the value of the given attribute.
 
         Args:
@@ -289,7 +289,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
 
         return value
 
-    def __setattr__(self, attr: str, value: t.Any):
+    def __setattr__(self, attr: str, value: t.Any) -> None:  # noqa: ANN401
         """Set the given attribute to the given value.
 
         Args:
@@ -301,7 +301,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         else:
             self._dict[attr] = value
 
-    def __getitem__(self, attr: str) -> t.Any:
+    def __getitem__(self, attr: str) -> t.Any:  # noqa: ANN401
         """Return the value of the given attribute.
 
         Args:
@@ -312,7 +312,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         """
         return getattr(self, attr)
 
-    def __setitem__(self, attr: str, value: t.Any) -> None:
+    def __setitem__(self, attr: str, value: t.Any) -> None:  # noqa: ANN401
         """Set the given attribute to the given value.
 
         Args:
@@ -324,7 +324,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         """
         return setattr(self, attr, value)
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: ANN204
         """Return an iterator over the attributes set on the current instance.
 
         Yields:
@@ -352,7 +352,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
             else:
                 yield (key, val)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the number of attributes set on the current instance.
 
         Returns:
@@ -360,7 +360,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         """
         return len(self._dict)
 
-    def __contains__(self, obj: t.Any):
+    def __contains__(self, obj: t.Any) -> bool:  # noqa: ANN401
         """Return whether the current instance contains the given object.
 
         Args:
@@ -388,7 +388,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
                 setattr(self, key, val)
 
     @classmethod
-    def yaml(cls, dumper: yaml.BaseDumper, obj: t.Any) -> yaml.MappingNode:
+    def yaml(cls, dumper: yaml.BaseDumper, obj: t.Any) -> yaml.MappingNode:  # noqa: ANN401
         """YAML serializer for Canonical objects.
 
         Args:
@@ -405,7 +405,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         )
 
     @classmethod
-    def to_yaml(cls, representer: Representer, obj: t.Any):
+    def to_yaml(cls, representer: Representer, obj: t.Any):  # noqa: ANN206, ANN401
         """YAML serializer for Canonical objects.
 
         Args:

--- a/src/meltano/core/behavior/hookable.py
+++ b/src/meltano/core/behavior/hookable.py
@@ -22,7 +22,7 @@ class hook:  # noqa: N801
     accordingly.
     """
 
-    def __init__(self, hook_name, can_fail=False):
+    def __init__(self, hook_name, *, can_fail=False):
         self.name = hook_name
         self.can_fail = can_fail
 

--- a/src/meltano/core/behavior/hookable.py
+++ b/src/meltano/core/behavior/hookable.py
@@ -22,11 +22,11 @@ class hook:  # noqa: N801
     accordingly.
     """
 
-    def __init__(self, hook_name, *, can_fail=False):
+    def __init__(self, hook_name, *, can_fail=False) -> None:  # noqa: ANN001
         self.name = hook_name
         self.can_fail = can_fail
 
-    def __call__(self, func):
+    def __call__(self, func):  # noqa: ANN001, ANN204
         func.__hook__ = self
         return func
 
@@ -37,7 +37,7 @@ class Hookable(type):
     Hooks are registered in declaration order.
     """
 
-    def __new__(cls, name, bases, dct):
+    def __new__(cls, name, bases, dct):  # noqa: ANN001, ANN204
         new_type = type.__new__(cls, name, bases, dct)
         new_type.__hooks__ = {}
 
@@ -54,7 +54,7 @@ class Hookable(type):
 
         return new_type
 
-    def __prepare__(cls, bases, **kwds):
+    def __prepare__(cls, bases, **kwds):  # noqa: ANN001, ANN003, ANN204
         return OrderedDict()
 
 
@@ -66,7 +66,7 @@ class HookObject(metaclass=Hookable):
     """
 
     @asynccontextmanager
-    async def trigger_hooks(self, hook_name, *args, **kwargs):
+    async def trigger_hooks(self, hook_name, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN201
         """Trigger all registered before and after functions for a given hook.
 
         Yields to the caller in between triggers.
@@ -100,7 +100,7 @@ class HookObject(metaclass=Hookable):
             self._triggering_hooks.remove(hook_name)
 
     @classmethod
-    async def trigger(cls, target, hook_name, *args, **kwargs):
+    async def trigger(cls, target, hook_name, *args, **kwargs) -> None:  # noqa: ANN001, ANN002, ANN003
         """Trigger a registered hook function."""
         hooks = [
             hook

--- a/src/meltano/core/behavior/name_eq.py
+++ b/src/meltano/core/behavior/name_eq.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 
 class NameEq:
-    def __eq__(self, other):
+    def __eq__(self, other):  # noqa: ANN001, ANN204
         return self is other or self.name == other.name
 
-    def __hash__(self):
+    def __hash__(self):  # noqa: ANN204
         return hash(self.name)

--- a/src/meltano/core/behavior/versioned.py
+++ b/src/meltano/core/behavior/versioned.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 class IncompatibleVersionError(Exception):
     """A component is incompatible with its representation."""
 
-    def __init__(self, message, file_version: int, version: int):
+    def __init__(self, message, file_version: int, version: int):  # noqa: ANN001
         super().__init__(message)
 
         self.file_version = file_version
@@ -21,14 +21,14 @@ class Versioned(ABC):
     def file_version(self) -> int:
         pass
 
-    def is_compatible(self, version: int | None = None):
+    def is_compatible(self, version: int | None = None) -> bool | None:
         try:
             self.ensure_compatible(version=version)
             return True
         except IncompatibleVersionError:
             return False
 
-    def ensure_compatible(self, version: int | None = None):
+    def ensure_compatible(self, version: int | None = None) -> None:
         version = self.__class__.__version__ if version is None else version
         file_version = self.file_version
 

--- a/src/meltano/core/behavior/visitor.py
+++ b/src/meltano/core/behavior/visitor.py
@@ -7,9 +7,9 @@ class visit_with:  # noqa: N801
     def __init__(self, visit: t.Callable):
         self.visit = visit
 
-    def __call__(self, base_cls):
+    def __call__(self, base_cls):  # noqa: ANN001, ANN204
         class Visitor(base_cls):
-            def visit(inner_self, node, *args, **kwargs):  # noqa: N805
+            def visit(inner_self, node, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202, N805
                 return self.visit(node, inner_self, *args, **kwargs)
 
         return Visitor

--- a/src/meltano/core/block/blockset.py
+++ b/src/meltano/core/block/blockset.py
@@ -39,7 +39,7 @@ class BlockSet(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def terminate(self, *, graceful: bool = True):
+    async def terminate(self, *, graceful: bool = True) -> t.NoReturn:
         """Terminate a currently executing BlockSet.
 
         Args:

--- a/src/meltano/core/block/blockset.py
+++ b/src/meltano/core/block/blockset.py
@@ -39,7 +39,7 @@ class BlockSet(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def terminate(self, graceful: bool = True):
+    async def terminate(self, *, graceful: bool = True):
         """Terminate a currently executing BlockSet.
 
         Args:

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -135,7 +135,7 @@ class ELBContextBuilder:
 
         self._base_output_logger = None
 
-    def with_job(self, job: Job):
+    def with_job(self, job: Job):  # noqa: ANN201
         """Set the associated job for the context.
 
         Args:
@@ -147,7 +147,7 @@ class ELBContextBuilder:
         self._job = job
         return self
 
-    def with_merge_state(self, *, merge_state: bool):
+    def with_merge_state(self, *, merge_state: bool):  # noqa: ANN201
         """Set whether the state is to be merged or overwritten.
 
         Args:
@@ -160,7 +160,7 @@ class ELBContextBuilder:
         self._merge_state = merge_state
         return self
 
-    def with_full_refresh(self, *, full_refresh: bool):
+    def with_full_refresh(self, *, full_refresh: bool):  # noqa: ANN201
         """Set whether this is a full refresh.
 
         Args:
@@ -172,7 +172,7 @@ class ELBContextBuilder:
         self._full_refresh = full_refresh
         return self
 
-    def with_refresh_catalog(self, *, refresh_catalog: bool):
+    def with_refresh_catalog(self, *, refresh_catalog: bool):  # noqa: ANN201
         """Set whether cached catalog should be ignored.
 
         Args:
@@ -184,7 +184,7 @@ class ELBContextBuilder:
         self._refresh_catalog = refresh_catalog
         return self
 
-    def with_no_state_update(self, *, no_state_update: bool):
+    def with_no_state_update(self, *, no_state_update: bool):  # noqa: ANN201
         """Set whether this run should not update state.
 
         By default we typically attempt to track state. This allows avoiding
@@ -199,7 +199,7 @@ class ELBContextBuilder:
         self._state_update = not no_state_update
         return self
 
-    def with_force(self, *, force: bool):
+    def with_force(self, *, force: bool):  # noqa: ANN201
         """Set whether the execution of the job should be forced if it is stale.
 
         Args:
@@ -211,7 +211,7 @@ class ELBContextBuilder:
         self._force = force
         return self
 
-    def with_state_id_suffix(self, state_id_suffix: str):
+    def with_state_id_suffix(self, state_id_suffix: str):  # noqa: ANN201
         """Set a state ID suffix for this run.
 
         Args:
@@ -223,7 +223,7 @@ class ELBContextBuilder:
         self._state_id_suffix = state_id_suffix
         return self
 
-    def with_run_id(self, run_id: uuid.UUID | None):
+    def with_run_id(self, run_id: uuid.UUID | None):  # noqa: ANN201
         """Set a run ID for this run.
 
         Args:
@@ -436,7 +436,7 @@ class ExtractLoadBlocks(BlockSet):
                 continue
             return False
 
-    async def upstream_stop(self, index) -> None:
+    async def upstream_stop(self, index) -> None:  # noqa: ANN001
         """Stop all blocks upstream of a given index.
 
         Args:

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -48,6 +48,7 @@ class ELBContext:
 
     def __init__(
         self,
+        *,
         project: Project,
         session: Session | None = None,
         job: Job | None = None,
@@ -146,7 +147,7 @@ class ELBContextBuilder:
         self._job = job
         return self
 
-    def with_merge_state(self, merge_state: bool):
+    def with_merge_state(self, *, merge_state: bool):
         """Set whether the state is to be merged or overwritten.
 
         Args:
@@ -159,7 +160,7 @@ class ELBContextBuilder:
         self._merge_state = merge_state
         return self
 
-    def with_full_refresh(self, full_refresh: bool):
+    def with_full_refresh(self, *, full_refresh: bool):
         """Set whether this is a full refresh.
 
         Args:
@@ -171,7 +172,7 @@ class ELBContextBuilder:
         self._full_refresh = full_refresh
         return self
 
-    def with_refresh_catalog(self, refresh_catalog: bool):
+    def with_refresh_catalog(self, *, refresh_catalog: bool):
         """Set whether cached catalog should be ignored.
 
         Args:
@@ -183,7 +184,7 @@ class ELBContextBuilder:
         self._refresh_catalog = refresh_catalog
         return self
 
-    def with_no_state_update(self, no_state_update: bool):
+    def with_no_state_update(self, *, no_state_update: bool):
         """Set whether this run should not update state.
 
         By default we typically attempt to track state. This allows avoiding
@@ -198,7 +199,7 @@ class ELBContextBuilder:
         self._state_update = not no_state_update
         return self
 
-    def with_force(self, force: bool):
+    def with_force(self, *, force: bool):
         """Set whether the execution of the job should be forced if it is stale.
 
         Args:
@@ -536,7 +537,7 @@ class ExtractLoadBlocks(BlockSet):
             async with job.run(session):
                 await self.execute()
 
-    async def terminate(self, graceful: bool = False) -> None:
+    async def terminate(self, *, graceful: bool = False) -> None:
         """Terminate an in flight ExtractLoad execution, potentially disruptive.
 
         Not actually implemented yet.

--- a/src/meltano/core/block/future_utils.py
+++ b/src/meltano/core/block/future_utils.py
@@ -42,7 +42,7 @@ def handle_producer_line_length_limit_error(
     exception: Exception,
     line_length_limit: int,
     stream_buffer_size: int,
-):
+) -> None:
     """Handle `asyncio.LimitOverrunError` from producers.
 
     Args:

--- a/src/meltano/core/block/ioblock.py
+++ b/src/meltano/core/block/ioblock.py
@@ -92,7 +92,7 @@ class IOBlock(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def stop(self, kill: bool = True) -> None:
+    async def stop(self, *, kill: bool = True) -> None:
         """Stop a block.
 
         Args:

--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -69,7 +69,7 @@ class BlockParser:
     def __init__(
         self,
         log: structlog.BoundLogger,
-        project,
+        project,  # noqa: ANN001
         blocks: list[str],
         *,
         full_refresh: bool | None = False,

--- a/src/meltano/core/block/parser.py
+++ b/src/meltano/core/block/parser.py
@@ -71,6 +71,7 @@ class BlockParser:
         log: structlog.BoundLogger,
         project,
         blocks: list[str],
+        *,
         full_refresh: bool | None = False,
         refresh_catalog: bool | None = False,
         no_state_update: bool | None = False,
@@ -247,12 +248,12 @@ class BlockParser:
 
         builder = (
             ELBContextBuilder(self.project)
-            .with_force(self._force)
-            .with_full_refresh(self._full_refresh)
-            .with_refresh_catalog(self._refresh_catalog)
-            .with_no_state_update(self._no_state_update)
+            .with_force(force=self._force)
+            .with_full_refresh(full_refresh=self._full_refresh)
+            .with_refresh_catalog(refresh_catalog=self._refresh_catalog)
+            .with_no_state_update(no_state_update=self._no_state_update)
             .with_state_id_suffix(self._state_id_suffix)
-            .with_merge_state(self._merge_state)
+            .with_merge_state(merge_state=self._merge_state)
             .with_run_id(self._run_id)
         )
 

--- a/src/meltano/core/block/plugin_command.py
+++ b/src/meltano/core/block/plugin_command.py
@@ -113,7 +113,7 @@ class InvokerCommand(InvokerBase, PluginCommandBlock):
         """
         return self._command_args
 
-    async def _start(self):
+    async def _start(self) -> None:
         invoke_args = (self.command_args,) if self.command_args else ()
         await self.start(*invoke_args)
 

--- a/src/meltano/core/block/singer.py
+++ b/src/meltano/core/block/singer.py
@@ -103,7 +103,7 @@ class InvokerBase:
         except Exception as err:
             raise RunnerError(f"Cannot start plugin: {err}") from err  # noqa: EM102
 
-    async def stop(self, kill: bool = True):
+    async def stop(self, *, kill: bool = True):
         """Stop (kill) the underlying process and cancel output proxying.
 
         Args:
@@ -338,7 +338,7 @@ class SingerBlock(InvokerBase, IOBlock):
         except Exception as err:
             raise RunnerError(f"Cannot start plugin {self.string_id}: {err}") from err  # noqa: EM102
 
-    async def stop(self, kill: bool = True):
+    async def stop(self, *, kill: bool = True):
         """Stop (kill) the underlying process and cancel output proxying.
 
         Args:

--- a/src/meltano/core/block/singer.py
+++ b/src/meltano/core/block/singer.py
@@ -82,7 +82,7 @@ class InvokerBase:
         """
         return self.invoker.plugin.name
 
-    async def start(self, *args, **kwargs):
+    async def start(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Invoke the process asynchronously.
 
         Args:
@@ -103,7 +103,7 @@ class InvokerBase:
         except Exception as err:
             raise RunnerError(f"Cannot start plugin: {err}") from err  # noqa: EM102
 
-    async def stop(self, *, kill: bool = True):
+    async def stop(self, *, kill: bool = True) -> None:
         """Stop (kill) the underlying process and cancel output proxying.
 
         Args:
@@ -222,7 +222,7 @@ class InvokerBase:
         else:
             raise IOLinkError("IO capture already in flight")  # noqa: EM101
 
-    def stderr_link(self, dst: SubprocessOutputWriter):
+    def stderr_link(self, dst: SubprocessOutputWriter) -> None:
         """Use stderr_link to instruct block to link/write stderr content to dst.
 
         Args:
@@ -236,7 +236,7 @@ class InvokerBase:
         else:
             raise IOLinkError("IO capture already in flight")  # noqa: EM101
 
-    async def pre(self, context) -> None:
+    async def pre(self, context) -> None:  # noqa: ANN001
         """Pre triggers preparation of the underlying plugin.
 
         Args:
@@ -318,7 +318,7 @@ class SingerBlock(InvokerBase, IOBlock):
         """
         return "state" in self.invoker.capabilities
 
-    async def start(self):
+    async def start(self) -> None:
         """Start the SingerBlock by invoking the underlying plugin.
 
         Raises:
@@ -338,7 +338,7 @@ class SingerBlock(InvokerBase, IOBlock):
         except Exception as err:
             raise RunnerError(f"Cannot start plugin {self.string_id}: {err}") from err  # noqa: EM102
 
-    async def stop(self, *, kill: bool = True):
+    async def stop(self, *, kill: bool = True) -> None:
         """Stop (kill) the underlying process and cancel output proxying.
 
         Args:

--- a/src/meltano/core/config_service.py
+++ b/src/meltano/core/config_service.py
@@ -52,7 +52,7 @@ class ConfigService:
         return self.project.meltano
 
     @contextmanager
-    def update_meltano_yml(self):
+    def update_meltano_yml(self):  # noqa: ANN201
         """Update meltano.yml.
 
         This method is a context manager that will update meltano.yml with the
@@ -65,7 +65,7 @@ class ConfigService:
             yield meltano_yml
 
     @contextmanager
-    def update_active_environment(self):
+    def update_active_environment(self):  # noqa: ANN201
         """Update active environment.
 
         Yields:
@@ -81,7 +81,7 @@ class ConfigService:
             yield environments[env_idx]
 
     @property
-    def current_config(self):
+    def current_config(self):  # noqa: ANN201
         """Return the current configuration.
 
         Returns:
@@ -89,7 +89,7 @@ class ConfigService:
         """
         return self.current_meltano_yml.extras
 
-    def update_config(self, config):
+    def update_config(self, config) -> None:  # noqa: ANN001
         """Update top-level Meltano configuration.
 
         Args:
@@ -98,12 +98,12 @@ class ConfigService:
         with self.update_meltano_yml() as meltano_yml:
             meltano_yml.extras = config
 
-    def make_meltano_secret_dir(self):
+    def make_meltano_secret_dir(self) -> None:
         """Create the secret directory."""
         os.makedirs(self.project.meltano_dir(), exist_ok=True)
 
     @property
-    def env(self):
+    def env(self):  # noqa: ANN201
         """Return the top-level env vars from meltano.yml.
 
         Returns:

--- a/src/meltano/core/container/container_service.py
+++ b/src/meltano/core/container/container_service.py
@@ -17,7 +17,7 @@ if t.TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def stop_container(container: DockerContainer):
+def stop_container(container: DockerContainer) -> None:
     """Stop a Docker container.
 
     Args:

--- a/src/meltano/core/db.py
+++ b/src/meltano/core/db.py
@@ -60,6 +60,7 @@ class NullConnectionStringError(MeltanoError):
 
 def project_engine(
     project: Project,
+    *,
     default: bool = False,
 ) -> tuple[Engine, sessionmaker]:
     """Create and register a SQLAlchemy engine for a Meltano project instance.

--- a/src/meltano/core/db.py
+++ b/src/meltano/core/db.py
@@ -53,7 +53,7 @@ class NullConnectionStringError(MeltanoError):
         "to check for missing environment variables"
     )
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the exception."""
         super().__init__(self.REASON, self.INSTRUCTION)
 

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -25,7 +25,7 @@ class PluginContext(t.NamedTuple):
     settings_service: PluginSettingsService
     session: Session
 
-    def __getattr__(self, attr: str) -> t.Any:
+    def __getattr__(self, attr: str) -> t.Any:  # noqa: ANN401
         """Get plugin attribute.
 
         Args:
@@ -36,7 +36,7 @@ class PluginContext(t.NamedTuple):
         """
         return getattr(self.plugin, attr)
 
-    def get_config(self, name: str, **kwargs: t.Any) -> t.Any:
+    def get_config(self, name: str, **kwargs: t.Any) -> t.Any:  # noqa: ANN401
         """Get plugin config by name.
 
         Args:
@@ -48,7 +48,7 @@ class PluginContext(t.NamedTuple):
         """
         return self.settings_service.get(name, session=self.session, **kwargs)
 
-    def config_dict(self, **kwargs) -> dict:
+    def config_dict(self, **kwargs) -> dict:  # noqa: ANN003
         """Get plugins config dict.
 
         Args:
@@ -59,7 +59,7 @@ class PluginContext(t.NamedTuple):
         """
         return self.settings_service.as_dict(session=self.session, **kwargs)
 
-    def config_env(self, **kwargs) -> dict[str, str]:
+    def config_env(self, **kwargs) -> dict[str, str]:  # noqa: ANN003
         """Get plugins config environment.
 
         Args:
@@ -88,7 +88,7 @@ class ELTContext:
         *,
         project: Project,
         job: Job | None = None,
-        session=None,
+        session=None,  # noqa: ANN001
         extractor: PluginContext | None = None,
         loader: PluginContext | None = None,
         transform: PluginContext | None = None,
@@ -144,7 +144,7 @@ class ELTContext:
         self.merge_state = merge_state
 
     @property
-    def elt_run_dir(self):
+    def elt_run_dir(self):  # noqa: ANN201
         """Get the ELT run directory.
 
         Returns:
@@ -357,7 +357,7 @@ class ELTContextBuilder:
         self._refresh_catalog = refresh_catalog
         return self
 
-    def with_merge_state(self, *, merge_state: bool):
+    def with_merge_state(self, *, merge_state: bool):  # noqa: ANN201
         """Set whether the state is to be merged or overwritten.
 
         Args:
@@ -405,7 +405,7 @@ class ELTContextBuilder:
         self._state = state
         return self
 
-    def set_base_output_logger(self, base_output_logger: OutputLogger):
+    def set_base_output_logger(self, base_output_logger: OutputLogger) -> None:
         """Set the base output logger for use in this ELTContext.
 
         Args:

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -85,6 +85,7 @@ class ELTContext:
 
     def __init__(
         self,
+        *,
         project: Project,
         job: Job | None = None,
         session=None,
@@ -307,7 +308,7 @@ class ELTContextBuilder:
         self._transformer = PluginRef(PluginType.TRANSFORMERS, transformer_name)
         return self
 
-    def with_only_transform(self, only_transform: bool) -> ELTContextBuilder:
+    def with_only_transform(self, *, only_transform: bool) -> ELTContextBuilder:
         """Include only transform flag when building context.
 
         Args:
@@ -319,7 +320,7 @@ class ELTContextBuilder:
         self._only_transform = only_transform
         return self
 
-    def with_dry_run(self, dry_run: bool) -> ELTContextBuilder:
+    def with_dry_run(self, *, dry_run: bool) -> ELTContextBuilder:
         """Include dry run flag when building context.
 
         Args:
@@ -331,7 +332,7 @@ class ELTContextBuilder:
         self._dry_run = dry_run
         return self
 
-    def with_full_refresh(self, full_refresh: bool) -> ELTContextBuilder:
+    def with_full_refresh(self, *, full_refresh: bool) -> ELTContextBuilder:
         """Include full refresh flag when building context.
 
         Args:
@@ -344,7 +345,7 @@ class ELTContextBuilder:
         self._full_refresh = full_refresh
         return self
 
-    def with_refresh_catalog(self, refresh_catalog: bool) -> ELTContextBuilder:
+    def with_refresh_catalog(self, *, refresh_catalog: bool) -> ELTContextBuilder:
         """Ignore cached catalog.
 
         Args:
@@ -356,7 +357,7 @@ class ELTContextBuilder:
         self._refresh_catalog = refresh_catalog
         return self
 
-    def with_merge_state(self, merge_state: bool):
+    def with_merge_state(self, *, merge_state: bool):
         """Set whether the state is to be merged or overwritten.
 
         Args:
@@ -508,7 +509,7 @@ class ELTContextBuilder:
             )
 
         return ELTContext(
-            self.project,
+            project=self.project,
             job=self._job,
             session=self._session,
             extractor=extractor,

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -44,7 +44,7 @@ class EnvironmentPluginConfig(PluginRef):
         name: str,
         config: dict | None = None,
         env: dict | None = None,
-        **extras,
+        **extras,  # noqa: ANN003
     ):
         """Create a new plugin configuration object.
 
@@ -61,7 +61,7 @@ class EnvironmentPluginConfig(PluginRef):
         self.extras = extras
 
     @property
-    def extra_config(self):
+    def extra_config(self):  # noqa: ANN201
         """Get extra config from the Meltano environment, like `select` and `schema`.
 
         Returns:
@@ -70,7 +70,7 @@ class EnvironmentPluginConfig(PluginRef):
         return {f"_{key}": value for key, value in self.extras.items()}
 
     @property
-    def config_with_extras(self):
+    def config_with_extras(self):  # noqa: ANN201
         """Get plugin configuration values from the Meltano environment.
 
         Returns:
@@ -79,7 +79,7 @@ class EnvironmentPluginConfig(PluginRef):
         return {**self.config, **self.extra_config}
 
     @config_with_extras.setter
-    def config_with_extras(self, new_config_with_extras: dict[str, t.Any]):
+    def config_with_extras(self, new_config_with_extras: dict[str, t.Any]) -> None:
         """Set plugin configuration values from the Meltano environment.
 
         Args:
@@ -115,7 +115,7 @@ class EnvironmentPluginConfig(PluginRef):
 class EnvironmentConfig(Canonical):
     """Meltano environment configuration."""
 
-    def __init__(self, plugins: dict[str, list[dict]] | None = None, **extras):
+    def __init__(self, plugins: dict[str, list[dict]] | None = None, **extras):  # noqa: ANN003
         """Create a new environment configuration.
 
         Args:

--- a/src/meltano/core/environment_service.py
+++ b/src/meltano/core/environment_service.py
@@ -35,7 +35,7 @@ class EnvironmentService:
         """
         self.project = project
 
-    def add(self, name) -> Environment:
+    def add(self, name) -> Environment:  # noqa: ANN001
         """Create a new Environment in `meltano.yml`.
 
         Args:

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -56,14 +56,14 @@ class MeltanoError(Exception):
 class Error(Exception):
     """Base exception for ELT errors."""
 
-    def exit_code(self):
+    def exit_code(self):  # noqa: ANN201
         return ExitCode.FAIL
 
 
 class ExtractError(Error):
     """Error in the extraction process, like API errors."""
 
-    def exit_code(self):
+    def exit_code(self):  # noqa: ANN201
         return ExitCode.NO_RETRY
 
 
@@ -132,6 +132,6 @@ class ProjectNotFound(Error):
 class ProjectReadonly(Error):
     """Attempting to update a readonly project."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Instantiate the error."""
         super().__init__("This Meltano project is deployed as read-only")

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -156,7 +156,7 @@ class MeltanoHubService(PluginRepository):
         return hub_api_root or f"{hub_url}/meltano/api/v1"
 
     @property
-    def hub_url_auth(self):
+    def hub_url_auth(self):  # noqa: ANN201
         """Return the `hub_url_auth` setting.
 
         Returns:

--- a/src/meltano/core/job/finder.py
+++ b/src/meltano/core/job/finder.py
@@ -18,7 +18,7 @@ class JobFinder:
         """
         self.state_id = state_id
 
-    def latest(self, session):
+    def latest(self, session):  # noqa: ANN001, ANN201
         """Get the latest state for this instance's state ID.
 
         Args:
@@ -34,7 +34,7 @@ class JobFinder:
             .first()
         )
 
-    def successful(self, session):
+    def successful(self, session):  # noqa: ANN001, ANN201
         """Get all successful jobs for this instance's state ID.
 
         Args:
@@ -49,7 +49,7 @@ class JobFinder:
             & Job.ended_at.isnot(None),
         )
 
-    def running(self, session):
+    def running(self, session):  # noqa: ANN001, ANN201
         """Find states in the running state.
 
         Args:
@@ -62,7 +62,7 @@ class JobFinder:
             (Job.job_name == self.state_id) & (Job.state == State.RUNNING),
         )
 
-    def latest_success(self, session):
+    def latest_success(self, session):  # noqa: ANN001, ANN201
         """Get the latest successful state for this instance's state ID.
 
         Args:
@@ -73,7 +73,7 @@ class JobFinder:
         """
         return self.successful(session).order_by(Job.ended_at.desc()).first()
 
-    def latest_running(self, session):
+    def latest_running(self, session):  # noqa: ANN001, ANN201
         """Find the most recent state in the running state, if any.
 
         Args:
@@ -84,7 +84,7 @@ class JobFinder:
         """
         return self.running(session).order_by(Job.started_at.desc()).first()
 
-    def with_payload(self, session, flags=0, since=None, state=None):
+    def with_payload(self, session, flags=0, since=None, state=None):  # noqa: ANN001, ANN201
         """Get all states for this instance's state ID matching the given args.
 
         Args:
@@ -113,7 +113,7 @@ class JobFinder:
             query = query.filter(Job.state == state)
         return query
 
-    def latest_with_payload(self, session, **kwargs):
+    def latest_with_payload(self, session, **kwargs):  # noqa: ANN001, ANN003, ANN201
         """Return the latest state matching the given kwargs.
 
         Args:
@@ -131,7 +131,7 @@ class JobFinder:
         )
 
     @classmethod
-    def all_stale(cls, session):
+    def all_stale(cls, session):  # noqa: ANN001, ANN206
         """Return all stale states.
 
         Args:
@@ -158,7 +158,7 @@ class JobFinder:
             ),
         )
 
-    def stale(self, session):
+    def stale(self, session):  # noqa: ANN001, ANN201
         """Return stale states with the instance's state ID.
 
         Args:
@@ -169,7 +169,7 @@ class JobFinder:
         """
         return self.all_stale(session).filter(Job.job_name == self.state_id)
 
-    def get_all(self, session: object, since=None):
+    def get_all(self, session: object, since=None):  # noqa: ANN001, ANN201
         """Return all state with the instance's state ID.
 
         Args:

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -49,7 +49,7 @@ class State(Enum):
     DEAD = (4, ())
     STATE_EDIT = (5, ())
 
-    def transitions(self):
+    def transitions(self):  # noqa: ANN201
         """Get possible next States for a job of this State.
 
         Returns:
@@ -57,7 +57,7 @@ class State(Enum):
         """
         return self.value[1]
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Get a string representation of this State.
 
         Returns:
@@ -69,7 +69,7 @@ class State(Enum):
 class StateComparator(Comparator):
     """Compare Job._state to State enums."""
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # noqa: ANN001, ANN204
         """Enable SQLAlchemy to directly compare Job.state values with State.
 
         Args:
@@ -81,7 +81,7 @@ class StateComparator(Comparator):
         return self.__clause_element__() == literal(other.name)
 
 
-def current_trigger():
+def current_trigger():  # noqa: ANN201
     """Get the trigger for running job.
 
     Returns:
@@ -123,7 +123,7 @@ class Job(SystemModel):
         default=current_trigger,
     )
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
         """Construct a Job.
 
         Args:
@@ -144,7 +144,7 @@ class Job(SystemModel):
         return State[self._state]
 
     @state.setter
-    def state(self, value):
+    def state(self, value) -> None:  # noqa: ANN001
         """Set the _state value for this Job from a State enum.
 
         Args:
@@ -153,7 +153,7 @@ class Job(SystemModel):
         self._state = str(value)
 
     @state.comparator
-    def state(cls):  # noqa: N805
+    def state(cls):  # noqa: ANN201, N805
         """Use this comparison to compare Job.state to State.
 
         See:
@@ -164,7 +164,7 @@ class Job(SystemModel):
         """
         return StateComparator(cls._state)
 
-    def is_running(self):
+    def is_running(self):  # noqa: ANN201
         """Return whether Job is running.
 
         Returns:
@@ -172,7 +172,7 @@ class Job(SystemModel):
         """
         return self.state is State.RUNNING
 
-    def is_stale(self):
+    def is_stale(self):  # noqa: ANN201
         """Return whether Job has gone stale.
 
         Running jobs with a heartbeat are considered stale after no heartbeat
@@ -195,7 +195,7 @@ class Job(SystemModel):
 
         return datetime.now(timezone.utc) - timestamp > valid_for
 
-    def has_error(self):
+    def has_error(self):  # noqa: ANN201
         """Return whether a job has failed.
 
         Returns:
@@ -203,7 +203,7 @@ class Job(SystemModel):
         """
         return self.state is State.FAIL
 
-    def is_complete(self):
+    def is_complete(self):  # noqa: ANN201
         """Return whether a job has completed.
 
         Returns:
@@ -211,7 +211,7 @@ class Job(SystemModel):
         """
         return self.state in {State.SUCCESS, State.FAIL}
 
-    def is_success(self):
+    def is_success(self):  # noqa: ANN201
         """Return whether a job has succeeded.
 
         Returns:
@@ -256,7 +256,7 @@ class Job(SystemModel):
         return transition
 
     @asynccontextmanager
-    async def run(self, session):
+    async def run(self, session):  # noqa: ANN001, ANN201
         """Run wrapped code in context of a job.
 
         Transitions state to RUNNING and SUCCESS/FAIL as appropriate and
@@ -287,12 +287,12 @@ class Job(SystemModel):
             self.save(session)
             raise
 
-    def start(self):
+    def start(self) -> None:
         """Mark the job has having started."""
         self.started_at = datetime.now(timezone.utc)
         self.transit(State.RUNNING)
 
-    def fail(self, error=None):
+    def fail(self, error=None) -> None:  # noqa: ANN001
         """Mark the job as having failed.
 
         Args:
@@ -303,12 +303,12 @@ class Job(SystemModel):
         if error:
             self.payload.update({"error": str(error)})
 
-    def success(self):
+    def success(self) -> None:
         """Mark the job as having succeeded."""
         self.ended_at = datetime.now(timezone.utc)
         self.transit(State.SUCCESS)
 
-    def fail_stale(self):
+    def fail_stale(self) -> bool:
         """Mark job as failed if it's gone stale.
 
         Returns:
@@ -326,7 +326,7 @@ class Job(SystemModel):
 
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Represent as a string.
 
         Returns:
@@ -338,7 +338,7 @@ class Job(SystemModel):
             f"ended_at='{self.ended_at}')>"
         )
 
-    def save(self, session):
+    def save(self, session):  # noqa: ANN001, ANN201
         """Save the job in the db.
 
         Args:
@@ -352,11 +352,11 @@ class Job(SystemModel):
 
         return self
 
-    def _heartbeat(self):
+    def _heartbeat(self) -> None:
         """Update last_heartbeat_at for this job in the db."""
         self.last_heartbeat_at = datetime.now(timezone.utc)
 
-    async def _heartbeater(self, session):
+    async def _heartbeater(self, session) -> None:  # noqa: ANN001
         """Heartbeat to the db every second.
 
         Args:
@@ -369,7 +369,7 @@ class Job(SystemModel):
             await asyncio.sleep(1)
 
     @asynccontextmanager
-    async def _heartbeating(self, session):
+    async def _heartbeating(self, session):  # noqa: ANN001, ANN202
         """Provide a context for heartbeating jobs.
 
         Args:
@@ -386,11 +386,11 @@ class Job(SystemModel):
                 await heartbeat_future
 
     @contextmanager
-    def _handling_sigterm(
+    def _handling_sigterm(  # noqa: ANN202
         self,
-        session,  # noqa: ARG002
+        session,  # noqa: ANN001, ARG002
     ):
-        def handler(*_):
+        def handler(*_) -> t.NoReturn:
             sigterm_status = 143
             raise SystemExit(sigterm_status)
 
@@ -401,7 +401,7 @@ class Job(SystemModel):
         finally:
             signal.signal(signal.SIGTERM, original_termination_handler)
 
-    def _error_message(self, err):
+    def _error_message(self, err):  # noqa: ANN001, ANN202
         if isinstance(err, SystemExit):
             return "The process was terminated"
 

--- a/src/meltano/core/job_state.py
+++ b/src/meltano/core/job_state.py
@@ -61,7 +61,7 @@ class JobState(SystemModel):
         )
 
     @classmethod
-    def from_job_history(cls, session: Session, state_id: str):
+    def from_job_history(cls, session: Session, state_id: str):  # noqa: ANN206
         """Build JobState from job run history.
 
         Args:
@@ -154,7 +154,7 @@ class JobState(SystemModel):
     def merge_partial(
         self,
         state: JobState,
-    ):
+    ) -> None:
         """Merge provided partial state onto this JobState.
 
         Args:
@@ -173,7 +173,7 @@ class JobState(SystemModel):
         """
         return bool(self.completed_state)
 
-    def to_file(self, file_obj: TextIOWrapper):
+    def to_file(self, file_obj: TextIOWrapper) -> None:
         """Persist JobState to a file-like object.
 
         Args:

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -50,7 +50,7 @@ def rich_exception_formatter_factory(
     """
 
     def _traceback(
-        sio,
+        sio,  # noqa: ANN001
         exc_info: tuple[type[t.Any], BaseException, TracebackType | None],
     ) -> None:
         sio.write("\n")

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -30,6 +30,7 @@ LEVELED_TIMESTAMPED_PRE_CHAIN = (
 
 def rich_exception_formatter_factory(
     color_system: t.Literal["auto", "standard", "256", "truecolor", "windows"] = "auto",
+    *,
     no_color: bool | None = None,
     show_locals: bool = False,
 ) -> t.Callable[[t.TextIO, structlog.types.ExcInfo], None]:
@@ -83,6 +84,7 @@ def _process_formatter(processor: Processor) -> structlog.stdlib.ProcessorFormat
 
 
 def console_log_formatter(
+    *,
     colors: bool = False,
     show_locals: bool = False,
 ) -> structlog.stdlib.ProcessorFormatter:
@@ -117,6 +119,7 @@ def console_log_formatter(
 
 
 def key_value_formatter(
+    *,
     sort_keys: bool = False,
     key_order: t.Sequence[str] | None = None,
     drop_missing: bool = False,

--- a/src/meltano/core/logging/job_logging_service.py
+++ b/src/meltano/core/logging/job_logging_service.py
@@ -30,7 +30,7 @@ class JobLoggingService:
         self.project = project
 
     @makedirs
-    def logs_dir(self, state_id, *joinpaths, make_dirs: bool = True):
+    def logs_dir(self, state_id, *joinpaths, make_dirs: bool = True):  # noqa: ANN001, ANN002, ANN201
         """Return the logs directory for a given state_id.
 
         Args:
@@ -62,7 +62,7 @@ class JobLoggingService:
         return self.logs_dir(state_id, str(run_id), file_name)
 
     @contextmanager
-    def create_log(self, state_id, run_id, file_name="elt.log"):
+    def create_log(self, state_id, run_id, file_name="elt.log"):  # noqa: ANN001, ANN201
         """Open a new log file for logging and yield it.
 
         Log will be created inside the logs_dir, which is
@@ -83,7 +83,7 @@ class JobLoggingService:
             with open(os.devnull, "w") as log_file:
                 yield log_file
 
-    def get_latest_log(self, state_id) -> str:
+    def get_latest_log(self, state_id) -> str:  # noqa: ANN001
         """Get the latest log.
 
         Args:
@@ -112,7 +112,7 @@ class JobLoggingService:
                 f"Cannot log for job with ID '{state_id}': '{latest_log}' is missing.",  # noqa: EM102
             ) from ex
 
-    def get_downloadable_log(self, state_id):
+    def get_downloadable_log(self, state_id):  # noqa: ANN001, ANN201
         """Get the `*.log` file of the most recent log for any ELT job that ran with the provided `state_id`."""  # noqa: E501
         try:
             latest_log = next(iter(self.get_all_logs(state_id)))
@@ -126,7 +126,7 @@ class JobLoggingService:
                 f"Cannot log for job with ID '{state_id}': '{latest_log}' is missing.",  # noqa: EM102
             ) from ex
 
-    def get_all_logs(self, state_id):
+    def get_all_logs(self, state_id):  # noqa: ANN001, ANN201
         """Get all the log files for any ELT job that ran with the provided `state_id`.
 
         The result is ordered so that the most recent is first on the list.
@@ -141,7 +141,7 @@ class JobLoggingService:
             reverse=True,
         )
 
-    def delete_all_logs(self, state_id) -> None:
+    def delete_all_logs(self, state_id) -> None:  # noqa: ANN001
         """Delete all the logs for any ELT job that ran with the provided `state_id`.
 
         Args:
@@ -150,11 +150,11 @@ class JobLoggingService:
         for log_path in self.get_all_logs(state_id):
             log_path.unlink()
 
-    def legacy_logs_dir(self, state_id, *joinpaths):
+    def legacy_logs_dir(self, state_id, *joinpaths):  # noqa: ANN001, ANN002, ANN201
         job_dir = self.project.run_dir("elt").joinpath(slugify(state_id), *joinpaths)
         return job_dir if job_dir.exists() else None
 
-    def logs_dirs(self, state_id, *joinpaths):
+    def logs_dirs(self, state_id, *joinpaths):  # noqa: ANN001, ANN002, ANN201
         logs_dir = self.logs_dir(state_id, *joinpaths)
         legacy_logs_dir = self.legacy_logs_dir(state_id, *joinpaths)
 

--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -35,7 +35,7 @@ class OutputLogger:
         self.stdout = sys.stdout
         self.stderr = sys.stderr
 
-        self.outs = {}
+        self.outs = {}  # type: ignore[var-annotated]
 
     def out(
         self,

--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -25,7 +25,7 @@ from .utils import capture_subprocess_output
 class OutputLogger:
     """Output Logger."""
 
-    def __init__(self, file):
+    def __init__(self, file) -> None:  # noqa: ANN001
         """Instantiate an Output Logger.
 
         Args:
@@ -40,7 +40,7 @@ class OutputLogger:
     def out(
         self,
         name: str,
-        logger=None,
+        logger=None,  # noqa: ANN001
         write_level: int = logging.INFO,
     ) -> Out:
         """Obtain an Out instance for use as a logger or use for output capture.
@@ -71,7 +71,7 @@ class OutputLogger:
 class LineWriter:
     """Line Writer."""
 
-    def __init__(self, out):
+    def __init__(self, out) -> None:  # noqa: ANN001
         """Instantiate a Line Writer.
 
         Args:
@@ -79,7 +79,7 @@ class LineWriter:
         """
         self.__out = out
 
-    def __getattr__(self, name):
+    def __getattr__(self, name):  # noqa: ANN001, ANN204
         """Get attribute.
 
         Args:
@@ -90,7 +90,7 @@ class LineWriter:
         """
         return getattr(self.__out, name)
 
-    def write(self, line):
+    def write(self, line) -> None:  # noqa: ANN001
         """Write a line.
 
         Args:
@@ -102,7 +102,7 @@ class LineWriter:
 class FileDescriptorWriter:
     """File Descriptor Writer."""
 
-    def __init__(self, out, fd):
+    def __init__(self, out, fd) -> None:  # noqa: ANN001
         """Instantiate File Descriptor Writer.
 
         Args:
@@ -112,7 +112,7 @@ class FileDescriptorWriter:
         self.__out = out
         self.__writer = os.fdopen(fd, "w")
 
-    def __getattr__(self, name):
+    def __getattr__(self, name):  # noqa: ANN001, ANN204
         """Get attribute.
 
         Args:
@@ -123,7 +123,7 @@ class FileDescriptorWriter:
         """
         return getattr(self.__writer, name)
 
-    def isatty(self):
+    def isatty(self):  # noqa: ANN201
         """Is out location a tty.
 
         Returns:
@@ -179,7 +179,7 @@ class Out:
         return handler
 
     @contextmanager
-    def line_writer(self):
+    def line_writer(self):  # noqa: ANN201
         """Yield a line writer instance.
 
         Yields:
@@ -188,7 +188,7 @@ class Out:
         yield LineWriter(self)
 
     @contextmanager
-    def redirect_logging(self, ignore_errors=()):
+    def redirect_logging(self, ignore_errors=()):  # noqa: ANN001, ANN201
         """Redirect log entries to a temporarily added file handler.
 
         Args:
@@ -218,7 +218,7 @@ class Out:
             logger.removeHandler(self.redirect_log_handler)
 
     @asynccontextmanager
-    async def writer(self):
+    async def writer(self):  # noqa: ANN201
         """Yield a writer.
 
         Yields:
@@ -238,7 +238,7 @@ class Out:
                 await reader
 
     @asynccontextmanager
-    async def redirect_stdout(self):
+    async def redirect_stdout(self):  # noqa: ANN201
         """Redirect STDOUT.
 
         Yields:
@@ -249,7 +249,7 @@ class Out:
                 yield
 
     @asynccontextmanager
-    async def redirect_stderr(self):
+    async def redirect_stderr(self):  # noqa: ANN201
         """Redirect STDERR.
 
         Yields:
@@ -270,7 +270,7 @@ class Out:
         self.last_line = line
         self.logger.log(self.write_level, line.rstrip(), name=self.name)
 
-    async def _read_from_fd(self, read_fd):
+    async def _read_from_fd(self, read_fd) -> None:  # noqa: ANN001
         # Since we're redirecting our own stdout and stderr output,
         # the line length limit can be arbitrarily large.
         line_length_limit = 1024 * 1024 * 1024  # 1 GiB

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -180,7 +180,7 @@ def change_console_log_level(log_level: int = logging.DEBUG) -> None:
 class SubprocessOutputWriter(t.Protocol):
     """A basic interface suitable for use with `capture_subprocess_output`."""
 
-    def writeline(self, line: str):
+    def writeline(self, line: str) -> None:
         """Write the provided line to an output.
 
         Args:
@@ -188,7 +188,7 @@ class SubprocessOutputWriter(t.Protocol):
         """
 
 
-async def _write_line_writer(writer: SubprocessOutputWriter, line: bytes):
+async def _write_line_writer(writer: SubprocessOutputWriter, line: bytes) -> bool:
     # StreamWriters like a subprocess's stdin need special consideration
     if isinstance(writer, asyncio.StreamWriter):
         try:

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -76,9 +76,9 @@ class YamlLimitedSafeLoader(type):
 
     def __new__(
         cls,
-        name,
-        bases,
-        namespace,
+        name,  # noqa: ANN001
+        bases,  # noqa: ANN001
+        namespace,  # noqa: ANN001
         do_not_resolve: Iterable[str],
     ) -> YamlLimitedSafeLoader:
         """Generate a new instance of this metaclass.
@@ -254,7 +254,7 @@ class Manifest:
         self,
         data: t.MutableMapping[str, t.Any],
         key: str,
-        value: t.Any,
+        value: t.Any,  # noqa: ANN401
         _: tuple[t.Any, ...] | None = None,
     ) -> None:
         """Merge behavior for `deep_merge` that expands env vars when the key is "env".
@@ -438,7 +438,7 @@ def _plugins_by_name_by_type(
 
 
 def _locations_trie(paths: Iterable[Iterable[str]]) -> Trie:
-    def defaultdict_defaultdict():
+    def defaultdict_defaultdict():  # noqa: ANN202
         return defaultdict(defaultdict_defaultdict)
 
     root = defaultdict_defaultdict()

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -119,7 +119,7 @@ class YamlNoTimestampSafeLoader(
 class Manifest:
     """A complete unambiguous static representation of a Meltano project."""
 
-    def __init__(self, project: Project, path: Path, check_schema: bool) -> None:
+    def __init__(self, project: Project, path: Path, *, check_schema: bool) -> None:
         """Initialize the manifest.
 
         This class does not write a manifest file. It merely generates the data

--- a/src/meltano/core/meltano_file.py
+++ b/src/meltano/core/meltano_file.py
@@ -26,7 +26,7 @@ class MeltanoFile(Canonical):
         environments: list[dict] | None = None,
         jobs: list[dict] | None = None,
         env: dict[str, str] | None = None,
-        **extras,
+        **extras,  # noqa: ANN003
     ):
         """Construct a new MeltanoFile object from meltano.yml file.
 

--- a/src/meltano/core/meltano_invoker.py
+++ b/src/meltano/core/meltano_invoker.py
@@ -57,7 +57,7 @@ class MeltanoInvoker:
             env=self._executable_env(env),
         )
 
-    def _executable_path(self, command):
+    def _executable_path(self, command):  # noqa: ANN001, ANN202
         if command == MELTANO_COMMAND:
             # This symlink is created by Project.activate
             executable_symlink = self.project.run_dir().joinpath("bin")

--- a/src/meltano/core/migration_service.py
+++ b/src/meltano/core/migration_service.py
@@ -64,6 +64,7 @@ class MigrationService:
 
     def upgrade(  # too many expression and too complex
         self,
+        *,
         silent: bool = False,
     ) -> None:
         """Upgrade to the latest revision.

--- a/src/meltano/core/plugin/airflow.py
+++ b/src/meltano/core/plugin/airflow.py
@@ -22,7 +22,7 @@ logger = structlog.stdlib.get_logger(__name__)
 class AirflowInvoker(PluginInvoker):
     """Invoker that prepares env for Airflow."""
 
-    def env(self):
+    def env(self):  # noqa: ANN201
         """Environment variables for Airflow.
 
         Returns:
@@ -44,7 +44,7 @@ class Airflow(BasePlugin):
     invoker_class = AirflowInvoker
 
     @property
-    def config_files(self):
+    def config_files(self):  # noqa: ANN201
         """Return the configuration files required by the plugin.
 
         Returns:
@@ -52,7 +52,7 @@ class Airflow(BasePlugin):
         """
         return {"config": "airflow.cfg"}
 
-    def process_config(self, flat_config):
+    def process_config(self, flat_config):  # noqa: ANN001, ANN201
         """Unflatten the config.
 
         Args:
@@ -94,7 +94,7 @@ class Airflow(BasePlugin):
             logger.debug(f"Saved '{airflow_cfg_path!s}'")  # noqa: G004
 
     @hook("before_install")
-    async def setup_env(self, *args, **kwargs):  # noqa: ARG002
+    async def setup_env(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003, ARG002
         """Configure the env to make airflow installable without GPL deps.
 
         Args:
@@ -104,7 +104,7 @@ class Airflow(BasePlugin):
         os.environ["SLUGIFY_USES_TEXT_UNIDECODE"] = "yes"
 
     @hook("before_configure")
-    async def before_configure(self, invoker: AirflowInvoker, session):
+    async def before_configure(self, invoker: AirflowInvoker, session) -> None:  # noqa: ANN001
         """Generate config file and keep metadata database up-to-date.
 
         Args:
@@ -176,7 +176,7 @@ class Airflow(BasePlugin):
         logger.debug("Completed `airflow initdb`")
 
     @hook("before_cleanup")
-    async def before_cleanup(self, invoker: PluginInvoker):
+    async def before_cleanup(self, invoker: PluginInvoker) -> None:
         """Delete the config file.
 
         Args:

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -659,6 +659,7 @@ class BasePlugin(HookObject):
 
     def env_prefixes(
         self,
+        *,
         for_writing=False,  # noqa: ARG002
     ) -> list[str]:
         """Return environment variable prefixes to use for settings.

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -183,7 +183,7 @@ class PluginType(YAMLEnum):
 class PluginRef(Canonical):
     """A reference to a plugin."""
 
-    def __init__(self, plugin_type: str | PluginType, name: str, **kwargs):
+    def __init__(self, plugin_type: str | PluginType, name: str, **kwargs):  # noqa: ANN003
         """Create a new PluginRef.
 
         Args:
@@ -234,7 +234,7 @@ class PluginRef(Canonical):
         """
         return hash((self.type, self.name))
 
-    def set_presentation_attrs(self, extras):
+    def set_presentation_attrs(self, extras) -> None:  # noqa: ANN001
         """Set the presentation attributes of the plugin reference.
 
         Args:
@@ -272,7 +272,7 @@ class Variant(NameEq, Canonical):
         commands: dict | None = None,
         requires: dict[PluginType, list] | None = None,
         env: dict[str, str] | None = None,
-        **extras,
+        **extras,  # noqa: ANN003
     ):
         """Create a new Variant.
 
@@ -330,7 +330,7 @@ class PluginDefinition(PluginRef):
         variant: str | None = None,
         variants: list | None = None,
         is_default_variant: bool | None = None,
-        **extras,
+        **extras,  # noqa: ANN003
     ):
         """Create a new PluginDefinition.
 
@@ -349,7 +349,7 @@ class PluginDefinition(PluginRef):
 
         self._defaults["label"] = lambda plugin: plugin.name
 
-        def default_logo_url(plugin_def):
+        def default_logo_url(plugin_def) -> str:  # noqa: ANN001
             short_name = re.sub(
                 r"^(tap|target)-",
                 "",
@@ -377,7 +377,7 @@ class PluginDefinition(PluginRef):
         self.variants = [Variant.parse(x) for x in variants]
         self.is_default_variant = is_default_variant
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: ANN204
         """Iterate over the variants of the plugin definition.
 
         Yields:
@@ -412,7 +412,7 @@ class PluginDefinition(PluginRef):
         except NotFound as err:
             raise VariantNotFoundError(self, variant_name) from err
 
-    def find_variant(self, variant_or_name: str | Variant | None = None):
+    def find_variant(self, variant_or_name: str | Variant | None = None):  # noqa: ANN201
         """Find the variant with the given name or variant.
 
         Args:
@@ -435,7 +435,7 @@ class PluginDefinition(PluginRef):
 
         return self.get_variant(variant_or_name)
 
-    def variant_label(self, variant):
+    def variant_label(self, variant):  # noqa: ANN001, ANN201
         """Return label for specified variant.
 
         Args:
@@ -457,7 +457,7 @@ class PluginDefinition(PluginRef):
         return label
 
     @property
-    def variant_labels(self):
+    def variant_labels(self):  # noqa: ANN201
         """Return labels for supported variants.
 
         Returns:
@@ -519,7 +519,7 @@ class BasePlugin(HookObject):
         self._plugin_def = plugin_def
         self._variant = variant
 
-    def __eq__(self, other: BasePlugin):
+    def __eq__(self, other: BasePlugin):  # noqa: ANN204
         """Compare two plugins.
 
         Args:
@@ -538,7 +538,7 @@ class BasePlugin(HookObject):
         """
         return hash((self._plugin_def, self._variant))
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: ANN204
         """Iterate over the settings of the plugin.
 
         Yields:
@@ -546,7 +546,7 @@ class BasePlugin(HookObject):
         """
         yield from self._plugin_def
 
-    def __getattr__(self, attr: str):
+    def __getattr__(self, attr: str):  # noqa: ANN204
         """Get the value of the setting.
 
         Args:
@@ -579,7 +579,7 @@ class BasePlugin(HookObject):
         return self._variant.executable or self._plugin_def.name
 
     @property
-    def extras(self):
+    def extras(self):  # noqa: ANN201
         """Return the plugin extras.
 
         Returns:
@@ -588,7 +588,7 @@ class BasePlugin(HookObject):
         return {**self._plugin_def.extras, **self._variant.extras}
 
     @property
-    def all_commands(self):
+    def all_commands(self):  # noqa: ANN201
         """Return a dictionary of supported commands.
 
         Returns:
@@ -610,7 +610,7 @@ class BasePlugin(HookObject):
         }
 
     @property
-    def all_settings(self):
+    def all_settings(self):  # noqa: ANN201
         """Return a list of settings.
 
         Returns:
@@ -619,7 +619,7 @@ class BasePlugin(HookObject):
         return self._variant.settings
 
     @property
-    def extra_settings(self):
+    def extra_settings(self):  # noqa: ANN201
         """Return the extra settings for this plugin.
 
         Returns:
@@ -649,7 +649,7 @@ class BasePlugin(HookObject):
         return existing_settings
 
     @property
-    def all_requires(self):
+    def all_requires(self):  # noqa: ANN201
         """Return a list of requires.
 
         Returns:
@@ -660,7 +660,7 @@ class BasePlugin(HookObject):
     def env_prefixes(
         self,
         *,
-        for_writing=False,  # noqa: ARG002
+        for_writing=False,  # noqa: ANN001, ARG002
     ) -> list[str]:
         """Return environment variable prefixes to use for settings.
 
@@ -704,7 +704,7 @@ class BasePlugin(HookObject):
         """
         return True
 
-    def exec_args(
+    def exec_args(  # noqa: ANN201
         self,
         files: dict,  # noqa: ARG002
     ):
@@ -719,7 +719,7 @@ class BasePlugin(HookObject):
         return []
 
     @property
-    def config_files(self):
+    def config_files(self):  # noqa: ANN201
         """Return a list of stubbed files created for this plugin.
 
         Returns:
@@ -728,7 +728,7 @@ class BasePlugin(HookObject):
         return {}
 
     @property
-    def output_files(self):
+    def output_files(self):  # noqa: ANN201
         """Return a list of stubbed files created for this plugin.
 
         Returns:
@@ -736,7 +736,7 @@ class BasePlugin(HookObject):
         """
         return {}
 
-    def process_config(self, config):
+    def process_config(self, config):  # noqa: ANN001, ANN201
         """Process the config for this plugin.
 
         Args:
@@ -780,7 +780,7 @@ class StandalonePlugin(Canonical):
         commands: dict | None = None,
         requires: dict[PluginType, list] | None = None,
         env: dict[str, str] | None = None,
-        **extras,
+        **extras,  # noqa: ANN003
     ):
         """Create a locked plugin.
 
@@ -858,7 +858,7 @@ class StandalonePlugin(Canonical):
                 )
 
     @classmethod
-    def from_variant(
+    def from_variant(  # noqa: ANN206
         cls: type[StandalonePlugin],
         variant: Variant,
         plugin_def: PluginDefinition,

--- a/src/meltano/core/plugin/command.py
+++ b/src/meltano/core/plugin/command.py
@@ -16,7 +16,7 @@ TCommand = t.TypeVar("TCommand")
 class UndefinedEnvVarError(Error):
     """An environment variable is used as a command argument but is not set."""
 
-    def __init__(self, command_name, var):
+    def __init__(self, command_name, var) -> None:  # noqa: ANN001
         """Initialize UndefinedEnvVarError.
 
         Args:
@@ -58,7 +58,7 @@ class Command(Canonical):
         else:
             self.container_spec = None
 
-    def expanded_args(self, name, env):
+    def expanded_args(self, name, env):  # noqa: ANN001, ANN201
         """Replace any env var arguments with their values.
 
         Args:
@@ -82,7 +82,7 @@ class Command(Canonical):
         return expanded
 
     @classmethod
-    def as_canonical(cls, target):
+    def as_canonical(cls, target):  # noqa: ANN001, ANN206
         """Serialize the target command.
 
         Args:
@@ -100,7 +100,7 @@ class Command(Canonical):
         return canonical
 
     @classmethod
-    def parse(cls, obj):
+    def parse(cls, obj):  # noqa: ANN001, ANN206
         """Deserialize data into a Command.
 
         Args:

--- a/src/meltano/core/plugin/config_service.py
+++ b/src/meltano/core/plugin/config_service.py
@@ -30,7 +30,7 @@ class PluginConfigService:
         self.config_dir = Path(config_dir)
         self.run_dir = Path(run_dir)
 
-    def configure(self):
+    def configure(self):  # noqa: ANN201
         os.makedirs(self.run_dir, exist_ok=True)
 
         config_file = self.config_dir.joinpath

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -25,7 +25,7 @@ logger = structlog.stdlib.get_logger(__name__)
 class DbtInvoker(PluginInvoker):
     """dbt plugin invoker."""
 
-    def Popen_options(self):  # noqa: N802
+    def Popen_options(self):  # noqa: ANN201, N802
         """Get options for `subprocess.Popen`.
 
         Returns:
@@ -47,7 +47,7 @@ async def install_dbt_plugin(
     project: Project,
     plugin: ProjectPlugin,
     reason: PluginInstallReason,
-    **kwargs,  # noqa: ARG001
+    **kwargs,  # noqa: ANN003, ARG001
 ) -> None:
     """Install the transform into the project.
 
@@ -104,7 +104,7 @@ class DbtTransformPlugin(BasePlugin):
         SettingDefinition(name="_vars", kind=SettingKind.OBJECT, value={}),
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Initialize the `DbtTransformPlugin`.
 
         Args:

--- a/src/meltano/core/plugin/error.py
+++ b/src/meltano/core/plugin/error.py
@@ -10,7 +10,7 @@ from . import PluginRef
 class PluginNotFoundError(Exception):
     """Base exception when a plugin could not be found."""
 
-    def __init__(self, plugin_or_name):
+    def __init__(self, plugin_or_name) -> None:  # noqa: ANN001
         if isinstance(plugin_or_name, PluginRef):
             self.plugin_type = plugin_or_name.type.descriptor
             self.plugin_name = plugin_or_name.name
@@ -18,7 +18,7 @@ class PluginNotFoundError(Exception):
             self.plugin_type = "plugin"
             self.plugin_name = plugin_or_name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"{self.plugin_type.capitalize()} '{self.plugin_name}' is not "
             "known to Meltano"
@@ -28,12 +28,12 @@ class PluginNotFoundError(Exception):
 class PluginParentNotFoundError(Exception):
     """Base exception when a plugin's parent could not be found."""
 
-    def __init__(self, plugin, parent_not_found_error):
+    def __init__(self, plugin, parent_not_found_error) -> None:  # noqa: ANN001
         """Initialize exception for when plugin's parent could not be found."""
         self.plugin = plugin
         self.parent_not_found_error = parent_not_found_error
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"Could not find parent plugin for {self.plugin.type.descriptor} "
             f"'{self.plugin.name}': {self.parent_not_found_error}"
@@ -47,7 +47,7 @@ class PluginNotSupportedError(Exception):
         """Construct a PluginNotSupportedError instance."""
         self.plugin = plugin
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             "Operation not supported for "
             f"{self.plugin.type.descriptor} '{self.plugin.name}'"
@@ -65,7 +65,7 @@ class PluginLacksCapabilityError(Exception):
 class InvalidPluginDefinitionError(Exception):
     """Base exception when a plugin definition is invalid."""
 
-    def __init__(self, definition=None):
+    def __init__(self, definition=None) -> None:  # noqa: ANN001
         """Construct a new "InvalidPluginDefinitionError instance.
 
         Args:
@@ -82,5 +82,5 @@ class InvalidPluginDefinitionError(Exception):
         else:
             self.reason = "incorrect format"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Plugin definition is invalid: {self.reason}"

--- a/src/meltano/core/plugin/factory.py
+++ b/src/meltano/core/plugin/factory.py
@@ -7,7 +7,7 @@ import importlib
 from . import BasePlugin, PluginDefinition, PluginType, Variant
 
 
-def lazy_import(module: str, classname: str):
+def lazy_import(module: str, classname: str):  # noqa: ANN201
     """Lazily import a class.
 
     Args:
@@ -18,7 +18,7 @@ def lazy_import(module: str, classname: str):
         Function for lazily importing the given class.
     """
 
-    def lazy():
+    def lazy():  # noqa: ANN202
         return getattr(
             importlib.import_module(module, "meltano.core.plugin"),
             classname,

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -120,7 +120,7 @@ class FilePlugin(BasePlugin):
             A dictionary of file names and their contents.
         """
 
-        def with_update_header(content: str, relative_path: PathLike):
+        def with_update_header(content: str, relative_path: PathLike):  # noqa: ANN202
             return (
                 "\n\n".join([self.update_file_header(relative_path), content])
                 if any(relative_path.match(path) for path in paths_to_update)
@@ -192,7 +192,7 @@ class FilePlugin(BasePlugin):
             A dictionary of file names and their contents.
         """
 
-        def rename_if_exists(relative_path: Path):
+        def rename_if_exists(relative_path: Path):  # noqa: ANN202
             if not project.root_dir(relative_path).exists():
                 return relative_path
 
@@ -282,7 +282,7 @@ class FilePlugin(BasePlugin):
         install_service: PluginInstallService,
         plugin: ProjectPlugin,
         reason: PluginInstallReason,
-    ):
+    ) -> None:
         """Trigger after install tasks.
 
         Args:

--- a/src/meltano/core/plugin/meltano_file.py
+++ b/src/meltano/core/plugin/meltano_file.py
@@ -17,13 +17,13 @@ if t.TYPE_CHECKING:
 class MeltanoFilePlugin(FilePlugin):
     overwrite: t.ClassVar[set[str]] = {"meltano.yml"}
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the MeltanoFilePlugin."""
         super().__init__(None, None)
 
     def file_contents(
         self,
-        project,  # noqa: ARG002
+        project,  # noqa: ANN001, ARG002
     ) -> dict[Path, str]:
         """Get a mapping of paths to contents.
 
@@ -39,7 +39,7 @@ class MeltanoFilePlugin(FilePlugin):
                 for relative_path, content in yaml.safe_load(f).items()
             }
 
-    def update_config(self, project):  # noqa: ARG002
+    def update_config(self, project):  # noqa: ANN001, ANN201, ARG002
         return {}
 
     def files_to_create(

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -32,7 +32,7 @@ class CyclicInheritanceError(Exception):
         self.plugin = plugin
         self.ancestor = ancestor
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return error message.
 
         Returns:
@@ -69,9 +69,9 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         commands: dict | None = None,
         requires: dict[PluginType, list] | None = None,
         config: dict | None = None,
-        default_variant=Variant.ORIGINAL_NAME,
+        default_variant=Variant.ORIGINAL_NAME,  # noqa: ANN001
         env: dict[str, str] | None = None,
-        **extras,
+        **extras,  # noqa: ANN003
     ):
         """ProjectPlugin.
 
@@ -202,7 +202,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         return self._parent
 
     @parent.setter
-    def parent(self, new_parent):
+    def parent(self, new_parent) -> None:  # noqa: ANN001
         ancestor = new_parent
         while isinstance(ancestor, self.__class__):
             if ancestor == self:
@@ -274,7 +274,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         """
         return list(self.all_commands.keys())
 
-    def env_prefixes(self, *, for_writing=False) -> list[str]:
+    def env_prefixes(self, *, for_writing=False) -> list[str]:  # noqa: ANN001
         """Return environment variable prefixes.
 
         Args:
@@ -311,7 +311,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         return {**self.config, **self.extra_config}
 
     @config_with_extras.setter
-    def config_with_extras(self, new_config_with_extras):
+    def config_with_extras(self, new_config_with_extras) -> None:  # noqa: ANN001
         self.config.clear()
         self.extras.clear()
 

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -274,7 +274,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         """
         return list(self.all_commands.keys())
 
-    def env_prefixes(self, for_writing=False) -> list[str]:
+    def env_prefixes(self, *, for_writing=False) -> list[str]:
         """Return environment variable prefixes.
 
         Args:

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -21,8 +21,8 @@ class PluginSettingsService(SettingsService):
         self,
         project: Project,
         plugin: ProjectPlugin,
-        *args,
-        **kwargs,
+        *args,  # noqa: ANN002
+        **kwargs,  # noqa: ANN003
     ):
         """Create a new plugin settings manager.
 
@@ -94,7 +94,7 @@ class PluginSettingsService(SettingsService):
         self.env_override.update(environment_plugin_env)
 
     @property
-    def project_settings_service(self):
+    def project_settings_service(self):  # noqa: ANN201
         """Get the settings service for the active project.
 
         Returns:
@@ -103,7 +103,7 @@ class PluginSettingsService(SettingsService):
         return self.project.settings
 
     @property
-    def label(self):
+    def label(self) -> str:
         """Get the label for this plugin.
 
         Returns:
@@ -112,7 +112,7 @@ class PluginSettingsService(SettingsService):
         return f"{self.plugin.type.descriptor} '{self.plugin.name}'"
 
     @property
-    def docs_url(self):
+    def docs_url(self):  # noqa: ANN201
         """Get the documentation URL for this plugin.
 
         Returns:
@@ -120,7 +120,7 @@ class PluginSettingsService(SettingsService):
         """
         return self.plugin.docs
 
-    def setting_env_vars(self, setting_def: SettingDefinition, *, for_writing=False):
+    def setting_env_vars(self, setting_def: SettingDefinition, *, for_writing=False):  # noqa: ANN001, ANN201
         """Get environment variables for a setting.
 
         Args:
@@ -137,7 +137,7 @@ class PluginSettingsService(SettingsService):
         )
 
     @property
-    def db_namespace(self):
+    def db_namespace(self):  # noqa: ANN201
         """Return namespace for setting value records in system database.
 
         Returns:
@@ -163,7 +163,7 @@ class PluginSettingsService(SettingsService):
         return settings
 
     @property
-    def meltano_yml_config(self):
+    def meltano_yml_config(self):  # noqa: ANN201
         """Return current configuration in `meltano.yml`.
 
         Returns:
@@ -172,7 +172,7 @@ class PluginSettingsService(SettingsService):
         return self.plugin.config_with_extras
 
     @property
-    def environment_config(self):
+    def environment_config(self):  # noqa: ANN201
         """Return current environment configuration in `meltano.yml`.
 
         Returns:
@@ -182,7 +182,7 @@ class PluginSettingsService(SettingsService):
             return self.environment_plugin_config.config_with_extras
         return {}
 
-    def update_meltano_yml_config(self, config_with_extras):
+    def update_meltano_yml_config(self, config_with_extras) -> None:  # noqa: ANN001
         """Update configuration in `meltano.yml`.
 
         Args:
@@ -191,7 +191,10 @@ class PluginSettingsService(SettingsService):
         self.plugin.config_with_extras = config_with_extras
         self.project.plugins.update_plugin(self.plugin)
 
-    def update_meltano_environment_config(self, config_with_extras: dict[str, t.Any]):
+    def update_meltano_environment_config(
+        self,
+        config_with_extras: dict[str, t.Any],
+    ) -> None:
         """Update environment configuration in `meltano.yml`.
 
         Args:
@@ -201,7 +204,7 @@ class PluginSettingsService(SettingsService):
         self.project.plugins.update_environment_plugin(self.environment_plugin_config)
 
     @cached_property
-    def inherited_settings_service(self):
+    def inherited_settings_service(self):  # noqa: ANN201
         """Return settings service to inherit configuration from.
 
         Returns:
@@ -217,7 +220,7 @@ class PluginSettingsService(SettingsService):
             else None
         )
 
-    def process_config(self, config):
+    def process_config(self, config):  # noqa: ANN001, ANN201
         """Process configuration dictionary to be passed to plugin.
 
         Args:

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -120,7 +120,7 @@ class PluginSettingsService(SettingsService):
         """
         return self.plugin.docs
 
-    def setting_env_vars(self, setting_def: SettingDefinition, for_writing=False):
+    def setting_env_vars(self, setting_def: SettingDefinition, *, for_writing=False):
         """Get environment variables for a setting.
 
         Args:

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -13,7 +13,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 class SingerPlugin(BasePlugin):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Initialize a `SingerPlugin`.
 
         Args:
@@ -26,7 +26,7 @@ class SingerPlugin(BasePlugin):
         # errors from Canonical.
         self._instance_uuid: str | None = None
 
-    def process_config(self, flat_config):
+    def process_config(self, flat_config):  # noqa: ANN001, ANN201
         non_null_config = {k: v for k, v in flat_config.items() if v is not None}
         processed_config = nest_object(non_null_config)
         # Result at this point will contain duplicate entries for nested config
@@ -46,9 +46,9 @@ class SingerPlugin(BasePlugin):
     @hook("before_configure")
     async def before_configure(
         self,
-        invoker,
-        session,  # noqa: ARG002
-    ):
+        invoker,  # noqa: ANN001
+        session,  # noqa: ANN001, ARG002
+    ) -> None:
         """Create configuration file."""
         config_path = invoker.files["config"]
         with open(config_path, "w") as config_file:
@@ -58,14 +58,14 @@ class SingerPlugin(BasePlugin):
         logger.debug(f"Created configuration at {config_path}")  # noqa: G004
 
     @hook("before_cleanup")
-    async def before_cleanup(self, invoker):
+    async def before_cleanup(self, invoker) -> None:  # noqa: ANN001
         """Delete configuration file."""
         config_path = invoker.files["config"]
         config_path.unlink()
         logger.debug(f"Deleted configuration at {config_path}")  # noqa: G004
 
     @property
-    def instance_uuid(self):
+    def instance_uuid(self):  # noqa: ANN201
         """Multiple processes running at the same time have a unique value to use."""
         if not self._instance_uuid:
             self._instance_uuid = str(uuid4())

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -37,6 +37,7 @@ class CatalogRule:
         self,
         tap_stream_id: str | list[str],
         breadcrumb: list[str] | None = None,
+        *,
         negated: bool = False,
     ):
         """Create a catalog rule for a stream and property."""
@@ -92,6 +93,7 @@ class MetadataRule(CatalogRule):
         tap_stream_id: str | list[str],
         breadcrumb: list[str] | None,
         key: str,
+        *,
         value: bool,
         negated: bool = False,
     ):
@@ -107,6 +109,7 @@ class SchemaRule(CatalogRule):
         tap_stream_id: str | list[str],
         breadcrumb: list[str] | None,
         payload: dict,
+        *,
         negated: bool = False,
     ):
         """Create a schema rule for a stream and property."""

--- a/src/meltano/core/plugin/singer/mapper.py
+++ b/src/meltano/core/plugin/singer/mapper.py
@@ -38,12 +38,12 @@ class SingerMapper(SingerPlugin):
         ),
     ]
 
-    def exec_args(self, plugin_invoker: PluginInvoker):
+    def exec_args(self, plugin_invoker: PluginInvoker):  # noqa: ANN201
         """Return the arguments to be passed to the plugin's executable."""
         return ["--config", plugin_invoker.files["config"]]
 
     @property
-    def config_files(self):
+    def config_files(self):  # noqa: ANN201
         """Return the configuration files required by the plugin."""
         return {"config": f"mapper.{self.instance_uuid}.config.json"}
 
@@ -51,8 +51,8 @@ class SingerMapper(SingerPlugin):
     async def before_configure(
         self,
         invoker: PluginInvoker,
-        session,  # noqa: ARG002
-    ):
+        session,  # noqa: ANN001, ARG002
+    ) -> None:
         """Create configuration file."""
         config_path = invoker.files["config"]
 

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -46,9 +46,9 @@ logger = structlog.getLogger(__name__)
 
 async def _stream_redirect(
     stream: asyncio.StreamReader | None,
-    *file_like_objs,
-    write_str=False,
-):
+    *file_like_objs,  # noqa: ANN002
+    write_str=False,  # noqa: ANN001
+) -> None:
     """Redirect stream to a file like obj.
 
     Args:
@@ -67,7 +67,7 @@ def _debug_logging_handler(
     name: str,
     plugin_invoker: PluginInvoker,
     stderr: StreamReader,
-    *other_dsts,
+    *other_dsts,  # noqa: ANN002
 ) -> asyncio.Task:
     """Route debug log lines.
 
@@ -109,7 +109,7 @@ def _debug_logging_handler(
         )
 
 
-def config_metadata_rules(config):
+def config_metadata_rules(config):  # noqa: ANN001, ANN201
     """Get metadata rules from config.
 
     Args:
@@ -141,7 +141,7 @@ def config_metadata_rules(config):
     return rules
 
 
-def config_schema_rules(config):
+def config_schema_rules(config):  # noqa: ANN001, ANN201
     """Get schema rules from config.
 
     Args:
@@ -192,7 +192,7 @@ class SingerTap(SingerPlugin):
         ),
     ]
 
-    def exec_args(self, plugin_invoker):
+    def exec_args(self, plugin_invoker):  # noqa: ANN001, ANN201
         """Return the arguments list with the complete runtime paths.
 
         Args:
@@ -229,7 +229,7 @@ class SingerTap(SingerPlugin):
         return args
 
     @property
-    def config_files(self):
+    def config_files(self):  # noqa: ANN201
         """Get the configuration files for this tap."""
         return {
             "config": f"tap.{self.instance_uuid}.config.json",
@@ -239,7 +239,7 @@ class SingerTap(SingerPlugin):
         }
 
     @property
-    def output_files(self):
+    def output_files(self):  # noqa: ANN201
         """Get the output files for this tap."""
         return {"output": "tap.out"}
 
@@ -248,7 +248,7 @@ class SingerTap(SingerPlugin):
         self,
         plugin_invoker: PluginInvoker,
         exec_args: tuple[str, ...] = (),
-    ):
+    ) -> None:
         """Look up state before being invoked if in sync mode.
 
         Args:
@@ -268,7 +268,7 @@ class SingerTap(SingerPlugin):
     async def look_up_state(
         self,
         plugin_invoker: PluginInvoker,
-    ):
+    ) -> None:
         """Look up state, cleaning up and refreshing as needed.
 
         Args:
@@ -346,7 +346,7 @@ class SingerTap(SingerPlugin):
         self,
         plugin_invoker: PluginInvoker,
         exec_args: tuple[str, ...] = (),
-    ):
+    ) -> None:
         """Discover Singer catalog before invoking tap if in sync mode.
 
         Args:
@@ -366,7 +366,7 @@ class SingerTap(SingerPlugin):
     async def discover_catalog(  # ,
         self,
         plugin_invoker: PluginInvoker,
-    ):
+    ) -> None:
         """Perform catalog discovery.
 
         Args:
@@ -434,7 +434,7 @@ class SingerTap(SingerPlugin):
         self,
         plugin_invoker: PluginInvoker,
         catalog_path: Path,
-    ):
+    ) -> None:
         """Run tap in discovery mode and store the result.
 
         Args:
@@ -513,7 +513,7 @@ class SingerTap(SingerPlugin):
         self,
         plugin_invoker: PluginInvoker,
         exec_args: tuple[str, ...] = (),
-    ):
+    ) -> None:
         """Apply catalog rules before invoke if in sync mode.
 
         Args:
@@ -534,7 +534,7 @@ class SingerTap(SingerPlugin):
         self,
         plugin_invoker: PluginInvoker,
         exec_args: tuple[str, ...] = (),  # noqa: ARG002
-    ):
+    ) -> None:
         """Apply Singer catalog and schema rules to discovered catalog.
 
         Args:
@@ -608,7 +608,7 @@ class SingerTap(SingerPlugin):
                 f"Applying catalog rules failed: catalog file is invalid: {err}",  # noqa: EM102
             ) from err
 
-    def catalog_cache_key(self, plugin_invoker):
+    def catalog_cache_key(self, plugin_invoker):  # noqa: ANN001, ANN201
         """Get a cache key for the catalog.
 
         Args:
@@ -649,7 +649,7 @@ class SingerTap(SingerPlugin):
 
     @staticmethod
     @lru_cache
-    def _warn_missing_stream(stream_id: str):
+    def _warn_missing_stream(stream_id: str) -> None:
         logger.warning(
             "Stream `%s` was not found in the catalog",
             stream_id,
@@ -657,7 +657,7 @@ class SingerTap(SingerPlugin):
 
     @staticmethod
     @lru_cache
-    def _warn_missing_property(stream_id: str, breadcrumb: tuple[str, ...]):
+    def _warn_missing_property(stream_id: str, breadcrumb: tuple[str, ...]) -> None:
         logger.warning(
             "Property `%s` was not found in the schema of stream `%s`",
             ".".join(breadcrumb[1:]),
@@ -668,7 +668,7 @@ class SingerTap(SingerPlugin):
         self,
         rules: list[MetadataRule],
         catalog: CatalogDict,
-    ):
+    ) -> None:
         """Validate MetadataRules conforms to discovered Catalog.
 
         Validate MetadataRules against the tap's discovered Catalog & emit
@@ -690,10 +690,10 @@ class SingerTap(SingerPlugin):
             if isinstance(stream, dict)
         }
 
-        def is_not_star(x):
+        def is_not_star(x):  # noqa: ANN001, ANN202
             return "*" not in x
 
-        def dict_get(dictionary, key):
+        def dict_get(dictionary, key):  # noqa: ANN001, ANN202
             return dictionary.get(key, {})
 
         for rule in rules:

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -50,7 +50,7 @@ class BookmarkWriter:
         self.state_service = state_service or StateService(session=self.session)
         self.payload_flag = payload_flag
 
-    def writeline(self, line: str):
+    def writeline(self, line: str) -> None:
         """Persist a state entry.
 
         Args:
@@ -103,7 +103,7 @@ class SingerTarget(SingerPlugin):
         SettingDefinition(name="_dialect", value="$MELTANO_LOADER_NAMESPACE"),
     ]
 
-    def exec_args(self, plugin_invoker):
+    def exec_args(self, plugin_invoker):  # noqa: ANN001, ANN201
         """Get command-line args to pass to the plugin.
 
         Args:
@@ -115,7 +115,7 @@ class SingerTarget(SingerPlugin):
         return ["--config", plugin_invoker.files["config"]]
 
     @property
-    def config_files(self):
+    def config_files(self):  # noqa: ANN201
         """Get config files for this target.
 
         Returns:
@@ -124,7 +124,7 @@ class SingerTarget(SingerPlugin):
         return {"config": f"target.{self.instance_uuid}.config.json"}
 
     @property
-    def output_files(self):
+    def output_files(self):  # noqa: ANN201
         """Get output files for this target.
 
         Returns:
@@ -137,7 +137,7 @@ class SingerTarget(SingerPlugin):
         self,
         plugin_invoker: PluginInvoker,
         exec_args: list[str],
-    ):
+    ) -> None:
         """Before invoke hook to trigger setting up the bookmark writer for this target.
 
         Args:
@@ -152,7 +152,7 @@ class SingerTarget(SingerPlugin):
 
         self.setup_bookmark_writer(plugin_invoker)
 
-    def setup_bookmark_writer(self, plugin_invoker: PluginInvoker):
+    def setup_bookmark_writer(self, plugin_invoker: PluginInvoker) -> None:
         """Configure the bookmark writer.
 
         If running in a pipeline context, we configure the bookmark writer as

--- a/src/meltano/core/plugin/superset.py
+++ b/src/meltano/core/plugin/superset.py
@@ -22,7 +22,7 @@ logger = structlog.getLogger(__name__)
 class SupersetInvoker(PluginInvoker):
     """Invoker that prepares env for Superset."""
 
-    def env(self):
+    def env(self):  # noqa: ANN201
         """Environment variables for Superset.
 
         Returns:
@@ -49,7 +49,7 @@ class Superset(BasePlugin):
     ]
 
     @property
-    def config_files(self):
+    def config_files(self):  # noqa: ANN201
         """Return the configuration files required by the plugin.
 
         Returns:
@@ -61,8 +61,8 @@ class Superset(BasePlugin):
     async def before_configure(
         self,
         invoker: SupersetInvoker,
-        session,  # noqa: ARG002
-    ):
+        session,  # noqa: ANN001, ARG002
+    ) -> None:
         """Write plugin configuration to superset_config.py.
 
         Args:
@@ -115,7 +115,7 @@ class Superset(BasePlugin):
         self,
         invoker: PluginInvoker,
         exec_args: list[str],  # noqa: ARG002
-    ):
+    ) -> None:
         """Create or upgrade metadata database.
 
         Args:
@@ -149,7 +149,7 @@ class Superset(BasePlugin):
         self,
         invoker: PluginInvoker,
         exec_args: list[str],  # noqa: ARG002
-    ):
+    ) -> None:
         """Create default roles and permissions.
 
         Args:
@@ -178,7 +178,7 @@ class Superset(BasePlugin):
         logger.debug("Completed `superset init`")
 
     @hook("before_cleanup")
-    async def before_cleanup(self, invoker: PluginInvoker):
+    async def before_cleanup(self, invoker: PluginInvoker) -> None:
         """Delete the config file.
 
         Args:

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -145,6 +145,7 @@ class PluginInstallService:
         self,
         project: Project,
         status_cb: t.Callable[[PluginInstallState], t.Any] = noop,
+        *,
         parallelism: int | None = None,
         clean: bool = False,
         force: bool = False,
@@ -559,7 +560,7 @@ async def install_pip_plugin(
         ValueError: If the venv backend is not supported.
     """
     pip_install_args = get_pip_install_args(project, plugin, env=env)
-    backend = project.settings.get("venv.backend", "virtualenv")
+    backend = project.settings.get("venv.backend")
 
     if backend == "virtualenv":
         service = VenvService(

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -80,7 +80,7 @@ class PluginInstallState:
     details: str | None = None
 
     @cached_property
-    def successful(self):
+    def successful(self):  # noqa: ANN201
         """Plugin install success status.
 
         Returns:
@@ -89,7 +89,7 @@ class PluginInstallState:
         return self.status in {PluginInstallStatus.SUCCESS, PluginInstallStatus.SKIPPED}
 
     @cached_property
-    def skipped(self):
+    def skipped(self):  # noqa: ANN201
         """Plugin install skipped status.
 
         Returns:
@@ -120,7 +120,7 @@ class PluginInstallState:
         return "Errored"
 
 
-def with_semaphore(func):
+def with_semaphore(func):  # noqa: ANN001, ANN201
     """Gate access to the method using its class's semaphore.
 
     Args:
@@ -131,7 +131,7 @@ def with_semaphore(func):
     """
 
     @functools.wraps(func)
-    async def wrapper(self, *args, **kwargs):
+    async def wrapper(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
         async with self.semaphore:
             return await func(self, *args, **kwargs)
 
@@ -179,7 +179,7 @@ class PluginInstallService:
         return self._parallelism
 
     @cached_property
-    def semaphore(self):
+    def semaphore(self):  # noqa: ANN201
         """An asyncio semaphore with a counter starting at `self.parallelism`.
 
         Returns:
@@ -188,7 +188,7 @@ class PluginInstallService:
         return asyncio.Semaphore(self.parallelism)
 
     @staticmethod
-    def remove_duplicates(
+    def remove_duplicates(  # noqa: ANN205
         plugins: t.Iterable[ProjectPlugin],
         reason: PluginInstallReason,
     ):
@@ -230,7 +230,7 @@ class PluginInstallService:
 
     async def install_all_plugins(
         self,
-        reason=PluginInstallReason.INSTALL,
+        reason=PluginInstallReason.INSTALL,  # noqa: ANN001
     ) -> tuple[PluginInstallState]:
         """
         Install all the plugins for the project.
@@ -248,7 +248,7 @@ class PluginInstallService:
     async def install_plugins(
         self,
         plugins: t.Iterable[ProjectPlugin],
-        reason=PluginInstallReason.INSTALL,
+        reason=PluginInstallReason.INSTALL,  # noqa: ANN001
     ) -> tuple[PluginInstallState]:
         """Install all the provided plugins.
 
@@ -273,7 +273,7 @@ class PluginInstallService:
     def install_plugin(
         self,
         plugin: ProjectPlugin,
-        reason=PluginInstallReason.INSTALL,
+        reason=PluginInstallReason.INSTALL,  # noqa: ANN001
     ) -> PluginInstallState:
         """
         Install a plugin.
@@ -298,7 +298,7 @@ class PluginInstallService:
     async def install_plugin_async(
         self,
         plugin: ProjectPlugin,
-        reason=PluginInstallReason.INSTALL,
+        reason=PluginInstallReason.INSTALL,  # noqa: ANN001
     ) -> PluginInstallState:
         """Install a plugin asynchronously.
 
@@ -494,7 +494,7 @@ class PluginInstaller(t.Protocol):
         *,
         project: Project,
         plugin: ProjectPlugin,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ) -> None:
         """Install the plugin.
 
@@ -544,8 +544,8 @@ async def install_pip_plugin(
     clean: bool = False,
     force: bool = False,
     env: t.Mapping[str, str] | None = None,
-    **kwargs,  # noqa: ARG001
-):
+    **kwargs,  # noqa: ANN003, ARG001
+) -> None:
     """Install the plugin with pip.
 
     Args:

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -33,7 +33,7 @@ if t.TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def invoker_factory(project, plugin: ProjectPlugin, *args, **kwargs):
+def invoker_factory(project, plugin: ProjectPlugin, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN201
     """Instantiate a plugin invoker from a project plugin.
 
     Args:
@@ -85,7 +85,7 @@ class InvokerNotPreparedError(InvokerError):
 class UnknownCommandError(InvokerError):
     """Occurs when `invoke` is called in command mode with an undefined command."""
 
-    def __init__(self, plugin: PluginRef, command):
+    def __init__(self, plugin: PluginRef, command):  # noqa: ANN001
         """Initialize UnknownCommandError.
 
         Args:
@@ -95,7 +95,7 @@ class UnknownCommandError(InvokerError):
         self.plugin = plugin
         self.command = command
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return error message.
 
         Returns:
@@ -131,7 +131,7 @@ class PluginInvoker:
         self,
         project: Project,
         plugin: ProjectPlugin,
-        context: t.Any | None = None,
+        context: t.Any | None = None,  # noqa: ANN401
         output_handlers: dict | None = None,
         run_dir: Path | None = None,
         config_dir: Path | None = None,
@@ -184,7 +184,7 @@ class PluginInvoker:
         self.plugin_config_env = {}
 
     @property
-    def capabilities(self):
+    def capabilities(self):  # noqa: ANN201
         """Get plugin immutable capabilities.
 
         Makes sure the capabilities are immutable from the `PluginInvoker` interface.
@@ -207,7 +207,7 @@ class PluginInvoker:
             for _key, filename in plugin_files.items()
         }
 
-    async def prepare(self, session: Session):
+    async def prepare(self, session: Session) -> None:
         """Prepare plugin config.
 
         Args:
@@ -231,7 +231,7 @@ class PluginInvoker:
             self.plugin_config_service.configure()
             self._prepared = True
 
-    async def cleanup(self):
+    async def cleanup(self) -> None:
         """Reset the plugin config."""
         self.plugin_config = {}
         self.plugin_config_processed = {}
@@ -242,7 +242,7 @@ class PluginInvoker:
             self._prepared = False
 
     @asynccontextmanager
-    async def prepared(self, session: Session):
+    async def prepared(self, session: Session):  # noqa: ANN201
         """Context manager that prepares plugin config.
 
         Args:
@@ -280,7 +280,7 @@ class PluginInvoker:
         # Return executable within venv
         return self.venv_service.exec_path(executable)
 
-    def exec_args(self, *args, command=None, env=None):
+    def exec_args(self, *args, command=None, env=None):  # noqa: ANN001, ANN002, ANN201
         """Materialize the arguments to be passed to the executable.
 
         Args:
@@ -303,7 +303,7 @@ class PluginInvoker:
 
         return [str(arg) for arg in (executable, *plugin_args, *args)]
 
-    def find_command(self, name):
+    def find_command(self, name):  # noqa: ANN001, ANN201
         """Find a Command by name.
 
         Args:
@@ -320,7 +320,7 @@ class PluginInvoker:
         except KeyError as err:
             raise UnknownCommandError(self.plugin, name) from err
 
-    def env(self):
+    def env(self):  # noqa: ANN201
         """Environment variable mapping.
 
         Returns:
@@ -418,7 +418,7 @@ class PluginInvoker:
         require_preparation: bool = True,
         env: dict[str, t.Any] | None = None,
         command: str | None = None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ) -> t.Generator[list[str], dict[str, t.Any], dict[str, t.Any]]:
         env = env or {}
 
@@ -439,7 +439,7 @@ class PluginInvoker:
                     self.plugin.executable,
                 ) from err
 
-    async def invoke_async(self, *args, **kwargs) -> asyncio.subprocess.Process:
+    async def invoke_async(self, *args, **kwargs) -> asyncio.subprocess.Process:  # noqa: ANN002, ANN003
         """Invoke a command.
 
         Args:
@@ -463,8 +463,8 @@ class PluginInvoker:
     async def invoke_docker(
         self,
         plugin_command: str,
-        *args,
-        **kwargs,
+        *args,  # noqa: ANN002
+        **kwargs,  # noqa: ANN003
     ) -> int:
         """Invoke a containerized command.
 
@@ -519,7 +519,7 @@ class PluginInvoker:
             # Unwrap FileNotFoundError
             raise err.__cause__ from None
 
-    def add_output_handler(self, src: str, handler: SubprocessOutputWriter):
+    def add_output_handler(self, src: str, handler: SubprocessOutputWriter) -> None:
         """Append an output handler for a given stdio stream.
 
         Args:

--- a/src/meltano/core/plugin_location_remove.py
+++ b/src/meltano/core/plugin_location_remove.py
@@ -32,7 +32,7 @@ class PluginLocationRemoveStatus(Enum):
 class PluginLocationRemoveManager(ABC):
     """Handle removal of a plugin from a given location."""
 
-    def __init__(self, plugin: ProjectPlugin, location):
+    def __init__(self, plugin: ProjectPlugin, location):  # noqa: ANN001
         """Construct a PluginLocationRemoveManager instance.
 
         Args:
@@ -46,7 +46,7 @@ class PluginLocationRemoveManager(ABC):
         self.remove_message = None
 
     @abstractmethod
-    def remove(self):
+    def remove(self):  # noqa: ANN201
         """Abstract remove method."""
 
     @property
@@ -80,7 +80,7 @@ class PluginLocationRemoveManager(ABC):
 class DbRemoveManager(PluginLocationRemoveManager):
     """Handle removal from the system db `plugin_settings` table."""
 
-    def __init__(self, plugin, project):
+    def __init__(self, plugin, project) -> None:  # noqa: ANN001
         """Construct a DbRemoveManager instance.
 
         Args:
@@ -91,7 +91,7 @@ class DbRemoveManager(PluginLocationRemoveManager):
         self.plugins_settings_service = PluginSettingsService(project, plugin)
         self.session = project_engine(project)[1]
 
-    def remove(self):
+    def remove(self) -> None:
         """Remove the plugin's settings from the system db `plugin_settings` table.
 
         Returns:
@@ -114,7 +114,7 @@ class DbRemoveManager(PluginLocationRemoveManager):
 class MeltanoYmlRemoveManager(PluginLocationRemoveManager):
     """Handle removal of a plugin from `meltano.yml`."""
 
-    def __init__(self, plugin, project: Project):
+    def __init__(self, plugin, project: Project):  # noqa: ANN001
         """Construct a MeltanoYmlRemoveManager instance.
 
         Args:
@@ -124,7 +124,7 @@ class MeltanoYmlRemoveManager(PluginLocationRemoveManager):
         super().__init__(plugin, str(project.meltanofile.relative_to(project.root)))
         self.project = project
 
-    def remove(self):
+    def remove(self) -> None:
         """Remove the plugin from `meltano.yml`."""
         try:
             self.project.plugins.remove_from_file(self.plugin)
@@ -142,7 +142,7 @@ class MeltanoYmlRemoveManager(PluginLocationRemoveManager):
 class LockedDefinitionRemoveManager(PluginLocationRemoveManager):
     """Handle removal of a plugin locked definition from `plugins/`."""
 
-    def __init__(self, plugin, project: Project):
+    def __init__(self, plugin, project: Project):  # noqa: ANN001
         """Construct a LockedDefinitionRemoveManager instance.
 
         Args:
@@ -158,7 +158,7 @@ class LockedDefinitionRemoveManager(PluginLocationRemoveManager):
 
         self.paths = list(lockfile_dir.glob(glob_expr))
 
-    def remove(self):
+    def remove(self) -> None:
         """Remove the plugin from `plugins/`."""
         if not self.paths:
             self.remove_status = PluginLocationRemoveStatus.NOT_FOUND
@@ -178,7 +178,7 @@ class LockedDefinitionRemoveManager(PluginLocationRemoveManager):
 class InstallationRemoveManager(PluginLocationRemoveManager):
     """Handle removal of a plugin installation from `.meltano`."""
 
-    def __init__(self, plugin, project: Project):
+    def __init__(self, plugin, project: Project):  # noqa: ANN001
         """Construct a InstallationRemoveManager instance.
 
         Args:
@@ -189,7 +189,7 @@ class InstallationRemoveManager(PluginLocationRemoveManager):
         super().__init__(plugin, str(path.parent.relative_to(project.root)))
         self.path = path
 
-    def remove(self):
+    def remove(self) -> None:
         """Remove the plugin installation from `.meltano`."""
         if not self.path.exists():
             self.remove_status = PluginLocationRemoveStatus.NOT_FOUND

--- a/src/meltano/core/plugin_location_remove.py
+++ b/src/meltano/core/plugin_location_remove.py
@@ -42,7 +42,7 @@ class PluginLocationRemoveManager(ABC):
         self.plugin = plugin
         self.plugin_descriptor = f"{plugin.type.descriptor} '{plugin.name}'"
         self.location = location
-        self.remove_status = None
+        self.remove_status: PluginLocationRemoveStatus | None = None
         self.remove_message = None
 
     @abstractmethod

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -64,6 +64,7 @@ class PluginLock:
 
     def load(
         self,
+        *,
         create: bool = False,
         loader: t.Callable = lambda x: StandalonePlugin(**json.load(x)),
     ) -> StandalonePlugin:

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -82,7 +82,7 @@ class PluginLock:
             The loaded plugin.
         """
 
-        def _load():
+        def _load():  # noqa: ANN202
             with open(self.path) as lockfile:
                 return loader(lockfile)
 
@@ -120,7 +120,7 @@ class PluginLockService:
         plugin: ProjectPlugin,
         *,
         exists_ok: bool = False,
-    ):
+    ) -> None:
         """Save the plugin lockfile.
 
         Args:

--- a/src/meltano/core/plugin_remove_service.py
+++ b/src/meltano/core/plugin_remove_service.py
@@ -32,8 +32,8 @@ class PluginRemoveService:
     def remove_plugins(
         self,
         plugins: t.Sequence[ProjectPlugin],
-        plugin_status_cb=noop,
-        removal_manager_status_cb=noop,
+        plugin_status_cb=noop,  # noqa: ANN001
+        removal_manager_status_cb=noop,  # noqa: ANN001
     ) -> tuple[int, int]:
         """
         Remove multiple plugins.

--- a/src/meltano/core/plugin_repository.py
+++ b/src/meltano/core/plugin_repository.py
@@ -56,7 +56,7 @@ class PluginRepository(metaclass=ABCMeta):
     def get_base_plugin(
         self,
         project_plugin: ProjectPlugin,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ) -> BasePlugin:
         """Get the base plugin for a project plugin.
 

--- a/src/meltano/core/plugin_test_service.py
+++ b/src/meltano/core/plugin_test_service.py
@@ -29,7 +29,7 @@ class PluginTestServiceFactory:
         """
         self.plugin_invoker = plugin_invoker
 
-    def get_test_service(self):
+    def get_test_service(self):  # noqa: ANN201
         """Resolve a test service instance for a plugin type.
 
         Returns:

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -80,6 +80,7 @@ class Project(Versioned):
         self,
         root: StrPath,
         environment: Environment | None = None,
+        *,
         readonly: bool = False,
     ):
         """Initialize a `Project` instance.
@@ -257,7 +258,7 @@ class Project(Versioned):
 
     @classmethod
     @fasteners.locked(lock="_find_lock")
-    def find(cls, project_root: Path | str | None = None, activate=True):
+    def find(cls, project_root: Path | str | None = None, *, activate=True):
         """Find a Project.
 
         Args:

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -51,7 +51,7 @@ PROJECT_READONLY_ENV = "MELTANO_PROJECT_READONLY"
 PROJECT_SYS_DIR_ROOT_ENV = "MELTANO_SYS_DIR_ROOT"
 
 
-def walk_parent_directories():
+def walk_parent_directories():  # noqa: ANN201
     """Yield each directory starting with the current up to the root.
 
     Yields:
@@ -97,7 +97,7 @@ class Project(Versioned):
             os.getenv(PROJECT_SYS_DIR_ROOT_ENV, self.root / ".meltano"),
         ).resolve()
 
-    def refresh(self, **kwargs) -> None:
+    def refresh(self, **kwargs) -> None:  # noqa: ANN003
         """Refresh the project instance to reflect external changes.
 
         This should be called whenever env vars change, project files change,
@@ -126,7 +126,7 @@ class Project(Versioned):
         self.__dict__.update(cls(**kwargs).__dict__)
 
     @cached_property
-    def config_service(self):
+    def config_service(self):  # noqa: ANN201
         """Get the project config service.
 
         Returns:
@@ -144,7 +144,7 @@ class Project(Versioned):
         return ProjectFiles(root=self.root, meltano_file_path=self.meltanofile)
 
     @cached_property
-    def settings(self):
+    def settings(self):  # noqa: ANN201
         """Get the project settings.
 
         Returns:
@@ -153,7 +153,7 @@ class Project(Versioned):
         return ProjectSettingsService(self)
 
     @cached_property
-    def plugins(self):
+    def plugins(self):  # noqa: ANN201
         """Get the project plugins.
 
         Returns:
@@ -162,7 +162,7 @@ class Project(Versioned):
         return ProjectPluginsService(self)
 
     @cached_property
-    def hub_service(self):
+    def hub_service(self):  # noqa: ANN201
         """Get the Meltano Hub service.
 
         Returns:
@@ -171,11 +171,11 @@ class Project(Versioned):
         return MeltanoHubService(self)
 
     @cached_property
-    def _meltano_interprocess_lock(self):
+    def _meltano_interprocess_lock(self):  # noqa: ANN202
         return fasteners.InterProcessLock(self.run_dir("meltano.yml.lock"))
 
     @property
-    def env(self):
+    def env(self):  # noqa: ANN201
         """Get environment variables for this project.
 
         Returns:
@@ -190,7 +190,7 @@ class Project(Versioned):
 
     @classmethod
     @fasteners.locked(lock="_activate_lock")
-    def activate(cls, project: Project):
+    def activate(cls, project: Project) -> None:
         """Activate the given Project.
 
         Args:
@@ -243,12 +243,12 @@ class Project(Versioned):
         cls._default = project
 
     @classmethod
-    def deactivate(cls):
+    def deactivate(cls) -> None:
         """Deactivate the given Project."""
         cls._default = None
 
     @property
-    def file_version(self):
+    def file_version(self):  # noqa: ANN201
         """Get the version of Meltano found in this project's meltano.yml.
 
         Returns:
@@ -258,7 +258,7 @@ class Project(Versioned):
 
     @classmethod
     @fasteners.locked(lock="_find_lock")
-    def find(cls, project_root: Path | str | None = None, *, activate=True):
+    def find(cls, project_root: Path | str | None = None, *, activate=True):  # noqa: ANN001, ANN206
         """Find a Project.
 
         Args:
@@ -322,7 +322,7 @@ class Project(Versioned):
             return MeltanoFile.parse(self.project_files.load())
 
     @contextmanager
-    def meltano_update(self):
+    def meltano_update(self):  # noqa: ANN201
         """Yield the current meltano configuration.
 
         Update the meltanofile if the context ends gracefully.
@@ -406,7 +406,7 @@ class Project(Versioned):
             self.refresh(environment=None)
 
     @contextmanager
-    def dotenv_update(self):
+    def dotenv_update(self):  # noqa: ANN201
         """Raise error if project is readonly.
 
         Used in context where .env files would be updated.
@@ -502,7 +502,7 @@ class Project(Versioned):
         return self.meltano_dir("logs", *joinpaths, make_dirs=make_dirs)
 
     @makedirs
-    def job_dir(self, state_id, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
+    def job_dir(self, state_id, *joinpaths: StrPath, make_dirs: bool = True) -> Path:  # noqa: ANN001
         """Path to the `elt` directory in `.meltano/run`.
 
         Args:
@@ -523,7 +523,7 @@ class Project(Versioned):
     @makedirs
     def job_logs_dir(
         self,
-        state_id,
+        state_id,  # noqa: ANN001
         *joinpaths: StrPath,
         make_dirs: bool = True,
     ) -> Path:
@@ -582,7 +582,7 @@ class Project(Versioned):
         return self.root_dir("plugins", *joinpaths)
 
     @makedirs
-    def plugin_lock_path(
+    def plugin_lock_path(  # noqa: ANN201
         self,
         plugin_type: str,
         plugin_name: str,
@@ -612,7 +612,7 @@ class Project(Versioned):
             make_dirs=make_dirs,
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # noqa: ANN001, ANN204
         """Project equivalence check.
 
         Args:
@@ -623,7 +623,7 @@ class Project(Versioned):
         """
         return self.root == getattr(other, "root", object())
 
-    def __hash__(self):
+    def __hash__(self):  # noqa: ANN204
         """Project hash.
 
         Returns:

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -247,26 +247,26 @@ class ProjectFiles:
                 included_file_contents.append(contents)
         return included_file_contents
 
-    def _add_mapping_entry(self, file_dicts, file, key, value):
+    def _add_mapping_entry(self, file_dicts, file, key, value) -> None:  # noqa: ANN001
         file_dict = file_dicts.setdefault(file, CommentedMap())
         entries = file_dict.setdefault(key, CommentedSeq())
         if value["name"] not in {scd["name"] for scd in entries}:
             entries.append(value)
 
-    def _add_sequence_entry(self, file_dicts, key, elements):
+    def _add_sequence_entry(self, file_dicts, key, elements) -> None:  # noqa: ANN001
         for elem in elements:
             file_key = (key, elem["name"])
             file = self._plugin_file_map.get(file_key, str(self._meltano_file_path))
             self._add_mapping_entry(file_dicts, file, key, elem)
 
-    def _add_plugin(self, file_dicts, file, plugin_type, plugin):
+    def _add_plugin(self, file_dicts, file, plugin_type, plugin) -> None:  # noqa: ANN001
         file_dict = file_dicts.setdefault(file, CommentedMap())
         plugins_dict = file_dict.setdefault("plugins", CommentedMap())
         plugins = plugins_dict.setdefault(plugin_type, CommentedSeq())
         if plugin["name"] not in {plg["name"] for plg in plugins}:
             plugins.append(plugin)
 
-    def _add_plugins(self, file_dicts, all_plugins):
+    def _add_plugins(self, file_dicts, all_plugins) -> None:  # noqa: ANN001
         for plugin_type, plugins in all_plugins.items():
             plugin_type = str(plugin_type)
             for plugin in plugins:
@@ -274,7 +274,7 @@ class ProjectFiles:
                 file = self._plugin_file_map.get(key, str(self._meltano_file_path))
                 self._add_plugin(file_dicts, file, plugin_type, plugin)
 
-    def _split_config_dict(self, config: CommentedMap):
+    def _split_config_dict(self, config: CommentedMap):  # noqa: ANN202
         file_dicts: dict[str, CommentedMap] = {}
 
         # Fill in the top-level entries
@@ -296,7 +296,7 @@ class ProjectFiles:
         self._copy_yaml_attributes(sorted_file_dicts)
         return sorted_file_dicts
 
-    def _restore_file_key_order(self, file_dicts: dict[str, CommentedMap]):
+    def _restore_file_key_order(self, file_dicts: dict[str, CommentedMap]):  # noqa: ANN202
         """Restore the order of the keys in the meltano project files.
 
         Args:
@@ -328,7 +328,7 @@ class ProjectFiles:
     def _copy_yaml_attributes(
         self,
         file_dicts: dict[str, CommentedMap],
-    ):
+    ) -> None:
         """Restore comments from top-level YAML entries in project files.
 
         For every file, use the top-level entries (e.g. "plugins") to copy the comments
@@ -365,6 +365,6 @@ class ProjectFiles:
             schedules = file_dict.get("schedules", CommentedSeq())
             original_schedules.copy_attributes(schedules)
 
-    def _write_file(self, file_path: PathLike, contents: t.Mapping):
+    def _write_file(self, file_path: PathLike, contents: t.Mapping) -> None:
         with atomic_write(file_path, overwrite=True) as fl:
             yaml.dump(contents, fl)

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -93,7 +93,7 @@ class ProjectInitService:
 
         return project
 
-    def create_dot_meltano_dir(self, project: Project):
+    def create_dot_meltano_dir(self, project: Project) -> None:
         """Create .meltano directory.
 
         Args:
@@ -105,7 +105,7 @@ class ProjectInitService:
         click.secho("created", fg="blue", nl=False)
         click.echo(f" .meltano in {project.sys_dir_root}")
 
-    def create_files(self, project: Project):
+    def create_files(self, project: Project) -> None:
         """Create project files.
 
         Args:
@@ -128,7 +128,7 @@ class ProjectInitService:
                 click.secho("   |--", fg="yellow", nl=False)
                 click.echo(f" {path} (skipped)")
 
-    def set_send_anonymous_usage_stats(self, project: Project):
+    def set_send_anonymous_usage_stats(self, project: Project) -> None:
         """Set Anonymous Usage Stats flag.
 
         Args:
@@ -142,7 +142,7 @@ class ProjectInitService:
                 store=SettingValueStore.MELTANO_YML,
             )
 
-    def create_system_database(self, project: Project):
+    def create_system_database(self, project: Project) -> None:
         """Create Meltano System DB.
 
         Args:
@@ -165,7 +165,7 @@ class ProjectInitService:
         except MigrationError as err:
             raise ProjectInitServiceError(str(err)) from err
 
-    def echo_instructions(self, project: Project):
+    def echo_instructions(self, project: Project) -> None:
         """Echo Next Steps to Click CLI.
 
         Args:

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -336,6 +336,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
     def get_plugins_of_type(
         self,
         plugin_type: PluginType,
+        *,
         ensure_parent=True,
     ) -> list[ProjectPlugin]:
         """Return plugins of specified type.
@@ -355,7 +356,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
 
         return plugins
 
-    def plugins_by_type(self, ensure_parent=True):
+    def plugins_by_type(self, *, ensure_parent=True):
         """Return plugins grouped by type.
 
         Args:
@@ -372,7 +373,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
             for plugin_type in PluginType
         }
 
-    def plugins(self, ensure_parent=True) -> t.Generator[ProjectPlugin, None, None]:
+    def plugins(self, *, ensure_parent=True) -> t.Generator[ProjectPlugin, None, None]:
         """Return all plugins.
 
         Args:
@@ -387,7 +388,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
             for plugin in plugins
         )
 
-    def update_plugin(self, plugin: ProjectPlugin, keep_config: bool = False):
+    def update_plugin(self, plugin: ProjectPlugin, *, keep_config: bool = False):
         """Update a plugin.
 
         Args:

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -117,7 +117,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
         self._prefer_source = DefinitionSource.LOCAL
 
     @cached_property
-    def current_plugins(self):
+    def current_plugins(self):  # noqa: ANN201
         """Return the current plugins.
 
         Returns:
@@ -126,7 +126,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
         return self.project.config_service.current_meltano_yml.plugins
 
     @contextmanager
-    def update_plugins(self):
+    def update_plugins(self):  # noqa: ANN201
         """Update the current plugins.
 
         Yields:
@@ -135,7 +135,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
         with self.project.config_service.update_meltano_yml() as meltano_yml:
             yield meltano_yml.plugins
 
-    def add_to_file(self, plugin: ProjectPlugin):
+    def add_to_file(self, plugin: ProjectPlugin):  # noqa: ANN201
         """Add plugin to `meltano.yml`.
 
         Args:
@@ -167,7 +167,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
 
         return plugin
 
-    def remove_from_file(self, plugin: ProjectPlugin):
+    def remove_from_file(self, plugin: ProjectPlugin):  # noqa: ANN201
         """Remove plugin from `meltano.yml`.
 
         Args:
@@ -203,8 +203,8 @@ class ProjectPluginsService:  # (too many methods, attributes)
         self,
         plugin_name: str,
         plugin_type: PluginType | None = None,
-        invokable=None,
-        configurable=None,
+        invokable=None,  # noqa: ANN001
+        configurable=None,  # noqa: ANN001
     ) -> ProjectPlugin:
         """
         Find a plugin.
@@ -337,7 +337,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
         self,
         plugin_type: PluginType,
         *,
-        ensure_parent=True,
+        ensure_parent=True,  # noqa: ANN001
     ) -> list[ProjectPlugin]:
         """Return plugins of specified type.
 
@@ -356,7 +356,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
 
         return plugins
 
-    def plugins_by_type(self, *, ensure_parent=True):
+    def plugins_by_type(self, *, ensure_parent=True):  # noqa: ANN001, ANN201
         """Return plugins grouped by type.
 
         Args:
@@ -373,7 +373,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
             for plugin_type in PluginType
         }
 
-    def plugins(self, *, ensure_parent=True) -> t.Generator[ProjectPlugin, None, None]:
+    def plugins(self, *, ensure_parent=True) -> t.Generator[ProjectPlugin, None, None]:  # noqa: ANN001
         """Return all plugins.
 
         Args:
@@ -388,7 +388,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
             for plugin in plugins
         )
 
-    def update_plugin(self, plugin: ProjectPlugin, *, keep_config: bool = False):
+    def update_plugin(self, plugin: ProjectPlugin, *, keep_config: bool = False):  # noqa: ANN201
         """Update a plugin.
 
         Args:
@@ -420,7 +420,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
             except StopIteration as stop:
                 raise PluginNotFoundError(plugin) from stop
 
-    def update_environment_plugin(self, plugin: EnvironmentPluginConfig):
+    def update_environment_plugin(self, plugin: EnvironmentPluginConfig) -> None:
         """Update a plugin configuration inside a Meltano environment.
 
         Args:

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -27,6 +27,7 @@ class ProjectSettingsService(SettingsService):
     def __init__(
         self,
         project: Project,
+        *,
         show_hidden: bool = True,
         env_override: dict | None = None,
         config_override: dict | None = None,

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -70,7 +70,7 @@ class ProjectSettingsService(SettingsService):
             )
 
     @property
-    def project_settings_service(self):
+    def project_settings_service(self):  # noqa: ANN201
         """Get the settings service for this project.
 
         For ProjectSettingsService, just returns self.
@@ -146,7 +146,7 @@ class ProjectSettingsService(SettingsService):
         return self.project.config_service.settings
 
     @property
-    def meltano_yml_config(self):
+    def meltano_yml_config(self):  # noqa: ANN201
         """Return current configuration in `meltano.yml`.
 
         Returns:
@@ -154,7 +154,7 @@ class ProjectSettingsService(SettingsService):
         """
         return self.project.config_service.current_config
 
-    def update_meltano_yml_config(self, config):
+    def update_meltano_yml_config(self, config) -> None:  # noqa: ANN001
         """Update configuration in `meltano.yml`.
 
         Args:
@@ -162,7 +162,7 @@ class ProjectSettingsService(SettingsService):
         """
         self.project.config_service.update_config(config)
 
-    def process_config(self, config) -> dict:
+    def process_config(self, config) -> dict:  # noqa: ANN001
         """Process configuration dict for presentation in `meltano config meltano`.
 
         Args:

--- a/src/meltano/core/runner/__init__.py
+++ b/src/meltano/core/runner/__init__.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 
 class RunnerError(Exception):
-    def __init__(self, message, exitcodes=None):
+    def __init__(self, message, exitcodes=None) -> None:  # noqa: ANN001
         super().__init__(message)
         self.exitcodes = {} if exitcodes is None else exitcodes
 
 
 class Runner:
-    def run(self):
+    def run(self) -> None:
         pass

--- a/src/meltano/core/runner/dbt.py
+++ b/src/meltano/core/runner/dbt.py
@@ -19,14 +19,14 @@ class DbtRunner(Runner):
         self.context = elt_context
 
     @property
-    def project(self):
+    def project(self):  # noqa: ANN201
         return self.context.project
 
     @property
-    def plugin_context(self):
+    def plugin_context(self):  # noqa: ANN201
         return self.context.transformer
 
-    async def invoke(self, dbt: PluginInvoker, *args, log=None, **kwargs):
+    async def invoke(self, dbt: PluginInvoker, *args, log=None, **kwargs) -> None:  # noqa: ANN001, ANN002, ANN003
         """Call the dbt executable with the given arguments in a new process."""
         log = log or sys.stderr
 
@@ -59,7 +59,7 @@ class DbtRunner(Runner):
                 {PluginType.TRANSFORMERS: exitcode},
             )
 
-    async def run(self, log=None):
+    async def run(self, log=None) -> None:  # noqa: ANN001
         dbt = self.context.transformer_invoker()
 
         async with dbt.prepared(self.context.session):

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -24,7 +24,7 @@ class SingerRunner(Runner):
     def __init__(self, elt_context: ELTContext):
         self.context = elt_context
 
-    def stop(self, process, **wait_args):
+    def stop(self, process, **wait_args):  # noqa: ANN001, ANN003, ANN201
         while True:  # pragma: no cover
             try:
                 code = process.wait(**wait_args)
@@ -38,11 +38,11 @@ class SingerRunner(Runner):
         self,
         tap: PluginInvoker,
         target: PluginInvoker,
-        extractor_log=None,
-        loader_log=None,
-        extractor_out=None,
-        loader_out=None,
-    ):
+        extractor_log=None,  # noqa: ANN001
+        loader_log=None,  # noqa: ANN001
+        extractor_out=None,  # noqa: ANN001
+        loader_out=None,  # noqa: ANN001
+    ) -> None:
         """Invoke tap and target together."""
         extractor_log = extractor_log or sys.stderr
         loader_log = loader_log or sys.stderr
@@ -204,17 +204,17 @@ class SingerRunner(Runner):
         if target_code:
             raise RunnerError("Loader failed", {PluginType.LOADERS: target_code})  # noqa: EM101
 
-    def dry_run(self, tap: PluginInvoker, target: PluginInvoker):
+    def dry_run(self, tap: PluginInvoker, target: PluginInvoker) -> None:
         logger.info("Dry run:")
         logger.info(f"\textractor: {tap.plugin.name} at '{tap.exec_path()}'")  # noqa: G004
         logger.info(f"\tloader: {target.plugin.name} at '{target.exec_path()}'")  # noqa: G004
 
-    async def run(
+    async def run(  # noqa: ANN201
         self,
-        extractor_log=None,
-        loader_log=None,
-        extractor_out=None,
-        loader_out=None,
+        extractor_log=None,  # noqa: ANN001
+        loader_log=None,  # noqa: ANN001
+        extractor_out=None,  # noqa: ANN001
+        loader_out=None,  # noqa: ANN001
     ):
         tap = self.context.extractor_invoker()
         target = self.context.loader_invoker()
@@ -236,10 +236,10 @@ class SingerRunner(Runner):
 
     def _handle_tap_line_length_limit_error(
         self,
-        exception,
-        line_length_limit,
-        stream_buffer_size,
-    ):
+        exception,  # noqa: ANN001
+        line_length_limit,  # noqa: ANN001
+        stream_buffer_size,  # noqa: ANN001
+    ) -> None:
         # StreamReader.readline can raise a ValueError wrapping a LimitOverrunError:
         # https://github.com/python/cpython/blob/v3.8.7/Lib/asyncio/streams.py#L549
         if not isinstance(exception, ValueError):

--- a/src/meltano/core/schedule.py
+++ b/src/meltano/core/schedule.py
@@ -124,7 +124,7 @@ class Schedule(NameEq, Canonical):
             f"--state-id={self.name}",
         ]
 
-    def last_successful_run(self, session) -> StateJob:
+    def last_successful_run(self, session) -> StateJob:  # noqa: ANN001
         """Return the last successful run for this schedule.
 
         Args:

--- a/src/meltano/core/schedule_service.py
+++ b/src/meltano/core/schedule_service.py
@@ -103,14 +103,14 @@ class ScheduleService:
 
     def add_elt(
         self,
-        session,
-        name,
+        session,  # noqa: ANN001
+        name,  # noqa: ANN001
         extractor: str,
         loader: str,
         transform: str,
         interval: str,
         start_date: datetime | None = None,
-        **env,
+        **env,  # noqa: ANN003
     ) -> Schedule:
         """Add a scheduled legacy elt task.
 
@@ -143,7 +143,7 @@ class ScheduleService:
         )
         return self.add_schedule(schedule)
 
-    def add(self, name: str, job: str, interval: str, **env) -> Schedule:
+    def add(self, name: str, job: str, interval: str, **env) -> Schedule:  # noqa: ANN003
         """Add a scheduled job.
 
         Args:
@@ -164,7 +164,7 @@ class ScheduleService:
             ),
         )
 
-    def remove(self, name) -> str:
+    def remove(self, name) -> str:  # noqa: ANN001
         """Remove a schedule from the project.
 
         Args:
@@ -175,7 +175,7 @@ class ScheduleService:
         """
         return self.remove_schedule(name)
 
-    def default_start_date(self, session, extractor: str) -> datetime:
+    def default_start_date(self, session, extractor: str) -> datetime:  # noqa: ANN001
         """Obtain the default start date for an elt schedule.
 
         Args:
@@ -259,7 +259,7 @@ class ScheduleService:
 
         return name
 
-    def update_schedule(self, schedule: Schedule):
+    def update_schedule(self, schedule: Schedule) -> None:
         """Update a schedule.
 
         Args:
@@ -314,7 +314,7 @@ class ScheduleService:
         """
         return self.project.meltano.schedules.copy()
 
-    def find_schedule(self, name) -> Schedule:
+    def find_schedule(self, name) -> Schedule:  # noqa: ANN001
         """Find a schedule by name.
 
         Args:
@@ -334,9 +334,9 @@ class ScheduleService:
     def run(
         self,
         schedule: Schedule,
-        *args,
+        *args,  # noqa: ANN002
         env: dict | None = None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ) -> subprocess.CompletedProcess:
         """Run a scheduled elt task or named job.
 

--- a/src/meltano/core/select_service.py
+++ b/src/meltano/core/select_service.py
@@ -39,7 +39,7 @@ class SelectService:
         plugin_settings_service = PluginSettingsService(self.project, self.extractor)
         return plugin_settings_service.get("_select")
 
-    async def load_catalog(self, session, refresh=False):
+    async def load_catalog(self, session, *, refresh=False):
         """Load the catalog."""
         invoker = invoker_factory(self.project, self.extractor)
 
@@ -51,10 +51,10 @@ class SelectService:
 
         return json.loads(catalog_json)
 
-    async def list_all(self, session, refresh=False) -> ListSelectedExecutor:
+    async def list_all(self, session, *, refresh=False) -> ListSelectedExecutor:
         """List all select."""
         try:
-            catalog = await self.load_catalog(session, refresh)
+            catalog = await self.load_catalog(session, refresh=refresh)
         except FileNotFoundError as err:
             raise PluginExecutionError(
                 "Could not find catalog. Verify that the tap supports discovery "  # noqa: EM101
@@ -67,7 +67,7 @@ class SelectService:
 
         return list_all
 
-    def update(self, entities_filter, attributes_filter, exclude, remove=False):
+    def update(self, entities_filter, attributes_filter, exclude, *, remove=False):
         """Update plugins' select patterns."""
         plugin: PluginRef
 

--- a/src/meltano/core/select_service.py
+++ b/src/meltano/core/select_service.py
@@ -35,11 +35,11 @@ class SelectService:
         return self._extractor
 
     @property
-    def current_select(self):
+    def current_select(self):  # noqa: ANN201
         plugin_settings_service = PluginSettingsService(self.project, self.extractor)
         return plugin_settings_service.get("_select")
 
-    async def load_catalog(self, session, *, refresh=False):
+    async def load_catalog(self, session, *, refresh=False):  # noqa: ANN001, ANN201
         """Load the catalog."""
         invoker = invoker_factory(self.project, self.extractor)
 
@@ -51,7 +51,7 @@ class SelectService:
 
         return json.loads(catalog_json)
 
-    async def list_all(self, session, *, refresh=False) -> ListSelectedExecutor:
+    async def list_all(self, session, *, refresh=False) -> ListSelectedExecutor:  # noqa: ANN001
         """List all select."""
         try:
             catalog = await self.load_catalog(session, refresh=refresh)
@@ -67,7 +67,14 @@ class SelectService:
 
         return list_all
 
-    def update(self, entities_filter, attributes_filter, exclude, *, remove=False):
+    def update(
+        self,
+        entities_filter,  # noqa: ANN001
+        attributes_filter,  # noqa: ANN001
+        exclude,  # noqa: ANN001
+        *,
+        remove=False,  # noqa: ANN001
+    ) -> None:
         """Update plugins' select patterns."""
         plugin: PluginRef
 
@@ -97,7 +104,7 @@ class SelectService:
             self.project.plugins.update_environment_plugin(plugin)
 
     @staticmethod
-    def _get_pattern_string(entities_filter, attributes_filter, exclude) -> str:
+    def _get_pattern_string(entities_filter, attributes_filter, exclude) -> str:  # noqa: ANN001
         """Return a select pattern in string form."""
         exclude = "!" if exclude else ""
         return f"{exclude}{entities_filter}.{attributes_filter}"

--- a/src/meltano/core/setting.py
+++ b/src/meltano/core/setting.py
@@ -24,6 +24,6 @@ class Setting(SystemModel):
     value: Mapped[t.Optional[str]] = mapped_column(types.PickleType)  # noqa: UP007
     enabled: Mapped[bool] = mapped_column(default=False)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         enabled_marker = "E" if self.enabled else ""
         return f"<({self.namespace}) {self.name}={self.value} {enabled_marker}>"

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -177,6 +177,7 @@ class SettingDefinition(NameEq, Canonical):
 
     def __init__(
         self,
+        *,
         name: str | None = None,
         aliases: list[str] | None = None,
         env: str | None = None,
@@ -317,6 +318,7 @@ class SettingDefinition(NameEq, Canonical):
         cls,
         key: str,
         value: t.Any,
+        *,
         custom: bool = True,
         default: t.Any | bool = False,
     ) -> SettingDefinition:
@@ -382,6 +384,7 @@ class SettingDefinition(NameEq, Canonical):
     def env_vars(
         self,
         prefixes: list[str],
+        *,
         include_custom: bool = True,
         for_writing: bool = False,
     ) -> list[EnvVar]:

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -54,7 +54,7 @@ class EnvVar:
         prefix = "!" if self.negated else ""
         return f"{prefix}{self.key}"
 
-    def get(self, env) -> str:
+    def get(self, env) -> str:  # noqa: ANN001
         """Get env value.
 
         Args:
@@ -91,7 +91,7 @@ class YAMLEnum(str, Enum):
         return self.value
 
     @staticmethod
-    def yaml_representer(dumper, obj) -> str:
+    def yaml_representer(dumper, obj) -> str:  # noqa: ANN001
         """Represent as yaml.
 
         Args:
@@ -104,7 +104,7 @@ class YAMLEnum(str, Enum):
         return dumper.represent_scalar("tag:yaml.org,2002:str", str(obj))
 
     @classmethod
-    def to_yaml(cls, representer: Representer, node: t.Any) -> ScalarNode:
+    def to_yaml(cls, representer: Representer, node: t.Any) -> ScalarNode:  # noqa: ANN401
         """Represent as yaml.
 
         Args:
@@ -119,7 +119,7 @@ class YAMLEnum(str, Enum):
     @classmethod
     def from_yaml(
         cls,
-        constructor,  # noqa: ARG003
+        constructor,  # noqa: ANN001, ARG003
         node: Node,
     ) -> YAMLEnum:
         """Construct from yaml.
@@ -183,7 +183,7 @@ class SettingDefinition(NameEq, Canonical):
         env: str | None = None,
         env_aliases: list[str] | None = None,
         kind: str | None = None,
-        value=None,
+        value=None,  # noqa: ANN001
         label: str | None = None,
         documentation: str | None = None,
         description: str | None = None,
@@ -195,9 +195,9 @@ class SettingDefinition(NameEq, Canonical):
         hidden: bool | None = None,
         sensitive: bool | None = None,
         custom: bool = False,
-        value_processor=None,
-        value_post_processor=None,
-        **attrs,
+        value_processor=None,  # noqa: ANN001
+        value_post_processor=None,  # noqa: ANN001
+        **attrs,  # noqa: ANN003
     ):
         """Instantiate new SettingDefinition.
 
@@ -290,7 +290,7 @@ class SettingDefinition(NameEq, Canonical):
         cls,
         defs: t.Iterable[SettingDefinition],
         config: dict,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ) -> list[SettingDefinition]:
         """Create SettingDefinition instances for missing settings.
 
@@ -317,10 +317,10 @@ class SettingDefinition(NameEq, Canonical):
     def from_key_value(
         cls,
         key: str,
-        value: t.Any,
+        value: t.Any,  # noqa: ANN401
         *,
         custom: bool = True,
-        default: t.Any | bool = False,
+        default: t.Any | bool = False,  # noqa: ANN401
     ) -> SettingDefinition:
         """Create SettingDefinition instance from key-value pair.
 
@@ -464,7 +464,7 @@ class SettingDefinition(NameEq, Canonical):
             raise parse_error
         return parsed
 
-    def cast_value(self, value: t.Any) -> t.Any:
+    def cast_value(self, value: t.Any) -> t.Any:  # noqa: ANN401
         """Cast given value.
 
         Args:
@@ -508,7 +508,7 @@ class SettingDefinition(NameEq, Canonical):
 
         return value
 
-    def post_process_value(self, value: t.Any) -> t.Any:
+    def post_process_value(self, value: t.Any) -> t.Any:  # noqa: ANN401
         """Post-process given value.
 
         Args:
@@ -526,7 +526,7 @@ class SettingDefinition(NameEq, Canonical):
 
         return value
 
-    def stringify_value(self, value: t.Any) -> str:
+    def stringify_value(self, value: t.Any) -> str:  # noqa: ANN401
         """Return value in string form.
 
         Args:

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -89,6 +89,7 @@ class SettingsService(metaclass=ABCMeta):
     def __init__(
         self,
         project: Project,
+        *,
         show_hidden: bool = True,
         env_override: dict | None = None,
         config_override: dict | None = None,
@@ -301,6 +302,7 @@ class SettingsService(metaclass=ABCMeta):
     def get_with_metadata(
         self,
         name: str,
+        *,
         redacted: bool = False,
         source: SettingValueStore = SettingValueStore.AUTO,
         source_manager: SettingsStoreManager | None = None,
@@ -632,6 +634,7 @@ class SettingsService(metaclass=ABCMeta):
     def setting_env_vars(
         self,
         setting_def,
+        *,
         for_writing=False,  # noqa: ARG002
     ):
         """Get environment variables for the given setting definition.
@@ -669,6 +672,7 @@ class SettingsService(metaclass=ABCMeta):
     def feature_flag(
         self,
         feature: str,
+        *,
         raise_error: bool = True,
     ) -> t.Generator[bool, None, None]:
         """Gate code paths based on feature flags.

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -41,7 +41,7 @@ class FeatureFlags(Enum):
     STRICT_ENV_VAR_MODE = "strict_env_var_mode"
     PLUGIN_LOCKS_REQUIRED = "plugin_locks_required"
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return feature name.
 
         Returns:
@@ -62,7 +62,7 @@ class FeatureFlags(Enum):
 class FeatureNotAllowedException(Exception):
     """A disallowed code path is run."""
 
-    def __init__(self, feature):
+    def __init__(self, feature) -> None:  # noqa: ANN001
         """Instantiate the error.
 
         Args:
@@ -110,7 +110,7 @@ class SettingsService(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def label(self):
+    def label(self):  # noqa: ANN201
         """Return label.
 
         Returns:
@@ -119,7 +119,7 @@ class SettingsService(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def docs_url(self):
+    def docs_url(self):  # noqa: ANN201
         """Return docs URL.
 
         Returns:
@@ -155,7 +155,7 @@ class SettingsService(metaclass=ABCMeta):
         """Return definitions of supported settings."""
 
     @property
-    def inherited_settings_service(self):
+    def inherited_settings_service(self) -> None:
         """Return settings service to inherit configuration from."""
         return None
 
@@ -165,7 +165,7 @@ class SettingsService(metaclass=ABCMeta):
         """Return current configuration in `meltano.yml`."""
 
     @abstractmethod
-    def update_meltano_yml_config(self, config):
+    def update_meltano_yml_config(self, config):  # noqa: ANN001, ANN201
         """Update configuration in `meltano.yml`.
 
         Args:
@@ -181,7 +181,7 @@ class SettingsService(metaclass=ABCMeta):
         """
 
     @property
-    def flat_meltano_yml_config(self):
+    def flat_meltano_yml_config(self):  # noqa: ANN201
         """Flatten meltano config.
 
         Returns:
@@ -191,7 +191,7 @@ class SettingsService(metaclass=ABCMeta):
         return flatten(self.meltano_yml_config, "dot")
 
     @property
-    def env(self):
+    def env(self):  # noqa: ANN201
         """Return the environment as a dict.
 
         Returns:
@@ -199,13 +199,13 @@ class SettingsService(metaclass=ABCMeta):
         """
         return {**os.environ, **self.env_override}
 
-    def config_with_metadata(
+    def config_with_metadata(  # noqa: ANN201
         self,
         prefix: str | None = None,
         extras: bool | None = None,
         source: SettingValueStore = SettingValueStore.AUTO,
         source_manager: SettingsStoreManager | None = None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Return all config values with associated metadata.
 
@@ -246,7 +246,7 @@ class SettingsService(metaclass=ABCMeta):
 
         return config
 
-    def as_dict(self, *args, process: bool = False, **kwargs) -> dict:
+    def as_dict(self, *args, process: bool = False, **kwargs) -> dict:  # noqa: ANN002, ANN003
         """Return settings without associated metadata.
 
         Args:
@@ -272,7 +272,7 @@ class SettingsService(metaclass=ABCMeta):
 
         return config
 
-    def as_env(self, *args, **kwargs) -> dict[str, str]:
+    def as_env(self, *args, **kwargs) -> dict[str, str]:  # noqa: ANN002, ANN003
         """Return settings as an dictionary of environment variables.
 
         Args:
@@ -299,7 +299,7 @@ class SettingsService(metaclass=ABCMeta):
 
         return env
 
-    def get_with_metadata(
+    def get_with_metadata(  # noqa: ANN201
         self,
         name: str,
         *,
@@ -309,7 +309,7 @@ class SettingsService(metaclass=ABCMeta):
         setting_def: SettingDefinition | None = None,
         expand_env_vars: bool = True,
         redacted_value: str = REDACTED_VALUE,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Get a setting with associated metadata.
 
@@ -433,7 +433,7 @@ class SettingsService(metaclass=ABCMeta):
 
         return value, metadata
 
-    def get_with_source(self, *args, **kwargs):
+    def get_with_source(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
         """Get a setting value along with its source.
 
         Args:
@@ -446,7 +446,7 @@ class SettingsService(metaclass=ABCMeta):
         value, metadata = self.get_with_metadata(*args, **kwargs)
         return value, metadata["source"]
 
-    def get(self, *args, **kwargs):
+    def get(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
         """Get a setting value.
 
         Args:
@@ -459,14 +459,14 @@ class SettingsService(metaclass=ABCMeta):
         value, _ = self.get_with_source(*args, **kwargs)
         return value
 
-    def set_with_metadata(
+    def set_with_metadata(  # noqa: ANN201
         self,
         path: str | list[str],
-        value,
-        store=SettingValueStore.AUTO,
+        value,  # noqa: ANN001
+        store=SettingValueStore.AUTO,  # noqa: ANN001
         *,
         redacted_value: str = REDACTED_VALUE,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Set the value and metadata for a setting.
 
@@ -518,7 +518,7 @@ class SettingsService(metaclass=ABCMeta):
         self.log(f"Set setting {name!r} with metadata: {metadata}")
         return value, metadata
 
-    def set(self, *args, **kwargs):
+    def set(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
         """Set the value for a setting.
 
         Args:
@@ -531,7 +531,7 @@ class SettingsService(metaclass=ABCMeta):
         value, _ = self.set_with_metadata(*args, **kwargs)
         return value
 
-    def unset(self, path: list[str], store=SettingValueStore.AUTO, **kwargs):
+    def unset(self, path: list[str], store=SettingValueStore.AUTO, **kwargs):  # noqa: ANN001, ANN003, ANN201
         """Unset a setting.
 
         Args:
@@ -566,7 +566,7 @@ class SettingsService(metaclass=ABCMeta):
         self.log(f"Unset setting {name!r} with metadata: {metadata}")
         return metadata
 
-    def reset(self, store=SettingValueStore.AUTO, **kwargs):
+    def reset(self, store=SettingValueStore.AUTO, **kwargs):  # noqa: ANN001, ANN003, ANN201
         """Reset a setting.
 
         Args:
@@ -631,11 +631,11 @@ class SettingsService(metaclass=ABCMeta):
 
     # TODO: The `for_writing` parameter is unused, but referenced elsewhere.
     # Callers should be updated to not use it, and then it should be removed.
-    def setting_env_vars(
+    def setting_env_vars(  # noqa: ANN201
         self,
-        setting_def,
+        setting_def,  # noqa: ANN001
         *,
-        for_writing=False,  # noqa: ARG002
+        for_writing=False,  # noqa: ANN001, ARG002
     ):
         """Get environment variables for the given setting definition.
 
@@ -648,7 +648,7 @@ class SettingsService(metaclass=ABCMeta):
         """
         return setting_def.env_vars(self.env_prefixes)
 
-    def setting_env(self, setting_def):
+    def setting_env(self, setting_def):  # noqa: ANN001, ANN201
         """Get a single environment variable for the given setting definition.
 
         Args:
@@ -659,7 +659,7 @@ class SettingsService(metaclass=ABCMeta):
         """
         return self.setting_env_vars(setting_def)[0].key
 
-    def log(self, message):
+    def log(self, message) -> None:  # noqa: ANN001
         """Log the given message.
 
         Args:

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -231,6 +231,7 @@ class SettingsStoreManager(ABC):
         self,
         name: str,
         setting_def: SettingDefinition | None = None,
+        *,
         cast_value: bool = False,
     ) -> tuple[str, dict]:
         """Abstract get method.
@@ -317,6 +318,7 @@ class ConfigOverrideStoreManager(SettingsStoreManager):
         self,
         name: str,
         setting_def: SettingDefinition | None = None,  # noqa: ARG002
+        *,
         cast_value: bool = False,  # noqa: ARG002
     ) -> tuple[str, dict]:
         """Get value by name from the .env file.
@@ -349,6 +351,7 @@ class BaseEnvStoreManager(SettingsStoreManager):
         self,
         name: str,  # noqa: ARG002
         setting_def: SettingDefinition | None = None,
+        *,
         cast_value: bool = False,
     ) -> tuple[str, dict]:
         """Get value by name from the .env file.
@@ -634,6 +637,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         self,
         name: str,
         setting_def: SettingDefinition | None = None,
+        *,
         cast_value: bool = False,
     ) -> tuple[str, dict]:
         """Get value by name from the system database.
@@ -918,6 +922,7 @@ class DbStoreManager(SettingsStoreManager):
         self,
         name: str,
         setting_def: SettingDefinition | None = None,  # noqa: ARG002
+        *,
         cast_value: bool = False,  # noqa: ARG002
     ) -> tuple[str, dict]:
         """Get value by name from the system database.
@@ -1074,6 +1079,7 @@ class InheritedStoreManager(SettingsStoreManager):
         self,
         name: str,
         setting_def: SettingDefinition | None = None,
+        *,
         cast_value: bool = False,  # noqa: ARG002
     ) -> tuple[str, dict]:
         """Get a Setting value by name and SettingDefinition.
@@ -1152,6 +1158,7 @@ class DefaultStoreManager(SettingsStoreManager):
         self,
         name: str,
         setting_def: SettingDefinition | None = None,
+        *,
         cast_value: bool = False,  # noqa: ARG002
     ) -> tuple[str, dict]:
         """Get a Setting value by name and SettingDefinition.
@@ -1319,6 +1326,7 @@ class AutoStoreManager(SettingsStoreManager):
         self,
         name: str,
         setting_def: SettingDefinition | None = None,
+        *,
         cast_value: bool = False,
         **kwargs,
     ) -> tuple[str, dict]:

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -32,7 +32,7 @@ logger = structlog.stdlib.get_logger(__name__)
 class ConflictingSettingValueException(Exception):
     """A setting has multiple conflicting values via aliases."""
 
-    def __init__(self, setting_names):
+    def __init__(self, setting_names) -> None:  # noqa: ANN001
         """Instantiate the error.
 
         Args:
@@ -54,7 +54,7 @@ class ConflictingSettingValueException(Exception):
 class MultipleEnvVarsSetException(Exception):
     """A setting value is set via multiple environment variable names."""
 
-    def __init__(self, names):
+    def __init__(self, names) -> None:  # noqa: ANN001
         """Instantiate the error.
 
         Args:
@@ -79,7 +79,7 @@ class StoreNotSupportedError(Error):
 
 
 def cast_setting_value(
-    value: t.Any,
+    value: t.Any,  # noqa: ANN401
     metadata: dict[str, t.Any],
     setting_def: SettingDefinition | None,
 ) -> tuple[t.Any, dict[str, t.Any]]:
@@ -215,7 +215,7 @@ class SettingsStoreManager(ABC):
     def __init__(
         self,
         settings_service: SettingsService,
-        **kwargs,  # noqa: ARG002
+        **kwargs,  # noqa: ANN003, ARG002
     ):
         """Initialise settings store manager.
 
@@ -246,7 +246,7 @@ class SettingsStoreManager(ABC):
         self,
         name: str,
         path: list[str],
-        value: t.Any,
+        value: t.Any,  # noqa: ANN401
         setting_def: SettingDefinition | None = None,
     ) -> dict:
         """Unimplemented set method.
@@ -344,7 +344,7 @@ class BaseEnvStoreManager(SettingsStoreManager):
 
     @property
     @abstractmethod
-    def env(self):
+    def env(self):  # noqa: ANN201
         """Abstract environment values property."""
 
     def get(
@@ -395,7 +395,7 @@ class BaseEnvStoreManager(SettingsStoreManager):
             else (value, metadata)
         )
 
-    def setting_env_vars(self, *args, **kwargs) -> dict:
+    def setting_env_vars(self, *args, **kwargs) -> dict:  # noqa: ANN002, ANN003
         """Return setting environment variables.
 
         Args:
@@ -414,7 +414,7 @@ class EnvStoreManager(BaseEnvStoreManager):
     label = "the environment"
 
     @property
-    def env(self):
+    def env(self):  # noqa: ANN201
         """Return values from the calling terminals environment.
 
         Returns:
@@ -422,7 +422,7 @@ class EnvStoreManager(BaseEnvStoreManager):
         """
         return self.settings_service.env
 
-    def get(self, *args, **kwargs):
+    def get(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
         """Get value by name from the .env file.
 
         Args:
@@ -447,7 +447,7 @@ class DotEnvStoreManager(BaseEnvStoreManager):
     label = "`.env`"
     writable = True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Initialise a .env file store manager instance.
 
         Args:
@@ -483,7 +483,7 @@ class DotEnvStoreManager(BaseEnvStoreManager):
             self._env = self.project.dotenv_env
         return self._env
 
-    def get(self, *args, **kwargs) -> tuple[str, dict]:
+    def get(self, *args, **kwargs) -> tuple[str, dict]:  # noqa: ANN002, ANN003
         """Get value by name from the .env file.
 
         Args:
@@ -501,7 +501,7 @@ class DotEnvStoreManager(BaseEnvStoreManager):
 
         return value, metadata
 
-    def set(self, name: str, path: list[str], value, setting_def=None):  # noqa: ARG002
+    def set(self, name: str, path: list[str], value, setting_def=None):  # noqa: ANN001, ANN201, ARG002
         """Set value by name in the .env file.
 
         Args:
@@ -584,7 +584,7 @@ class DotEnvStoreManager(BaseEnvStoreManager):
         return {}
 
     @contextmanager
-    def update_dotenv(self):
+    def update_dotenv(self):  # noqa: ANN201
         """Update .env configuration.
 
         Yields:
@@ -608,7 +608,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
     label = "`meltano.yml`"
     writable = True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Initialise MeltanoYmlStoreManager instance.
 
         Args:
@@ -685,7 +685,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         self,
         name: str,
         path: list[str],
-        value: t.Any,
+        value: t.Any,  # noqa: ANN401
         setting_def: SettingDefinition | None = None,
     ) -> dict:
         """Set value by name in the Meltano YAML File.
@@ -783,7 +783,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         return self._flat_config
 
     @contextmanager
-    def update_config(self):
+    def update_config(self):  # noqa: ANN201
         """Update Meltano YAML configuration.
 
         Yields:
@@ -812,7 +812,7 @@ class MeltanoEnvStoreManager(MeltanoYmlStoreManager):
 
     label = "the active environment in `meltano.yml`"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Initialise MeltanoEnvStoreManager instance.
 
         Args:
@@ -833,7 +833,7 @@ class MeltanoEnvStoreManager(MeltanoYmlStoreManager):
             self._flat_config = flatten(self.settings_service.environment_config, "dot")
         return self._flat_config
 
-    def ensure_supported(self, method: str = "get"):
+    def ensure_supported(self, method: str = "get") -> None:
         """Ensure project is not read-only and an environment is active.
 
         Args:
@@ -884,10 +884,10 @@ class DbStoreManager(SettingsStoreManager):
 
     def __init__(
         self,
-        *args,
+        *args,  # noqa: ANN002
         bulk: bool = False,
         session: Session | None = None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Initialise DbStoreManager.
 
@@ -955,7 +955,7 @@ class DbStoreManager(SettingsStoreManager):
         self,
         name: str,
         path: list[str],  # noqa: ARG002
-        value: t.Any,
+        value: t.Any,  # noqa: ANN401
         setting_def: SettingDefinition | None = None,  # noqa: ARG002
     ) -> dict:
         """Set value by name in the system database.
@@ -1058,9 +1058,9 @@ class InheritedStoreManager(SettingsStoreManager):
     def __init__(
         self,
         settings_service: SettingsService,
-        *args,
+        *args,  # noqa: ANN002
         bulk: bool = False,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Initialize inherited store manager.
 
@@ -1189,7 +1189,7 @@ class AutoStoreManager(SettingsStoreManager):
     label = "the system database, `meltano.yml`, and `.env`"
     writable = True
 
-    def __init__(self, *args, cache: bool = True, **kwargs):
+    def __init__(self, *args, cache: bool = True, **kwargs):  # noqa: ANN002, ANN003
         """Initialise AutoStoreManager.
 
         Args:
@@ -1237,7 +1237,7 @@ class AutoStoreManager(SettingsStoreManager):
         stores.remove(SettingValueStore.AUTO)
         return stores
 
-    def ensure_supported(self, store, method="set"):
+    def ensure_supported(self, store, method="set") -> bool | None:  # noqa: ANN001
         """Return if a given store is supported for the given method.
 
         Args:
@@ -1328,7 +1328,7 @@ class AutoStoreManager(SettingsStoreManager):
         setting_def: SettingDefinition | None = None,
         *,
         cast_value: bool = False,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ) -> tuple[str, dict]:
         """Get a Setting value by name and SettingDefinition.
 
@@ -1381,7 +1381,7 @@ class AutoStoreManager(SettingsStoreManager):
             else (value, metadata)
         )
 
-    def set(self, name: str, path: list[str], value, setting_def=None) -> dict:
+    def set(self, name: str, path: list[str], value, setting_def=None) -> dict:  # noqa: ANN001
         """Set a Setting by name, path and (optionally) SettingDefinition.
 
         Args:

--- a/src/meltano/core/sqlalchemy.py
+++ b/src/meltano/core/sqlalchemy.py
@@ -22,20 +22,20 @@ class JSONEncodedDict(TypeDecorator):
     impl = VARCHAR
     cache_ok = True
 
-    def process_bind_param(
+    def process_bind_param(  # noqa: ANN201
         self,
-        value,
-        dialect,  # noqa: ARG002
+        value,  # noqa: ANN001
+        dialect,  # noqa: ANN001, ARG002
     ):
         if value is not None:
             value = json.dumps(value)
 
         return value
 
-    def process_result_value(
+    def process_result_value(  # noqa: ANN201
         self,
-        value,
-        dialect,  # noqa: ARG002
+        value,  # noqa: ANN001
+        dialect,  # noqa: ANN001, ARG002
     ):
         if value is not None:
             value = json.loads(value)
@@ -47,10 +47,10 @@ class IntFlag(TypeDecorator):
     cache_ok = True
 
     # force the cast to INTEGER
-    def process_bind_param(
+    def process_bind_param(  # noqa: ANN201
         self,
-        value,
-        dialect,  # noqa: ARG002
+        value,  # noqa: ANN001
+        dialect,  # noqa: ANN001, ARG002
     ):
         return int(value)
 
@@ -68,13 +68,13 @@ class GUID(TypeDecorator):
     impl = CHAR
     cache_ok = True
 
-    def load_dialect_impl(self, dialect):
+    def load_dialect_impl(self, dialect):  # noqa: ANN001, ANN201
         if dialect.name == "postgresql":
             return dialect.type_descriptor(UUID())
         type_descriptor_length = 32
         return dialect.type_descriptor(CHAR(type_descriptor_length))
 
-    def process_bind_param(self, value, dialect):
+    def process_bind_param(self, value, dialect):  # noqa: ANN001, ANN201
         if value is None:
             return value
         if dialect.name == "postgresql":
@@ -83,10 +83,10 @@ class GUID(TypeDecorator):
             value = uuid.UUID(value)
         return value.hex
 
-    def process_result_value(
+    def process_result_value(  # noqa: ANN201
         self,
-        value,
-        dialect,  # noqa: ARG002
+        value,  # noqa: ANN001
+        dialect,  # noqa: ANN001, ARG002
     ):
         if value is None:
             return value
@@ -101,7 +101,7 @@ class DateTimeUTC(TypeDecorator):
     impl = DateTime
     cache_ok = True
 
-    def process_bind_param(self, value: datetime.datetime | None, _dialect: str):
+    def process_bind_param(self, value: datetime.datetime | None, _dialect: str):  # noqa: ANN201
         """Convert the datetime value to UTC and remove the timezone.
 
         Args:
@@ -117,7 +117,7 @@ class DateTimeUTC(TypeDecorator):
             value = value.astimezone(datetime.timezone.utc)
         return value.replace(tzinfo=None)
 
-    def process_result_value(self, value: datetime.datetime | None, _dialect: str):
+    def process_result_value(self, value: datetime.datetime | None, _dialect: str):  # noqa: ANN201
         """Convert the naive datetime value to UTC.
 
         Args:

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -117,6 +117,7 @@ class StateService:
         job: Job | str,
         new_state: str,
         payload_flags: Payload = Payload.STATE,
+        *,
         validate=True,
     ):
         """Add state for the given Job.
@@ -162,7 +163,7 @@ class StateService:
             return json.loads(state.json_merged())
         return {}
 
-    def set_state(self, state_id: str, new_state: str, validate: bool = True):
+    def set_state(self, state_id: str, new_state: str, *, validate: bool = True):
         """Set the state for the state_id.
 
         Args:
@@ -177,7 +178,7 @@ class StateService:
             validate=validate,
         )
 
-    def clear_state(self, state_id, save: bool = True):  # noqa: ARG002
+    def clear_state(self, state_id, *, save: bool = True):  # noqa: ARG002
         """Clear the state for the state_id.
 
         Args:

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -45,7 +45,7 @@ class StateService:
         self.session = session
         self._state_store_manager = None
 
-    def list_state(self, state_id_pattern: str | None = None):
+    def list_state(self, state_id_pattern: str | None = None):  # noqa: ANN201
         """List all state found in the db.
 
         Args:
@@ -84,7 +84,7 @@ class StateService:
         raise TypeError("job must be of type Job or of type str")  # noqa: EM101
 
     @property
-    def state_store_manager(self):
+    def state_store_manager(self):  # noqa: ANN201
         """Initialize and return the correct StateStoreManager.
 
         Returns:
@@ -98,7 +98,7 @@ class StateService:
         return self._state_store_manager
 
     @staticmethod
-    def validate_state(state: dict[str, t.Any]):
+    def validate_state(state: dict[str, t.Any]) -> None:
         """Check that the given state str is valid.
 
         Args:
@@ -118,8 +118,8 @@ class StateService:
         new_state: str,
         payload_flags: Payload = Payload.STATE,
         *,
-        validate=True,
-    ):
+        validate=True,  # noqa: ANN001
+    ) -> None:
         """Add state for the given Job.
 
         Args:
@@ -150,7 +150,7 @@ class StateService:
         )
         self.state_store_manager.set(job_state)
 
-    def get_state(self, state_id: str):
+    def get_state(self, state_id: str):  # noqa: ANN201
         """Get state for the given state_id.
 
         Args:
@@ -163,7 +163,13 @@ class StateService:
             return json.loads(state.json_merged())
         return {}
 
-    def set_state(self, state_id: str, new_state: str, *, validate: bool = True):
+    def set_state(
+        self,
+        state_id: str,
+        new_state: str,
+        *,
+        validate: bool = True,
+    ) -> None:
         """Set the state for the state_id.
 
         Args:
@@ -178,7 +184,7 @@ class StateService:
             validate=validate,
         )
 
-    def clear_state(self, state_id, *, save: bool = True):  # noqa: ARG002
+    def clear_state(self, state_id, *, save: bool = True) -> None:  # noqa: ANN001, ARG002
         """Clear the state for the state_id.
 
         Args:
@@ -187,7 +193,7 @@ class StateService:
         """
         self.state_store_manager.clear(state_id)
 
-    def merge_state(self, state_id_src: str, state_id_dst: str):
+    def merge_state(self, state_id_src: str, state_id_dst: str) -> None:
         """Merge state from state_id_src into state_id_dst.
 
         Args:
@@ -200,7 +206,7 @@ class StateService:
             payload_flags=Payload.INCOMPLETE_STATE,
         )
 
-    def copy_state(self, state_id_src: str, state_id_dst: str):
+    def copy_state(self, state_id_src: str, state_id_dst: str) -> None:
         """Copy state from Job state_id_src onto Job state_id_dst.
 
         Args:
@@ -209,7 +215,7 @@ class StateService:
         """
         self.set_state(state_id_dst, json.dumps(self.get_state(state_id_src)))
 
-    def move_state(self, state_id_src: str, state_id_dst: str):
+    def move_state(self, state_id_src: str, state_id_dst: str) -> None:
         """Move state from Job state_id_src to Job state_id_dst.
 
         Args:

--- a/src/meltano/core/state_store/azure.py
+++ b/src/meltano/core/state_store/azure.py
@@ -25,7 +25,7 @@ except ImportError:
 class MissingAzureError(Exception):
     """Raised when azure is required but no installed."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a MissingAzureError."""
         super().__init__(
             "azure required but not installed. Install meltano[azure] to use Azure Blob Storage as a state backend.",  # noqa: E501
@@ -33,7 +33,7 @@ class MissingAzureError(Exception):
 
 
 @contextmanager
-def requires_azure():
+def requires_azure():  # noqa: ANN201
     """Raise MissingAzureError if azure is required but missing in context.
 
     Raises:
@@ -57,7 +57,7 @@ class AZStorageStateStoreManager(CloudStateStoreManager):
         connection_string: str | None = None,
         prefix: str | None = None,
         storage_account_url: str | None = None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Initialize the BaseFilesystemStateStoreManager.
 
@@ -129,7 +129,7 @@ class AZStorageStateStoreManager(CloudStateStoreManager):
                 "Read https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string for more information.",  # noqa: E501
             )
 
-    def delete(self, file_path: str):
+    def delete(self, file_path: str) -> None:
         """Delete the file/blob at the given path.
 
         Args:

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -24,7 +24,7 @@ class StateIDLockedError(Exception):
 class StateStoreManager(ABC):
     """Base state store manager."""
 
-    def __init__(self, **kwargs):  # noqa: B027
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003, B027
         """Initialize state store manager.
 
         Args:
@@ -37,7 +37,7 @@ class StateStoreManager(ABC):
         ...
 
     @abstractmethod
-    def set(self, state: JobState):
+    def set(self, state: JobState):  # noqa: ANN201
         """Set the job state for the given state_id.
 
         Args:
@@ -49,7 +49,7 @@ class StateStoreManager(ABC):
         ...
 
     @abstractmethod
-    def get(self, state_id) -> JobState | None:
+    def get(self, state_id) -> JobState | None:  # noqa: ANN001
         """Get the job state for the given state_id.
 
         Args:
@@ -61,7 +61,7 @@ class StateStoreManager(ABC):
         ...
 
     @abstractmethod
-    def clear(self, state_id):
+    def clear(self, state_id):  # noqa: ANN001, ANN201
         """Clear state for the given state_id.
 
         Args:
@@ -70,7 +70,7 @@ class StateStoreManager(ABC):
         ...
 
     @abstractmethod
-    def get_state_ids(self, pattern=None):
+    def get_state_ids(self, pattern=None):  # noqa: ANN001, ANN201
         """Get all state_ids available in this state store manager.
 
         Args:
@@ -79,7 +79,7 @@ class StateStoreManager(ABC):
         ...
 
     @abstractmethod
-    def acquire_lock(self, state_id):
+    def acquire_lock(self, state_id):  # noqa: ANN001, ANN201
         """Acquire a naive lock for the given job's state.
 
         Args:

--- a/src/meltano/core/state_store/db.py
+++ b/src/meltano/core/state_store/db.py
@@ -19,7 +19,7 @@ class DBStateStoreManager(StateStoreManager):
 
     label = "Database"
 
-    def __init__(self, session: Session, **kwargs):
+    def __init__(self, session: Session, **kwargs):  # noqa: ANN003
         """Initialize the DBStateStoreManager.
 
         Args:
@@ -60,7 +60,7 @@ class DBStateStoreManager(StateStoreManager):
         self.session.add(new_job_state)
         self.session.commit()
 
-    def get(self, state_id):
+    def get(self, state_id):  # noqa: ANN001, ANN201
         """Get the job state for the given state_id.
 
         Args:
@@ -73,7 +73,7 @@ class DBStateStoreManager(StateStoreManager):
             self.session.query(JobState).filter(JobState.state_id == state_id).first()
         )
 
-    def clear(self, state_id):
+    def clear(self, state_id) -> None:  # noqa: ANN001
         """Clear state for the given state_id.
 
         Args:
@@ -85,7 +85,7 @@ class DBStateStoreManager(StateStoreManager):
             self.session.delete(job_state)
             self.session.commit()
 
-    def get_state_ids(self, pattern: str | None = None):
+    def get_state_ids(self, pattern: str | None = None):  # noqa: ANN201
         """Get all state_ids available in this state store manager.
 
         Args:
@@ -106,7 +106,7 @@ class DBStateStoreManager(StateStoreManager):
             for record in self.session.execute(select(JobState.state_id)).all()
         )
 
-    def acquire_lock(self, state_id):
+    def acquire_lock(self, state_id) -> None:  # noqa: ANN001
         """Acquire a naive lock for the given job's state.
 
         For DBStateStoreManager, the db manages transactions.
@@ -116,7 +116,7 @@ class DBStateStoreManager(StateStoreManager):
             state_id: the state_id to lock
         """
 
-    def release_lock(self, state_id):
+    def release_lock(self, state_id) -> None:  # noqa: ANN001
         """Release the lock for the given job's state.
 
         For DBStateStoreManager, the db manages transactions.

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -39,7 +39,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
 
     delimiter = "/"
 
-    def __init__(self, uri: str, lock_timeout_seconds: int, **kwargs):
+    def __init__(self, uri: str, lock_timeout_seconds: int, **kwargs):  # noqa: ANN003
         """Initialize the BaseFilesystemStateStoreManager.
 
         Args:
@@ -139,7 +139,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
                 yield writer
 
     @abstractproperty
-    def client(self):
+    def client(self):  # noqa: ANN201
         """Get a client for performing fs operations.
 
         Used for cloud backends, particularly in deleting and listing blobs.
@@ -233,7 +233,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
                 return False
             raise e
 
-    def create_state_id_dir_if_not_exists(self, state_id: str):
+    def create_state_id_dir_if_not_exists(self, state_id: str) -> None:
         """Create the directory or prefix for a given state_id.
 
         Does nothing, but not @abstractmethod because many state backends
@@ -301,7 +301,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
                     return None
                 raise e
 
-    def set(self, state: JobState):
+    def set(self, state: JobState) -> None:
         """Set state for the given state_id.
 
         Args:
@@ -332,7 +332,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
                 writer.write(state_to_write.json())
 
     @abstractmethod
-    def delete(self, file_or_dir_path: str):
+    def delete(self, file_or_dir_path: str):  # noqa: ANN201
         """Delete the file/blob/directory/prefix at the given path.
 
         Args:
@@ -340,7 +340,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
         """
         ...
 
-    def clear(self, state_id: str):
+    def clear(self, state_id: str) -> None:
         """Clear state for the given state_id.
 
         Args:
@@ -355,7 +355,7 @@ class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
 
     label: str = "Local Filesystem"
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
         """Initialize the LocalFilesystemStateStoreManager.
 
         Args:
@@ -378,7 +378,7 @@ class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
         return isinstance(err, FileNotFoundError)
 
     @property
-    def client(self):
+    def client(self) -> None:
         """Get a client for performing fs operations.
 
         Returns:
@@ -409,7 +409,7 @@ class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
         """
         return os.path.join(*components)
 
-    def create_state_id_dir_if_not_exists(self, state_id: str):
+    def create_state_id_dir_if_not_exists(self, state_id: str) -> None:
         """Create the directory for a given state_id.
 
         Args:
@@ -417,7 +417,7 @@ class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
         """
         Path(self.get_state_dir(state_id)).mkdir(parents=True, exist_ok=True)
 
-    def get_state_ids(self, pattern: str | None = None):
+    def get_state_ids(self, pattern: str | None = None):  # noqa: ANN201
         """Get list of state_ids stored in the backend.
 
         Args:
@@ -438,7 +438,7 @@ class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
             )
         ]
 
-    def delete(self, file_or_dir_path: str):
+    def delete(self, file_or_dir_path: str) -> None:
         """Delete the file/blob/directory/prefix at the given path, if it exists.
 
         Args:
@@ -455,7 +455,7 @@ class LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
             if not self.is_file_not_found_error(e):
                 raise e
 
-    def clear(self, state_id: str):
+    def clear(self, state_id: str) -> None:
         """Clear state for the given state_id.
 
         Args:
@@ -471,7 +471,7 @@ class WindowsFilesystemStateStoreManager(LocalFilesystemStateStoreManager):
     label: str = "Local Windows Filesystem"
     delimiter = "\\"
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
         """Initialize the LocalFilesystemStateStoreManager.
 
         Args:
@@ -498,7 +498,7 @@ class WindowsFilesystemStateStoreManager(LocalFilesystemStateStoreManager):
             else self.join_path(self.state_dir, state_id)
         )
 
-    def get_state_ids(self, pattern: str | None = None):
+    def get_state_ids(self, pattern: str | None = None):  # noqa: ANN201
         """Get list of state_ids stored in the backend.
 
         Args:
@@ -527,7 +527,7 @@ class WindowsFilesystemStateStoreManager(LocalFilesystemStateStoreManager):
 class CloudStateStoreManager(BaseFilesystemStateStoreManager):
     """Base class for cloud storage state store managers."""
 
-    def __init__(self, prefix: str | None = None, **kwargs):
+    def __init__(self, prefix: str | None = None, **kwargs):  # noqa: ANN003
         """Initialize the CloudStateStoreManager.
 
         Args:
@@ -576,7 +576,7 @@ class CloudStateStoreManager(BaseFilesystemStateStoreManager):
         """
         ...
 
-    def get_state_ids(self, pattern: str | None = None):
+    def get_state_ids(self, pattern: str | None = None):  # noqa: ANN201
         """Get list of state_ids stored in the backend.
 
         Args:

--- a/src/meltano/core/state_store/google.py
+++ b/src/meltano/core/state_store/google.py
@@ -24,7 +24,7 @@ except ImportError:
 class MissingGoogleError(Exception):
     """Raised when google is required but not installed."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a MissingGoogleError."""
         super().__init__(
             "google-cloud-storage required but not installed. Install meltano[gcs] to use GCS as a state backend.",  # noqa: E501
@@ -32,7 +32,7 @@ class MissingGoogleError(Exception):
 
 
 @contextmanager
-def requires_gcs():
+def requires_gcs():  # noqa: ANN201
     """Raise MissingGoogleError if gcs is required but missing in context.
 
     Raises:
@@ -56,7 +56,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
         bucket: str | None = None,
         prefix: str | None = None,
         application_credentials: str | None = None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Initialize the BaseFilesystemStateStoreManager.
 
@@ -88,7 +88,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
         )
 
     @cached_property
-    def client(self):
+    def client(self):  # noqa: ANN201
         """Get an authenticated google.cloud.storage.Client.
 
         Returns:
@@ -102,7 +102,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
             # Use default authentication in environment
             return google.cloud.storage.Client()
 
-    def delete(self, file_path: str):
+    def delete(self, file_path: str) -> None:
         """Delete the file/blob at the given path.
 
         Args:
@@ -128,7 +128,8 @@ class GCSStateStoreManager(CloudStateStoreManager):
             The next file in the backend.
         """
         for blob in self.client.list_blobs(
-            bucket_or_name=self.bucket, prefix=self.state_dir
+            bucket_or_name=self.bucket,
+            prefix=self.state_dir,
         ):
             yield blob.name
 

--- a/src/meltano/core/state_store/s3.py
+++ b/src/meltano/core/state_store/s3.py
@@ -25,7 +25,7 @@ except ImportError:
 class MissingBoto3Error(Exception):
     """Raised when boto3 is required but not installed."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a MissingBoto3Error."""
         super().__init__(
             "boto3 required but not installed. Install meltano[s3] to use S3 as a state backend.",  # noqa: E501
@@ -33,7 +33,7 @@ class MissingBoto3Error(Exception):
 
 
 @contextmanager
-def requires_boto3():
+def requires_boto3():  # noqa: ANN201
     """Raise MissingBoto3Error if boto3 is required but missing in context.
 
     Raises:
@@ -59,7 +59,7 @@ class S3StateStoreManager(CloudStateStoreManager):
         bucket: str | None = None,
         prefix: str | None = None,
         endpoint_url: str | None = None,
-        **kwargs,
+        **kwargs,  # noqa: ANN003
     ):
         """Initialize the BaseFilesystemStateStoreManager.
 
@@ -95,7 +95,7 @@ class S3StateStoreManager(CloudStateStoreManager):
         )
 
     @cached_property
-    def client(self):
+    def client(self):  # noqa: ANN201
         """Get an authenticated boto3.Client.
 
         Returns:
@@ -123,7 +123,7 @@ class S3StateStoreManager(CloudStateStoreManager):
             session = boto3.Session()
             return session.client("s3")
 
-    def delete(self, file_path: str):
+    def delete(self, file_path: str) -> None:
         """Delete the file/blob at the given path.
 
         Args:

--- a/src/meltano/core/task_sets.py
+++ b/src/meltano/core/task_sets.py
@@ -70,7 +70,11 @@ class TaskSets(NameEq, Canonical):
         self.name = name
         self.tasks = tasks
 
-    def _as_args(self, preserve_top_level: bool = False) -> list[str] | list[list[str]]:
+    def _as_args(
+        self,
+        *,
+        preserve_top_level: bool = False,
+    ) -> list[str] | list[list[str]]:
         """Get job tasks as CLI args.
 
         Args:

--- a/src/meltano/core/task_sets.py
+++ b/src/meltano/core/task_sets.py
@@ -45,7 +45,7 @@ class InvalidTasksError(Exception):
         super().__init__(f"Job '{name}' has invalid tasks. {message}")
 
 
-def _flat_split(items):
+def _flat_split(items):  # noqa: ANN001, ANN202
     for el in items:
         if isinstance(el, Iterable) and not isinstance(el, str):
             yield from _flat_split(el)

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -79,7 +79,7 @@ class EnvironmentContext(SelfDescribingJson):
                 except ValueError:
                     yield env_var_name, None
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the environment context."""
         super().__init__(
             EnvironmentContextSchema.url,

--- a/src/meltano/core/tracking/contexts/exception.py
+++ b/src/meltano/core/tracking/contexts/exception.py
@@ -28,7 +28,7 @@ ExceptionContextJSON = t.Dict[
 class ExceptionContext(SelfDescribingJson):
     """Exception context for the Snowplow tracker."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Init the exceptions context with the exceptions currently being handled."""
         ex = sys.exc_info()[1]
         super().__init__(

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -111,7 +111,7 @@ class Tracker:  # - too many (public) methods
         self.project = project
         self.send_anonymous_usage_stats = project.settings.get(
             "send_anonymous_usage_stats",
-            redacted=not project.settings.get("disable_tracking", redacted=False),
+            redacted=not project.settings.get("disable_tracking"),
         )
 
         endpoints = project.settings.get("snowplow.collector_endpoints")

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -276,7 +276,7 @@ class Tracker:  # - too many (public) methods
         except Exception:
             return datetime.now().astimezone().tzname()
 
-    def add_contexts(self, *extra_contexts):
+    def add_contexts(self, *extra_contexts) -> None:  # noqa: ANN002
         """Permanently add additional Snowplow contexts to the `Tracker`.
 
         Args:
@@ -285,7 +285,7 @@ class Tracker:  # - too many (public) methods
         self._contexts = (*self._contexts, *extra_contexts)
 
     @contextmanager
-    def with_contexts(self, *extra_contexts) -> Tracker:
+    def with_contexts(self, *extra_contexts) -> Tracker:  # noqa: ANN002
         """Context manager within which the `Tracker` has additional Snowplow contexts.
 
         Args:
@@ -468,7 +468,7 @@ class Tracker:  # - too many (public) methods
 
     def _uuid_from_str(
         self,
-        from_val: t.Any | None,
+        from_val: t.Any | None,  # noqa: ANN401
         *,
         warn: bool,
     ) -> uuid.UUID | None:
@@ -517,7 +517,7 @@ class Tracker:  # - too many (public) methods
             ),
         )
 
-    def setup_exit_event(self):
+    def setup_exit_event(self) -> None:
         """If not already done, register the atexit handler to fire the exit event.
 
         This method also provides this tracker instance to the CLI module for
@@ -538,7 +538,7 @@ class Tracker:  # - too many (public) methods
         # As a fallback, use atexit to help ensure the exit event is sent.
         atexit.register(self.track_exit_event)
 
-    def track_exit_event(self):
+    def track_exit_event(self) -> None:
         """Fire exit event."""
         from meltano import cli
 

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -111,7 +111,7 @@ class Tracker:  # - too many (public) methods
         self.project = project
         self.send_anonymous_usage_stats = project.settings.get(
             "send_anonymous_usage_stats",
-            not project.settings.get("disable_tracking", False),
+            redacted=not project.settings.get("disable_tracking", redacted=False),
         )
 
         endpoints = project.settings.get("snowplow.collector_endpoints")
@@ -469,6 +469,7 @@ class Tracker:  # - too many (public) methods
     def _uuid_from_str(
         self,
         from_val: t.Any | None,
+        *,
         warn: bool,
     ) -> uuid.UUID | None:
         """Safely convert string to a UUID. Return None if invalid UUID.

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -54,7 +54,7 @@ class UpgradeService:
         self.project = project
         self.engine = engine
 
-    def _upgrade_package(self, pip_url: str | None, force: bool) -> bool:
+    def _upgrade_package(self, pip_url: str | None, *, force: bool) -> bool:
         fail_reason = None
         instructions = ""
 
@@ -95,7 +95,12 @@ class UpgradeService:
 
         return True
 
-    def upgrade_package(self, pip_url: str | None = None, force: bool = False) -> bool:
+    def upgrade_package(
+        self,
+        pip_url: str | None = None,
+        *,
+        force: bool = False,
+    ) -> bool:
         """Upgrade the Meltano package.
 
         Args:
@@ -108,7 +113,7 @@ class UpgradeService:
         click.secho("Upgrading `meltano` package...", fg="blue")
 
         try:
-            self._upgrade_package(pip_url, force)
+            self._upgrade_package(pip_url=pip_url, force=force)
         except AutomaticPackageUpgradeError as err:
             msg = click.style(
                 "The `meltano` package could not be upgraded automatically",
@@ -191,7 +196,7 @@ class UpgradeService:
                     manager.copy_file(filepath, new_path)
                     click.secho(f"Copied state from {filepath} to {new_path}")
 
-    def upgrade(self, skip_package: bool = False, **kwargs):
+    def upgrade(self, *, skip_package: bool = False, **kwargs):
         """Upgrade Meltano.
 
         Note: this is not actually called as part of the `meltano upgrade` command

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -128,7 +128,7 @@ class UpgradeService:
         click.echo()
         return True
 
-    def update_files(self):
+    def update_files(self) -> None:
         """Update the files managed by Meltano inside the current project.
 
         Raises:
@@ -146,12 +146,12 @@ class UpgradeService:
                 self.project,
                 file_plugins,
                 reason=PluginInstallReason.UPGRADE,
-            )
+            ),
         )
         if not success:
             raise MeltanoError("Failed to upgrade plugin(s)")  # noqa: EM101
 
-    def migrate_database(self):
+    def migrate_database(self) -> None:
         """Migrate the Meltano database.
 
         Raises:
@@ -167,7 +167,7 @@ class UpgradeService:
         except MigrationError as err:
             raise UpgradeError(str(err)) from err
 
-    def migrate_state(self):
+    def migrate_state(self) -> None:
         """Move cloud state files to deduplicated prefix paths.
 
         See: https://github.com/meltano/meltano/issues/7938
@@ -196,7 +196,7 @@ class UpgradeService:
                     manager.copy_file(filepath, new_path)
                     click.secho(f"Copied state from {filepath} to {new_path}")
 
-    def upgrade(self, *, skip_package: bool = False, **kwargs):
+    def upgrade(self, *, skip_package: bool = False, **kwargs) -> None:  # noqa: ANN003
         """Upgrade Meltano.
 
         Note: this is not actually called as part of the `meltano upgrade` command

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -45,7 +45,7 @@ except AttributeError:
 class NotFound(Exception):
     """An element is not found."""
 
-    def __init__(self, name, obj_type=None):
+    def __init__(self, name, obj_type=None) -> None:  # noqa: ANN001
         """Create a new exception.
 
         Args:
@@ -58,7 +58,7 @@ class NotFound(Exception):
             super().__init__(f"{obj_type.__name__} '{name}' was not found.")
 
 
-def run_async(func: t.Callable[..., t.Coroutine[t.Any, t.Any, t.Any]]):
+def run_async(func: t.Callable[..., t.Coroutine[t.Any, t.Any, t.Any]]):  # noqa: ANN201
     """Run the given async function using `asyncio.run`.
 
     Args:
@@ -69,14 +69,14 @@ def run_async(func: t.Callable[..., t.Coroutine[t.Any, t.Any, t.Any]]):
     """
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
         return asyncio.run(func(*args, **kwargs))
 
     return wrapper
 
 
 # from https://github.com/jonathanj/compose/blob/master/compose.py
-def compose(*fs: t.Callable[[t.Any], t.Any]):
+def compose(*fs: t.Callable[[t.Any], t.Any]):  # noqa: ANN201
     """Create a composition of unary functions.
 
     Args:
@@ -95,7 +95,7 @@ def compose(*fs: t.Callable[[t.Any], t.Any]):
 
 
 # from http://www.dolphmathews.com/2012/09/slugify-string-in-python.html
-def slugify(s):
+def slugify(s):  # noqa: ANN001, ANN201
     """Normalize strings into something URL-friendly.
 
     Args:
@@ -130,20 +130,20 @@ def slugify(s):
     return s.replace(" ", "-")
 
 
-def get_basic_auth(user, token):
+def get_basic_auth(user, token):  # noqa: ANN001, ANN201
     return HTTPBasicAuth(user, token)
 
 
-def pop_all(keys, d: dict):
+def pop_all(keys, d: dict):  # noqa: ANN001, ANN201
     return {k: d.pop(k) for k in keys}
 
 
-def get_all(keys, d: dict, default=None):
+def get_all(keys, d: dict, default=None):  # noqa: ANN001, ANN201
     return {k: d.get(k, default) for k in keys}
 
 
 # Taken from https://stackoverflow.com/a/20666342
-def merge(src, dest):
+def merge(src, dest):  # noqa: ANN001, ANN201
     """Merge both given dictionaries together at depth, modifying `dest` in-place.
 
     Args:
@@ -171,11 +171,11 @@ def merge(src, dest):
     return dest
 
 
-def are_similar_types(left, right):
+def are_similar_types(left, right):  # noqa: ANN001, ANN201
     return isinstance(left, type(right)) or isinstance(right, type(left))
 
 
-def nest(d: dict, path: str, value=None, maxsplit=-1, *, force=False):
+def nest(d: dict, path: str, value=None, maxsplit=-1, *, force=False):  # noqa: ANN001, ANN201
     """Create a hierarchical dictionary path and return the leaf dict.
 
     Args:
@@ -227,7 +227,7 @@ def nest(d: dict, path: str, value=None, maxsplit=-1, *, force=False):
     return cursor[tail]
 
 
-def nest_object(flat_object):
+def nest_object(flat_object):  # noqa: ANN001, ANN201
     obj = {}
     for key, value in flat_object.items():
         nest(obj, key, value)
@@ -254,7 +254,7 @@ def to_env_var(*xs: str) -> str:
     return "_".join(re.sub("[^A-Za-z0-9]", "_", x).upper() for x in xs if x)
 
 
-def flatten(d: dict, reducer: str | t.Callable = "tuple", **kwargs):
+def flatten(d: dict, reducer: str | t.Callable = "tuple", **kwargs):  # noqa: ANN003, ANN201
     """Flatten a dictionary with `dot` and `env_var` reducers.
 
     Wrapper around `flatten_dict.flatten`.
@@ -287,16 +287,16 @@ def compact(xs: t.Iterable) -> t.Iterable:
     return (x for x in xs if x is not None)
 
 
-def file_has_data(file: Path | str):
+def file_has_data(file: Path | str):  # noqa: ANN201
     file = Path(file)  # ensure it is a Path object
     return file.exists() and file.stat().st_size > 0
 
 
-def identity(x):
+def identity(x):  # noqa: ANN001, ANN201
     return x
 
 
-def noop(*_args, **_kwargs):
+def noop(*_args, **_kwargs) -> None:
     pass
 
 
@@ -390,9 +390,9 @@ def find_named(xs: t.Iterable[_G], name: str, obj_type: type | None = None) -> _
         raise NotFound(name, obj_type) from stop
 
 
-def makedirs(func):
+def makedirs(func):  # noqa: ANN001, ANN201
     @functools.wraps(func)
-    def decorate(*args, **kwargs):
+    def decorate(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
         enabled = kwargs.pop("make_dirs", True)
 
         path = func(*args, **kwargs, make_dirs=enabled)
@@ -408,11 +408,11 @@ def makedirs(func):
     return decorate
 
 
-def is_email_valid(value: str):
+def is_email_valid(value: str):  # noqa: ANN201
     return re.match(REGEX_EMAIL, value)
 
 
-def pop_at_path(d, path, default=None):
+def pop_at_path(d, path, default=None):  # noqa: ANN001, ANN201
     if isinstance(path, str):
         path = path.split(".")
 
@@ -437,7 +437,7 @@ def pop_at_path(d, path, default=None):
     return popped
 
 
-def set_at_path(d, path, value):
+def set_at_path(d, path, value) -> None:  # noqa: ANN001
     if isinstance(path, str):
         path = path.split(".")
 
@@ -600,7 +600,7 @@ def uniques_in(original: t.Sequence[T]) -> list[T]:
 
 
 # https://gist.github.com/cbwar/d2dfbc19b140bd599daccbe0fe925597#gistcomment-2845059
-def human_size(num, suffix="B"):
+def human_size(num, suffix="B") -> str:  # noqa: ANN001
     """Return human-readable file size.
 
     Args:
@@ -656,7 +656,7 @@ def format_exception(exception: BaseException) -> str:
     )
 
 
-def safe_hasattr(obj: t.Any, name: str) -> bool:
+def safe_hasattr(obj: t.Any, name: str) -> bool:  # noqa: ANN401
     """Safely checks if an object has a given attribute.
 
     This is a hacky workaround for the fact that `hasattr` is not allowed by WPS.
@@ -759,7 +759,7 @@ class MergeStrategy(t.NamedTuple):
 class Extendable(t.Protocol):
     """A type protocol for types which have an `extend` method."""
 
-    def extend(self, x: t.Any) -> None:
+    def extend(self, x: t.Any) -> None:  # noqa: ANN401
         """Extend the current instance with another value.
 
         Args:
@@ -811,7 +811,7 @@ def deep_merge(
     return reduce(lambda a, b: _deep_merge(a, b, strategies), data)
 
 
-def _deep_merge(a, b, strategies):
+def _deep_merge(a, b, strategies):  # noqa: ANN001, ANN202
     base: TMapping = copy(a)
     for key, value in b.items():
         for applicable_types, behavior in strategies:

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -175,7 +175,7 @@ def are_similar_types(left, right):
     return isinstance(left, type(right)) or isinstance(right, type(left))
 
 
-def nest(d: dict, path: str, value=None, maxsplit=-1, force=False):
+def nest(d: dict, path: str, value=None, maxsplit=-1, *, force=False):
     """Create a hierarchical dictionary path and return the leaf dict.
 
     Args:
@@ -551,7 +551,7 @@ def expand_env_vars(
             logger.debug(f"Variable '${var}' is empty.")  # noqa: G004
         return val
 
-    return _expand_env_vars(raw_value, replacer, flat)
+    return _expand_env_vars(raw_value, replacer, flat=flat)
 
 
 # Separate inner-function for `expand_env_vars` for performance reasons. Like
@@ -560,13 +560,14 @@ def expand_env_vars(
 def _expand_env_vars(
     raw_value: Expandable,
     replacer: t.Callable[[re.Match], str],
+    *,
     flat: bool,
 ) -> Expandable:
     if isinstance(raw_value, t.Mapping):
         if flat:
             return {k: ENV_VAR_PATTERN.sub(replacer, v) for k, v in raw_value.items()}
         return {
-            k: _expand_env_vars(v, replacer, flat)
+            k: _expand_env_vars(v, replacer, flat=flat)
             if isinstance(v, (str, t.Mapping, list))
             else v
             for k, v in raw_value.items()
@@ -575,7 +576,7 @@ def _expand_env_vars(
         # `flat=True` doesn't seem to be used anywhere and probably doesn't make sense
         # for lists anyway, so we don't support it here.
         return [
-            _expand_env_vars(v, replacer, flat)
+            _expand_env_vars(v, replacer, flat=flat)
             if isinstance(v, (str, t.Mapping, list))
             else v
             for v in raw_value
@@ -703,7 +704,7 @@ def strtobool(val: str) -> bool:
     raise ValueError(f"invalid truth value {val!r}")  # noqa: EM102
 
 
-def get_boolean_env_var(env_var: str, default: bool = False) -> bool:
+def get_boolean_env_var(env_var: str, *, default: bool = False) -> bool:
     """Get the value of an environment variable as a boolean.
 
     Args:

--- a/src/meltano/core/utils/pidfile.py
+++ b/src/meltano/core/utils/pidfile.py
@@ -14,7 +14,7 @@ class PIDFile:
         self._pid = None
 
     @property
-    def pid(self):
+    def pid(self):  # noqa: ANN201
         return self._pid or self.load_pid()
 
     def load_pid(self) -> int:
@@ -29,7 +29,7 @@ class PIDFile:
         logger.debug(f"Loaded PID {self._pid} from {self.path}")  # noqa: G004
         return self._pid
 
-    def write_pid(self, pid: int):
+    def write_pid(self, pid: int) -> None:
         with self.path.open("w") as raw:
             raw.write(str(pid))
             self._pid = pid
@@ -44,7 +44,7 @@ class PIDFile:
         except psutil.NoSuchProcess as ex:
             raise UnknownProcessError(self) from ex
 
-    def unlink(self):
+    def unlink(self):  # noqa: ANN201
         return self.path.unlink()
 
     def __str__(self) -> str:

--- a/src/meltano/core/validation_service.py
+++ b/src/meltano/core/validation_service.py
@@ -106,7 +106,7 @@ class ValidationsRunner(metaclass=ABCMeta):
         if not self.tests_selection:
             return {}
 
-        results = {}
+        results = {}  # type: ignore[var-annotated]
         async with self.invoker.prepared(session):
             for name, selected in self.tests_selection.items():
                 if selected:

--- a/src/meltano/core/validation_service.py
+++ b/src/meltano/core/validation_service.py
@@ -117,6 +117,7 @@ class ValidationsRunner(metaclass=ABCMeta):
     def collect(
         cls: type[T],
         project: Project,
+        *,
         select_all: bool = True,
     ) -> dict[str, T]:
         """Collect all tests for CLI invocation.

--- a/src/meltano/core/validation_service.py
+++ b/src/meltano/core/validation_service.py
@@ -35,7 +35,7 @@ class ValidationOutcome(str, Enum):
         return "green" if self == self.SUCCESS else "red"
 
     @classmethod
-    def from_exit_code(cls, exit_code: int):
+    def from_exit_code(cls, exit_code: int):  # noqa: ANN206
         """Create validation outcome from an exit code.
 
         Args:
@@ -141,7 +141,7 @@ class ValidationsRunner(metaclass=ABCMeta):
         }
 
     @abstractmethod
-    async def run_test(self, name: str):
+    async def run_test(self, name: str) -> t.NoReturn:
         """Run a test command.
 
         Args:

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -241,11 +241,11 @@ class VirtualEnv:
         self.plugin_fingerprint_path.write_text(fingerprint(pip_install_args))
 
 
-async def _extract_stderr(_):
+async def _extract_stderr(_) -> None:
     return None  # pragma: no cover
 
 
-async def exec_async(*args, extract_stderr=_extract_stderr, **kwargs) -> Process:
+async def exec_async(*args, extract_stderr=_extract_stderr, **kwargs) -> Process:  # noqa: ANN001, ANN002, ANN003
     """Run an executable asynchronously in a subprocess.
 
     Args:
@@ -366,7 +366,8 @@ class VenvService:
             Whether virtual environment doesn't exist or can't be reused.
         """
 
-        def checks():  # A generator is used to perform the checks lazily
+        # A generator is used to perform the checks lazily
+        def checks():  # noqa: ANN202
             # The Python installation used to create this venv no longer exists
             yield not self.exec_path("python").exists()
             # The fingerprint of the venv does not match the pip install args
@@ -437,7 +438,7 @@ class VenvService:
         """
         logger.debug(f"Creating virtual environment for '{self.namespace}/{self.name}'")  # noqa: G004
 
-        async def extract_stderr(proc: Process):
+        async def extract_stderr(proc: Process):  # noqa: ANN202
             return (await t.cast(asyncio.StreamReader, proc.stdout).read()).decode(
                 "utf-8",
                 errors="replace",

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -332,8 +332,8 @@ class VenvService:
     async def install(
         self,
         pip_install_args: t.Sequence[str],
-        clean: bool = False,
         *,
+        clean: bool = False,
         env: dict[str, str | None] | None = None,
     ) -> None:
         """Configure a virtual environment, then run pip install with the given args.
@@ -573,8 +573,8 @@ class VenvService:
     async def _pip_install(
         self,
         pip_install_args: t.Sequence[str],
-        clean: bool = False,
         *,
+        clean: bool = False,
         env: dict[str, str | None] | None = None,
     ) -> Process:
         """Install a package using `pip` in the proper virtual environment.

--- a/src/meltano/migrations/env.py
+++ b/src/meltano/migrations/env.py
@@ -6,7 +6,7 @@ from sqlalchemy import engine_from_config, pool
 config = context.config
 
 
-def run_migrations_offline():
+def run_migrations_offline():  # noqa: ANN201
     """Run migrations in 'offline' mode.
 
     This configures the context with just a URL
@@ -25,7 +25,7 @@ def run_migrations_offline():
         context.run_migrations()
 
 
-def run_migrations_online():
+def run_migrations_online():  # noqa: ANN201
     """Run migrations in 'online' mode.
 
     In this scenario we need to create an Engine
@@ -46,7 +46,7 @@ def run_migrations_online():
         _run_migrations_online(new_connection)
 
 
-def _run_migrations_online(connection):
+def _run_migrations_online(connection):  # noqa: ANN001, ANN202
     context.configure(connection=connection)
 
     with context.begin_transaction():

--- a/src/meltano/migrations/utils/dialect_typing.py
+++ b/src/meltano/migrations/utils/dialect_typing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.mssql import DATETIME2
-from sqlalchemy.engine import Connection
+from sqlalchemy.engine import Connection  # noqa: TCH002
 
 
 def get_dialect_name() -> str:

--- a/tests/asserts.py
+++ b/tests/asserts.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:
     from click.testing import Result
 
 
-def assert_cli_runner(results: Result, message=None) -> None:  # noqa: ANN001
+def assert_cli_runner(results: Result, message=None) -> None:
     assertion_message = str(message or results.output)
 
     if results.exception:

--- a/tests/asserts.py
+++ b/tests/asserts.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:
     from click.testing import Result
 
 
-def assert_cli_runner(results: Result, message=None):
+def assert_cli_runner(results: Result, message=None) -> None:  # noqa: ANN001
     assertion_message = str(message or results.output)
 
     if results.exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,6 +163,7 @@ class MockAdapter(BaseAdapter):
     def send(
         self,
         request: requests.PreparedRequest,
+        *,
         stream: bool = False,  # noqa: ARG002
         timeout: float  # noqa: ARG002
         | tuple[float, float]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ else:
 BACKEND = ["sqlite", "postgresql", "mssql", "mysql"]
 
 
-def pytest_runtest_setup(item) -> None:  # noqa: ANN001
+def pytest_runtest_setup(item) -> None:
     backend_marker = item.get_closest_marker("backend")
 
     # currently, there is no distinction between the SYSTEM database
@@ -55,7 +55,7 @@ def pytest_runtest_setup(item) -> None:  # noqa: ANN001
 
 
 @pytest.fixture(scope="session")
-def concurrency():  # noqa: ANN201
+def concurrency():
     return {
         "threads": int(os.getenv("PYTEST_CONCURRENCY_THREADS", 8)),
         "processes": int(os.getenv("PYTEST_CONCURRENCY_PROCESSES", 8)),
@@ -160,7 +160,7 @@ class MockAdapter(BaseAdapter):
             },
         }
 
-    def send(  # noqa: ANN201
+    def send(
         self,
         request: requests.PreparedRequest,
         *,
@@ -170,7 +170,7 @@ class MockAdapter(BaseAdapter):
         | tuple[float, None]
         | None = None,
         verify: bool | str = True,  # noqa: ARG002
-        cert: t.Any | None = None,  # noqa: ANN401, ARG002
+        cert: t.Any | None = None,  # noqa: ARG002
         proxies: abc.Mapping[str, str] | None = None,  # noqa: ARG002
     ):
         _, endpoint = request.path_url.split("/meltano/api/v1/plugins")
@@ -200,7 +200,7 @@ class MockAdapter(BaseAdapter):
 
 
 @pytest.fixture(scope="class")
-def hub_mock_adapter(discovery) -> t.Callable[[str], MockAdapter]:  # noqa: ANN001
+def hub_mock_adapter(discovery) -> t.Callable[[str], MockAdapter]:
     def _get_adapter(api_url: str) -> MockAdapter:
         return MockAdapter(api_url, discovery)
 
@@ -208,13 +208,13 @@ def hub_mock_adapter(discovery) -> t.Callable[[str], MockAdapter]:  # noqa: ANN0
 
 
 @pytest.fixture(scope="class")
-def hub_endpoints(project: Project):  # noqa: ANN201
+def hub_endpoints(project: Project):
     adapter = project.hub_service.session.adapters[project.hub_service.hub_api_url]
     return adapter._mapping
 
 
 @pytest.fixture()
-def hub_request_counter(project: Project):  # noqa: ANN201
+def hub_request_counter(project: Project):
     counter: Counter = project.hub_service.session.get_adapter(
         project.hub_service.hub_api_url,
     ).count

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ else:
 BACKEND = ["sqlite", "postgresql", "mssql", "mysql"]
 
 
-def pytest_runtest_setup(item):
+def pytest_runtest_setup(item) -> None:  # noqa: ANN001
     backend_marker = item.get_closest_marker("backend")
 
     # currently, there is no distinction between the SYSTEM database
@@ -55,7 +55,7 @@ def pytest_runtest_setup(item):
 
 
 @pytest.fixture(scope="session")
-def concurrency():
+def concurrency():  # noqa: ANN201
     return {
         "threads": int(os.getenv("PYTEST_CONCURRENCY_THREADS", 8)),
         "processes": int(os.getenv("PYTEST_CONCURRENCY_PROCESSES", 8)),
@@ -160,7 +160,7 @@ class MockAdapter(BaseAdapter):
             },
         }
 
-    def send(
+    def send(  # noqa: ANN201
         self,
         request: requests.PreparedRequest,
         *,
@@ -170,7 +170,7 @@ class MockAdapter(BaseAdapter):
         | tuple[float, None]
         | None = None,
         verify: bool | str = True,  # noqa: ARG002
-        cert: t.Any | None = None,  # noqa: ARG002
+        cert: t.Any | None = None,  # noqa: ANN401, ARG002
         proxies: abc.Mapping[str, str] | None = None,  # noqa: ARG002
     ):
         _, endpoint = request.path_url.split("/meltano/api/v1/plugins")
@@ -200,7 +200,7 @@ class MockAdapter(BaseAdapter):
 
 
 @pytest.fixture(scope="class")
-def hub_mock_adapter(discovery) -> t.Callable[[str], MockAdapter]:
+def hub_mock_adapter(discovery) -> t.Callable[[str], MockAdapter]:  # noqa: ANN001
     def _get_adapter(api_url: str) -> MockAdapter:
         return MockAdapter(api_url, discovery)
 
@@ -208,13 +208,13 @@ def hub_mock_adapter(discovery) -> t.Callable[[str], MockAdapter]:
 
 
 @pytest.fixture(scope="class")
-def hub_endpoints(project: Project):
+def hub_endpoints(project: Project):  # noqa: ANN201
     adapter = project.hub_service.session.adapters[project.hub_service.hub_api_url]
     return adapter._mapping
 
 
 @pytest.fixture()
-def hub_request_counter(project: Project):
+def hub_request_counter(project: Project):  # noqa: ANN201
     counter: Counter = project.hub_service.session.get_adapter(
         project.hub_service.hub_api_url,
     ).count

--- a/tests/fixtures/cli.py
+++ b/tests/fixtures/cli.py
@@ -23,12 +23,12 @@ plugins_dir = current_dir / "plugins"
 
 
 class MeltanoCliRunner(CliRunner):
-    def __init__(self, *args, snowplow: SnowplowMicro | None = None, **kwargs):  # noqa: ANN002, ANN003
+    def __init__(self, *args, snowplow: SnowplowMicro | None = None, **kwargs):
         """Initialize the `MeltanoCliRunner`."""
         self.snowplow = snowplow
         super().__init__(*args, **kwargs)
 
-    def invoke(self, cli: Command, *args, **kwargs) -> Result:  # noqa: ANN002, ANN003
+    def invoke(self, cli: Command, *args, **kwargs) -> Result:
         results = super().invoke(cli, *args, **kwargs)
         if self.snowplow:  # pragma: no cover
             assert self.snowplow.all()["bad"] == 0  # pragma: no cover
@@ -37,7 +37,7 @@ class MeltanoCliRunner(CliRunner):
 
 
 @pytest.fixture()
-def cli_runner(pushd, snowplow_optional: SnowplowMicro | None):  # noqa: ANN001, ANN201
+def cli_runner(pushd, snowplow_optional: SnowplowMicro | None):
     pushd(os.getcwd())  # Ensure we return to the CWD after the test
     root_logger = logging.getLogger()  # noqa: TID251
     log_level = root_logger.level
@@ -48,8 +48,8 @@ def cli_runner(pushd, snowplow_optional: SnowplowMicro | None):  # noqa: ANN001,
 
 
 @pytest.fixture(scope="class")
-def large_config_project(  # noqa: ANN201
-    compatible_copy_tree,  # noqa: ANN001
+def large_config_project(
+    compatible_copy_tree,
     tmp_path_factory: pytest.TempPathFactory,
 ):
     with cd(tmp_path_factory.mktemp("meltano-large-config-project")), tmp_project(
@@ -61,7 +61,7 @@ def large_config_project(  # noqa: ANN201
 
 
 @pytest.fixture(scope="class")
-def project_files_cli(compatible_copy_tree, tmp_path_factory: pytest.TempPathFactory):  # noqa: ANN001, ANN201
+def project_files_cli(compatible_copy_tree, tmp_path_factory: pytest.TempPathFactory):
     with cd(tmp_path_factory.mktemp("meltano-project-files-cli")), tmp_project(
         "a_multifile_meltano_project_cli",
         current_dir / "multifile_project",

--- a/tests/fixtures/cli.py
+++ b/tests/fixtures/cli.py
@@ -23,12 +23,12 @@ plugins_dir = current_dir / "plugins"
 
 
 class MeltanoCliRunner(CliRunner):
-    def __init__(self, *args, snowplow: SnowplowMicro | None = None, **kwargs):
+    def __init__(self, *args, snowplow: SnowplowMicro | None = None, **kwargs):  # noqa: ANN002, ANN003
         """Initialize the `MeltanoCliRunner`."""
         self.snowplow = snowplow
         super().__init__(*args, **kwargs)
 
-    def invoke(self, cli: Command, *args, **kwargs) -> Result:
+    def invoke(self, cli: Command, *args, **kwargs) -> Result:  # noqa: ANN002, ANN003
         results = super().invoke(cli, *args, **kwargs)
         if self.snowplow:  # pragma: no cover
             assert self.snowplow.all()["bad"] == 0  # pragma: no cover
@@ -37,7 +37,7 @@ class MeltanoCliRunner(CliRunner):
 
 
 @pytest.fixture()
-def cli_runner(pushd, snowplow_optional: SnowplowMicro | None):
+def cli_runner(pushd, snowplow_optional: SnowplowMicro | None):  # noqa: ANN001, ANN201
     pushd(os.getcwd())  # Ensure we return to the CWD after the test
     root_logger = logging.getLogger()  # noqa: TID251
     log_level = root_logger.level
@@ -48,8 +48,8 @@ def cli_runner(pushd, snowplow_optional: SnowplowMicro | None):
 
 
 @pytest.fixture(scope="class")
-def large_config_project(
-    compatible_copy_tree,
+def large_config_project(  # noqa: ANN201
+    compatible_copy_tree,  # noqa: ANN001
     tmp_path_factory: pytest.TempPathFactory,
 ):
     with cd(tmp_path_factory.mktemp("meltano-large-config-project")), tmp_project(
@@ -61,7 +61,7 @@ def large_config_project(
 
 
 @pytest.fixture(scope="class")
-def project_files_cli(compatible_copy_tree, tmp_path_factory: pytest.TempPathFactory):
+def project_files_cli(compatible_copy_tree, tmp_path_factory: pytest.TempPathFactory):  # noqa: ANN001, ANN201
     with cd(tmp_path_factory.mktemp("meltano-project-files-cli")), tmp_project(
         "a_multifile_meltano_project_cli",
         current_dir / "multifile_project",

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -45,7 +45,7 @@ current_dir = Path(__file__).parent
 
 
 @pytest.fixture(scope="class")
-def discovery():  # noqa: ANN201
+def discovery():
     return {
         PluginType.EXTRACTORS: [
             {
@@ -1871,36 +1871,36 @@ def discovery():  # noqa: ANN201
 
 
 @pytest.fixture(scope="class")
-def locked_definition_service(project):  # noqa: ANN001, ANN201
+def locked_definition_service(project):
     return LockedDefinitionService(project)
 
 
 @pytest.fixture(scope="class")
-def project_init_service(request):  # noqa: ANN001, ANN201
+def project_init_service(request):
     return ProjectInitService(f"project_{request.node.name}")
 
 
 @pytest.fixture(scope="class")
-def plugin_install_service(project):  # noqa: ANN001, ANN201
+def plugin_install_service(project):
     return PluginInstallService(project)
 
 
 @pytest.fixture(scope="class")
-def project_add_service(project):  # noqa: ANN001, ANN201
+def project_add_service(project):
     return ProjectAddService(project)
 
 
 @pytest.fixture(scope="class")
-def plugin_settings_service_factory(project):  # noqa: ANN001, ANN201
-    def _factory(plugin, **kwargs):  # noqa: ANN001, ANN003, ANN202
+def plugin_settings_service_factory(project):
+    def _factory(plugin, **kwargs):
         return PluginSettingsService(project, plugin, **kwargs)
 
     return _factory
 
 
 @pytest.fixture(scope="class")
-def plugin_invoker_factory(project, plugin_settings_service_factory):  # noqa: ANN001, ANN201
-    def _factory(plugin, **kwargs):  # noqa: ANN001, ANN003, ANN202
+def plugin_invoker_factory(project, plugin_settings_service_factory):
+    def _factory(plugin, **kwargs):
         return invoker_factory(
             project,
             plugin,
@@ -1912,7 +1912,7 @@ def plugin_invoker_factory(project, plugin_settings_service_factory):  # noqa: A
 
 
 @pytest.fixture(scope="class")
-def tap(project_add_service):  # noqa: ANN001, ANN201
+def tap(project_add_service):
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1924,7 +1924,7 @@ def tap(project_add_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def alternative_tap(project_add_service, tap):  # noqa: ANN001, ANN201
+def alternative_tap(project_add_service, tap):
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1937,7 +1937,7 @@ def alternative_tap(project_add_service, tap):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def inherited_tap(project_add_service, tap):  # noqa: ANN001, ANN201
+def inherited_tap(project_add_service, tap):
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1953,7 +1953,7 @@ def inherited_tap(project_add_service, tap):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def nonpip_tap(project_add_service):  # noqa: ANN001, ANN201
+def nonpip_tap(project_add_service):
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1965,7 +1965,7 @@ def nonpip_tap(project_add_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def target(project_add_service):  # noqa: ANN001, ANN201
+def target(project_add_service):
     try:
         return project_add_service.add(PluginType.LOADERS, "target-mock")
     except PluginAlreadyAddedException as err:
@@ -1973,7 +1973,7 @@ def target(project_add_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def alternative_target(project_add_service):  # noqa: ANN001, ANN201
+def alternative_target(project_add_service):
     # We don't load the `target` fixture here since this ProjectPlugin should
     # have a BasePlugin parent, not the `target` ProjectPlugin
     try:
@@ -1987,7 +1987,7 @@ def alternative_target(project_add_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def dbt(project_add_service):  # noqa: ANN001, ANN201
+def dbt(project_add_service):
     try:
         return project_add_service.add(PluginType.TRANSFORMERS, "dbt")
     except PluginAlreadyAddedException as err:
@@ -1995,7 +1995,7 @@ def dbt(project_add_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def transformer(project_add_service: ProjectAddService):  # noqa: ANN201
+def transformer(project_add_service: ProjectAddService):
     try:
         return project_add_service.add(PluginType.TRANSFORMERS, "transformer-mock")
     except PluginAlreadyAddedException as err:
@@ -2003,7 +2003,7 @@ def transformer(project_add_service: ProjectAddService):  # noqa: ANN201
 
 
 @pytest.fixture(scope="class")
-def utility(project_add_service):  # noqa: ANN001, ANN201
+def utility(project_add_service):
     try:
         return project_add_service.add(PluginType.UTILITIES, "utility-mock")
     except PluginAlreadyAddedException as err:
@@ -2011,21 +2011,21 @@ def utility(project_add_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def schedule_service(project):  # noqa: ANN001, ANN201
+def schedule_service(project):
     return ScheduleService(project)
 
 
 @pytest.fixture(scope="class")
-def task_sets_service(project):  # noqa: ANN001, ANN201
+def task_sets_service(project):
     return TaskSetsService(project)
 
 
 @pytest.fixture(scope="class")
-def elt_schedule(  # noqa: ANN201
-    project,  # noqa: ANN001, ARG001
-    tap,  # noqa: ANN001
-    target,  # noqa: ANN001
-    schedule_service,  # noqa: ANN001
+def elt_schedule(
+    project,  # noqa: ARG001
+    tap,
+    target,
+    schedule_service,
 ):
     try:
         return schedule_service.add_elt(
@@ -2042,11 +2042,11 @@ def elt_schedule(  # noqa: ANN201
 
 
 @pytest.fixture(scope="class")
-def job_schedule(  # noqa: ANN201
-    project,  # noqa: ANN001, ARG001
-    tap,  # noqa: ANN001, ARG001
-    target,  # noqa: ANN001, ARG001
-    schedule_service,  # noqa: ANN001
+def job_schedule(
+    project,  # noqa: ARG001
+    tap,  # noqa: ARG001
+    target,  # noqa: ARG001
+    schedule_service,
 ):
     try:
         return schedule_service.add(
@@ -2059,7 +2059,7 @@ def job_schedule(  # noqa: ANN201
 
 
 @pytest.fixture()
-def environment_service(project):  # noqa: ANN001, ANN201
+def environment_service(project):
     service = EnvironmentService(project)
     try:
         yield service
@@ -2070,17 +2070,17 @@ def environment_service(project):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def elt_context_builder(project):  # noqa: ANN001, ANN201
+def elt_context_builder(project):
     return ELTContextBuilder(project)
 
 
 @pytest.fixture(scope="class")
-def job_logging_service(project):  # noqa: ANN001, ANN201
+def job_logging_service(project):
     return JobLoggingService(project)
 
 
 @contextmanager
-def project_directory(project_init_service):  # noqa: ANN001, ANN201
+def project_directory(project_init_service):
     project = project_init_service.init()
     logging.debug(f"Created new project at {project.root}")  # noqa: G004, TID251
 
@@ -2101,8 +2101,8 @@ def project_directory(project_init_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def project(  # noqa: ANN201
-    project_init_service,  # noqa: ANN001
+def project(
+    project_init_service,
     tmp_path_factory: pytest.TempPathFactory,
     hub_mock_adapter: t.Callable[[str], BaseAdapter],
 ):
@@ -2117,13 +2117,13 @@ def project(  # noqa: ANN201
 
 
 @pytest.fixture()
-def project_function(project_init_service, tmp_path: Path):  # noqa: ANN001, ANN201
+def project_function(project_init_service, tmp_path: Path):
     with cd(tmp_path), project_directory(project_init_service) as project:
         yield project
 
 
 @pytest.fixture(scope="class")
-def project_files(tmp_path_factory: pytest.TempPathFactory, compatible_copy_tree):  # noqa: ANN001, ANN201
+def project_files(tmp_path_factory: pytest.TempPathFactory, compatible_copy_tree):
     with cd(tmp_path_factory.mktemp("meltano-project-files")), tmp_project(
         "a_multifile_meltano_project_core",
         current_dir / "multifile_project",
@@ -2133,7 +2133,7 @@ def project_files(tmp_path_factory: pytest.TempPathFactory, compatible_copy_tree
 
 
 @pytest.fixture(scope="class")
-def mapper(project_add_service):  # noqa: ANN001, ANN201
+def mapper(project_add_service):
     try:
         return project_add_service.add(
             PluginType.MAPPERS,
@@ -2180,7 +2180,7 @@ def num_params() -> int:
 
 
 @pytest.fixture()
-def payloads(num_params):  # noqa: ANN001, ANN201
+def payloads(num_params):
     mock_payloads_dict = {
         "mock_state_payloads": [
             {
@@ -2198,8 +2198,8 @@ def payloads(num_params):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def state_ids(  # noqa: ANN201
-    num_params,  # noqa: ANN001, ARG001
+def state_ids(
+    num_params,  # noqa: ARG001
 ):
     state_id_dict = {
         "single_incomplete_state_id": create_state_id("single-incomplete"),
@@ -2218,8 +2218,8 @@ def state_ids(  # noqa: ANN201
 
 
 @pytest.fixture()
-def mock_time():  # noqa: ANN201
-    def _mock_time():  # noqa: ANN202
+def mock_time():
+    def _mock_time():
         for idx in itertools.count():
             yield datetime.datetime(
                 1,
@@ -2232,7 +2232,7 @@ def mock_time():  # noqa: ANN201
 
 
 @pytest.fixture()
-def job_args():  # noqa: ANN201
+def job_args():
     job_args_dict = {
         "complete_job_args": {"state": State.SUCCESS, "payload_flags": Payload.STATE},
         "incomplete_job_args": {
@@ -2245,7 +2245,7 @@ def job_args():  # noqa: ANN201
 
 
 @pytest.fixture()
-def state_ids_with_jobs(state_ids, job_args, payloads, mock_time):  # noqa: ANN001, ANN201
+def state_ids_with_jobs(state_ids, job_args, payloads, mock_time):
     jobs = {
         state_ids.single_incomplete_state_id: [
             Job(
@@ -2316,15 +2316,15 @@ def state_ids_with_jobs(state_ids, job_args, payloads, mock_time):  # noqa: ANN0
 
 
 @pytest.fixture()
-def jobs(state_ids_with_jobs):  # noqa: ANN001, ANN201
+def jobs(state_ids_with_jobs):
     return [job for job_list in state_ids_with_jobs.values() for job in job_list]
 
 
 @pytest.fixture()
-def state_ids_with_expected_states(  # noqa: ANN201
-    state_ids,  # noqa: ANN001
-    payloads,  # noqa: ANN001
-    state_ids_with_jobs,  # noqa: ANN001
+def state_ids_with_expected_states(
+    state_ids,
+    payloads,
+    state_ids_with_jobs,
 ):
     final_state = {}
     for state in payloads.mock_state_payloads:
@@ -2376,7 +2376,7 @@ def state_ids_with_expected_states(  # noqa: ANN201
 
 
 @pytest.fixture()
-def job_history_session(jobs, session):  # noqa: ANN001, ANN201
+def job_history_session(jobs, session):
     job: Job
     job_names = set()
     for job in jobs:
@@ -2389,12 +2389,12 @@ def job_history_session(jobs, session):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def state_service(job_history_session, project):  # noqa: ANN001, ANN201
+def state_service(job_history_session, project):
     return StateService(project, session=job_history_session)
 
 
 @pytest.fixture()
-def project_with_environment(project: Project):  # noqa: ANN201
+def project_with_environment(project: Project):
     project.activate_environment("dev")
     project.environment.env["ENVIRONMENT_ENV_VAR"] = "${MELTANO_PROJECT_ROOT}/file.txt"
     try:
@@ -2432,7 +2432,7 @@ test_log_config = {
 
 
 @pytest.fixture()
-def use_test_log_config():  # noqa: ANN201
+def use_test_log_config():
     with mock.patch(
         "meltano.core.logging.utils.default_config",
         return_value=test_log_config,

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -45,7 +45,7 @@ current_dir = Path(__file__).parent
 
 
 @pytest.fixture(scope="class")
-def discovery():
+def discovery():  # noqa: ANN201
     return {
         PluginType.EXTRACTORS: [
             {
@@ -1871,36 +1871,36 @@ def discovery():
 
 
 @pytest.fixture(scope="class")
-def locked_definition_service(project):
+def locked_definition_service(project):  # noqa: ANN001, ANN201
     return LockedDefinitionService(project)
 
 
 @pytest.fixture(scope="class")
-def project_init_service(request):
+def project_init_service(request):  # noqa: ANN001, ANN201
     return ProjectInitService(f"project_{request.node.name}")
 
 
 @pytest.fixture(scope="class")
-def plugin_install_service(project):
+def plugin_install_service(project):  # noqa: ANN001, ANN201
     return PluginInstallService(project)
 
 
 @pytest.fixture(scope="class")
-def project_add_service(project):
+def project_add_service(project):  # noqa: ANN001, ANN201
     return ProjectAddService(project)
 
 
 @pytest.fixture(scope="class")
-def plugin_settings_service_factory(project):
-    def _factory(plugin, **kwargs):
+def plugin_settings_service_factory(project):  # noqa: ANN001, ANN201
+    def _factory(plugin, **kwargs):  # noqa: ANN001, ANN003, ANN202
         return PluginSettingsService(project, plugin, **kwargs)
 
     return _factory
 
 
 @pytest.fixture(scope="class")
-def plugin_invoker_factory(project, plugin_settings_service_factory):
-    def _factory(plugin, **kwargs):
+def plugin_invoker_factory(project, plugin_settings_service_factory):  # noqa: ANN001, ANN201
+    def _factory(plugin, **kwargs):  # noqa: ANN001, ANN003, ANN202
         return invoker_factory(
             project,
             plugin,
@@ -1912,7 +1912,7 @@ def plugin_invoker_factory(project, plugin_settings_service_factory):
 
 
 @pytest.fixture(scope="class")
-def tap(project_add_service):
+def tap(project_add_service):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1924,7 +1924,7 @@ def tap(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def alternative_tap(project_add_service, tap):
+def alternative_tap(project_add_service, tap):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1937,7 +1937,7 @@ def alternative_tap(project_add_service, tap):
 
 
 @pytest.fixture(scope="class")
-def inherited_tap(project_add_service, tap):
+def inherited_tap(project_add_service, tap):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1953,7 +1953,7 @@ def inherited_tap(project_add_service, tap):
 
 
 @pytest.fixture(scope="class")
-def nonpip_tap(project_add_service):
+def nonpip_tap(project_add_service):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1965,7 +1965,7 @@ def nonpip_tap(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def target(project_add_service):
+def target(project_add_service):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(PluginType.LOADERS, "target-mock")
     except PluginAlreadyAddedException as err:
@@ -1973,7 +1973,7 @@ def target(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def alternative_target(project_add_service):
+def alternative_target(project_add_service):  # noqa: ANN001, ANN201
     # We don't load the `target` fixture here since this ProjectPlugin should
     # have a BasePlugin parent, not the `target` ProjectPlugin
     try:
@@ -1987,7 +1987,7 @@ def alternative_target(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def dbt(project_add_service):
+def dbt(project_add_service):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(PluginType.TRANSFORMERS, "dbt")
     except PluginAlreadyAddedException as err:
@@ -1995,7 +1995,7 @@ def dbt(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def transformer(project_add_service: ProjectAddService):
+def transformer(project_add_service: ProjectAddService):  # noqa: ANN201
     try:
         return project_add_service.add(PluginType.TRANSFORMERS, "transformer-mock")
     except PluginAlreadyAddedException as err:
@@ -2003,7 +2003,7 @@ def transformer(project_add_service: ProjectAddService):
 
 
 @pytest.fixture(scope="class")
-def utility(project_add_service):
+def utility(project_add_service):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(PluginType.UTILITIES, "utility-mock")
     except PluginAlreadyAddedException as err:
@@ -2011,21 +2011,21 @@ def utility(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def schedule_service(project):
+def schedule_service(project):  # noqa: ANN001, ANN201
     return ScheduleService(project)
 
 
 @pytest.fixture(scope="class")
-def task_sets_service(project):
+def task_sets_service(project):  # noqa: ANN001, ANN201
     return TaskSetsService(project)
 
 
 @pytest.fixture(scope="class")
-def elt_schedule(
-    project,  # noqa: ARG001
-    tap,
-    target,
-    schedule_service,
+def elt_schedule(  # noqa: ANN201
+    project,  # noqa: ANN001, ARG001
+    tap,  # noqa: ANN001
+    target,  # noqa: ANN001
+    schedule_service,  # noqa: ANN001
 ):
     try:
         return schedule_service.add_elt(
@@ -2042,11 +2042,11 @@ def elt_schedule(
 
 
 @pytest.fixture(scope="class")
-def job_schedule(
-    project,  # noqa: ARG001
-    tap,  # noqa: ARG001
-    target,  # noqa: ARG001
-    schedule_service,
+def job_schedule(  # noqa: ANN201
+    project,  # noqa: ANN001, ARG001
+    tap,  # noqa: ANN001, ARG001
+    target,  # noqa: ANN001, ARG001
+    schedule_service,  # noqa: ANN001
 ):
     try:
         return schedule_service.add(
@@ -2059,7 +2059,7 @@ def job_schedule(
 
 
 @pytest.fixture()
-def environment_service(project):
+def environment_service(project):  # noqa: ANN001, ANN201
     service = EnvironmentService(project)
     try:
         yield service
@@ -2070,17 +2070,17 @@ def environment_service(project):
 
 
 @pytest.fixture(scope="class")
-def elt_context_builder(project):
+def elt_context_builder(project):  # noqa: ANN001, ANN201
     return ELTContextBuilder(project)
 
 
 @pytest.fixture(scope="class")
-def job_logging_service(project):
+def job_logging_service(project):  # noqa: ANN001, ANN201
     return JobLoggingService(project)
 
 
 @contextmanager
-def project_directory(project_init_service):
+def project_directory(project_init_service):  # noqa: ANN001, ANN201
     project = project_init_service.init()
     logging.debug(f"Created new project at {project.root}")  # noqa: G004, TID251
 
@@ -2101,8 +2101,8 @@ def project_directory(project_init_service):
 
 
 @pytest.fixture(scope="class")
-def project(
-    project_init_service,
+def project(  # noqa: ANN201
+    project_init_service,  # noqa: ANN001
     tmp_path_factory: pytest.TempPathFactory,
     hub_mock_adapter: t.Callable[[str], BaseAdapter],
 ):
@@ -2117,13 +2117,13 @@ def project(
 
 
 @pytest.fixture()
-def project_function(project_init_service, tmp_path: Path):
+def project_function(project_init_service, tmp_path: Path):  # noqa: ANN001, ANN201
     with cd(tmp_path), project_directory(project_init_service) as project:
         yield project
 
 
 @pytest.fixture(scope="class")
-def project_files(tmp_path_factory: pytest.TempPathFactory, compatible_copy_tree):
+def project_files(tmp_path_factory: pytest.TempPathFactory, compatible_copy_tree):  # noqa: ANN001, ANN201
     with cd(tmp_path_factory.mktemp("meltano-project-files")), tmp_project(
         "a_multifile_meltano_project_core",
         current_dir / "multifile_project",
@@ -2133,7 +2133,7 @@ def project_files(tmp_path_factory: pytest.TempPathFactory, compatible_copy_tree
 
 
 @pytest.fixture(scope="class")
-def mapper(project_add_service):
+def mapper(project_add_service):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(
             PluginType.MAPPERS,
@@ -2175,12 +2175,12 @@ def create_state_id(description: str, env: str = "dev") -> str:
 
 
 @pytest.fixture()
-def num_params():
+def num_params() -> int:
     return 10
 
 
 @pytest.fixture()
-def payloads(num_params):
+def payloads(num_params):  # noqa: ANN001, ANN201
     mock_payloads_dict = {
         "mock_state_payloads": [
             {
@@ -2198,8 +2198,8 @@ def payloads(num_params):
 
 
 @pytest.fixture()
-def state_ids(
-    num_params,  # noqa: ARG001
+def state_ids(  # noqa: ANN201
+    num_params,  # noqa: ANN001, ARG001
 ):
     state_id_dict = {
         "single_incomplete_state_id": create_state_id("single-incomplete"),
@@ -2218,8 +2218,8 @@ def state_ids(
 
 
 @pytest.fixture()
-def mock_time():
-    def _mock_time():
+def mock_time():  # noqa: ANN201
+    def _mock_time():  # noqa: ANN202
         for idx in itertools.count():
             yield datetime.datetime(
                 1,
@@ -2232,7 +2232,7 @@ def mock_time():
 
 
 @pytest.fixture()
-def job_args():
+def job_args():  # noqa: ANN201
     job_args_dict = {
         "complete_job_args": {"state": State.SUCCESS, "payload_flags": Payload.STATE},
         "incomplete_job_args": {
@@ -2245,7 +2245,7 @@ def job_args():
 
 
 @pytest.fixture()
-def state_ids_with_jobs(state_ids, job_args, payloads, mock_time):
+def state_ids_with_jobs(state_ids, job_args, payloads, mock_time):  # noqa: ANN001, ANN201
     jobs = {
         state_ids.single_incomplete_state_id: [
             Job(
@@ -2316,15 +2316,15 @@ def state_ids_with_jobs(state_ids, job_args, payloads, mock_time):
 
 
 @pytest.fixture()
-def jobs(state_ids_with_jobs):
+def jobs(state_ids_with_jobs):  # noqa: ANN001, ANN201
     return [job for job_list in state_ids_with_jobs.values() for job in job_list]
 
 
 @pytest.fixture()
-def state_ids_with_expected_states(
-    state_ids,
-    payloads,
-    state_ids_with_jobs,
+def state_ids_with_expected_states(  # noqa: ANN201
+    state_ids,  # noqa: ANN001
+    payloads,  # noqa: ANN001
+    state_ids_with_jobs,  # noqa: ANN001
 ):
     final_state = {}
     for state in payloads.mock_state_payloads:
@@ -2376,7 +2376,7 @@ def state_ids_with_expected_states(
 
 
 @pytest.fixture()
-def job_history_session(jobs, session):
+def job_history_session(jobs, session):  # noqa: ANN001, ANN201
     job: Job
     job_names = set()
     for job in jobs:
@@ -2389,12 +2389,12 @@ def job_history_session(jobs, session):
 
 
 @pytest.fixture()
-def state_service(job_history_session, project):
+def state_service(job_history_session, project):  # noqa: ANN001, ANN201
     return StateService(project, session=job_history_session)
 
 
 @pytest.fixture()
-def project_with_environment(project: Project):
+def project_with_environment(project: Project):  # noqa: ANN201
     project.activate_environment("dev")
     project.environment.env["ENVIRONMENT_ENV_VAR"] = "${MELTANO_PROJECT_ROOT}/file.txt"
     try:
@@ -2432,7 +2432,7 @@ test_log_config = {
 
 
 @pytest.fixture()
-def use_test_log_config():
+def use_test_log_config():  # noqa: ANN201
     with mock.patch(
         "meltano.core.logging.utils.default_config",
         return_value=test_log_config,
@@ -2444,7 +2444,7 @@ def use_test_log_config():
 def reset_project_context(
     project: Project,
     project_init_service: ProjectInitService,
-):
+) -> None:
     for path in project.root.iterdir():
         if path.is_dir():
             shutil.rmtree(path)

--- a/tests/fixtures/db/__init__.py
+++ b/tests/fixtures/db/__init__.py
@@ -28,7 +28,7 @@ def engine_uri_env(engine_uri: str) -> t.Generator:
 
 
 @pytest.fixture()
-def un_engine_uri(monkeypatch):
+def un_engine_uri(monkeypatch) -> None:  # noqa: ANN001
     """When we want to test functionality that doesn't use the current DB URI.
 
     Note that this fixture must run before the project fixture as
@@ -38,7 +38,7 @@ def un_engine_uri(monkeypatch):
 
 
 @pytest.fixture(scope="class", autouse=True)
-def vacuum_db(engine_sessionmaker):
+def vacuum_db(engine_sessionmaker):  # noqa: ANN001, ANN201
     try:
         yield
     finally:
@@ -51,13 +51,13 @@ def vacuum_db(engine_sessionmaker):
 
 
 @pytest.fixture(scope="class")
-def engine_sessionmaker(engine_uri):
+def engine_sessionmaker(engine_uri):  # noqa: ANN001, ANN201
     engine = create_engine(engine_uri, poolclass=NullPool, future=True)
     return (engine, sessionmaker(bind=engine, future=True))
 
 
 @pytest.fixture()
-def connection(engine_sessionmaker):
+def connection(engine_sessionmaker):  # noqa: ANN001, ANN201
     engine, _ = engine_sessionmaker
     connection = engine.connect()
     transaction = connection.begin()
@@ -77,10 +77,10 @@ def connection(engine_sessionmaker):
 
 
 @pytest.fixture()
-def session(
+def session(  # noqa: ANN201
     project: Project,  # noqa: ARG001
-    engine_sessionmaker,
-    connection,
+    engine_sessionmaker,  # noqa: ANN001
+    connection,  # noqa: ANN001
 ):
     """Create a new database session for a test.
 

--- a/tests/fixtures/db/__init__.py
+++ b/tests/fixtures/db/__init__.py
@@ -28,7 +28,7 @@ def engine_uri_env(engine_uri: str) -> t.Generator:
 
 
 @pytest.fixture()
-def un_engine_uri(monkeypatch) -> None:  # noqa: ANN001
+def un_engine_uri(monkeypatch) -> None:
     """When we want to test functionality that doesn't use the current DB URI.
 
     Note that this fixture must run before the project fixture as
@@ -38,7 +38,7 @@ def un_engine_uri(monkeypatch) -> None:  # noqa: ANN001
 
 
 @pytest.fixture(scope="class", autouse=True)
-def vacuum_db(engine_sessionmaker):  # noqa: ANN001, ANN201
+def vacuum_db(engine_sessionmaker):
     try:
         yield
     finally:
@@ -51,13 +51,13 @@ def vacuum_db(engine_sessionmaker):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(scope="class")
-def engine_sessionmaker(engine_uri):  # noqa: ANN001, ANN201
+def engine_sessionmaker(engine_uri):
     engine = create_engine(engine_uri, poolclass=NullPool, future=True)
     return (engine, sessionmaker(bind=engine, future=True))
 
 
 @pytest.fixture()
-def connection(engine_sessionmaker):  # noqa: ANN001, ANN201
+def connection(engine_sessionmaker):
     engine, _ = engine_sessionmaker
     connection = engine.connect()
     transaction = connection.begin()
@@ -77,10 +77,10 @@ def connection(engine_sessionmaker):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def session(  # noqa: ANN201
+def session(
     project: Project,  # noqa: ARG001
-    engine_sessionmaker,  # noqa: ANN001
-    connection,  # noqa: ANN001
+    engine_sessionmaker,
+    connection,
 ):
     """Create a new database session for a test.
 

--- a/tests/fixtures/db/mssql.py
+++ b/tests/fixtures/db/mssql.py
@@ -14,7 +14,7 @@ if t.TYPE_CHECKING:
     from sqlalchemy.engine import URL
 
 
-def recreate_database(engine, db_name):
+def recreate_database(engine, db_name) -> None:  # noqa: ANN001
     """Drop & Create a new database.
 
     We need to use the master connection to do this.
@@ -61,7 +61,7 @@ def create_connection_url(
 
 
 @pytest.fixture(scope="session")
-def engine_uri(worker_id: str):
+def engine_uri(worker_id: str):  # noqa: ANN201
     host = os.getenv("MSSQL_ADDRESS")
     port = os.getenv("MSSQL_PORT", 1433)
     user = os.getenv("MSSQL_USER")
@@ -85,7 +85,7 @@ def engine_uri(worker_id: str):
 
 
 @pytest.fixture()
-def pg_stats(request, session):
+def pg_stats(request, session):  # noqa: ANN001, ANN201
     yield
 
     from meltano.core.job import Job

--- a/tests/fixtures/db/mssql.py
+++ b/tests/fixtures/db/mssql.py
@@ -14,7 +14,7 @@ if t.TYPE_CHECKING:
     from sqlalchemy.engine import URL
 
 
-def recreate_database(engine, db_name) -> None:  # noqa: ANN001
+def recreate_database(engine, db_name) -> None:
     """Drop & Create a new database.
 
     We need to use the master connection to do this.
@@ -61,7 +61,7 @@ def create_connection_url(
 
 
 @pytest.fixture(scope="session")
-def engine_uri(worker_id: str):  # noqa: ANN201
+def engine_uri(worker_id: str):
     host = os.getenv("MSSQL_ADDRESS")
     port = os.getenv("MSSQL_PORT", 1433)
     user = os.getenv("MSSQL_USER")
@@ -85,7 +85,7 @@ def engine_uri(worker_id: str):  # noqa: ANN201
 
 
 @pytest.fixture()
-def pg_stats(request, session):  # noqa: ANN001, ANN201
+def pg_stats(request, session):
     yield
 
     from meltano.core.job import Job

--- a/tests/fixtures/db/postgresql.py
+++ b/tests/fixtures/db/postgresql.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
 
-def recreate_database(engine, db_name) -> None:  # noqa: ANN001
+def recreate_database(engine, db_name) -> None:
     """Drop & Create a new database, PostgreSQL only."""
     with contextlib.suppress(sqlalchemy.exc.ProgrammingError), engine.begin() as conn:
         conn.execute(text(f"DROP DATABASE {db_name}"))

--- a/tests/fixtures/db/postgresql.py
+++ b/tests/fixtures/db/postgresql.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
 
-def recreate_database(engine, db_name):
+def recreate_database(engine, db_name) -> None:  # noqa: ANN001
     """Drop & Create a new database, PostgreSQL only."""
     with contextlib.suppress(sqlalchemy.exc.ProgrammingError), engine.begin() as conn:
         conn.execute(text(f"DROP DATABASE {db_name}"))
@@ -19,7 +19,7 @@ def recreate_database(engine, db_name):
 
 
 @pytest.fixture(scope="session")
-def engine_uri(worker_id: str):
+def engine_uri(worker_id: str) -> str:
     host = os.getenv("POSTGRES_ADDRESS")
     port = os.getenv("POSTGRES_PORT", 5432)
     user = os.getenv("POSTGRES_USER")

--- a/tests/fixtures/db/postgresql_psycopg3.py
+++ b/tests/fixtures/db/postgresql_psycopg3.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
 
-def recreate_database(engine, db_name) -> None:  # noqa: ANN001
+def recreate_database(engine, db_name) -> None:
     """Drop & Create a new database, PostgreSQL only."""
     with contextlib.suppress(sqlalchemy.exc.ProgrammingError), engine.begin() as conn:
         conn.execute(text(f"DROP DATABASE {db_name}"))

--- a/tests/fixtures/db/postgresql_psycopg3.py
+++ b/tests/fixtures/db/postgresql_psycopg3.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
 
-def recreate_database(engine, db_name):
+def recreate_database(engine, db_name) -> None:  # noqa: ANN001
     """Drop & Create a new database, PostgreSQL only."""
     with contextlib.suppress(sqlalchemy.exc.ProgrammingError), engine.begin() as conn:
         conn.execute(text(f"DROP DATABASE {db_name}"))
@@ -19,7 +19,7 @@ def recreate_database(engine, db_name):
 
 
 @pytest.fixture(scope="session")
-def engine_uri(worker_id: str):
+def engine_uri(worker_id: str) -> str:
     host = os.getenv("POSTGRES_ADDRESS")
     port = os.getenv("POSTGRES_PORT", 5432)
     user = os.getenv("POSTGRES_USER")

--- a/tests/fixtures/db/sqlite.py
+++ b/tests/fixtures/db/sqlite.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def engine_uri(tmp_path_factory, worker_id: str) -> str:  # noqa: ANN001
+def engine_uri(tmp_path_factory, worker_id: str) -> str:
     database_path = (
         tmp_path_factory.mktemp("fixture_db_sqlite_engine_uri")
         / f"pytest_meltano_{worker_id}.db"

--- a/tests/fixtures/db/sqlite.py
+++ b/tests/fixtures/db/sqlite.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def engine_uri(tmp_path_factory, worker_id: str) -> str:
+def engine_uri(tmp_path_factory, worker_id: str) -> str:  # noqa: ANN001
     database_path = (
         tmp_path_factory.mktemp("fixture_db_sqlite_engine_uri")
         / f"pytest_meltano_{worker_id}.db"

--- a/tests/fixtures/docker/snowplow.py
+++ b/tests/fixtures/docker/snowplow.py
@@ -28,7 +28,7 @@ class SnowplowMicro:
         self.all()  # Wait until a connection is established
 
     @backoff.on_exception(backoff.expo, ConnectionError, max_tries=5)
-    def get(self, endpoint: str) -> t.Any:  # noqa: ANN401
+    def get(self, endpoint: str) -> t.Any:
         with urlopen(f"{self.url}/{endpoint}") as response:
             return json.load(response)
 
@@ -50,7 +50,7 @@ class SnowplowMicro:
 
 
 @pytest.fixture(scope="session")
-def snowplow_session(request) -> SnowplowMicro | None:  # noqa: ANN001
+def snowplow_session(request) -> SnowplowMicro | None:
     """Start a Snowplow Micro Docker container, then yield a `SnowplowMicro` instance.
 
     The environment variable `$MELTANO_SNOWPLOW_COLLECTOR_ENDPOINTS` is set to
@@ -78,7 +78,7 @@ def snowplow_session(request) -> SnowplowMicro | None:  # noqa: ANN001
 @pytest.fixture()
 def snowplow_optional(
     snowplow_session: SnowplowMicro | None,
-    monkeypatch,  # noqa: ANN001
+    monkeypatch,
 ) -> SnowplowMicro | None:
     """Provide a clean `SnowplowMicro` instance.
 

--- a/tests/fixtures/docker/snowplow.py
+++ b/tests/fixtures/docker/snowplow.py
@@ -28,7 +28,7 @@ class SnowplowMicro:
         self.all()  # Wait until a connection is established
 
     @backoff.on_exception(backoff.expo, ConnectionError, max_tries=5)
-    def get(self, endpoint: str) -> t.Any:
+    def get(self, endpoint: str) -> t.Any:  # noqa: ANN401
         with urlopen(f"{self.url}/{endpoint}") as response:
             return json.load(response)
 
@@ -50,7 +50,7 @@ class SnowplowMicro:
 
 
 @pytest.fixture(scope="session")
-def snowplow_session(request) -> SnowplowMicro | None:
+def snowplow_session(request) -> SnowplowMicro | None:  # noqa: ANN001
     """Start a Snowplow Micro Docker container, then yield a `SnowplowMicro` instance.
 
     The environment variable `$MELTANO_SNOWPLOW_COLLECTOR_ENDPOINTS` is set to
@@ -78,7 +78,7 @@ def snowplow_session(request) -> SnowplowMicro | None:
 @pytest.fixture()
 def snowplow_optional(
     snowplow_session: SnowplowMicro | None,
-    monkeypatch,
+    monkeypatch,  # noqa: ANN001
 ) -> SnowplowMicro | None:
     """Provide a clean `SnowplowMicro` instance.
 

--- a/tests/fixtures/fs.py
+++ b/tests/fixtures/fs.py
@@ -14,10 +14,10 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture(scope="class")
-def compatible_copy_tree():
+def compatible_copy_tree():  # noqa: ANN201
     """Copy files recursively from source to destination, ignoring existing dirs."""
 
-    def _compatible_copy_tree(source: Path, destination: Path):
+    def _compatible_copy_tree(source: Path, destination: Path) -> None:
         """Copy files recursively from source to destination, ignoring existing dirs."""
         shutil.copytree(source, destination, dirs_exist_ok=True)
 
@@ -25,7 +25,7 @@ def compatible_copy_tree():
 
 
 @pytest.fixture()
-def function_scoped_test_dir(tmp_path_factory) -> Path:
+def function_scoped_test_dir(tmp_path_factory) -> Path:  # noqa: ANN001
     tmp_path = tmp_path_factory.mktemp("meltano_root")
     cwd = os.getcwd()
     try:
@@ -36,15 +36,15 @@ def function_scoped_test_dir(tmp_path_factory) -> Path:
 
 
 @pytest.fixture()
-def empty_meltano_yml_dir(tmp_path):
+def empty_meltano_yml_dir(tmp_path):  # noqa: ANN001, ANN201
     with cd(tmp_path):
         (tmp_path / "meltano.yml").touch()
         return tmp_path
 
 
 @pytest.fixture()
-def pushd(request):
-    def _pushd(path):
+def pushd(request):  # noqa: ANN001, ANN201
+    def _pushd(path):  # noqa: ANN001, ANN202
         popd = partial(os.chdir, os.getcwd())
         request.addfinalizer(popd)
         os.chdir(path)
@@ -55,7 +55,7 @@ def pushd(request):
 
 
 @pytest.mark.meta()
-def test_pushd(tmp_path, pushd):
+def test_pushd(tmp_path, pushd) -> None:  # noqa: ANN001
     os.makedirs(tmp_path / "a")
     os.makedirs(tmp_path / "a" / "b")
 

--- a/tests/fixtures/fs.py
+++ b/tests/fixtures/fs.py
@@ -14,7 +14,7 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture(scope="class")
-def compatible_copy_tree():  # noqa: ANN201
+def compatible_copy_tree():
     """Copy files recursively from source to destination, ignoring existing dirs."""
 
     def _compatible_copy_tree(source: Path, destination: Path) -> None:
@@ -25,7 +25,7 @@ def compatible_copy_tree():  # noqa: ANN201
 
 
 @pytest.fixture()
-def function_scoped_test_dir(tmp_path_factory) -> Path:  # noqa: ANN001
+def function_scoped_test_dir(tmp_path_factory) -> Path:
     tmp_path = tmp_path_factory.mktemp("meltano_root")
     cwd = os.getcwd()
     try:
@@ -36,15 +36,15 @@ def function_scoped_test_dir(tmp_path_factory) -> Path:  # noqa: ANN001
 
 
 @pytest.fixture()
-def empty_meltano_yml_dir(tmp_path):  # noqa: ANN001, ANN201
+def empty_meltano_yml_dir(tmp_path):
     with cd(tmp_path):
         (tmp_path / "meltano.yml").touch()
         return tmp_path
 
 
 @pytest.fixture()
-def pushd(request):  # noqa: ANN001, ANN201
-    def _pushd(path):  # noqa: ANN001, ANN202
+def pushd(request):
+    def _pushd(path):
         popd = partial(os.chdir, os.getcwd())
         request.addfinalizer(popd)
         os.chdir(path)
@@ -55,7 +55,7 @@ def pushd(request):  # noqa: ANN001, ANN201
 
 
 @pytest.mark.meta()
-def test_pushd(tmp_path, pushd) -> None:  # noqa: ANN001
+def test_pushd(tmp_path, pushd) -> None:
     os.makedirs(tmp_path / "a")
     os.makedirs(tmp_path / "a" / "b")
 

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -25,7 +25,7 @@ def cd(path: Path) -> Path:
 
 
 @contextmanager
-def tmp_project(name: str, source: Path, compatible_copy_tree) -> Project:  # noqa: ANN001
+def tmp_project(name: str, source: Path, compatible_copy_tree) -> Project:
     project_init_service = ProjectInitService(name)
     blank_project = project_init_service.init()
     logging.debug(f"Created new project at {blank_project.root}")  # noqa: G004, TID251

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -25,7 +25,7 @@ def cd(path: Path) -> Path:
 
 
 @contextmanager
-def tmp_project(name: str, source: Path, compatible_copy_tree) -> Project:
+def tmp_project(name: str, source: Path, compatible_copy_tree) -> Project:  # noqa: ANN001
     project_init_service = ProjectInitService(name)
     blank_project = project_init_service.init()
     logging.debug(f"Created new project at {blank_project.root}")  # noqa: G004, TID251

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -56,13 +56,13 @@ class TestCliAdd:
     )
     def test_add(
         self,
-        plugin_type,
-        plugin_name,
-        default_variant,
-        required_plugin_refs,
+        plugin_type,  # noqa: ANN001
+        plugin_name,  # noqa: ANN001
+        default_variant,  # noqa: ANN001
+        required_plugin_refs,  # noqa: ANN001
         project: Project,
-        cli_runner,
-    ):
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         # ensure the plugin is not present
         with pytest.raises(PluginNotFoundError):
             project.plugins.find_plugin(plugin_name, plugin_type=plugin_type)
@@ -109,7 +109,7 @@ class TestCliAdd:
                 install_plugin_mock.assert_called()
 
     @pytest.mark.order(1)
-    def test_add_multiple(self, project: Project, cli_runner):
+    def test_add_multiple(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             cli_runner.invoke(cli, ["add", "extractors", "tap-gitlab"])
@@ -152,7 +152,7 @@ class TestCliAdd:
             )
 
     @pytest.mark.order(1)
-    def test_add_different_variant(self, cli_runner):
+    def test_add_different_variant(self, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock"])
@@ -173,7 +173,7 @@ class TestCliAdd:
             assert "variant: singer-io" in res.stdout
 
     @pytest.mark.order(2)
-    def test_add_transform(self, project: Project, cli_runner):
+    def test_add_transform(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         # adding Transforms requires the legacy 'dbt' Transformer
         cli_runner.invoke(cli, ["add", "transformer", "dbt"])
         cli_runner.invoke(cli, ["install", "transformer", "dbt"])
@@ -201,9 +201,9 @@ class TestCliAdd:
     def test_add_files_with_updates(
         self,
         project: Project,
-        cli_runner,
-        plugin_settings_service_factory,
-    ):
+        cli_runner,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         # if plugin is locked, we actually wouldn't expect it to update.
         # So we must remove lockfile
         shutil.rmtree("plugins/files", ignore_errors=True)
@@ -232,7 +232,7 @@ class TestCliAdd:
             "This file is managed by the 'airflow' file bundle" in file_path.read_text()
         )
 
-    def test_add_files_without_updates(self, project: Project, cli_runner):
+    def test_add_files_without_updates(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         result = cli_runner.invoke(cli, ["add", "files", "docker-compose"])
         output = result.stdout + result.stderr
         assert_cli_runner(result)
@@ -251,7 +251,7 @@ class TestCliAdd:
         assert "This file is managed" not in file_path.read_text()
 
     @fails_on_windows
-    def test_add_files_that_already_exists(self, project: Project, cli_runner):
+    def test_add_files_that_already_exists(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         # dbt lockfile was created in an upstream test. Need to remove.
         shutil.rmtree(project.root_dir("plugins/files"), ignore_errors=True)
         project.root_dir("transform/dbt_project.yml").write_text("Exists!")
@@ -266,7 +266,7 @@ class TestCliAdd:
         assert "Created transform/dbt_project (dbt).yml" in output
         assert project.root_dir("transform/dbt_project (dbt).yml").is_file()
 
-    def test_add_missing(self, project: Project, cli_runner):
+    def test_add_missing(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         res = cli_runner.invoke(cli, ["add", "extractor", "tap-unknown"])
 
         assert res.exit_code == 1
@@ -281,7 +281,7 @@ class TestCliAdd:
             project.plugins.find_plugin("tap-unknown", PluginType.EXTRACTORS)
 
     @pytest.mark.xfail(reason="Uninstall not implemented yet.")
-    def test_add_fails(self, project: Project, cli_runner):
+    def test_add_fails(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         result = cli_runner.invoke(cli, ["add", "extractor", "tap-mock"])
         output = result.stdout + result.stderr
 
@@ -293,7 +293,7 @@ class TestCliAdd:
         with pytest.raises(PluginNotFoundError):
             project.plugins.find_plugin("tap-mock", PluginType.EXTRACTORS)
 
-    def test_add_variant(self, project: Project, cli_runner):
+    def test_add_variant(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(
@@ -317,9 +317,9 @@ class TestCliAdd:
     def test_add_inherited(
         self,
         project: Project,
-        tap,
-        cli_runner,
-    ):
+        tap,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         # Make sure tap-mock is not in the project as a project plugin
         project.plugins.remove_from_file(tap)
 
@@ -422,7 +422,7 @@ class TestCliAdd:
             ) in str(res.exception)
 
     @pytest.mark.usefixtures("reset_project_context")
-    def test_add_custom(self, project: Project, cli_runner):
+    def test_add_custom(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         pip_url = "-e path/to/tap-custom"
         executable = "tap-custom-bin"
         stdin = os.linesep.join(
@@ -469,7 +469,7 @@ class TestCliAdd:
                 force=False,
             )
 
-    def test_add_custom_no_install(self, project: Project, cli_runner):
+    def test_add_custom_no_install(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         executable = "tap-custom-noinstall"
         stdin = os.linesep.join(
             # namespace, pip_url, executable, capabilities, settings
@@ -519,7 +519,7 @@ class TestCliAdd:
                 force=False,
             )
 
-    def test_add_custom_variant(self, project: Project, cli_runner):
+    def test_add_custom_variant(self, project: Project, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(
@@ -567,13 +567,13 @@ class TestCliAdd:
     @pytest.mark.usefixtures("reset_project_context")
     def test_add_no_install(
         self,
-        plugin_type,
-        plugin_name,
-        default_variant,
-        required_plugin_refs,
+        plugin_type,  # noqa: ANN001
+        plugin_name,  # noqa: ANN001
+        default_variant,  # noqa: ANN001
+        required_plugin_refs,  # noqa: ANN001
         project: Project,
-        cli_runner,
-    ):
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         # ensure the plugin is not present
         with pytest.raises(PluginNotFoundError):
             project.plugins.find_plugin(plugin_name, plugin_type=plugin_type)
@@ -651,12 +651,12 @@ class TestCliAdd:
     @mock.patch("meltano.cli.add.requests.get")
     def test_add_from_ref(
         self,
-        ref_request_mock,
-        install_plugin_mock,
-        ref,
-        project,
-        cli_runner,
-    ):
+        ref_request_mock,  # noqa: ANN001
+        install_plugin_mock,  # noqa: ANN001
+        ref,  # noqa: ANN001
+        project,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         ref_request_mock.return_value.status_code = 200
         ref_request_mock.return_value.text = plugin_ref.read_text()
 
@@ -706,10 +706,10 @@ class TestCliAdd:
     )
     def test_add_from_ref_invalid_ref(
         self,
-        ref,
-        invalid_reason,
-        cli_runner,
-    ):
+        ref,  # noqa: ANN001
+        invalid_reason,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         res = cli_runner.invoke(
             cli,
             ["add", "extractor", "tap-custom", "--from-ref", ref],
@@ -750,10 +750,10 @@ class TestCliAdd:
     )
     def test_add_from_ref_invalid_definiton(
         self,
-        definition,
-        invalid_reason,
-        cli_runner,
-    ):
+        definition,  # noqa: ANN001
+        invalid_reason,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         with open("test.yml", "w") as f:
             yaml.dump(definition, f)
 
@@ -766,9 +766,9 @@ class TestCliAdd:
         assert isinstance(res.exception, InvalidPluginDefinitionError)
         assert res.exception.reason == invalid_reason
 
-    def test_add_with_python_version(self, cli_runner: CliRunner):
+    def test_add_with_python_version(self, cli_runner: CliRunner) -> None:
         with mock.patch(
-            "meltano.core.venv_service._resolve_python_path"
+            "meltano.core.venv_service._resolve_python_path",
         ) as venv_mock, mock.patch("meltano.core.venv_service.VenvService.install"):
             python = "python3.X"
             assert_cli_runner(
@@ -785,7 +785,7 @@ class TestCliAdd:
             )
             venv_mock.assert_called_with(python)
 
-    def test_add_with_force_flag(self, project: Project, cli_runner: CliRunner):
+    def test_add_with_force_flag(self, project: Project, cli_runner: CliRunner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(
@@ -807,7 +807,7 @@ class TestCliAdd:
         )
 
     @pytest.mark.usefixtures("reset_project_context")
-    def test_add_update(self, cli_runner):
+    def test_add_update(self, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock"])
@@ -822,14 +822,14 @@ class TestCliAdd:
             assert "Updated extractor 'tap-mock" in res.stdout
 
     @pytest.mark.usefixtures("reset_project_context")
-    def test_add_update_not_in_project(self, cli_runner):
+    def test_add_update_not_in_project(self, cli_runner) -> None:  # noqa: ANN001
         res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock", "--update"])
 
         assert res.exit_code == 1
         assert res.exception
         assert str(res.exception) == "Extractor 'tap-mock' is not known to Meltano"
 
-    def test_lockfile_exists(self, cli_runner):
+    def test_lockfile_exists(self, cli_runner) -> None:  # noqa: ANN001
         plugins_dir = Path("plugins/utilities")
         plugins_dir.mkdir(parents=True, exist_ok=True)
         lockfile = plugins_dir / "utility-mock--original.lock"
@@ -839,8 +839,8 @@ class TestCliAdd:
                     "plugin_type": "utilities",
                     "name": "utility-mock",
                     "namespace": "utility_mock",
-                }
-            )
+                },
+            ),
         )
         lockfile.touch()
 

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -56,12 +56,12 @@ class TestCliAdd:
     )
     def test_add(
         self,
-        plugin_type,  # noqa: ANN001
-        plugin_name,  # noqa: ANN001
-        default_variant,  # noqa: ANN001
-        required_plugin_refs,  # noqa: ANN001
+        plugin_type,
+        plugin_name,
+        default_variant,
+        required_plugin_refs,
         project: Project,
-        cli_runner,  # noqa: ANN001
+        cli_runner,
     ) -> None:
         # ensure the plugin is not present
         with pytest.raises(PluginNotFoundError):
@@ -109,7 +109,7 @@ class TestCliAdd:
                 install_plugin_mock.assert_called()
 
     @pytest.mark.order(1)
-    def test_add_multiple(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_multiple(self, project: Project, cli_runner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             cli_runner.invoke(cli, ["add", "extractors", "tap-gitlab"])
@@ -152,7 +152,7 @@ class TestCliAdd:
             )
 
     @pytest.mark.order(1)
-    def test_add_different_variant(self, cli_runner) -> None:  # noqa: ANN001
+    def test_add_different_variant(self, cli_runner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock"])
@@ -173,7 +173,7 @@ class TestCliAdd:
             assert "variant: singer-io" in res.stdout
 
     @pytest.mark.order(2)
-    def test_add_transform(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_transform(self, project: Project, cli_runner) -> None:
         # adding Transforms requires the legacy 'dbt' Transformer
         cli_runner.invoke(cli, ["add", "transformer", "dbt"])
         cli_runner.invoke(cli, ["install", "transformer", "dbt"])
@@ -201,8 +201,8 @@ class TestCliAdd:
     def test_add_files_with_updates(
         self,
         project: Project,
-        cli_runner,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        cli_runner,
+        plugin_settings_service_factory,
     ) -> None:
         # if plugin is locked, we actually wouldn't expect it to update.
         # So we must remove lockfile
@@ -232,7 +232,7 @@ class TestCliAdd:
             "This file is managed by the 'airflow' file bundle" in file_path.read_text()
         )
 
-    def test_add_files_without_updates(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_files_without_updates(self, project: Project, cli_runner) -> None:
         result = cli_runner.invoke(cli, ["add", "files", "docker-compose"])
         output = result.stdout + result.stderr
         assert_cli_runner(result)
@@ -251,7 +251,7 @@ class TestCliAdd:
         assert "This file is managed" not in file_path.read_text()
 
     @fails_on_windows
-    def test_add_files_that_already_exists(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_files_that_already_exists(self, project: Project, cli_runner) -> None:
         # dbt lockfile was created in an upstream test. Need to remove.
         shutil.rmtree(project.root_dir("plugins/files"), ignore_errors=True)
         project.root_dir("transform/dbt_project.yml").write_text("Exists!")
@@ -266,7 +266,7 @@ class TestCliAdd:
         assert "Created transform/dbt_project (dbt).yml" in output
         assert project.root_dir("transform/dbt_project (dbt).yml").is_file()
 
-    def test_add_missing(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_missing(self, project: Project, cli_runner) -> None:
         res = cli_runner.invoke(cli, ["add", "extractor", "tap-unknown"])
 
         assert res.exit_code == 1
@@ -281,7 +281,7 @@ class TestCliAdd:
             project.plugins.find_plugin("tap-unknown", PluginType.EXTRACTORS)
 
     @pytest.mark.xfail(reason="Uninstall not implemented yet.")
-    def test_add_fails(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_fails(self, project: Project, cli_runner) -> None:
         result = cli_runner.invoke(cli, ["add", "extractor", "tap-mock"])
         output = result.stdout + result.stderr
 
@@ -293,7 +293,7 @@ class TestCliAdd:
         with pytest.raises(PluginNotFoundError):
             project.plugins.find_plugin("tap-mock", PluginType.EXTRACTORS)
 
-    def test_add_variant(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_variant(self, project: Project, cli_runner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(
@@ -317,8 +317,8 @@ class TestCliAdd:
     def test_add_inherited(
         self,
         project: Project,
-        tap,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        tap,
+        cli_runner,
     ) -> None:
         # Make sure tap-mock is not in the project as a project plugin
         project.plugins.remove_from_file(tap)
@@ -422,7 +422,7 @@ class TestCliAdd:
             ) in str(res.exception)
 
     @pytest.mark.usefixtures("reset_project_context")
-    def test_add_custom(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_custom(self, project: Project, cli_runner) -> None:
         pip_url = "-e path/to/tap-custom"
         executable = "tap-custom-bin"
         stdin = os.linesep.join(
@@ -469,7 +469,7 @@ class TestCliAdd:
                 force=False,
             )
 
-    def test_add_custom_no_install(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_custom_no_install(self, project: Project, cli_runner) -> None:
         executable = "tap-custom-noinstall"
         stdin = os.linesep.join(
             # namespace, pip_url, executable, capabilities, settings
@@ -519,7 +519,7 @@ class TestCliAdd:
                 force=False,
             )
 
-    def test_add_custom_variant(self, project: Project, cli_runner) -> None:  # noqa: ANN001
+    def test_add_custom_variant(self, project: Project, cli_runner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(
@@ -567,12 +567,12 @@ class TestCliAdd:
     @pytest.mark.usefixtures("reset_project_context")
     def test_add_no_install(
         self,
-        plugin_type,  # noqa: ANN001
-        plugin_name,  # noqa: ANN001
-        default_variant,  # noqa: ANN001
-        required_plugin_refs,  # noqa: ANN001
+        plugin_type,
+        plugin_name,
+        default_variant,
+        required_plugin_refs,
         project: Project,
-        cli_runner,  # noqa: ANN001
+        cli_runner,
     ) -> None:
         # ensure the plugin is not present
         with pytest.raises(PluginNotFoundError):
@@ -651,11 +651,11 @@ class TestCliAdd:
     @mock.patch("meltano.cli.add.requests.get")
     def test_add_from_ref(
         self,
-        ref_request_mock,  # noqa: ANN001
-        install_plugin_mock,  # noqa: ANN001
-        ref,  # noqa: ANN001
-        project,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        ref_request_mock,
+        install_plugin_mock,
+        ref,
+        project,
+        cli_runner,
     ) -> None:
         ref_request_mock.return_value.status_code = 200
         ref_request_mock.return_value.text = plugin_ref.read_text()
@@ -706,9 +706,9 @@ class TestCliAdd:
     )
     def test_add_from_ref_invalid_ref(
         self,
-        ref,  # noqa: ANN001
-        invalid_reason,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        ref,
+        invalid_reason,
+        cli_runner,
     ) -> None:
         res = cli_runner.invoke(
             cli,
@@ -750,9 +750,9 @@ class TestCliAdd:
     )
     def test_add_from_ref_invalid_definiton(
         self,
-        definition,  # noqa: ANN001
-        invalid_reason,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        definition,
+        invalid_reason,
+        cli_runner,
     ) -> None:
         with open("test.yml", "w") as f:
             yaml.dump(definition, f)
@@ -807,7 +807,7 @@ class TestCliAdd:
         )
 
     @pytest.mark.usefixtures("reset_project_context")
-    def test_add_update(self, cli_runner) -> None:  # noqa: ANN001
+    def test_add_update(self, cli_runner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock"])
@@ -822,14 +822,14 @@ class TestCliAdd:
             assert "Updated extractor 'tap-mock" in res.stdout
 
     @pytest.mark.usefixtures("reset_project_context")
-    def test_add_update_not_in_project(self, cli_runner) -> None:  # noqa: ANN001
+    def test_add_update_not_in_project(self, cli_runner) -> None:
         res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock", "--update"])
 
         assert res.exit_code == 1
         assert res.exception
         assert str(res.exception) == "Extractor 'tap-mock' is not known to Meltano"
 
-    def test_lockfile_exists(self, cli_runner) -> None:  # noqa: ANN001
+    def test_lockfile_exists(self, cli_runner) -> None:
         plugins_dir = Path("plugins/utilities")
         plugins_dir.mkdir(parents=True, exist_ok=True)
         lockfile = plugins_dir / "utility-mock--original.lock"

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -32,7 +32,7 @@ ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 
 class TestCli:
     @pytest.fixture()
-    def test_cli_project(self, tmp_path: Path, project_init_service):
+    def test_cli_project(self, tmp_path: Path, project_init_service):  # noqa: ANN001, ANN201
         """Return the non-activated project."""
         os.chdir(tmp_path)
         project = project_init_service.init(activate=False)
@@ -44,14 +44,14 @@ class TestCli:
             shutil.rmtree(project.root)
 
     @pytest.fixture()
-    def deactivate_project(self):
+    def deactivate_project(self) -> None:
         Project.deactivate()
 
     @pytest.fixture()
-    def empty_project(
+    def empty_project(  # noqa: ANN201
         self,
-        empty_meltano_yml_dir,
-        pushd,  # noqa: ARG002
+        empty_meltano_yml_dir,  # noqa: ANN001
+        pushd,  # noqa: ANN001, ARG002
     ):
         project = Project(empty_meltano_yml_dir)
         try:
@@ -60,7 +60,7 @@ class TestCli:
             Project.deactivate()
 
     @pytest.mark.order(0)
-    def test_activate_project(self, test_cli_project, cli_runner, pushd):
+    def test_activate_project(self, test_cli_project, cli_runner, pushd) -> None:  # noqa: ANN001
         project = test_cli_project
 
         pushd(project.root)
@@ -71,7 +71,7 @@ class TestCli:
         assert Project._default.readonly is False
 
     @pytest.mark.order(1)
-    def test_empty_meltano_yml_project(self, empty_project, cli_runner, pushd):
+    def test_empty_meltano_yml_project(self, empty_project, cli_runner, pushd) -> None:  # noqa: ANN001
         pushd(empty_project.root)
         with pytest.raises(EmptyMeltanoFileException):
             cli_runner.invoke(cli, ["config"], catch_exceptions=False)
@@ -79,11 +79,11 @@ class TestCli:
     @pytest.mark.order(2)
     def test_activate_project_readonly_env(
         self,
-        test_cli_project,
-        cli_runner,
-        pushd,
-        monkeypatch,
-    ):
+        test_cli_project,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         monkeypatch.setenv(PROJECT_READONLY_ENV, "true")
         assert Project._default is None
         pushd(test_cli_project.root)
@@ -93,10 +93,10 @@ class TestCli:
     @pytest.mark.order(2)
     def test_activate_project_readonly_dotenv(
         self,
-        test_cli_project,
-        cli_runner,
-        pushd,
-    ):
+        test_cli_project,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         test_cli_project.settings.set("project_readonly", value=True)
         assert Project._default is None
         pushd(test_cli_project.root)
@@ -106,10 +106,10 @@ class TestCli:
     def test_environment_precedence(
         self,
         project: Project,
-        pushd,
+        pushd,  # noqa: ANN001
         cli_runner: MeltanoCliRunner,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         pushd(project.root)
         monkeypatch.delenv(PROJECT_ENVIRONMENT_ENV, raising=False)
         environment_names = {
@@ -140,7 +140,7 @@ class TestCli:
                 == f"Environment {name!r} was not found."
             )
 
-    def test_version(self, cli_runner):
+    def test_version(self, cli_runner) -> None:  # noqa: ANN001
         cli_version = cli_runner.invoke(cli, ["--version"])
 
         assert cli_version.output == f"meltano, version {meltano.__version__}\n"
@@ -148,10 +148,10 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_default_environment_is_activated(
         self,
-        project_files_cli,
-        cli_runner,
-        pushd,
-    ):
+        project_files_cli,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
@@ -162,10 +162,10 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_environment_flag_overrides_default(
         self,
-        project_files_cli,
-        cli_runner,
-        pushd,
-    ):
+        project_files_cli,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
@@ -177,11 +177,11 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_environment_variable_overrides_default(
         self,
-        project_files_cli,
-        cli_runner,
-        pushd,
-        monkeypatch,
-    ):
+        project_files_cli,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         monkeypatch.setenv("MELTANO_ENVIRONMENT", "test-subconfig-2-yml")
         pushd(project_files_cli.root)
         cli_runner.invoke(
@@ -193,10 +193,10 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_lower_null_environment_overrides_default(
         self,
-        project_files_cli,
-        cli_runner,
-        pushd,
-    ):
+        project_files_cli,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
@@ -207,10 +207,10 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_upper_null_environment_overrides_default(
         self,
-        project_files_cli,
-        cli_runner,
-        pushd,
-    ):
+        project_files_cli,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
@@ -221,10 +221,10 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_no_environment_overrides_default(
         self,
-        project_files_cli,
-        cli_runner,
-        pushd,
-    ):
+        project_files_cli,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
@@ -235,10 +235,10 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_no_environment_and_null_environment_overrides_default(
         self,
-        project_files_cli,
-        cli_runner,
-        pushd,
-    ):
+        project_files_cli,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
             cli,
@@ -246,13 +246,18 @@ class TestCli:
         )
         assert Project._default.environment is None
 
-    def test_handle_meltano_error(self):
+    def test_handle_meltano_error(self) -> None:
         exception = MeltanoError(reason="This failed", instruction="Try again")
         with pytest.raises(CliError, match="This failed. Try again."):
             handle_meltano_error(exception)
 
     @pytest.mark.usefixtures("pushd")
-    def test_cwd_option(self, cli_runner, test_cli_project, tmp_path: Path):
+    def test_cwd_option(
+        self,
+        cli_runner,  # noqa: ANN001
+        test_cli_project,  # noqa: ANN001
+        tmp_path: Path,
+    ) -> t.NoReturn:
         project = test_cli_project
         with cd(project.root_dir()):
             assert_cli_runner(cli_runner.invoke(cli, ("dragon",)))
@@ -300,7 +305,7 @@ class TestCli:
         self,
         tmp_path: Path,
         command_args: tuple[str, ...],
-    ):
+    ) -> None:
         # Unless this test runs before every test that uses a project, we
         # cannot use `cli_runner` to test this because the code path taken
         # differs after any project has been found.
@@ -324,7 +329,7 @@ class TestCli:
         )
 
 
-def _get_dummy_logging_config(*, colors=True):
+def _get_dummy_logging_config(*, colors=True):  # noqa: ANN001, ANN202
     return {
         "version": 1,
         "disable_existing_loggers": False,
@@ -440,14 +445,14 @@ class TestCliColors:
     )
     def test_no_color(
         self,
-        cli_runner,
-        env,
-        log_config,
-        cli_colors_expected,
-        log_colors_expected,
-        tmp_path,
-        monkeypatch,
-    ):
+        cli_runner,  # noqa: ANN001
+        env,  # noqa: ANN001
+        log_config,  # noqa: ANN001
+        cli_colors_expected,  # noqa: ANN001
+        log_colors_expected,  # noqa: ANN001
+        tmp_path,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         monkeypatch.delenv("NO_COLOR", raising=False)
         styled_text = click.style(self.TEST_TEXT, fg="red")
 
@@ -458,7 +463,7 @@ class TestCliColors:
             log_config_path = None
 
         @click.command("dummy")
-        def dummy_command():
+        def dummy_command() -> None:
             setup_logging(None, "DEBUG", log_config_path)
             logger = get_logger("meltano.cli.dummy")
             logger.info(self.TEST_TEXT)
@@ -478,7 +483,7 @@ class TestCliColors:
 
 class TestLargeConfigProject:
     @pytest.mark.usefixtures("large_config_project")
-    def test_list_config_performance(self, cli_runner):
+    def test_list_config_performance(self, cli_runner) -> None:  # noqa: ANN001
         start = perf_counter_ns()
         assert (
             cli_runner.invoke(

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -97,7 +97,7 @@ class TestCli:
         cli_runner,
         pushd,
     ):
-        test_cli_project.settings.set("project_readonly", True)
+        test_cli_project.settings.set("project_readonly", value=True)
         assert Project._default is None
         pushd(test_cli_project.root)
         cli_runner.invoke(cli, ["hub", "ping"])
@@ -324,7 +324,7 @@ class TestCli:
         )
 
 
-def _get_dummy_logging_config(colors=True):
+def _get_dummy_logging_config(*, colors=True):
     return {
         "version": 1,
         "disable_existing_loggers": False,

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -32,7 +32,7 @@ ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 
 class TestCli:
     @pytest.fixture()
-    def test_cli_project(self, tmp_path: Path, project_init_service):  # noqa: ANN001, ANN201
+    def test_cli_project(self, tmp_path: Path, project_init_service):
         """Return the non-activated project."""
         os.chdir(tmp_path)
         project = project_init_service.init(activate=False)
@@ -48,10 +48,10 @@ class TestCli:
         Project.deactivate()
 
     @pytest.fixture()
-    def empty_project(  # noqa: ANN201
+    def empty_project(
         self,
-        empty_meltano_yml_dir,  # noqa: ANN001
-        pushd,  # noqa: ANN001, ARG002
+        empty_meltano_yml_dir,
+        pushd,  # noqa: ARG002
     ):
         project = Project(empty_meltano_yml_dir)
         try:
@@ -60,7 +60,7 @@ class TestCli:
             Project.deactivate()
 
     @pytest.mark.order(0)
-    def test_activate_project(self, test_cli_project, cli_runner, pushd) -> None:  # noqa: ANN001
+    def test_activate_project(self, test_cli_project, cli_runner, pushd) -> None:
         project = test_cli_project
 
         pushd(project.root)
@@ -71,7 +71,7 @@ class TestCli:
         assert Project._default.readonly is False
 
     @pytest.mark.order(1)
-    def test_empty_meltano_yml_project(self, empty_project, cli_runner, pushd) -> None:  # noqa: ANN001
+    def test_empty_meltano_yml_project(self, empty_project, cli_runner, pushd) -> None:
         pushd(empty_project.root)
         with pytest.raises(EmptyMeltanoFileException):
             cli_runner.invoke(cli, ["config"], catch_exceptions=False)
@@ -79,10 +79,10 @@ class TestCli:
     @pytest.mark.order(2)
     def test_activate_project_readonly_env(
         self,
-        test_cli_project,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        test_cli_project,
+        cli_runner,
+        pushd,
+        monkeypatch,
     ) -> None:
         monkeypatch.setenv(PROJECT_READONLY_ENV, "true")
         assert Project._default is None
@@ -93,9 +93,9 @@ class TestCli:
     @pytest.mark.order(2)
     def test_activate_project_readonly_dotenv(
         self,
-        test_cli_project,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        test_cli_project,
+        cli_runner,
+        pushd,
     ) -> None:
         test_cli_project.settings.set("project_readonly", value=True)
         assert Project._default is None
@@ -106,7 +106,7 @@ class TestCli:
     def test_environment_precedence(
         self,
         project: Project,
-        pushd,  # noqa: ANN001
+        pushd,
         cli_runner: MeltanoCliRunner,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -140,7 +140,7 @@ class TestCli:
                 == f"Environment {name!r} was not found."
             )
 
-    def test_version(self, cli_runner) -> None:  # noqa: ANN001
+    def test_version(self, cli_runner) -> None:
         cli_version = cli_runner.invoke(cli, ["--version"])
 
         assert cli_version.output == f"meltano, version {meltano.__version__}\n"
@@ -148,9 +148,9 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_default_environment_is_activated(
         self,
-        project_files_cli,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        project_files_cli,
+        cli_runner,
+        pushd,
     ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
@@ -162,9 +162,9 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_environment_flag_overrides_default(
         self,
-        project_files_cli,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        project_files_cli,
+        cli_runner,
+        pushd,
     ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
@@ -177,10 +177,10 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_environment_variable_overrides_default(
         self,
-        project_files_cli,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        project_files_cli,
+        cli_runner,
+        pushd,
+        monkeypatch,
     ) -> None:
         monkeypatch.setenv("MELTANO_ENVIRONMENT", "test-subconfig-2-yml")
         pushd(project_files_cli.root)
@@ -193,9 +193,9 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_lower_null_environment_overrides_default(
         self,
-        project_files_cli,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        project_files_cli,
+        cli_runner,
+        pushd,
     ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
@@ -207,9 +207,9 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_upper_null_environment_overrides_default(
         self,
-        project_files_cli,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        project_files_cli,
+        cli_runner,
+        pushd,
     ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
@@ -221,9 +221,9 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_no_environment_overrides_default(
         self,
-        project_files_cli,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        project_files_cli,
+        cli_runner,
+        pushd,
     ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
@@ -235,9 +235,9 @@ class TestCli:
     @pytest.mark.usefixtures("deactivate_project")
     def test_no_environment_and_null_environment_overrides_default(
         self,
-        project_files_cli,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        project_files_cli,
+        cli_runner,
+        pushd,
     ) -> None:
         pushd(project_files_cli.root)
         cli_runner.invoke(
@@ -254,8 +254,8 @@ class TestCli:
     @pytest.mark.usefixtures("pushd")
     def test_cwd_option(
         self,
-        cli_runner,  # noqa: ANN001
-        test_cli_project,  # noqa: ANN001
+        cli_runner,
+        test_cli_project,
         tmp_path: Path,
     ) -> t.NoReturn:
         project = test_cli_project
@@ -329,7 +329,7 @@ class TestCli:
         )
 
 
-def _get_dummy_logging_config(*, colors=True):  # noqa: ANN001, ANN202
+def _get_dummy_logging_config(*, colors=True):
     return {
         "version": 1,
         "disable_existing_loggers": False,
@@ -445,13 +445,13 @@ class TestCliColors:
     )
     def test_no_color(
         self,
-        cli_runner,  # noqa: ANN001
-        env,  # noqa: ANN001
-        log_config,  # noqa: ANN001
-        cli_colors_expected,  # noqa: ANN001
-        log_colors_expected,  # noqa: ANN001
-        tmp_path,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        cli_runner,
+        env,
+        log_config,
+        cli_colors_expected,
+        log_colors_expected,
+        tmp_path,
+        monkeypatch,
     ) -> None:
         monkeypatch.delenv("NO_COLOR", raising=False)
         styled_text = click.style(self.TEST_TEXT, fg="red")
@@ -483,7 +483,7 @@ class TestCliColors:
 
 class TestLargeConfigProject:
     @pytest.mark.usefixtures("large_config_project")
-    def test_list_config_performance(self, cli_runner) -> None:  # noqa: ANN001
+    def test_list_config_performance(self, cli_runner) -> None:
         start = perf_counter_ns()
         assert (
             cli_runner.invoke(

--- a/tests/meltano/cli/test_compile.py
+++ b/tests/meltano/cli/test_compile.py
@@ -24,7 +24,7 @@ if t.TYPE_CHECKING:
 schema_path = Path(meltano_init_file).parent / "schemas" / "meltano.schema.json"
 
 
-def check_indent(json_path: Path, indent: int):
+def check_indent(json_path: Path, indent: int) -> None:
     text = json_path.read_text()
     # If the indent is as-expected, then a trip through `json.loads` and
     # `json.dumps` should produce the same text, usually. This isn't true in
@@ -41,7 +41,7 @@ class TestCompile:
     def clear_default_manifest_dir(self, manifest_dir: Path) -> None:
         shutil.rmtree(manifest_dir, ignore_errors=True)
 
-    def test_compile(self, manifest_dir: Path, cli_runner: CliRunner):
+    def test_compile(self, manifest_dir: Path, cli_runner: CliRunner) -> None:
         assert cli_runner.invoke(cli, ("compile",)).exit_code == 0
         assert {x.name for x in manifest_dir.iterdir()} == {
             f"meltano-manifest{x}.json" for x in (".dev", ".staging", ".prod", "")
@@ -53,14 +53,18 @@ class TestCompile:
         manifest_dir: Path,
         cli_runner: CliRunner,
         environment_name: str,
-    ):
+    ) -> None:
         result = cli_runner.invoke(cli, ("--environment", environment_name, "compile"))
         assert result.exit_code == 0
         assert {x.name for x in manifest_dir.iterdir()} == {
             f"meltano-manifest.{environment_name}.json",
         }
 
-    def test_compile_no_environment(self, manifest_dir: Path, cli_runner: CliRunner):
+    def test_compile_no_environment(
+        self,
+        manifest_dir: Path,
+        cli_runner: CliRunner,
+    ) -> None:
         result = cli_runner.invoke(cli, ("--no-environment", "compile"))
         assert result.exit_code == 0
         assert {x.name for x in manifest_dir.iterdir()} == {"meltano-manifest.json"}
@@ -71,7 +75,7 @@ class TestCompile:
         manifest_dir: Path,
         cli_runner: CliRunner,
         indent: int,
-    ):
+    ) -> None:
         assert (
             cli_runner.invoke(
                 cli,
@@ -86,7 +90,7 @@ class TestCompile:
         manifest_dir: Path,
         cli_runner: CliRunner,
         tmp_path: Path,
-    ):
+    ) -> None:
         result = cli_runner.invoke(cli, ("compile", "--directory", tmp_path))
         assert result.exit_code == 0
         assert not manifest_dir.exists()
@@ -101,10 +105,10 @@ class TestCompile:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         log: StructuredLogCapture,
-    ):
+    ) -> None:
         original_yaml_load = manifest.yaml.load
 
-        def patch(*args, **kwargs):
+        def patch(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
             project_files = original_yaml_load(*args, **kwargs)
             project_files["invalid_key"] = None
             return project_files

--- a/tests/meltano/cli/test_compile.py
+++ b/tests/meltano/cli/test_compile.py
@@ -108,7 +108,7 @@ class TestCompile:
     ) -> None:
         original_yaml_load = manifest.yaml.load
 
-        def patch(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        def patch(*args, **kwargs):
             project_files = original_yaml_load(*args, **kwargs)
             project_files["invalid_key"] = None
             return project_files

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -26,10 +26,10 @@ class TestCliConfig:
     def test_config(
         self,
         cli_runner: CliRunner,
-        tap,
-        session,
-        plugin_settings_service_factory,
-    ):
+        tap,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         plugin_settings_service = plugin_settings_service_factory(tap)
         plugin_settings_service.set(
             "secure",
@@ -45,7 +45,7 @@ class TestCliConfig:
         assert json_config["secure"] == "*****"
 
     @pytest.mark.usefixtures("project")
-    def test_config_extras(self, cli_runner, tap):
+    def test_config_extras(self, cli_runner, tap) -> None:  # noqa: ANN001
         result = cli_runner.invoke(cli, ["config", "--extras", tap.name])
         assert_cli_runner(result)
 
@@ -56,10 +56,10 @@ class TestCliConfig:
     def test_config_env(
         self,
         cli_runner: CliRunner,
-        tap,
-        session,
-        plugin_settings_service_factory,
-    ):
+        tap,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         plugin_settings_service = plugin_settings_service_factory(tap)
         plugin_settings_service.set(
             "secure",
@@ -75,7 +75,7 @@ class TestCliConfig:
         assert env_config["TAP_MOCK_SECURE"] == "*****"
 
     @pytest.mark.usefixtures("project")
-    def test_config_meltano(self, cli_runner, engine_uri):
+    def test_config_meltano(self, cli_runner, engine_uri) -> None:  # noqa: ANN001
         result = cli_runner.invoke(cli, ["config", "meltano"])
         assert_cli_runner(result)
 
@@ -84,7 +84,7 @@ class TestCliConfig:
         assert json_config["cli"]["log_level"] == "info"
 
     @pytest.mark.usefixtures("project")
-    def test_config_meltano_set(self, cli_runner):
+    def test_config_meltano_set(self, cli_runner) -> None:  # noqa: ANN001
         result = cli_runner.invoke(
             cli,
             ["config", "meltano", "set", "cli.log_config", "log_config.yml"],
@@ -97,7 +97,7 @@ class TestCliConfig:
 
     @pytest.mark.usefixtures("project")
     @pytest.mark.parametrize("message_type", ("RECORD", "BATCH"))
-    def test_config_test(self, cli_runner, tap, message_type: str):
+    def test_config_test(self, cli_runner, tap, message_type: str) -> None:  # noqa: ANN001
         mock_invoke = mock.Mock()
         mock_invoke.stderr.at_eof.side_effect = True
         mock_invoke.stdout.at_eof.side_effect = (False, True)
@@ -117,7 +117,7 @@ class TestCliConfig:
             assert "Plugin configuration is valid" in result.stdout
 
     @pytest.mark.usefixtures("project")
-    def test_config_meltano_test(self, cli_runner):
+    def test_config_meltano_test(self, cli_runner) -> None:  # noqa: ANN001
         result = cli_runner.invoke(cli, ["config", "meltano", "test"])
 
         assert result.exit_code == 1
@@ -129,11 +129,11 @@ class TestCliConfig:
     @pytest.mark.usefixtures("project")
     def test_config_list_redacted(
         self,
-        cli_runner,
-        tap,
-        session,
-        plugin_settings_service_factory,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         plugin_settings_service = plugin_settings_service_factory(tap)
         plugin_settings_service.set(
             "secure",
@@ -153,12 +153,12 @@ class TestCliConfig:
     @pytest.mark.usefixtures("project")
     def test_config_list_inherited(
         self,
-        cli_runner,
-        tap,
-        inherited_tap,
-        session,
-        plugin_settings_service_factory,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        inherited_tap,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         plugin_settings_service = plugin_settings_service_factory(tap)
         plugin_settings_service.set(
             "secure",
@@ -178,11 +178,11 @@ class TestCliConfig:
     @pytest.mark.usefixtures("project")
     def test_config_list_unsafe(
         self,
-        cli_runner,
-        tap,
-        session,
-        plugin_settings_service_factory,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         value = "thisisatest"
 
         plugin_settings_service = plugin_settings_service_factory(tap)
@@ -204,7 +204,7 @@ class TestCliConfig:
 
 class TestCliConfigSet:
     @pytest.mark.usefixtures("project")
-    def test_config_set_redacted(self, cli_runner, tap):
+    def test_config_set_redacted(self, cli_runner, tap) -> None:  # noqa: ANN001
         result = cli_runner.invoke(
             cli,
             ["config", tap.name, "set", "secure", "thisisatest"],
@@ -217,7 +217,7 @@ class TestCliConfigSet:
         ) in result.stdout
 
     @pytest.mark.usefixtures("project")
-    def test_config_set_unsafe(self, cli_runner, tap):
+    def test_config_set_unsafe(self, cli_runner, tap) -> None:  # noqa: ANN001
         value = "thisisatest"
 
         result = cli_runner.invoke(
@@ -231,7 +231,7 @@ class TestCliConfigSet:
         ) in result.stdout
 
     @pytest.mark.usefixtures("project")
-    def test_config_set_from_file(self, cli_runner, tap, tmp_path: Path):
+    def test_config_set_from_file(self, cli_runner, tap, tmp_path: Path) -> None:  # noqa: ANN001
         result = cli_runner.invoke(
             cli,
             ["config", tap.name, "set", "private_key", "--from-file", "-"],
@@ -259,7 +259,11 @@ class TestCliConfigSet:
         ) in result.stdout
 
     @pytest.mark.usefixtures("tap")
-    def test_environments_order_of_precedence(self, project: Project, cli_runner):
+    def test_environments_order_of_precedence(
+        self,
+        project: Project,
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         # set base config in `meltano.yml`
         result = cli_runner.invoke(
             cli,

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -26,9 +26,9 @@ class TestCliConfig:
     def test_config(
         self,
         cli_runner: CliRunner,
-        tap,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        tap,
+        session,
+        plugin_settings_service_factory,
     ) -> None:
         plugin_settings_service = plugin_settings_service_factory(tap)
         plugin_settings_service.set(
@@ -45,7 +45,7 @@ class TestCliConfig:
         assert json_config["secure"] == "*****"
 
     @pytest.mark.usefixtures("project")
-    def test_config_extras(self, cli_runner, tap) -> None:  # noqa: ANN001
+    def test_config_extras(self, cli_runner, tap) -> None:
         result = cli_runner.invoke(cli, ["config", "--extras", tap.name])
         assert_cli_runner(result)
 
@@ -56,9 +56,9 @@ class TestCliConfig:
     def test_config_env(
         self,
         cli_runner: CliRunner,
-        tap,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        tap,
+        session,
+        plugin_settings_service_factory,
     ) -> None:
         plugin_settings_service = plugin_settings_service_factory(tap)
         plugin_settings_service.set(
@@ -75,7 +75,7 @@ class TestCliConfig:
         assert env_config["TAP_MOCK_SECURE"] == "*****"
 
     @pytest.mark.usefixtures("project")
-    def test_config_meltano(self, cli_runner, engine_uri) -> None:  # noqa: ANN001
+    def test_config_meltano(self, cli_runner, engine_uri) -> None:
         result = cli_runner.invoke(cli, ["config", "meltano"])
         assert_cli_runner(result)
 
@@ -84,7 +84,7 @@ class TestCliConfig:
         assert json_config["cli"]["log_level"] == "info"
 
     @pytest.mark.usefixtures("project")
-    def test_config_meltano_set(self, cli_runner) -> None:  # noqa: ANN001
+    def test_config_meltano_set(self, cli_runner) -> None:
         result = cli_runner.invoke(
             cli,
             ["config", "meltano", "set", "cli.log_config", "log_config.yml"],
@@ -97,7 +97,7 @@ class TestCliConfig:
 
     @pytest.mark.usefixtures("project")
     @pytest.mark.parametrize("message_type", ("RECORD", "BATCH"))
-    def test_config_test(self, cli_runner, tap, message_type: str) -> None:  # noqa: ANN001
+    def test_config_test(self, cli_runner, tap, message_type: str) -> None:
         mock_invoke = mock.Mock()
         mock_invoke.stderr.at_eof.side_effect = True
         mock_invoke.stdout.at_eof.side_effect = (False, True)
@@ -117,7 +117,7 @@ class TestCliConfig:
             assert "Plugin configuration is valid" in result.stdout
 
     @pytest.mark.usefixtures("project")
-    def test_config_meltano_test(self, cli_runner) -> None:  # noqa: ANN001
+    def test_config_meltano_test(self, cli_runner) -> None:
         result = cli_runner.invoke(cli, ["config", "meltano", "test"])
 
         assert result.exit_code == 1
@@ -129,10 +129,10 @@ class TestCliConfig:
     @pytest.mark.usefixtures("project")
     def test_config_list_redacted(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        cli_runner,
+        tap,
+        session,
+        plugin_settings_service_factory,
     ) -> None:
         plugin_settings_service = plugin_settings_service_factory(tap)
         plugin_settings_service.set(
@@ -153,11 +153,11 @@ class TestCliConfig:
     @pytest.mark.usefixtures("project")
     def test_config_list_inherited(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        inherited_tap,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        cli_runner,
+        tap,
+        inherited_tap,
+        session,
+        plugin_settings_service_factory,
     ) -> None:
         plugin_settings_service = plugin_settings_service_factory(tap)
         plugin_settings_service.set(
@@ -178,10 +178,10 @@ class TestCliConfig:
     @pytest.mark.usefixtures("project")
     def test_config_list_unsafe(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        cli_runner,
+        tap,
+        session,
+        plugin_settings_service_factory,
     ) -> None:
         value = "thisisatest"
 
@@ -204,7 +204,7 @@ class TestCliConfig:
 
 class TestCliConfigSet:
     @pytest.mark.usefixtures("project")
-    def test_config_set_redacted(self, cli_runner, tap) -> None:  # noqa: ANN001
+    def test_config_set_redacted(self, cli_runner, tap) -> None:
         result = cli_runner.invoke(
             cli,
             ["config", tap.name, "set", "secure", "thisisatest"],
@@ -217,7 +217,7 @@ class TestCliConfigSet:
         ) in result.stdout
 
     @pytest.mark.usefixtures("project")
-    def test_config_set_unsafe(self, cli_runner, tap) -> None:  # noqa: ANN001
+    def test_config_set_unsafe(self, cli_runner, tap) -> None:
         value = "thisisatest"
 
         result = cli_runner.invoke(
@@ -231,7 +231,7 @@ class TestCliConfigSet:
         ) in result.stdout
 
     @pytest.mark.usefixtures("project")
-    def test_config_set_from_file(self, cli_runner, tap, tmp_path: Path) -> None:  # noqa: ANN001
+    def test_config_set_from_file(self, cli_runner, tap, tmp_path: Path) -> None:
         result = cli_runner.invoke(
             cli,
             ["config", tap.name, "set", "private_key", "--from-file", "-"],
@@ -262,7 +262,7 @@ class TestCliConfigSet:
     def test_environments_order_of_precedence(
         self,
         project: Project,
-        cli_runner,  # noqa: ANN001
+        cli_runner,
     ) -> None:
         # set base config in `meltano.yml`
         result = cli_runner.invoke(

--- a/tests/meltano/cli/test_elt.py
+++ b/tests/meltano/cli/test_elt.py
@@ -97,7 +97,7 @@ def assert_log_lines(result_output: str, expected: list[LogEntry]) -> None:
         assert entry.matches(seen_lines), f"Expected log entry not found: {entry}"
 
 
-def failure_help_log_suffix(job_logs_file) -> str:  # noqa: ANN001
+def failure_help_log_suffix(job_logs_file) -> str:
     return (
         "For more detailed log messages re-run the command using 'meltano "
         "--log-level=debug ...' CLI flag.\nNote that you can also check the "
@@ -108,7 +108,7 @@ def failure_help_log_suffix(job_logs_file) -> str:  # noqa: ANN001
 
 
 @pytest.fixture(scope="class")
-def tap_mock_transform(project_add_service):  # noqa: ANN001, ANN201
+def tap_mock_transform(project_add_service):
     try:
         return project_add_service.add(PluginType.TRANSFORMS, "tap-mock-transform")
     except PluginAlreadyAddedException as err:
@@ -116,8 +116,8 @@ def tap_mock_transform(project_add_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def process_mock_factory():  # noqa: ANN201
-    def _factory(name):  # noqa: ANN001, ANN202
+def process_mock_factory():
+    def _factory(name):
         process_mock = mock.Mock()
         process_mock.name = name
         process_mock.wait = AsyncMock(return_value=0)
@@ -129,7 +129,7 @@ def process_mock_factory():  # noqa: ANN201
 
 
 @pytest.fixture()
-def tap_process(process_mock_factory, tap):  # noqa: ANN001, ANN201
+def tap_process(process_mock_factory, tap):
     tap = process_mock_factory(tap)
     tap.stdout.at_eof.side_effect = (False, False, False, True)
     tap.stdout.readline = AsyncMock(side_effect=(b"SCHEMA\n", b"RECORD\n", b"STATE\n"))
@@ -141,11 +141,11 @@ def tap_process(process_mock_factory, tap):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def target_process(process_mock_factory, target):  # noqa: ANN001, ANN201
+def target_process(process_mock_factory, target):
     target = process_mock_factory(target)
 
     # Have `target.wait` take 1s to make sure the tap always finishes before the target
-    async def wait_mock():  # noqa: ANN202
+    async def wait_mock():
         await asyncio.sleep(1)
         return target.wait.return_value
 
@@ -163,7 +163,7 @@ def target_process(process_mock_factory, target):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def silent_dbt_process(process_mock_factory, dbt):  # noqa: ANN001, ANN201
+def silent_dbt_process(process_mock_factory, dbt):
     dbt = process_mock_factory(dbt)
     dbt.stdout.at_eof.side_effect = (True, True)
     dbt.stderr.at_eof.side_effect = (True, True)
@@ -171,7 +171,7 @@ def silent_dbt_process(process_mock_factory, dbt):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def dbt_process(process_mock_factory, dbt):  # noqa: ANN001, ANN201
+def dbt_process(process_mock_factory, dbt):
     dbt = process_mock_factory(dbt)
     dbt.stdout.at_eof.side_effect = (True,)
     dbt.stderr.at_eof.side_effect = (False, False, False, True)
@@ -182,7 +182,7 @@ def dbt_process(process_mock_factory, dbt):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture(autouse=True)
-def mock_plugin_installation_env():  # noqa: ANN201
+def mock_plugin_installation_env():
     with mock.patch.object(
         PluginInstallService,
         "plugin_installation_env",
@@ -199,9 +199,9 @@ class TestWindowsELT:
     @pytest.mark.usefixtures("use_test_log_config")
     def test_elt_windows(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
     ) -> None:
         args = ["elt", tap.name, target.name]
         result = cli_runner.invoke(cli, args)
@@ -225,12 +225,12 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        job_logging_service,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        job_logging_service,
         command: str,
     ) -> None:
         result = cli_runner.invoke(cli, [command])
@@ -308,13 +308,13 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt_debug_logging(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        job_logging_service,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        job_logging_service,
+        monkeypatch,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}_debug"
@@ -447,12 +447,12 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt_tap_failure(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        job_logging_service,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        job_logging_service,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}"
@@ -508,12 +508,12 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt_target_failure_before_tap_finishes(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        job_logging_service,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        job_logging_service,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}"
@@ -521,7 +521,7 @@ class TestCliEltScratchpadOne:
 
         # Have `tap_process.wait` take 2s to make sure the target can fail
         # before tap finishes
-        async def tap_wait_mock():  # noqa: ANN202
+        async def tap_wait_mock():
             await asyncio.sleep(2)
             return tap_process.wait.return_value
 
@@ -589,12 +589,12 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt_target_failure_after_tap_finishes(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        job_logging_service,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        job_logging_service,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}"
@@ -650,12 +650,12 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt_tap_and_target_failure(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        job_logging_service,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        job_logging_service,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}"
@@ -720,12 +720,12 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt_tap_line_length_limit_error(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        job_logging_service,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        job_logging_service,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}"
@@ -749,7 +749,7 @@ class TestCliEltScratchpadOne:
 
         # Have `tap_process.wait` take 1s to make sure the `LimitOverrunError`
         # exception can be raised before tap finishes
-        async def wait_mock():  # noqa: ANN202
+        async def wait_mock():
             await asyncio.sleep(1)
             return tap_process.wait.return_value
 
@@ -796,11 +796,11 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt_output_handler_error(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}"
@@ -811,7 +811,7 @@ class TestCliEltScratchpadOne:
 
         # Have `tap_process.wait` take 1s to make sure the exception can be
         # raised before tap finishes
-        async def wait_mock():  # noqa: ANN202
+        async def wait_mock():
             await asyncio.sleep(1)
             return tap_process.wait.return_value
 
@@ -842,10 +842,10 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_elt_already_running(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        session,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        session,
         command: str,
     ) -> None:
         state_id = "already_running"
@@ -867,10 +867,10 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_dump_catalog(
         self,
-        cli_runner,  # noqa: ANN001
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
+        cli_runner,
+        project,
+        tap,
+        target,
         command: str,
     ) -> None:
         catalog = {"streams": []}
@@ -899,10 +899,10 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_dump_state(
         self,
-        cli_runner,  # noqa: ANN001
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
+        cli_runner,
+        project,
+        tap,
+        target,
         command: str,
     ) -> None:
         state = {"success": True}
@@ -935,10 +935,10 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_dump_extractor_config(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        plugin_settings_service_factory,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}"
@@ -970,10 +970,10 @@ class TestCliEltScratchpadOne:
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_dump_loader_config(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        plugin_settings_service_factory,
         command: str,
     ) -> None:
         state_id = f"pytest_test_{command}"
@@ -1016,13 +1016,13 @@ class TestCliEltScratchpadTwo:
     )
     def test_elt_transform_run(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        silent_dbt_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        silent_dbt_process,
+        dbt_process,
     ) -> None:
         args = ["elt", tap.name, target.name, "--transform", "run"]
 
@@ -1077,14 +1077,14 @@ class TestCliEltScratchpadTwo:
     )
     def test_elt_transform_run_dbt_failure(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        silent_dbt_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
-        job_logging_service,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        silent_dbt_process,
+        dbt_process,
+        job_logging_service,
     ) -> None:
         state_id = "pytest_test_elt"
         args = [
@@ -1166,9 +1166,9 @@ class TestCliEltScratchpadThree:
     @pytest.mark.usefixtures("use_test_log_config", "project", "dbt")
     def test_elt_transform_only(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
     ) -> None:
         args = ["elt", tap.name, target.name, "--transform", "only"]
 
@@ -1200,9 +1200,9 @@ class TestCliEltScratchpadThree:
     )
     def test_elt_transform_only_with_transform(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
     ) -> None:
         args = ["elt", tap.name, target.name, "--transform", "only"]
 

--- a/tests/meltano/cli/test_hub.py
+++ b/tests/meltano/cli/test_hub.py
@@ -22,7 +22,7 @@ class TestCliHub:
         project: Project,
         cli_runner: CliRunner,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         with mock.patch(
             "requests.adapters.HTTPAdapter.send",
             project.hub_service.session.get_adapter(
@@ -45,7 +45,7 @@ class TestCliHub:
         cli_runner: CliRunner,
         hub_request_counter: Counter,
         requests_mock: RequestsMocker,
-    ):
+    ) -> None:
         hub_api = project.hub_service.hub_api_url
         requests_mock.get(
             hub_api,

--- a/tests/meltano/cli/test_initialize.py
+++ b/tests/meltano/cli/test_initialize.py
@@ -9,7 +9,7 @@ from meltano.core.project_init_service import ProjectInitServiceError
 
 
 class TestCliInit:
-    def test_init(self, cli_runner, tmp_path_factory, pushd):
+    def test_init(self, cli_runner, tmp_path_factory, pushd) -> None:  # noqa: ANN001
         new_project_root = tmp_path_factory.mktemp("new_meltano_root")
         pushd(new_project_root)
 
@@ -52,7 +52,12 @@ class TestCliInit:
         assert "send_anonymous_usage_stats: false" in meltano_yml
         assert "project_id:" in meltano_yml
 
-    def test_init_existing_empty_directory(self, cli_runner, tmp_path_factory, pushd):
+    def test_init_existing_empty_directory(
+        self,
+        cli_runner,  # noqa: ANN001
+        tmp_path_factory,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         new_project_root = tmp_path_factory.mktemp("new_meltano_root")
         pushd(new_project_root)
 
@@ -77,7 +82,12 @@ class TestCliInit:
 
         Project.deactivate()
 
-    def test_init_existing_meltano_yml(self, cli_runner, tmp_path_factory, pushd):
+    def test_init_existing_meltano_yml(
+        self,
+        cli_runner,  # noqa: ANN001
+        tmp_path_factory,  # noqa: ANN001
+        pushd,  # noqa: ANN001
+    ) -> None:
         new_project_root = tmp_path_factory.mktemp("new_meltano_root")
         new_project_root.joinpath("meltano.yml").touch()
         new_project_root.joinpath("README.md").touch()

--- a/tests/meltano/cli/test_initialize.py
+++ b/tests/meltano/cli/test_initialize.py
@@ -9,7 +9,7 @@ from meltano.core.project_init_service import ProjectInitServiceError
 
 
 class TestCliInit:
-    def test_init(self, cli_runner, tmp_path_factory, pushd) -> None:  # noqa: ANN001
+    def test_init(self, cli_runner, tmp_path_factory, pushd) -> None:
         new_project_root = tmp_path_factory.mktemp("new_meltano_root")
         pushd(new_project_root)
 
@@ -54,9 +54,9 @@ class TestCliInit:
 
     def test_init_existing_empty_directory(
         self,
-        cli_runner,  # noqa: ANN001
-        tmp_path_factory,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        cli_runner,
+        tmp_path_factory,
+        pushd,
     ) -> None:
         new_project_root = tmp_path_factory.mktemp("new_meltano_root")
         pushd(new_project_root)
@@ -84,9 +84,9 @@ class TestCliInit:
 
     def test_init_existing_meltano_yml(
         self,
-        cli_runner,  # noqa: ANN001
-        tmp_path_factory,  # noqa: ANN001
-        pushd,  # noqa: ANN001
+        cli_runner,
+        tmp_path_factory,
+        pushd,
     ) -> None:
         new_project_root = tmp_path_factory.mktemp("new_meltano_root")
         new_project_root.joinpath("meltano.yml").touch()

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -14,14 +14,14 @@ from meltano.core.project_add_service import PluginAlreadyAddedException
 
 class TestCliInstall:
     @pytest.fixture(scope="class")
-    def tap_gitlab(self, project_add_service):
+    def tap_gitlab(self, project_add_service):  # noqa: ANN001, ANN201
         try:
             return project_add_service.add(PluginType.EXTRACTORS, "tap-gitlab")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.mark.order(0)
-    def test_install(self, project, tap, tap_gitlab, target, dbt, cli_runner):
+    def test_install(self, project, tap, tap_gitlab, target, dbt, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
@@ -53,13 +53,13 @@ class TestCliInstall:
     @pytest.mark.usefixtures("dbt")
     def test_install_type(
         self,
-        project,
-        tap,
-        tap_gitlab,
-        target,
-        mapper,
-        cli_runner,
-    ):
+        project,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        tap_gitlab,  # noqa: ANN001
+        target,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
             install_plugin_mock_e.return_value = True
 
@@ -108,12 +108,12 @@ class TestCliInstall:
     @pytest.mark.usefixtures("tap_gitlab", "dbt")
     def test_install_type_name(
         self,
-        project,
-        tap,
-        target,
-        mapper,
-        cli_runner,
-    ):
+        project,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
             install_plugin_mock_e.return_value = True
 
@@ -160,7 +160,7 @@ class TestCliInstall:
             assert mappings_seen == 2
 
     @pytest.mark.usefixtures("target", "dbt")
-    def test_install_multiple(self, project, tap, tap_gitlab, cli_runner):
+    def test_install_multiple(self, project, tap, tap_gitlab, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
@@ -179,7 +179,14 @@ class TestCliInstall:
             )
 
     @pytest.mark.usefixtures("dbt")
-    def test_install_multiple_any_type(self, project, tap, target, dbt, cli_runner):
+    def test_install_multiple_any_type(
+        self,
+        project,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        dbt,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
@@ -199,14 +206,14 @@ class TestCliInstall:
 
     def test_install_parallel(
         self,
-        project,
-        tap,
-        tap_gitlab,
-        target,
-        dbt,
-        mapper,
-        cli_runner,
-    ):
+        project,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        tap_gitlab,  # noqa: ANN001
+        target,  # noqa: ANN001
+        dbt,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
@@ -235,14 +242,14 @@ class TestCliInstall:
 
     def test_clean_install(
         self,
-        project,
-        tap,
-        tap_gitlab,
-        target,
-        dbt,
-        mapper,
-        cli_runner,
-    ):
+        project,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        tap_gitlab,  # noqa: ANN001
+        target,  # noqa: ANN001
+        dbt,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
@@ -272,16 +279,16 @@ class TestCliInstall:
     @pytest.mark.usefixtures("tap_gitlab", "target")
     def test_install_schedule(
         self,
-        project,
-        tap_gitlab,
-        target,
-        dbt,
-        mapper,
-        cli_runner,
-        schedule_service,
-        job_schedule,
-        task_sets_service,
-    ):
+        project,  # noqa: ANN001
+        tap_gitlab,  # noqa: ANN001
+        target,  # noqa: ANN001
+        dbt,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        schedule_service,  # noqa: ANN001
+        job_schedule,  # noqa: ANN001
+        task_sets_service,  # noqa: ANN001
+    ) -> None:
         with mock.patch(
             "meltano.cli.install.ScheduleService",
             return_value=schedule_service,
@@ -317,14 +324,14 @@ class TestCliInstall:
 
     def test_install_schedule_elt(
         self,
-        project,
-        tap,
-        target,
-        cli_runner,
-        schedule_service,
-        elt_schedule,
-        task_sets_service,
-    ):
+        project,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        schedule_service,  # noqa: ANN001
+        elt_schedule,  # noqa: ANN001
+        task_sets_service,  # noqa: ANN001
+    ) -> None:
         with mock.patch(
             "meltano.cli.install.ScheduleService",
             return_value=schedule_service,
@@ -360,7 +367,7 @@ class TestCliInstall:
 # For more details
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("un_engine_uri", "project_function")
-def test_new_folder_should_autocreate_on_install(cli_runner):
+def test_new_folder_should_autocreate_on_install(cli_runner) -> None:  # noqa: ANN001
     """Be sure .meltano auto creates a db on install by default.
 
     We had a case https://github.com/meltano/meltano/issues/6383

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -14,14 +14,14 @@ from meltano.core.project_add_service import PluginAlreadyAddedException
 
 class TestCliInstall:
     @pytest.fixture(scope="class")
-    def tap_gitlab(self, project_add_service):  # noqa: ANN001, ANN201
+    def tap_gitlab(self, project_add_service):
         try:
             return project_add_service.add(PluginType.EXTRACTORS, "tap-gitlab")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.mark.order(0)
-    def test_install(self, project, tap, tap_gitlab, target, dbt, cli_runner) -> None:  # noqa: ANN001
+    def test_install(self, project, tap, tap_gitlab, target, dbt, cli_runner) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
@@ -53,12 +53,12 @@ class TestCliInstall:
     @pytest.mark.usefixtures("dbt")
     def test_install_type(
         self,
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        tap_gitlab,  # noqa: ANN001
-        target,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        project,
+        tap,
+        tap_gitlab,
+        target,
+        mapper,
+        cli_runner,
     ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
             install_plugin_mock_e.return_value = True
@@ -108,11 +108,11 @@ class TestCliInstall:
     @pytest.mark.usefixtures("tap_gitlab", "dbt")
     def test_install_type_name(
         self,
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        project,
+        tap,
+        target,
+        mapper,
+        cli_runner,
     ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
             install_plugin_mock_e.return_value = True
@@ -160,7 +160,7 @@ class TestCliInstall:
             assert mappings_seen == 2
 
     @pytest.mark.usefixtures("target", "dbt")
-    def test_install_multiple(self, project, tap, tap_gitlab, cli_runner) -> None:  # noqa: ANN001
+    def test_install_multiple(self, project, tap, tap_gitlab, cli_runner) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
@@ -181,11 +181,11 @@ class TestCliInstall:
     @pytest.mark.usefixtures("dbt")
     def test_install_multiple_any_type(
         self,
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        dbt,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        project,
+        tap,
+        target,
+        dbt,
+        cli_runner,
     ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
@@ -206,13 +206,13 @@ class TestCliInstall:
 
     def test_install_parallel(
         self,
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        tap_gitlab,  # noqa: ANN001
-        target,  # noqa: ANN001
-        dbt,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        project,
+        tap,
+        tap_gitlab,
+        target,
+        dbt,
+        mapper,
+        cli_runner,
     ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
@@ -242,13 +242,13 @@ class TestCliInstall:
 
     def test_clean_install(
         self,
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        tap_gitlab,  # noqa: ANN001
-        target,  # noqa: ANN001
-        dbt,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        project,
+        tap,
+        tap_gitlab,
+        target,
+        dbt,
+        mapper,
+        cli_runner,
     ) -> None:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
@@ -279,15 +279,15 @@ class TestCliInstall:
     @pytest.mark.usefixtures("tap_gitlab", "target")
     def test_install_schedule(
         self,
-        project,  # noqa: ANN001
-        tap_gitlab,  # noqa: ANN001
-        target,  # noqa: ANN001
-        dbt,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        schedule_service,  # noqa: ANN001
-        job_schedule,  # noqa: ANN001
-        task_sets_service,  # noqa: ANN001
+        project,
+        tap_gitlab,
+        target,
+        dbt,
+        mapper,
+        cli_runner,
+        schedule_service,
+        job_schedule,
+        task_sets_service,
     ) -> None:
         with mock.patch(
             "meltano.cli.install.ScheduleService",
@@ -324,13 +324,13 @@ class TestCliInstall:
 
     def test_install_schedule_elt(
         self,
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        schedule_service,  # noqa: ANN001
-        elt_schedule,  # noqa: ANN001
-        task_sets_service,  # noqa: ANN001
+        project,
+        tap,
+        target,
+        cli_runner,
+        schedule_service,
+        elt_schedule,
+        task_sets_service,
     ) -> None:
         with mock.patch(
             "meltano.cli.install.ScheduleService",
@@ -367,7 +367,7 @@ class TestCliInstall:
 # For more details
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("un_engine_uri", "project_function")
-def test_new_folder_should_autocreate_on_install(cli_runner) -> None:  # noqa: ANN001
+def test_new_folder_should_autocreate_on_install(cli_runner) -> None:
     """Be sure .meltano auto creates a db on install by default.
 
     We had a case https://github.com/meltano/meltano/issues/6383

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -22,14 +22,14 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture(scope="class")
-def project_tap_mock(project_add_service):  # noqa: ANN001, ANN201
+def project_tap_mock(project_add_service):
     return project_add_service.add(PluginType.EXTRACTORS, "tap-mock")
 
 
 @pytest.mark.usefixtures("project_tap_mock")
 class TestCliInvoke:
     @pytest.fixture()
-    def mock_invoke(self, utility, plugin_invoker_factory):  # noqa: ANN001, ANN201
+    def mock_invoke(self, utility, plugin_invoker_factory):
         process_mock = Mock()
         process_mock.name = "utility-mock"
         process_mock.wait = AsyncMock(return_value=0)
@@ -47,7 +47,7 @@ class TestCliInvoke:
             yield invoke_async
 
     @pytest.fixture()
-    def mock_invoke_containers(self, utility, plugin_invoker_factory):  # noqa: ANN001, ANN201
+    def mock_invoke_containers(self, utility, plugin_invoker_factory):
         with patch(
             "meltano.core.plugin_invoker.invoker_factory",
             return_value=plugin_invoker_factory,
@@ -61,7 +61,7 @@ class TestCliInvoke:
         ) as invoke_async:
             yield invoke_async
 
-    def test_invoke(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
+    def test_invoke(self, cli_runner, mock_invoke) -> None:
         res = cli_runner.invoke(cli, ["invoke", "utility-mock"])
 
         assert res.exit_code == 0, f"exit code: {res.exit_code} - {res.exception}"
@@ -70,7 +70,7 @@ class TestCliInvoke:
         assert args[0].endswith("utility-mock")
         assert isinstance(kwargs, dict)
 
-    def test_invoke_args(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
+    def test_invoke_args(self, cli_runner, mock_invoke) -> None:
         res = cli_runner.invoke(cli, ["invoke", "utility-mock", "--help"])
 
         assert res.exit_code == 0, f"exit code: {res.exit_code} - {res.exception}"
@@ -79,7 +79,7 @@ class TestCliInvoke:
         assert args[0].endswith("utility-mock")
         assert args[1] == "--help"
 
-    def test_invoke_command(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
+    def test_invoke_command(self, cli_runner, mock_invoke) -> None:
         res = cli_runner.invoke(
             cli,
             ["invoke", "utility-mock:cmd"],
@@ -95,16 +95,16 @@ class TestCliInvoke:
 
     def test_invoke_command_containerized(
         self,
-        project,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        mock_invoke_containers,  # noqa: ANN001
+        project,
+        cli_runner,
+        mock_invoke_containers,
     ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
             )
 
-        async def async_generator(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        async def async_generator(*args, **kwargs):  # noqa: ARG001
             yield "Line 1"
             yield "Line 2"
 
@@ -156,7 +156,7 @@ class TestCliInvoke:
         volume_bindings = args[0]["HostConfig"]["Binds"]
         assert volume_bindings[0].startswith(str(project.root))
 
-    def test_invoke_command_args(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
+    def test_invoke_command_args(self, cli_runner, mock_invoke) -> None:
         res = cli_runner.invoke(
             cli,
             ["invoke", "utility-mock:cmd"],
@@ -170,7 +170,7 @@ class TestCliInvoke:
         assert args[0].endswith("utility-mock")
         assert args[1:] == ("--option", "arg")
 
-    def test_invoke_exit_code(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
+    def test_invoke_exit_code(self, cli_runner, mock_invoke) -> None:
         mock_invoke.return_value.wait.return_value = 2
 
         basic = cli_runner.invoke(cli, ["invoke", "utility-mock"])
@@ -221,9 +221,9 @@ class TestCliInvoke:
 
     def test_invoke_dump_config(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        cli_runner,
+        tap,
+        plugin_settings_service_factory,
     ) -> None:
         settings_service = plugin_settings_service_factory(tap)
 
@@ -238,7 +238,7 @@ class TestCliInvoke:
                 process=True,
             )
 
-    def test_list_commands(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
+    def test_list_commands(self, cli_runner, mock_invoke) -> None:
         res = cli_runner.invoke(cli, ["invoke", "--list-commands", "utility-mock"])
 
         assert res.exit_code == 0, f"exit code: {res.exit_code} - {res.exception}"
@@ -246,7 +246,7 @@ class TestCliInvoke:
         assert "utility-mock:cmd" in res.output
         assert "description of utility command" in res.output
 
-    def test_invoke_only_install(self, cli_runner, project: Project, utility) -> None:  # noqa: ANN001
+    def test_invoke_only_install(self, cli_runner, project: Project, utility) -> None:
         with patch.object(
             ProjectPluginsService,
             "find_plugin",

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -22,14 +22,14 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture(scope="class")
-def project_tap_mock(project_add_service):
+def project_tap_mock(project_add_service):  # noqa: ANN001, ANN201
     return project_add_service.add(PluginType.EXTRACTORS, "tap-mock")
 
 
 @pytest.mark.usefixtures("project_tap_mock")
 class TestCliInvoke:
     @pytest.fixture()
-    def mock_invoke(self, utility, plugin_invoker_factory):
+    def mock_invoke(self, utility, plugin_invoker_factory):  # noqa: ANN001, ANN201
         process_mock = Mock()
         process_mock.name = "utility-mock"
         process_mock.wait = AsyncMock(return_value=0)
@@ -47,7 +47,7 @@ class TestCliInvoke:
             yield invoke_async
 
     @pytest.fixture()
-    def mock_invoke_containers(self, utility, plugin_invoker_factory):
+    def mock_invoke_containers(self, utility, plugin_invoker_factory):  # noqa: ANN001, ANN201
         with patch(
             "meltano.core.plugin_invoker.invoker_factory",
             return_value=plugin_invoker_factory,
@@ -61,7 +61,7 @@ class TestCliInvoke:
         ) as invoke_async:
             yield invoke_async
 
-    def test_invoke(self, cli_runner, mock_invoke):
+    def test_invoke(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
         res = cli_runner.invoke(cli, ["invoke", "utility-mock"])
 
         assert res.exit_code == 0, f"exit code: {res.exit_code} - {res.exception}"
@@ -70,7 +70,7 @@ class TestCliInvoke:
         assert args[0].endswith("utility-mock")
         assert isinstance(kwargs, dict)
 
-    def test_invoke_args(self, cli_runner, mock_invoke):
+    def test_invoke_args(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
         res = cli_runner.invoke(cli, ["invoke", "utility-mock", "--help"])
 
         assert res.exit_code == 0, f"exit code: {res.exit_code} - {res.exception}"
@@ -79,7 +79,7 @@ class TestCliInvoke:
         assert args[0].endswith("utility-mock")
         assert args[1] == "--help"
 
-    def test_invoke_command(self, cli_runner, mock_invoke):
+    def test_invoke_command(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
         res = cli_runner.invoke(
             cli,
             ["invoke", "utility-mock:cmd"],
@@ -95,16 +95,16 @@ class TestCliInvoke:
 
     def test_invoke_command_containerized(
         self,
-        project,
-        cli_runner,
-        mock_invoke_containers,
-    ):
+        project,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        mock_invoke_containers,  # noqa: ANN001
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
             )
 
-        async def async_generator(*args, **kwargs):  # noqa: ARG001
+        async def async_generator(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
             yield "Line 1"
             yield "Line 2"
 
@@ -156,7 +156,7 @@ class TestCliInvoke:
         volume_bindings = args[0]["HostConfig"]["Binds"]
         assert volume_bindings[0].startswith(str(project.root))
 
-    def test_invoke_command_args(self, cli_runner, mock_invoke):
+    def test_invoke_command_args(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
         res = cli_runner.invoke(
             cli,
             ["invoke", "utility-mock:cmd"],
@@ -170,7 +170,7 @@ class TestCliInvoke:
         assert args[0].endswith("utility-mock")
         assert args[1:] == ("--option", "arg")
 
-    def test_invoke_exit_code(self, cli_runner, mock_invoke):
+    def test_invoke_exit_code(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
         mock_invoke.return_value.wait.return_value = 2
 
         basic = cli_runner.invoke(cli, ["invoke", "utility-mock"])
@@ -181,7 +181,7 @@ class TestCliInvoke:
         cli_runner: CliRunner,
         project: Project,
         tap: ProjectPlugin,
-    ):
+    ) -> None:
         with patch.object(
             SingerTap,
             "discover_catalog",
@@ -219,7 +219,12 @@ class TestCliInvoke:
             assert apply_catalog_rules.call_count == 2
             assert look_up_state.call_count == 2
 
-    def test_invoke_dump_config(self, cli_runner, tap, plugin_settings_service_factory):
+    def test_invoke_dump_config(
+        self,
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         settings_service = plugin_settings_service_factory(tap)
 
         with patch.object(SingerTap, "discover_catalog"), patch.object(
@@ -233,7 +238,7 @@ class TestCliInvoke:
                 process=True,
             )
 
-    def test_list_commands(self, cli_runner, mock_invoke):
+    def test_list_commands(self, cli_runner, mock_invoke) -> None:  # noqa: ANN001
         res = cli_runner.invoke(cli, ["invoke", "--list-commands", "utility-mock"])
 
         assert res.exit_code == 0, f"exit code: {res.exit_code} - {res.exception}"
@@ -241,7 +246,7 @@ class TestCliInvoke:
         assert "utility-mock:cmd" in res.output
         assert "description of utility command" in res.output
 
-    def test_invoke_only_install(self, cli_runner, project: Project, utility):
+    def test_invoke_only_install(self, cli_runner, project: Project, utility) -> None:  # noqa: ANN001
         with patch.object(
             ProjectPluginsService,
             "find_plugin",

--- a/tests/meltano/cli/test_job_cmd.py
+++ b/tests/meltano/cli/test_job_cmd.py
@@ -11,7 +11,7 @@ from meltano.cli import cli
 
 class TestCliJob:
     @pytest.mark.usefixtures("session", "project")
-    def test_job_add(self, cli_runner, task_sets_service) -> None:  # noqa: ANN001
+    def test_job_add(self, cli_runner, task_sets_service) -> None:
         # singular task with job
         with mock.patch(
             "meltano.cli.job.TaskSetsService",
@@ -95,7 +95,7 @@ class TestCliJob:
             assert "Failed to parse yaml" in str(res.exception)
 
     @pytest.mark.usefixtures("session", "project")
-    def test_job_set(self, cli_runner, task_sets_service) -> None:  # noqa: ANN001
+    def test_job_set(self, cli_runner, task_sets_service) -> None:
         # singular task with job
         with mock.patch(
             "meltano.cli.job.TaskSetsService",
@@ -131,7 +131,7 @@ class TestCliJob:
 
     @pytest.mark.order(after="test_job_add")
     @pytest.mark.usefixtures("session", "project")
-    def test_job_remove(self, cli_runner, task_sets_service) -> None:  # noqa: ANN001
+    def test_job_remove(self, cli_runner, task_sets_service) -> None:
         # singular task with job
         with mock.patch(
             "meltano.cli.job.TaskSetsService",
@@ -155,7 +155,7 @@ class TestCliJob:
             assert not task_sets_service.exists("job-remove-mock")
 
     @pytest.mark.usefixtures("session", "project")
-    def test_job_list(self, cli_runner, task_sets_service) -> None:  # noqa: ANN001
+    def test_job_list(self, cli_runner, task_sets_service) -> None:
         # singular task with job
         with mock.patch(
             "meltano.cli.job.TaskSetsService",

--- a/tests/meltano/cli/test_job_cmd.py
+++ b/tests/meltano/cli/test_job_cmd.py
@@ -11,7 +11,7 @@ from meltano.cli import cli
 
 class TestCliJob:
     @pytest.mark.usefixtures("session", "project")
-    def test_job_add(self, cli_runner, task_sets_service):
+    def test_job_add(self, cli_runner, task_sets_service) -> None:  # noqa: ANN001
         # singular task with job
         with mock.patch(
             "meltano.cli.job.TaskSetsService",
@@ -95,7 +95,7 @@ class TestCliJob:
             assert "Failed to parse yaml" in str(res.exception)
 
     @pytest.mark.usefixtures("session", "project")
-    def test_job_set(self, cli_runner, task_sets_service):
+    def test_job_set(self, cli_runner, task_sets_service) -> None:  # noqa: ANN001
         # singular task with job
         with mock.patch(
             "meltano.cli.job.TaskSetsService",
@@ -131,7 +131,7 @@ class TestCliJob:
 
     @pytest.mark.order(after="test_job_add")
     @pytest.mark.usefixtures("session", "project")
-    def test_job_remove(self, cli_runner, task_sets_service):
+    def test_job_remove(self, cli_runner, task_sets_service) -> None:  # noqa: ANN001
         # singular task with job
         with mock.patch(
             "meltano.cli.job.TaskSetsService",
@@ -155,7 +155,7 @@ class TestCliJob:
             assert not task_sets_service.exists("job-remove-mock")
 
     @pytest.mark.usefixtures("session", "project")
-    def test_job_list(self, cli_runner, task_sets_service):
+    def test_job_list(self, cli_runner, task_sets_service) -> None:  # noqa: ANN001
         # singular task with job
         with mock.patch(
             "meltano.cli.job.TaskSetsService",

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -29,7 +29,7 @@ class TestLock:
         ),
         ids=("noop", "all-and-plugin-name"),
     )
-    def test_lock_invalid_options(self, cli_runner: CliRunner, args: list[str]):
+    def test_lock_invalid_options(self, cli_runner: CliRunner, args: list[str]) -> None:
         result = cli_runner.invoke(cli, args)
         assert result.exit_code == 1
 
@@ -42,7 +42,7 @@ class TestLock:
         self,
         cli_runner: CliRunner,
         project: Project,
-    ):
+    ) -> None:
         lockfiles = list(project.root_plugins_dir().glob("./*/*.lock"))
         assert len(lockfiles) == 2
 
@@ -59,7 +59,7 @@ class TestLock:
         project: Project,
         tap: ProjectPlugin,
         hub_endpoints: MeltanoHubService,
-    ):
+    ) -> None:
         tap_lock = PluginLock(project, tap)
 
         assert tap_lock.path.exists()
@@ -94,7 +94,7 @@ class TestLock:
         self,
         cli_runner: CliRunner,
         project: Project,
-    ):
+    ) -> None:
         lockfiles = list(project.root_plugins_dir().glob("./*/*.lock"))
         # 1 tap, 1 target
         assert len(lockfiles) == 2
@@ -108,7 +108,7 @@ class TestLock:
         assert "Locked definition for extractor tap-mock" in result.stdout
         assert "Extractor tap-mock-inherited is an inherited plugin" in result.stdout
 
-    def test_lock_plugin_not_found(self, cli_runner: CliRunner):
+    def test_lock_plugin_not_found(self, cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(cli, ["lock", "not-a-plugin"])
         assert result.exit_code == 1
         assert isinstance(result.exception, CliError)

--- a/tests/meltano/cli/test_remove.py
+++ b/tests/meltano/cli/test_remove.py
@@ -11,20 +11,20 @@ from meltano.core.project_add_service import PluginAlreadyAddedException
 
 class TestCliRemove:
     @pytest.fixture(scope="class")
-    def tap_gitlab(self, project_add_service):
+    def tap_gitlab(self, project_add_service):  # noqa: ANN001, ANN201
         try:
             return project_add_service.add(PluginType.EXTRACTORS, "tap-gitlab")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
-    def test_remove(self, project, tap, cli_runner):
+    def test_remove(self, project, tap, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
             result = cli_runner.invoke(cli, ["remove", tap.type, tap.name])
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_once_with(project, [tap])
 
-    def test_remove_multiple(self, project, tap, tap_gitlab, cli_runner):
+    def test_remove_multiple(self, project, tap, tap_gitlab, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
             result = cli_runner.invoke(
                 cli,
@@ -34,7 +34,7 @@ class TestCliRemove:
 
             remove_plugins_mock.assert_called_once_with(project, [tap, tap_gitlab])
 
-    def test_remove_type_name(self, project, tap, target, cli_runner):
+    def test_remove_type_name(self, project, tap, target, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
             result = cli_runner.invoke(cli, ["remove", "extractor", tap.name])
             assert_cli_runner(result)

--- a/tests/meltano/cli/test_remove.py
+++ b/tests/meltano/cli/test_remove.py
@@ -11,20 +11,20 @@ from meltano.core.project_add_service import PluginAlreadyAddedException
 
 class TestCliRemove:
     @pytest.fixture(scope="class")
-    def tap_gitlab(self, project_add_service):  # noqa: ANN001, ANN201
+    def tap_gitlab(self, project_add_service):
         try:
             return project_add_service.add(PluginType.EXTRACTORS, "tap-gitlab")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
-    def test_remove(self, project, tap, cli_runner) -> None:  # noqa: ANN001
+    def test_remove(self, project, tap, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
             result = cli_runner.invoke(cli, ["remove", tap.type, tap.name])
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_once_with(project, [tap])
 
-    def test_remove_multiple(self, project, tap, tap_gitlab, cli_runner) -> None:  # noqa: ANN001
+    def test_remove_multiple(self, project, tap, tap_gitlab, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
             result = cli_runner.invoke(
                 cli,
@@ -34,7 +34,7 @@ class TestCliRemove:
 
             remove_plugins_mock.assert_called_once_with(project, [tap, tap_gitlab])
 
-    def test_remove_type_name(self, project, tap, target, cli_runner) -> None:  # noqa: ANN001
+    def test_remove_type_name(self, project, tap, target, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
             result = cli_runner.invoke(cli, ["remove", "extractor", tap.name])
             assert_cli_runner(result)

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -32,7 +32,7 @@ class MockIOBlock(IOBlock):
 
 
 @pytest.fixture(scope="class")
-def tap_mock_transform(project_add_service):
+def tap_mock_transform(project_add_service):  # noqa: ANN001, ANN201
     try:
         return project_add_service.add(PluginType.TRANSFORMS, "tap-mock-transform")
     except PluginAlreadyAddedException as err:
@@ -40,8 +40,8 @@ def tap_mock_transform(project_add_service):
 
 
 @pytest.fixture()
-def process_mock_factory():
-    def _factory(name):
+def process_mock_factory():  # noqa: ANN201
+    def _factory(name):  # noqa: ANN001, ANN202
         process_mock = mock.Mock()
         process_mock.name = name
         process_mock.wait = AsyncMock(return_value=0)
@@ -53,7 +53,7 @@ def process_mock_factory():
 
 
 @pytest.fixture()
-def tap_process(process_mock_factory, tap):
+def tap_process(process_mock_factory, tap):  # noqa: ANN001, ANN201
     tap = process_mock_factory(tap)
     tap.stdout.at_eof.side_effect = (False, False, False, True)
     tap.stdout.readline = AsyncMock(side_effect=(b"SCHEMA\n", b"RECORD\n", b"STATE\n"))
@@ -65,11 +65,11 @@ def tap_process(process_mock_factory, tap):
 
 
 @pytest.fixture()
-def target_process(process_mock_factory, target):
+def target_process(process_mock_factory, target):  # noqa: ANN001, ANN201
     target = process_mock_factory(target)
 
     # Have `target.wait` take 2s to make sure the tap always finishes before the target
-    async def wait_mock():
+    async def wait_mock():  # noqa: ANN202
         await asyncio.sleep(2)
         return target.wait.return_value
 
@@ -87,12 +87,12 @@ def target_process(process_mock_factory, target):
 
 
 @pytest.fixture()
-def mapper_process(process_mock_factory, mapper):
+def mapper_process(process_mock_factory, mapper):  # noqa: ANN001, ANN201
     mapper = process_mock_factory(mapper)
 
     # Have `mapper.wait` take 1s to make sure the mapper always finishes after
     # the tap but before the target
-    async def wait_mock():
+    async def wait_mock():  # noqa: ANN202
         await asyncio.sleep(1)
         return mapper.wait.return_value
 
@@ -110,10 +110,10 @@ def mapper_process(process_mock_factory, mapper):
 
 
 @pytest.fixture()
-def dbt_process(process_mock_factory, dbt):
+def dbt_process(process_mock_factory, dbt):  # noqa: ANN001, ANN201
     dbt = process_mock_factory(dbt)
 
-    async def wait_mock():
+    async def wait_mock():  # noqa: ANN202
         await asyncio.sleep(1)
         return dbt.wait.return_value
 
@@ -178,12 +178,12 @@ class TestCliRunScratchpadOne:
     @pytest.mark.usefixtures("use_test_log_config", "project", "job_logging_service")
     def test_run_parsing_failures(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+    ) -> None:
         result = cli_runner.invoke(cli, ["run"])
         assert result.exit_code == 0
 
@@ -260,14 +260,14 @@ class TestCliRunScratchpadOne:
     )
     def test_run_basic_invocations(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        mapper_process,
-        dbt_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        mapper_process,  # noqa: ANN001
+        dbt_process,  # noqa: ANN001
+    ) -> None:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(
             side_effect=(tap_process, mapper_process, target_process),
@@ -320,13 +320,13 @@ class TestCliRunScratchpadOne:
     @pytest.mark.usefixtures("use_test_log_config", "project")
     def test_run_custom_suffix_command_option(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
         job_logging_service: JobLoggingService,
-    ):
+    ) -> None:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(side_effect=(tap_process, target_process))
 
@@ -383,15 +383,15 @@ class TestCliRunScratchpadOne:
     )
     def test_run_custom_suffix_active_environment(
         self,
-        suffix_args,
-        cli_runner,
+        suffix_args,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
         project: Project,
-        tap,
-        target,
-        tap_process,
-        target_process,
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
         job_logging_service: JobLoggingService,
-    ):
+    ) -> None:
         state_id_suffix, expected_suffix, suffix_env = suffix_args
 
         # exit cleanly when everything is fine
@@ -432,7 +432,7 @@ class TestCliRunScratchpadOne:
         "dbt",
         "job_logging_service",
     )
-    def test_run_multiple_commands(self, cli_runner, dbt_process):
+    def test_run_multiple_commands(self, cli_runner, dbt_process) -> None:  # noqa: ANN001
         # Verify that requesting the same command plugin multiple time with
         # different args works
         invoke_async = AsyncMock(
@@ -480,14 +480,14 @@ class TestCliRunScratchpadOne:
     )
     def test_run_complex_invocations(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        mapper_process,
-        dbt_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        mapper_process,  # noqa: ANN001
+        dbt_process,  # noqa: ANN001
+    ) -> None:
         invoke_async = AsyncMock(
             side_effect=(tap_process, mapper_process, target_process, dbt_process),
         )
@@ -543,13 +543,13 @@ class TestCliRunScratchpadOne:
     )
     def test_run_plugin_command_failure(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        dbt_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        dbt_process,  # noqa: ANN001
+    ) -> None:
         args = ["run", tap.name, target.name, "dbt:run"]
 
         dbt_process.wait.return_value = 1
@@ -610,13 +610,13 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_tap_failure(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        dbt_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        dbt_process,  # noqa: ANN001
+    ) -> None:
         # In this scenario, the tap fails on the third read. Target should still
         # complete, but dbt should not.
         args = ["run", tap.name, target.name, "dbt:run"]
@@ -680,18 +680,18 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_target_failure_before_tap_finished(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        dbt_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        dbt_process,  # noqa: ANN001
+    ) -> None:
         args = ["run", tap.name, target.name, "dbt:run"]
 
         # Have `tap_process.wait` take 2s to make sure the target can fail
         # before tap finishes
-        async def tap_wait_mock():
+        async def tap_wait_mock():  # noqa: ANN202
             await asyncio.sleep(2)
             return tap_process.wait.return_value
 
@@ -708,7 +708,7 @@ class TestCliRunScratchpadOne:
 
         # Have `target_process.wait` take 1s to make sure the
         # `stdin.write`/`drain` exceptions can be raised
-        async def target_wait_mock():
+        async def target_wait_mock() -> int:
             await asyncio.sleep(1)
             return 1
 
@@ -776,13 +776,13 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_target_failure_after_tap_finished(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        dbt_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        dbt_process,  # noqa: ANN001
+    ) -> None:
         args = ["run", tap.name, target.name, "dbt:run"]
 
         target_process.wait.return_value = 1
@@ -846,13 +846,13 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_tap_and_target_failed(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        dbt_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        dbt_process,  # noqa: ANN001
+    ) -> None:
         args = ["run", tap.name, target.name, "dbt:run"]
 
         tap_process.wait.return_value = 1
@@ -926,12 +926,12 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_tap_line_length_limit_error(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+    ) -> None:
         args = ["run", tap.name, target.name]
 
         # Raise a `ValueError` wrapping a `LimitOverrunError`, like
@@ -952,7 +952,7 @@ class TestCliRunScratchpadOne:
 
         # Have `tap_process.wait` take 1s to make sure the `LimitOverrunError`
         # exception can be raised before tap finishes
-        async def wait_mock():
+        async def wait_mock():  # noqa: ANN202
             await asyncio.sleep(1)
             return tap_process.wait.return_value
 
@@ -994,15 +994,15 @@ class TestCliRunScratchpadOne:
     )
     def test_run_mapper_config(
         self,
-        cli_runner,
-        tap,
-        target,
-        mapper,
-        tap_process,
-        target_process,
-        mapper_process,
-        project_add_service,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        mapper_process,  # noqa: ANN001
+        project_add_service,  # noqa: ANN001
+    ) -> None:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(
             side_effect=(tap_process, mapper_process, target_process),
@@ -1140,15 +1140,15 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_mapper_failure(
         self,
-        cli_runner,
-        tap,
-        target,
-        mapper,
-        tap_process,
-        target_process,
-        mapper_process,
-        dbt_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        mapper_process,  # noqa: ANN001
+        dbt_process,  # noqa: ANN001
+    ) -> None:
         # In this scenario, the map fails on the second read. Target should
         # still complete, but dbt should not.
         args = ["run", tap.name, "mock-mapping-0", target.name, "dbt:run"]
@@ -1219,13 +1219,13 @@ class TestCliRunScratchpadOne:
     )
     def test_run_dry_run(
         self,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        mapper_process,
-    ):
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        mapper_process,  # noqa: ANN001
+    ) -> None:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(
             side_effect=(tap_process, mapper_process, target_process),
@@ -1262,14 +1262,14 @@ class TestCliRunScratchpadOne:
     @pytest.mark.parametrize("colors", (True, False))
     def test_color_console_exception_handler(
         self,
-        colors,
-        cli_runner,
-        tap,
-        target,
-        tap_process,
-        target_process,
+        colors,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         monkeypatch.delenv("FORCE_COLOR", raising=False)
         # toggle color in logging configuration
         logging_config = default_config(log_level="info")
@@ -1314,11 +1314,11 @@ class TestUUIDParamType:
             pytest.param("123e4567e89b12d3a456426614174000", id="without hyphens"),
         ),
     )
-    def test_valid_uuid(self, value: str):
+    def test_valid_uuid(self, value: str) -> None:
         param = UUIDParamType()
         assert param.convert(value, None, None) == uuid.UUID(value)
 
-    def test_invalid_uuid(self):
+    def test_invalid_uuid(self) -> None:
         param = UUIDParamType()
         value = "zzz"
         with pytest.raises(click.BadParameter, match="is not a valid UUID"):

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -32,7 +32,7 @@ class MockIOBlock(IOBlock):
 
 
 @pytest.fixture(scope="class")
-def tap_mock_transform(project_add_service):  # noqa: ANN001, ANN201
+def tap_mock_transform(project_add_service):
     try:
         return project_add_service.add(PluginType.TRANSFORMS, "tap-mock-transform")
     except PluginAlreadyAddedException as err:
@@ -40,8 +40,8 @@ def tap_mock_transform(project_add_service):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def process_mock_factory():  # noqa: ANN201
-    def _factory(name):  # noqa: ANN001, ANN202
+def process_mock_factory():
+    def _factory(name):
         process_mock = mock.Mock()
         process_mock.name = name
         process_mock.wait = AsyncMock(return_value=0)
@@ -53,7 +53,7 @@ def process_mock_factory():  # noqa: ANN201
 
 
 @pytest.fixture()
-def tap_process(process_mock_factory, tap):  # noqa: ANN001, ANN201
+def tap_process(process_mock_factory, tap):
     tap = process_mock_factory(tap)
     tap.stdout.at_eof.side_effect = (False, False, False, True)
     tap.stdout.readline = AsyncMock(side_effect=(b"SCHEMA\n", b"RECORD\n", b"STATE\n"))
@@ -65,11 +65,11 @@ def tap_process(process_mock_factory, tap):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def target_process(process_mock_factory, target):  # noqa: ANN001, ANN201
+def target_process(process_mock_factory, target):
     target = process_mock_factory(target)
 
     # Have `target.wait` take 2s to make sure the tap always finishes before the target
-    async def wait_mock():  # noqa: ANN202
+    async def wait_mock():
         await asyncio.sleep(2)
         return target.wait.return_value
 
@@ -87,12 +87,12 @@ def target_process(process_mock_factory, target):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def mapper_process(process_mock_factory, mapper):  # noqa: ANN001, ANN201
+def mapper_process(process_mock_factory, mapper):
     mapper = process_mock_factory(mapper)
 
     # Have `mapper.wait` take 1s to make sure the mapper always finishes after
     # the tap but before the target
-    async def wait_mock():  # noqa: ANN202
+    async def wait_mock():
         await asyncio.sleep(1)
         return mapper.wait.return_value
 
@@ -110,10 +110,10 @@ def mapper_process(process_mock_factory, mapper):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def dbt_process(process_mock_factory, dbt):  # noqa: ANN001, ANN201
+def dbt_process(process_mock_factory, dbt):
     dbt = process_mock_factory(dbt)
 
-    async def wait_mock():  # noqa: ANN202
+    async def wait_mock():
         await asyncio.sleep(1)
         return dbt.wait.return_value
 
@@ -178,11 +178,11 @@ class TestCliRunScratchpadOne:
     @pytest.mark.usefixtures("use_test_log_config", "project", "job_logging_service")
     def test_run_parsing_failures(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
     ) -> None:
         result = cli_runner.invoke(cli, ["run"])
         assert result.exit_code == 0
@@ -260,13 +260,13 @@ class TestCliRunScratchpadOne:
     )
     def test_run_basic_invocations(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        mapper_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        mapper_process,
+        dbt_process,
     ) -> None:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(
@@ -320,11 +320,11 @@ class TestCliRunScratchpadOne:
     @pytest.mark.usefixtures("use_test_log_config", "project")
     def test_run_custom_suffix_command_option(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
         job_logging_service: JobLoggingService,
     ) -> None:
         # exit cleanly when everything is fine
@@ -383,13 +383,13 @@ class TestCliRunScratchpadOne:
     )
     def test_run_custom_suffix_active_environment(
         self,
-        suffix_args,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        suffix_args,
+        cli_runner,
         project: Project,
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
+        tap,
+        target,
+        tap_process,
+        target_process,
         job_logging_service: JobLoggingService,
     ) -> None:
         state_id_suffix, expected_suffix, suffix_env = suffix_args
@@ -432,7 +432,7 @@ class TestCliRunScratchpadOne:
         "dbt",
         "job_logging_service",
     )
-    def test_run_multiple_commands(self, cli_runner, dbt_process) -> None:  # noqa: ANN001
+    def test_run_multiple_commands(self, cli_runner, dbt_process) -> None:
         # Verify that requesting the same command plugin multiple time with
         # different args works
         invoke_async = AsyncMock(
@@ -480,13 +480,13 @@ class TestCliRunScratchpadOne:
     )
     def test_run_complex_invocations(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        mapper_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        mapper_process,
+        dbt_process,
     ) -> None:
         invoke_async = AsyncMock(
             side_effect=(tap_process, mapper_process, target_process, dbt_process),
@@ -543,12 +543,12 @@ class TestCliRunScratchpadOne:
     )
     def test_run_plugin_command_failure(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        dbt_process,
     ) -> None:
         args = ["run", tap.name, target.name, "dbt:run"]
 
@@ -610,12 +610,12 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_tap_failure(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        dbt_process,
     ) -> None:
         # In this scenario, the tap fails on the third read. Target should still
         # complete, but dbt should not.
@@ -680,18 +680,18 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_target_failure_before_tap_finished(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        dbt_process,
     ) -> None:
         args = ["run", tap.name, target.name, "dbt:run"]
 
         # Have `tap_process.wait` take 2s to make sure the target can fail
         # before tap finishes
-        async def tap_wait_mock():  # noqa: ANN202
+        async def tap_wait_mock():
             await asyncio.sleep(2)
             return tap_process.wait.return_value
 
@@ -776,12 +776,12 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_target_failure_after_tap_finished(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        dbt_process,
     ) -> None:
         args = ["run", tap.name, target.name, "dbt:run"]
 
@@ -846,12 +846,12 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_tap_and_target_failed(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        dbt_process,
     ) -> None:
         args = ["run", tap.name, target.name, "dbt:run"]
 
@@ -926,11 +926,11 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_tap_line_length_limit_error(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
     ) -> None:
         args = ["run", tap.name, target.name]
 
@@ -952,7 +952,7 @@ class TestCliRunScratchpadOne:
 
         # Have `tap_process.wait` take 1s to make sure the `LimitOverrunError`
         # exception can be raised before tap finishes
-        async def wait_mock():  # noqa: ANN202
+        async def wait_mock():
             await asyncio.sleep(1)
             return tap_process.wait.return_value
 
@@ -994,14 +994,14 @@ class TestCliRunScratchpadOne:
     )
     def test_run_mapper_config(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        mapper_process,  # noqa: ANN001
-        project_add_service,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        mapper,
+        tap_process,
+        target_process,
+        mapper_process,
+        project_add_service,
     ) -> None:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(
@@ -1140,14 +1140,14 @@ class TestCliRunScratchpadOne:
     )
     def test_run_elb_mapper_failure(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        mapper_process,  # noqa: ANN001
-        dbt_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        mapper,
+        tap_process,
+        target_process,
+        mapper_process,
+        dbt_process,
     ) -> None:
         # In this scenario, the map fails on the second read. Target should
         # still complete, but dbt should not.
@@ -1219,12 +1219,12 @@ class TestCliRunScratchpadOne:
     )
     def test_run_dry_run(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        mapper_process,  # noqa: ANN001
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        mapper_process,
     ) -> None:
         # exit cleanly when everything is fine
         create_subprocess_exec = AsyncMock(
@@ -1262,12 +1262,12 @@ class TestCliRunScratchpadOne:
     @pytest.mark.parametrize("colors", (True, False))
     def test_color_console_exception_handler(
         self,
-        colors,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
+        colors,
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.delenv("FORCE_COLOR", raising=False)

--- a/tests/meltano/cli/test_schedule.py
+++ b/tests/meltano/cli/test_schedule.py
@@ -16,7 +16,7 @@ class TestCliSchedule:
         "meltano.core.schedule_service.PluginSettingsService.get",
         autospec=True,
     )
-    def test_schedule_add(self, get, cli_runner, schedule_service):
+    def test_schedule_add(self, get, cli_runner, schedule_service) -> None:  # noqa: ANN001
         test_date = "2010-01-01"
         get.return_value = test_date
 
@@ -131,7 +131,13 @@ class TestCliSchedule:
         assert res.exit_code == 1
 
     @pytest.mark.parametrize("exit_code", (0, 1, 143))
-    def test_schedule_run(self, exit_code, cli_runner, elt_schedule, job_schedule):
+    def test_schedule_run(
+        self,
+        exit_code,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        elt_schedule,  # noqa: ANN001
+        job_schedule,  # noqa: ANN001
+    ) -> None:
         process_mock = mock.Mock(returncode=exit_code)
         with mock.patch(
             "meltano.cli.schedule.ScheduleService.run",
@@ -155,7 +161,7 @@ class TestCliSchedule:
             assert res.exit_code == exit_code
             run_mock.assert_called_once_with(job_schedule, "--dry-run")
 
-    def test_schedule_remove(self, cli_runner, job_schedule):
+    def test_schedule_remove(self, cli_runner, job_schedule) -> None:  # noqa: ANN001
         process_mock = mock.Mock(returncode=0)
 
         with mock.patch(
@@ -168,11 +174,11 @@ class TestCliSchedule:
 
     def test_schedule_set(
         self,
-        cli_runner,
-        elt_schedule,
-        job_schedule,
-        schedule_service,
-    ):
+        cli_runner,  # noqa: ANN001
+        elt_schedule,  # noqa: ANN001
+        job_schedule,  # noqa: ANN001
+        schedule_service,  # noqa: ANN001
+    ) -> None:
         with mock.patch(
             "meltano.cli.schedule.ScheduleService",
             return_value=schedule_service,

--- a/tests/meltano/cli/test_schedule.py
+++ b/tests/meltano/cli/test_schedule.py
@@ -16,7 +16,7 @@ class TestCliSchedule:
         "meltano.core.schedule_service.PluginSettingsService.get",
         autospec=True,
     )
-    def test_schedule_add(self, get, cli_runner, schedule_service) -> None:  # noqa: ANN001
+    def test_schedule_add(self, get, cli_runner, schedule_service) -> None:
         test_date = "2010-01-01"
         get.return_value = test_date
 
@@ -133,10 +133,10 @@ class TestCliSchedule:
     @pytest.mark.parametrize("exit_code", (0, 1, 143))
     def test_schedule_run(
         self,
-        exit_code,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        elt_schedule,  # noqa: ANN001
-        job_schedule,  # noqa: ANN001
+        exit_code,
+        cli_runner,
+        elt_schedule,
+        job_schedule,
     ) -> None:
         process_mock = mock.Mock(returncode=exit_code)
         with mock.patch(
@@ -161,7 +161,7 @@ class TestCliSchedule:
             assert res.exit_code == exit_code
             run_mock.assert_called_once_with(job_schedule, "--dry-run")
 
-    def test_schedule_remove(self, cli_runner, job_schedule) -> None:  # noqa: ANN001
+    def test_schedule_remove(self, cli_runner, job_schedule) -> None:
         process_mock = mock.Mock(returncode=0)
 
         with mock.patch(
@@ -174,10 +174,10 @@ class TestCliSchedule:
 
     def test_schedule_set(
         self,
-        cli_runner,  # noqa: ANN001
-        elt_schedule,  # noqa: ANN001
-        job_schedule,  # noqa: ANN001
-        schedule_service,  # noqa: ANN001
+        cli_runner,
+        elt_schedule,
+        job_schedule,
+        schedule_service,
     ) -> None:
         with mock.patch(
             "meltano.cli.schedule.ScheduleService",

--- a/tests/meltano/cli/test_select.py
+++ b/tests/meltano/cli/test_select.py
@@ -16,7 +16,7 @@ from meltano.core.select_service import SelectService
 
 class TestCliSelect:
     @pytest.mark.usefixtures("project")
-    def test_update_select_pattern(self, cli_runner, tap):
+    def test_update_select_pattern(self, cli_runner, tap) -> None:  # noqa: ANN001
         # add select pattern
         result = cli_runner.invoke(
             cli,
@@ -41,17 +41,22 @@ class TestCliSelect:
         assert "mock.*" not in json_config["_select"]
 
     @pytest.mark.usefixtures("project")
-    def test_select_list(self, cli_runner, tap, monkeypatch: pytest.MonkeyPatch):
-        async def mock_list_all(*args, **kwargs):  # noqa: ARG001
+    def test_select_list(
+        self,
+        cli_runner,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def mock_list_all(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
             result = ListSelectedExecutor()
             result.streams = {
-                SelectedNode(key="users", selection=SelectionType.SELECTED)
+                SelectedNode(key="users", selection=SelectionType.SELECTED),
             }
             result.properties = {
                 "users": {
                     SelectedNode(key="id", selection=SelectionType.SELECTED),
                     SelectedNode(key="name", selection=SelectionType.EXCLUDED),
-                }
+                },
             }
             return result
 

--- a/tests/meltano/cli/test_select.py
+++ b/tests/meltano/cli/test_select.py
@@ -16,7 +16,7 @@ from meltano.core.select_service import SelectService
 
 class TestCliSelect:
     @pytest.mark.usefixtures("project")
-    def test_update_select_pattern(self, cli_runner, tap) -> None:  # noqa: ANN001
+    def test_update_select_pattern(self, cli_runner, tap) -> None:
         # add select pattern
         result = cli_runner.invoke(
             cli,
@@ -43,11 +43,11 @@ class TestCliSelect:
     @pytest.mark.usefixtures("project")
     def test_select_list(
         self,
-        cli_runner,  # noqa: ANN001
-        tap,  # noqa: ANN001
+        cli_runner,
+        tap,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        async def mock_list_all(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        async def mock_list_all(*args, **kwargs):  # noqa: ARG001
             result = ListSelectedExecutor()
             result.streams = {
                 SelectedNode(key="users", selection=SelectionType.SELECTED),

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -33,16 +33,16 @@ class TestCliState:
     @pytest.mark.parametrize("state_id", unconventional_state_ids)
     def test_state_service_from_state_id_returns_none_non_convention(
         self,
-        project,  # noqa: ANN001
-        state_id,  # noqa: ANN001
+        project,
+        state_id,
     ) -> None:
         assert state.state_service_from_state_id(project, state_id) is None
 
     @pytest.mark.parametrize("state_id", conventional_state_ids)
     def test_state_service_from_state_id_returns_state_service_convention(
         self,
-        project,  # noqa: ANN001
-        state_id,  # noqa: ANN001
+        project,
+        state_id,
     ) -> None:
         with mock.patch(
             "meltano.cli.state.BlockParser",
@@ -53,20 +53,20 @@ class TestCliState:
             assert args in mock_block_parser.call_args.args
 
     @staticmethod
-    def get_result_set(result):  # noqa: ANN001, ANN205
+    def get_result_set(result):
         result_set = set(result.stdout.split("\n"))
         result_set.remove("")
         return result_set
 
     @pytest.mark.usefixtures("project")
-    def test_list(self, state_ids, state_service, cli_runner) -> None:  # noqa: ANN001
+    def test_list(self, state_ids, state_service, cli_runner) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             result = cli_runner.invoke(cli, ["state", "list"])
         assert_cli_runner(result)
         assert self.get_result_set(result) == set(state_ids)
 
     @pytest.fixture()
-    def patterns_with_expected_results(self, state_ids):  # noqa: ANN001, ANN201
+    def patterns_with_expected_results(self, state_ids):
         return [
             (
                 "test:*",
@@ -92,9 +92,9 @@ class TestCliState:
 
     def test_list_pattern(
         self,
-        state_service,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        patterns_with_expected_results,  # noqa: ANN001
+        state_service,
+        cli_runner,
+        patterns_with_expected_results,
     ) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for pattern, expected_result in patterns_with_expected_results:
@@ -104,10 +104,10 @@ class TestCliState:
 
     def test_set_from_string(
         self,
-        state_service,  # noqa: ANN001
-        state_ids,  # noqa: ANN001
-        payloads,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        state_service,
+        state_ids,
+        payloads,
+        cli_runner,
     ) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for state_id in state_ids:
@@ -127,11 +127,11 @@ class TestCliState:
 
     def test_set_from_file(
         self,
-        tmp_path,  # noqa: ANN001
-        state_service,  # noqa: ANN001
-        state_ids,  # noqa: ANN001
-        payloads,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        tmp_path,
+        state_service,
+        state_ids,
+        payloads,
+        cli_runner,
     ) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for idx_i, state_id in enumerate(state_ids):
@@ -149,7 +149,7 @@ class TestCliState:
                     assert_cli_runner(result)
                     assert state_service.get_state(state_id) == state_payload
 
-    def test_merge_from_string(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
+    def test_merge_from_string(self, state_service, state_ids, cli_runner) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             job_pairs = [
                 (state_ids[idx], state_ids[idx + 1])
@@ -171,10 +171,10 @@ class TestCliState:
     @pytest.mark.usefixtures("payloads")
     def test_merge_from_file(
         self,
-        tmp_path,  # noqa: ANN001
-        state_service,  # noqa: ANN001
-        state_ids,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
+        tmp_path,
+        state_service,
+        state_ids,
+        cli_runner,
     ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
@@ -201,7 +201,7 @@ class TestCliState:
                     job_dst_state,
                 )
 
-    def test_merge_from_job(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
+    def test_merge_from_job(self, state_service, state_ids, cli_runner) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             job_pairs = [
                 (state_ids[idx], state_ids[idx + 1])
@@ -218,7 +218,7 @@ class TestCliState:
                 assert_cli_runner(result)
                 assert state_service.get_state(job_dst) == merged_state
 
-    def test_copy_over_existing(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
+    def test_copy_over_existing(self, state_service, state_ids, cli_runner) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             job_pairs = [
                 (state_ids[idx], state_ids[idx + 1])
@@ -233,7 +233,7 @@ class TestCliState:
                 assert_cli_runner(result)
                 assert state_service.get_state(job_dst) == job_src_state
 
-    def test_copy_to_new(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
+    def test_copy_to_new(self, state_service, state_ids, cli_runner) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for job_src_id in state_ids:
                 job_src_state = state_service.get_state(job_src_id)
@@ -245,7 +245,7 @@ class TestCliState:
                 assert_cli_runner(result)
                 assert state_service.get_state(job_dst_id) == job_src_state
 
-    def test_move(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
+    def test_move(self, state_service, state_ids, cli_runner) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             job_pairs = [
                 (state_ids[idx], state_ids[idx + 1])
@@ -263,9 +263,9 @@ class TestCliState:
 
     def test_get(
         self,
-        state_service,  # noqa: ANN001
-        cli_runner,  # noqa: ANN001
-        state_ids_with_expected_states,  # noqa: ANN001
+        state_service,
+        cli_runner,
+        state_ids_with_expected_states,
     ) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for state_id, expected_state in state_ids_with_expected_states:
@@ -273,7 +273,7 @@ class TestCliState:
                 assert_cli_runner(result)
                 assert json.loads(result.stdout) == expected_state
 
-    def test_clear(self, state_service, cli_runner, state_ids) -> None:  # noqa: ANN001
+    def test_clear(self, state_service, cli_runner, state_ids) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for state_id in state_ids:
                 result = cli_runner.invoke(cli, ["state", "clear", "--force", state_id])
@@ -281,7 +281,7 @@ class TestCliState:
                 job_state = state_service.get_state(state_id)
                 assert (not job_state) or (not job_state.get("singer_state"))
 
-    def test_clear_prompt(self, state_service, cli_runner, state_ids) -> None:  # noqa: ANN001
+    def test_clear_prompt(self, state_service, cli_runner, state_ids) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for state_id in state_ids:
                 result = cli_runner.invoke(cli, ["state", "clear", state_id], input="n")

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -33,17 +33,17 @@ class TestCliState:
     @pytest.mark.parametrize("state_id", unconventional_state_ids)
     def test_state_service_from_state_id_returns_none_non_convention(
         self,
-        project,
-        state_id,
-    ):
+        project,  # noqa: ANN001
+        state_id,  # noqa: ANN001
+    ) -> None:
         assert state.state_service_from_state_id(project, state_id) is None
 
     @pytest.mark.parametrize("state_id", conventional_state_ids)
     def test_state_service_from_state_id_returns_state_service_convention(
         self,
-        project,
-        state_id,
-    ):
+        project,  # noqa: ANN001
+        state_id,  # noqa: ANN001
+    ) -> None:
         with mock.patch(
             "meltano.cli.state.BlockParser",
             autospec=True,
@@ -53,20 +53,20 @@ class TestCliState:
             assert args in mock_block_parser.call_args.args
 
     @staticmethod
-    def get_result_set(result):
+    def get_result_set(result):  # noqa: ANN001, ANN205
         result_set = set(result.stdout.split("\n"))
         result_set.remove("")
         return result_set
 
     @pytest.mark.usefixtures("project")
-    def test_list(self, state_ids, state_service, cli_runner):
+    def test_list(self, state_ids, state_service, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             result = cli_runner.invoke(cli, ["state", "list"])
         assert_cli_runner(result)
         assert self.get_result_set(result) == set(state_ids)
 
     @pytest.fixture()
-    def patterns_with_expected_results(self, state_ids):
+    def patterns_with_expected_results(self, state_ids):  # noqa: ANN001, ANN201
         return [
             (
                 "test:*",
@@ -92,17 +92,23 @@ class TestCliState:
 
     def test_list_pattern(
         self,
-        state_service,
-        cli_runner,
-        patterns_with_expected_results,
-    ):
+        state_service,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        patterns_with_expected_results,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for pattern, expected_result in patterns_with_expected_results:
                 result = cli_runner.invoke(cli, ["state", "list", "--pattern", pattern])
                 assert_cli_runner(result)
                 assert self.get_result_set(result) == expected_result
 
-    def test_set_from_string(self, state_service, state_ids, payloads, cli_runner):
+    def test_set_from_string(
+        self,
+        state_service,  # noqa: ANN001
+        state_ids,  # noqa: ANN001
+        payloads,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for state_id in state_ids:
                 for state_payload in payloads.mock_state_payloads:
@@ -121,12 +127,12 @@ class TestCliState:
 
     def test_set_from_file(
         self,
-        tmp_path,
-        state_service,
-        state_ids,
-        payloads,
-        cli_runner,
-    ):
+        tmp_path,  # noqa: ANN001
+        state_service,  # noqa: ANN001
+        state_ids,  # noqa: ANN001
+        payloads,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for idx_i, state_id in enumerate(state_ids):
                 for idx_j, state_payload in enumerate(payloads.mock_state_payloads):
@@ -143,7 +149,7 @@ class TestCliState:
                     assert_cli_runner(result)
                     assert state_service.get_state(state_id) == state_payload
 
-    def test_merge_from_string(self, state_service, state_ids, cli_runner):
+    def test_merge_from_string(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             job_pairs = [
                 (state_ids[idx], state_ids[idx + 1])
@@ -165,11 +171,11 @@ class TestCliState:
     @pytest.mark.usefixtures("payloads")
     def test_merge_from_file(
         self,
-        tmp_path,
-        state_service,
-        state_ids,
-        cli_runner,
-    ):
+        tmp_path,  # noqa: ANN001
+        state_service,  # noqa: ANN001
+        state_ids,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -195,7 +201,7 @@ class TestCliState:
                     job_dst_state,
                 )
 
-    def test_merge_from_job(self, state_service, state_ids, cli_runner):
+    def test_merge_from_job(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             job_pairs = [
                 (state_ids[idx], state_ids[idx + 1])
@@ -212,7 +218,7 @@ class TestCliState:
                 assert_cli_runner(result)
                 assert state_service.get_state(job_dst) == merged_state
 
-    def test_copy_over_existing(self, state_service, state_ids, cli_runner):
+    def test_copy_over_existing(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             job_pairs = [
                 (state_ids[idx], state_ids[idx + 1])
@@ -227,7 +233,7 @@ class TestCliState:
                 assert_cli_runner(result)
                 assert state_service.get_state(job_dst) == job_src_state
 
-    def test_copy_to_new(self, state_service, state_ids, cli_runner):
+    def test_copy_to_new(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for job_src_id in state_ids:
                 job_src_state = state_service.get_state(job_src_id)
@@ -239,7 +245,7 @@ class TestCliState:
                 assert_cli_runner(result)
                 assert state_service.get_state(job_dst_id) == job_src_state
 
-    def test_move(self, state_service, state_ids, cli_runner):
+    def test_move(self, state_service, state_ids, cli_runner) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             job_pairs = [
                 (state_ids[idx], state_ids[idx + 1])
@@ -255,14 +261,19 @@ class TestCliState:
                 assert not state_service.get_state(job_src)
                 assert state_service.get_state(job_dst) == job_src_state
 
-    def test_get(self, state_service, cli_runner, state_ids_with_expected_states):
+    def test_get(
+        self,
+        state_service,  # noqa: ANN001
+        cli_runner,  # noqa: ANN001
+        state_ids_with_expected_states,  # noqa: ANN001
+    ) -> None:
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for state_id, expected_state in state_ids_with_expected_states:
                 result = cli_runner.invoke(cli, ["state", "get", state_id])
                 assert_cli_runner(result)
                 assert json.loads(result.stdout) == expected_state
 
-    def test_clear(self, state_service, cli_runner, state_ids):
+    def test_clear(self, state_service, cli_runner, state_ids) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for state_id in state_ids:
                 result = cli_runner.invoke(cli, ["state", "clear", "--force", state_id])
@@ -270,7 +281,7 @@ class TestCliState:
                 job_state = state_service.get_state(state_id)
                 assert (not job_state) or (not job_state.get("singer_state"))
 
-    def test_clear_prompt(self, state_service, cli_runner, state_ids):
+    def test_clear_prompt(self, state_service, cli_runner, state_ids) -> None:  # noqa: ANN001
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
             for state_id in state_ids:
                 result = cli_runner.invoke(cli, ["state", "clear", state_id], input="n")

--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -74,7 +74,7 @@ class TestCliUpgrade:
 
     @pytest.mark.order(before="test_upgrade_files_glob_path")
     @pytest.mark.usefixtures("session")
-    def test_upgrade_files(self, project, cli_runner: CliRunner) -> None:  # noqa: ANN001
+    def test_upgrade_files(self, project, cli_runner: CliRunner) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -170,7 +170,7 @@ class TestCliUpgrade:
         assert "Updated orchestrate/dags/meltano.py" in output
 
     @pytest.mark.usefixtures("session")
-    def test_upgrade_files_glob_path(self, project, cli_runner: CliRunner) -> None:  # noqa: ANN001
+    def test_upgrade_files_glob_path(self, project, cli_runner: CliRunner) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -214,7 +214,7 @@ class TestCliUpgrade:
 
     @mock_aws
     @pytest.mark.usefixtures("project")
-    def test_upgrade_state(self, cli_runner, monkeypatch) -> None:  # noqa: ANN001
+    def test_upgrade_state(self, cli_runner, monkeypatch) -> None:
         state_ids = [f"dev:tap-{i}-to-target-{i}" for i in range(10)]
         conn = boto3.resource("s3", region_name="us-east-1")
         bucket = conn.create_bucket(Bucket="test-state-bucket")

--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -20,7 +20,7 @@ if t.TYPE_CHECKING:
 
 class TestCliUpgrade:
     @pytest.mark.usefixtures("project")
-    def test_upgrade(self, cli_runner: CliRunner):
+    def test_upgrade(self, cli_runner: CliRunner) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -49,14 +49,14 @@ class TestCliUpgrade:
             )
 
     @pytest.mark.usefixtures("project")
-    def test_upgrade_skip_package(self, cli_runner: CliRunner):
+    def test_upgrade_skip_package(self, cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(cli, ["upgrade", "--skip-package"])
         assert_cli_runner(result)
 
         assert "Your Meltano project has been upgraded!" in result.stdout
 
     @pytest.mark.usefixtures("project")
-    def test_upgrade_package(self, cli_runner: CliRunner):
+    def test_upgrade_package(self, cli_runner: CliRunner) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -74,7 +74,7 @@ class TestCliUpgrade:
 
     @pytest.mark.order(before="test_upgrade_files_glob_path")
     @pytest.mark.usefixtures("session")
-    def test_upgrade_files(self, project, cli_runner: CliRunner):
+    def test_upgrade_files(self, project, cli_runner: CliRunner) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -170,7 +170,7 @@ class TestCliUpgrade:
         assert "Updated orchestrate/dags/meltano.py" in output
 
     @pytest.mark.usefixtures("session")
-    def test_upgrade_files_glob_path(self, project, cli_runner: CliRunner):
+    def test_upgrade_files_glob_path(self, project, cli_runner: CliRunner) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -208,13 +208,13 @@ class TestCliUpgrade:
         assert "Updated orchestrate/dags/meltano.py" in output
 
     @pytest.mark.usefixtures("project")
-    def test_upgrade_database(self, cli_runner: CliRunner):
+    def test_upgrade_database(self, cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(cli, ["upgrade", "database"])
         assert_cli_runner(result)
 
     @mock_aws
     @pytest.mark.usefixtures("project")
-    def test_upgrade_state(self, cli_runner, monkeypatch):
+    def test_upgrade_state(self, cli_runner, monkeypatch) -> None:  # noqa: ANN001
         state_ids = [f"dev:tap-{i}-to-target-{i}" for i in range(10)]
         conn = boto3.resource("s3", region_name="us-east-1")
         bucket = conn.create_bucket(Bucket="test-state-bucket")

--- a/tests/meltano/core/behavior/test_canonical.py
+++ b/tests/meltano/core/behavior/test_canonical.py
@@ -18,10 +18,10 @@ definition = {
 
 class TestCanonical:
     @pytest.fixture()
-    def subject(self):
+    def subject(self):  # noqa: ANN201
         return Canonical(**definition)
 
-    def test_canonical(self, subject):
+    def test_canonical(self, subject) -> None:  # noqa: ANN001
         # make sure the Nones are removed
         assert len(list(subject)) == 5
 
@@ -34,12 +34,12 @@ class TestCanonical:
 
         assert buf.read().strip() == yaml_definition
 
-    def test_false(self, subject):
+    def test_false(self, subject) -> None:  # noqa: ANN001
         subject.false_value = False
 
         assert subject.canonical()["false_value"] is False
 
-    def test_nested(self, subject):
+    def test_nested(self, subject) -> None:  # noqa: ANN001
         nested = Canonical(test="value")
         subject.nested = nested
 
@@ -47,25 +47,25 @@ class TestCanonical:
             nested,
         )
 
-    def test_nested_empty(self, subject):
+    def test_nested_empty(self, subject) -> None:  # noqa: ANN001
         nested = Canonical(test="")
         subject.nested = nested
 
         assert "nested" not in Canonical.as_canonical(subject)
 
-    def test_update_canonical(self, subject):
+    def test_update_canonical(self, subject) -> None:  # noqa: ANN001
         subject.update(Canonical(test="value"))
         assert subject.test == "value"
 
-    def test_update_dict(self, subject):
+    def test_update_dict(self, subject) -> None:  # noqa: ANN001
         subject.update({"test": "value"})
         assert subject.test == "value"
 
-    def test_update_kwargs(self, subject):
+    def test_update_kwargs(self, subject) -> None:  # noqa: ANN001
         subject.update(test="value")
         assert subject.test == "value"
 
-    def test_with_attrs(self, subject):
+    def test_with_attrs(self, subject) -> None:  # noqa: ANN001
         subject.test = "value"
 
         assert subject.with_attrs().canonical() == subject.canonical()
@@ -78,7 +78,7 @@ class TestCanonical:
         assert new.new_test == "new_value"
         assert new.canonical() == {**subject.canonical(), "new_test": "new_value"}
 
-    def test_defaults(self, subject):
+    def test_defaults(self, subject) -> None:  # noqa: ANN001
         with pytest.raises(AttributeError):
             subject.test  # noqa: B018
 
@@ -99,7 +99,7 @@ class TestCanonical:
         assert subject.test == "changed"
         assert subject.canonical()["test"] == "changed"
 
-    def test_fallbacks(self, subject):
+    def test_fallbacks(self, subject) -> None:  # noqa: ANN001
         # Calling an unknown attribute is not supported
         with pytest.raises(AttributeError):
             subject.unknown  # noqa: B018
@@ -135,7 +135,7 @@ class TestCanonical:
         assert subject.known == "value"
         assert subject.canonical()["known"] == "value"
 
-    def test_preserve_comments(self):
+    def test_preserve_comments(self) -> None:
         contents = """\
             # This is a top-level comment
             test: value
@@ -164,7 +164,7 @@ class TestCanonical:
         new_contents = out_stream.read()
         assert new_contents == contents
 
-    def test_annotations(self):
+    def test_annotations(self) -> None:
         original = CommentedMap(
             {"a": 1, "annotations": {"cloud": {"data": 123}}, "z": -1},
         )

--- a/tests/meltano/core/behavior/test_canonical.py
+++ b/tests/meltano/core/behavior/test_canonical.py
@@ -18,10 +18,10 @@ definition = {
 
 class TestCanonical:
     @pytest.fixture()
-    def subject(self):  # noqa: ANN201
+    def subject(self):
         return Canonical(**definition)
 
-    def test_canonical(self, subject) -> None:  # noqa: ANN001
+    def test_canonical(self, subject) -> None:
         # make sure the Nones are removed
         assert len(list(subject)) == 5
 
@@ -34,12 +34,12 @@ class TestCanonical:
 
         assert buf.read().strip() == yaml_definition
 
-    def test_false(self, subject) -> None:  # noqa: ANN001
+    def test_false(self, subject) -> None:
         subject.false_value = False
 
         assert subject.canonical()["false_value"] is False
 
-    def test_nested(self, subject) -> None:  # noqa: ANN001
+    def test_nested(self, subject) -> None:
         nested = Canonical(test="value")
         subject.nested = nested
 
@@ -47,25 +47,25 @@ class TestCanonical:
             nested,
         )
 
-    def test_nested_empty(self, subject) -> None:  # noqa: ANN001
+    def test_nested_empty(self, subject) -> None:
         nested = Canonical(test="")
         subject.nested = nested
 
         assert "nested" not in Canonical.as_canonical(subject)
 
-    def test_update_canonical(self, subject) -> None:  # noqa: ANN001
+    def test_update_canonical(self, subject) -> None:
         subject.update(Canonical(test="value"))
         assert subject.test == "value"
 
-    def test_update_dict(self, subject) -> None:  # noqa: ANN001
+    def test_update_dict(self, subject) -> None:
         subject.update({"test": "value"})
         assert subject.test == "value"
 
-    def test_update_kwargs(self, subject) -> None:  # noqa: ANN001
+    def test_update_kwargs(self, subject) -> None:
         subject.update(test="value")
         assert subject.test == "value"
 
-    def test_with_attrs(self, subject) -> None:  # noqa: ANN001
+    def test_with_attrs(self, subject) -> None:
         subject.test = "value"
 
         assert subject.with_attrs().canonical() == subject.canonical()
@@ -78,7 +78,7 @@ class TestCanonical:
         assert new.new_test == "new_value"
         assert new.canonical() == {**subject.canonical(), "new_test": "new_value"}
 
-    def test_defaults(self, subject) -> None:  # noqa: ANN001
+    def test_defaults(self, subject) -> None:
         with pytest.raises(AttributeError):
             subject.test  # noqa: B018
 
@@ -99,7 +99,7 @@ class TestCanonical:
         assert subject.test == "changed"
         assert subject.canonical()["test"] == "changed"
 
-    def test_fallbacks(self, subject) -> None:  # noqa: ANN001
+    def test_fallbacks(self, subject) -> None:
         # Calling an unknown attribute is not supported
         with pytest.raises(AttributeError):
             subject.unknown  # noqa: B018

--- a/tests/meltano/core/behavior/test_hookable.py
+++ b/tests/meltano/core/behavior/test_hookable.py
@@ -12,11 +12,11 @@ class Hooked(HookObject):
     def __init__(self) -> None:
         self._calls = []
 
-    def call(self, hook_name) -> None:  # noqa: ANN001
+    def call(self, hook_name) -> None:
         self._calls.append(hook_name)
 
     @property
-    def calls(self):  # noqa: ANN201
+    def calls(self):
         return self._calls.copy()
 
     @hook("after_test")

--- a/tests/meltano/core/behavior/test_hookable.py
+++ b/tests/meltano/core/behavior/test_hookable.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import NoReturn  # noqa: ICN003
+
 import mock
 import pytest
 
@@ -7,48 +9,48 @@ from meltano.core.behavior.hookable import HookObject, hook
 
 
 class Hooked(HookObject):
-    def __init__(self):
+    def __init__(self) -> None:
         self._calls = []
 
-    def call(self, hook_name):
+    def call(self, hook_name) -> None:  # noqa: ANN001
         self._calls.append(hook_name)
 
     @property
-    def calls(self):
+    def calls(self):  # noqa: ANN201
         return self._calls.copy()
 
     @hook("after_test")
-    async def after_test(self):
+    async def after_test(self) -> None:
         self.call("after_test")
 
     @hook("after_test")
-    async def after_test2(self):
+    async def after_test2(self) -> None:
         self.call("after_test_2")
 
     @hook("before_test")
-    async def before_test(self):
+    async def before_test(self) -> None:
         self.call("before_test")
 
     @hook("before_test")
-    async def before_test2(self):
+    async def before_test2(self) -> None:
         self.call("before_test_2")
 
 
 class DerivedHooked(Hooked):
     @hook("before_test")
-    async def derived_before_test(self):
+    async def derived_before_test(self) -> None:
         super().call("derived_before_test")
 
 
 class Hooked2(HookObject):
     @hook("before_test")
-    async def another_class(self):
+    async def another_class(self) -> NoReturn:
         raise Exception
 
 
 class TestHookable:
     @pytest.mark.asyncio()
-    async def test_trigger_hook(self):
+    async def test_trigger_hook(self) -> None:
         subject = Hooked()
         process = mock.MagicMock()
         async with subject.trigger_hooks("test"):
@@ -63,7 +65,7 @@ class TestHookable:
         process.assert_called_once()
 
     @pytest.mark.asyncio()
-    async def test_trigger_hook_raise(self):
+    async def test_trigger_hook_raise(self) -> NoReturn:
         subject = Hooked()
         with pytest.raises(Exception):  # noqa: B017, PT011
             async with subject.trigger_hooks("test"):
@@ -72,7 +74,7 @@ class TestHookable:
         assert subject.calls == ["before_test", "before_test_2"]
 
     @pytest.mark.asyncio()
-    async def test_trigger_derived_hook(self):
+    async def test_trigger_derived_hook(self) -> None:
         subject = DerivedHooked()
 
         process = mock.MagicMock()

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -40,7 +40,7 @@ MOCK_STATE_MESSAGE = json.dumps({"type": "STATE"})
 MOCK_RECORD_MESSAGE = json.dumps({"type": "RECORD"})
 
 
-def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):
+def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):  # noqa: ANN201
     for file in plugin.config_files.values():
         Path(os.path.join(config_dir, file)).touch()
 
@@ -48,7 +48,7 @@ def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):
 
 
 @pytest.fixture()
-def test_job(session) -> Job:
+def test_job(session) -> Job:  # noqa: ANN001
     return Job(
         job_name=TEST_STATE_ID,
         state=State.SUCCESS,
@@ -63,7 +63,7 @@ def output_logger() -> OutputLogger:
 
 
 @pytest.fixture()
-def elb_context(project, session, test_job, output_logger) -> ELBContext:
+def elb_context(project, session, test_job, output_logger) -> ELBContext:  # noqa: ANN001
     ctx = ELBContext(
         project=project,
         job=test_job,
@@ -74,21 +74,26 @@ def elb_context(project, session, test_job, output_logger) -> ELBContext:
 
 
 class TestELBContext:
-    def test_elt_run_dir_is_returned(self, project, test_job, elb_context: ELBContext):
+    def test_elt_run_dir_is_returned(
+        self,
+        project,  # noqa: ANN001
+        test_job,  # noqa: ANN001
+        elb_context: ELBContext,
+    ) -> None:
         expected_path = project.job_dir(test_job.job_name, str(test_job.run_id))
         assert elb_context.elt_run_dir == Path(expected_path)
 
 
 class TestELBContextBuilder:
     @pytest.fixture()
-    def target_postgres(self, project_add_service):
+    def target_postgres(self, project_add_service):  # noqa: ANN001, ANN201
         try:
             return project_add_service.add(PluginType.LOADERS, "target-postgres")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.mark.usefixtures("target")
-    def test_builder_returns_elb_context(self, project, session, tap):
+    def test_builder_returns_elb_context(self, project, session, tap) -> None:  # noqa: ANN001
         """Ensure that builder is returning ELBContext and not itself."""
         builder = ELBContextBuilder(project)
         builder.session = session
@@ -96,7 +101,13 @@ class TestELBContextBuilder:
         assert isinstance(builder.context(), ELBContext)
         assert isinstance(builder.make_block(tap).invoker.context, ELBContext)
 
-    def test_make_block_returns_valid_singer_block(self, project, session, tap, target):
+    def test_make_block_returns_valid_singer_block(
+        self,
+        project,  # noqa: ANN001
+        session,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+    ) -> None:
         """Ensure that calling make_block returns a valid SingerBlock."""
         builder = ELBContextBuilder(project)
         builder.session = session
@@ -111,7 +122,7 @@ class TestELBContextBuilder:
         assert block.consumer
         assert not block.producer
 
-    def test_make_block_tracks_envs(self, project, session, tap, target):
+    def test_make_block_tracks_envs(self, project, session, tap, target) -> None:  # noqa: ANN001
         """Ensure that calling make_block correctly stacks env vars."""
         builder = ELBContextBuilder(project)
         builder.session = session
@@ -127,7 +138,7 @@ class TestELBContextBuilder:
         assert builder._env.items() >= block2.context.env.items()
 
     @pytest.mark.asyncio()
-    async def test_validate_envs(self, project, session, tap, target_postgres):
+    async def test_validate_envs(self, project, session, tap, target_postgres) -> None:  # noqa: ANN001
         """Ensure that expected environment variables are present."""
         builder = ELBContextBuilder(project)
         builder.session = session
@@ -170,7 +181,7 @@ class TestELBContextBuilder:
 
 class TestExtractLoadBlocks:
     @pytest.fixture()
-    def log_level_debug(self):
+    def log_level_debug(self):  # noqa: ANN201
         root_logger = logging.getLogger()  # noqa: TID251
         log_level = root_logger.level
         try:
@@ -180,26 +191,26 @@ class TestExtractLoadBlocks:
             root_logger.setLevel(log_level)
 
     @pytest.fixture()
-    def log(self, tmp_path: Path):
+    def log(self, tmp_path: Path):  # noqa: ANN201
         return tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path)
 
     @pytest.fixture()
-    def tap_config_dir(self, tmp_path: Path, tap) -> Path:
+    def tap_config_dir(self, tmp_path: Path, tap) -> Path:  # noqa: ANN001
         create_plugin_files(tmp_path, tap)
         return tmp_path
 
     @pytest.fixture()
-    def mapper_config_dir(self, tmp_path: Path, tap) -> Path:
+    def mapper_config_dir(self, tmp_path: Path, tap) -> Path:  # noqa: ANN001
         create_plugin_files(tmp_path, tap)
         return tmp_path
 
     @pytest.fixture()
-    def target_config_dir(self, tmp_path: Path, target) -> Path:
+    def target_config_dir(self, tmp_path: Path, target) -> Path:  # noqa: ANN001
         create_plugin_files(tmp_path, target)
         return tmp_path
 
     @pytest.fixture()
-    def subject(self, session, elb_context):
+    def subject(self, session, elb_context):  # noqa: ANN001, ANN201
         Job(
             job_name=TEST_STATE_ID,
             state=State.SUCCESS,
@@ -210,8 +221,8 @@ class TestExtractLoadBlocks:
         return SingerRunner(elb_context)
 
     @pytest.fixture()
-    def process_mock_factory(self):
-        def _factory(name):
+    def process_mock_factory(self):  # noqa: ANN201
+        def _factory(name):  # noqa: ANN001, ANN202
             process_mock = mock.Mock()
             process_mock.name = name
             process_mock.wait = AsyncMock(return_value=0)
@@ -220,21 +231,21 @@ class TestExtractLoadBlocks:
         return _factory
 
     @pytest.fixture()
-    def tap_process(self, process_mock_factory, tap):
+    def tap_process(self, process_mock_factory, tap):  # noqa: ANN001, ANN201
         tap = process_mock_factory(tap)
         tap.stdout.readline = AsyncMock(return_value="{}")
         tap.wait = AsyncMock(return_value=0)
         return tap
 
     @pytest.fixture()
-    def mapper_process(self, process_mock_factory, mapper):
+    def mapper_process(self, process_mock_factory, mapper):  # noqa: ANN001, ANN201
         mapper = process_mock_factory(mapper)
         mapper.stdout.readline = AsyncMock(return_value="{}")
         mapper.wait = AsyncMock(return_value=0)
         return mapper
 
     @pytest.fixture()
-    def target_process(self, process_mock_factory, target):
+    def target_process(self, process_mock_factory, target):  # noqa: ANN001, ANN201
         target = process_mock_factory(target)
         target.stdout.readline = AsyncMock(return_value="{}")
         target.wait = AsyncMock(return_value=0)
@@ -244,18 +255,18 @@ class TestExtractLoadBlocks:
     @pytest.mark.usefixtures("session", "subject", "log", "log_level_debug")
     async def test_link_io(
         self,
-        tap_config_dir,
-        target_config_dir,
-        mapper_config_dir,
-        tap,
-        target,
-        mapper,
-        tap_process,
-        target_process,
-        mapper_process,
-        plugin_invoker_factory,
-        elb_context,
-    ):
+        tap_config_dir,  # noqa: ANN001
+        target_config_dir,  # noqa: ANN001
+        mapper_config_dir,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        mapper_process,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        elb_context,  # noqa: ANN001
+    ) -> None:
         tap_process.sterr.at_eof.side_effect = True
         tap_process.stdout.at_eof.side_effect = (False, False, True)
         tap_process.stdout.readline = AsyncMock(
@@ -330,18 +341,18 @@ class TestExtractLoadBlocks:
     @pytest.mark.usefixtures("session", "subject", "log")
     async def test_extract_load_block(
         self,
-        tap_config_dir,
-        target_config_dir,
-        mapper_config_dir,
-        tap,
-        target,
-        mapper,
-        tap_process,
-        target_process,
-        mapper_process,
-        plugin_invoker_factory,
-        elb_context,
-    ):
+        tap_config_dir,  # noqa: ANN001
+        target_config_dir,  # noqa: ANN001
+        mapper_config_dir,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        mapper_process,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        elb_context,  # noqa: ANN001
+    ) -> None:
         tap_process.sterr.at_eof.side_effect = True
         tap_process.stdout.at_eof.side_effect = (False, False, True)
         tap_process.stdout.readline = AsyncMock(
@@ -411,15 +422,15 @@ class TestExtractLoadBlocks:
     @pytest.mark.usefixtures("session", "subject")
     async def test_elb_validation(
         self,
-        tap_config_dir,
-        target_config_dir,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        plugin_invoker_factory,
-        elb_context,
-    ):
+        tap_config_dir,  # noqa: ANN001
+        target_config_dir,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        elb_context,  # noqa: ANN001
+    ) -> None:
         tap_process.sterr.at_eof.side_effect = True
         tap_process.stdout.at_eof.side_effect = (False, False, True)
         tap_process.stdout.readline = AsyncMock(
@@ -503,19 +514,19 @@ class TestExtractLoadBlocks:
     @pytest.mark.usefixtures("session", "subject")
     async def test_elb_with_job_context(
         self,
-        tap_config_dir,
-        mapper_config_dir,
-        target_config_dir,
-        tap,
-        mapper,
-        target,
-        tap_process,
-        mapper_process,
-        target_process,
-        plugin_invoker_factory,
-        elb_context,
-        project,
-    ):
+        tap_config_dir,  # noqa: ANN001
+        mapper_config_dir,  # noqa: ANN001
+        target_config_dir,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        mapper,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        mapper_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        elb_context,  # noqa: ANN001
+        project,  # noqa: ANN001
+    ) -> None:
         tap_process.sterr.at_eof.side_effect = True
         tap_process.stdout.at_eof.side_effect = (False, False, True)
         tap_process.stdout.readline = AsyncMock(
@@ -581,10 +592,10 @@ class TestExtractLoadBlocks:
 
     def test_custom_run_id(
         self,
-        tap,
-        target,
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
         project_with_environment: Project,
-    ):
+    ) -> None:
         run_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
         builder = ELBContextBuilder(project_with_environment).with_run_id(run_id)
         assert builder._run_id == run_id
@@ -599,7 +610,7 @@ class TestExtractLoadBlocks:
 
 
 class TestExtractLoadUtils:
-    def test_generate_state_id(self):
+    def test_generate_state_id(self) -> None:
         block1 = mock.Mock(spec=IOBlock)
         block1.string_id = "block1"
 
@@ -619,7 +630,7 @@ class TestExtractLoadUtils:
             == "test:block1-to-block2:suffix"
         )
 
-    def test_generate_state_id_no_environment(self):
+    def test_generate_state_id_no_environment(self) -> None:
         block1 = mock.Mock(spec=IOBlock)
         block1.string_id = "block1"
 
@@ -634,7 +645,7 @@ class TestExtractLoadUtils:
         with pytest.raises(RunnerError):
             generate_state_id(project, None, block1, block2)
 
-    def test_generate_state_id_component_contains_delimiter(self):
+    def test_generate_state_id_component_contains_delimiter(self) -> None:
         block1 = mock.Mock(spec=IOBlock)
         block1.string_id = "block1"
 

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -40,7 +40,7 @@ MOCK_STATE_MESSAGE = json.dumps({"type": "STATE"})
 MOCK_RECORD_MESSAGE = json.dumps({"type": "RECORD"})
 
 
-def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):  # noqa: ANN201
+def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):
     for file in plugin.config_files.values():
         Path(os.path.join(config_dir, file)).touch()
 
@@ -48,7 +48,7 @@ def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):  # noqa: ANN20
 
 
 @pytest.fixture()
-def test_job(session) -> Job:  # noqa: ANN001
+def test_job(session) -> Job:
     return Job(
         job_name=TEST_STATE_ID,
         state=State.SUCCESS,
@@ -63,7 +63,7 @@ def output_logger() -> OutputLogger:
 
 
 @pytest.fixture()
-def elb_context(project, session, test_job, output_logger) -> ELBContext:  # noqa: ANN001
+def elb_context(project, session, test_job, output_logger) -> ELBContext:
     ctx = ELBContext(
         project=project,
         job=test_job,
@@ -76,8 +76,8 @@ def elb_context(project, session, test_job, output_logger) -> ELBContext:  # noq
 class TestELBContext:
     def test_elt_run_dir_is_returned(
         self,
-        project,  # noqa: ANN001
-        test_job,  # noqa: ANN001
+        project,
+        test_job,
         elb_context: ELBContext,
     ) -> None:
         expected_path = project.job_dir(test_job.job_name, str(test_job.run_id))
@@ -86,14 +86,14 @@ class TestELBContext:
 
 class TestELBContextBuilder:
     @pytest.fixture()
-    def target_postgres(self, project_add_service):  # noqa: ANN001, ANN201
+    def target_postgres(self, project_add_service):
         try:
             return project_add_service.add(PluginType.LOADERS, "target-postgres")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.mark.usefixtures("target")
-    def test_builder_returns_elb_context(self, project, session, tap) -> None:  # noqa: ANN001
+    def test_builder_returns_elb_context(self, project, session, tap) -> None:
         """Ensure that builder is returning ELBContext and not itself."""
         builder = ELBContextBuilder(project)
         builder.session = session
@@ -103,10 +103,10 @@ class TestELBContextBuilder:
 
     def test_make_block_returns_valid_singer_block(
         self,
-        project,  # noqa: ANN001
-        session,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
+        project,
+        session,
+        tap,
+        target,
     ) -> None:
         """Ensure that calling make_block returns a valid SingerBlock."""
         builder = ELBContextBuilder(project)
@@ -122,7 +122,7 @@ class TestELBContextBuilder:
         assert block.consumer
         assert not block.producer
 
-    def test_make_block_tracks_envs(self, project, session, tap, target) -> None:  # noqa: ANN001
+    def test_make_block_tracks_envs(self, project, session, tap, target) -> None:
         """Ensure that calling make_block correctly stacks env vars."""
         builder = ELBContextBuilder(project)
         builder.session = session
@@ -138,7 +138,7 @@ class TestELBContextBuilder:
         assert builder._env.items() >= block2.context.env.items()
 
     @pytest.mark.asyncio()
-    async def test_validate_envs(self, project, session, tap, target_postgres) -> None:  # noqa: ANN001
+    async def test_validate_envs(self, project, session, tap, target_postgres) -> None:
         """Ensure that expected environment variables are present."""
         builder = ELBContextBuilder(project)
         builder.session = session
@@ -181,7 +181,7 @@ class TestELBContextBuilder:
 
 class TestExtractLoadBlocks:
     @pytest.fixture()
-    def log_level_debug(self):  # noqa: ANN201
+    def log_level_debug(self):
         root_logger = logging.getLogger()  # noqa: TID251
         log_level = root_logger.level
         try:
@@ -191,26 +191,26 @@ class TestExtractLoadBlocks:
             root_logger.setLevel(log_level)
 
     @pytest.fixture()
-    def log(self, tmp_path: Path):  # noqa: ANN201
+    def log(self, tmp_path: Path):
         return tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path)
 
     @pytest.fixture()
-    def tap_config_dir(self, tmp_path: Path, tap) -> Path:  # noqa: ANN001
+    def tap_config_dir(self, tmp_path: Path, tap) -> Path:
         create_plugin_files(tmp_path, tap)
         return tmp_path
 
     @pytest.fixture()
-    def mapper_config_dir(self, tmp_path: Path, tap) -> Path:  # noqa: ANN001
+    def mapper_config_dir(self, tmp_path: Path, tap) -> Path:
         create_plugin_files(tmp_path, tap)
         return tmp_path
 
     @pytest.fixture()
-    def target_config_dir(self, tmp_path: Path, target) -> Path:  # noqa: ANN001
+    def target_config_dir(self, tmp_path: Path, target) -> Path:
         create_plugin_files(tmp_path, target)
         return tmp_path
 
     @pytest.fixture()
-    def subject(self, session, elb_context):  # noqa: ANN001, ANN201
+    def subject(self, session, elb_context):
         Job(
             job_name=TEST_STATE_ID,
             state=State.SUCCESS,
@@ -221,8 +221,8 @@ class TestExtractLoadBlocks:
         return SingerRunner(elb_context)
 
     @pytest.fixture()
-    def process_mock_factory(self):  # noqa: ANN201
-        def _factory(name):  # noqa: ANN001, ANN202
+    def process_mock_factory(self):
+        def _factory(name):
             process_mock = mock.Mock()
             process_mock.name = name
             process_mock.wait = AsyncMock(return_value=0)
@@ -231,21 +231,21 @@ class TestExtractLoadBlocks:
         return _factory
 
     @pytest.fixture()
-    def tap_process(self, process_mock_factory, tap):  # noqa: ANN001, ANN201
+    def tap_process(self, process_mock_factory, tap):
         tap = process_mock_factory(tap)
         tap.stdout.readline = AsyncMock(return_value="{}")
         tap.wait = AsyncMock(return_value=0)
         return tap
 
     @pytest.fixture()
-    def mapper_process(self, process_mock_factory, mapper):  # noqa: ANN001, ANN201
+    def mapper_process(self, process_mock_factory, mapper):
         mapper = process_mock_factory(mapper)
         mapper.stdout.readline = AsyncMock(return_value="{}")
         mapper.wait = AsyncMock(return_value=0)
         return mapper
 
     @pytest.fixture()
-    def target_process(self, process_mock_factory, target):  # noqa: ANN001, ANN201
+    def target_process(self, process_mock_factory, target):
         target = process_mock_factory(target)
         target.stdout.readline = AsyncMock(return_value="{}")
         target.wait = AsyncMock(return_value=0)
@@ -255,17 +255,17 @@ class TestExtractLoadBlocks:
     @pytest.mark.usefixtures("session", "subject", "log", "log_level_debug")
     async def test_link_io(
         self,
-        tap_config_dir,  # noqa: ANN001
-        target_config_dir,  # noqa: ANN001
-        mapper_config_dir,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        mapper_process,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        elb_context,  # noqa: ANN001
+        tap_config_dir,
+        target_config_dir,
+        mapper_config_dir,
+        tap,
+        target,
+        mapper,
+        tap_process,
+        target_process,
+        mapper_process,
+        plugin_invoker_factory,
+        elb_context,
     ) -> None:
         tap_process.sterr.at_eof.side_effect = True
         tap_process.stdout.at_eof.side_effect = (False, False, True)
@@ -341,17 +341,17 @@ class TestExtractLoadBlocks:
     @pytest.mark.usefixtures("session", "subject", "log")
     async def test_extract_load_block(
         self,
-        tap_config_dir,  # noqa: ANN001
-        target_config_dir,  # noqa: ANN001
-        mapper_config_dir,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        mapper_process,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        elb_context,  # noqa: ANN001
+        tap_config_dir,
+        target_config_dir,
+        mapper_config_dir,
+        tap,
+        target,
+        mapper,
+        tap_process,
+        target_process,
+        mapper_process,
+        plugin_invoker_factory,
+        elb_context,
     ) -> None:
         tap_process.sterr.at_eof.side_effect = True
         tap_process.stdout.at_eof.side_effect = (False, False, True)
@@ -422,14 +422,14 @@ class TestExtractLoadBlocks:
     @pytest.mark.usefixtures("session", "subject")
     async def test_elb_validation(
         self,
-        tap_config_dir,  # noqa: ANN001
-        target_config_dir,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        elb_context,  # noqa: ANN001
+        tap_config_dir,
+        target_config_dir,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        plugin_invoker_factory,
+        elb_context,
     ) -> None:
         tap_process.sterr.at_eof.side_effect = True
         tap_process.stdout.at_eof.side_effect = (False, False, True)
@@ -514,18 +514,18 @@ class TestExtractLoadBlocks:
     @pytest.mark.usefixtures("session", "subject")
     async def test_elb_with_job_context(
         self,
-        tap_config_dir,  # noqa: ANN001
-        mapper_config_dir,  # noqa: ANN001
-        target_config_dir,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        mapper,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        mapper_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        elb_context,  # noqa: ANN001
-        project,  # noqa: ANN001
+        tap_config_dir,
+        mapper_config_dir,
+        target_config_dir,
+        tap,
+        mapper,
+        target,
+        tap_process,
+        mapper_process,
+        target_process,
+        plugin_invoker_factory,
+        elb_context,
+        project,
     ) -> None:
         tap_process.sterr.at_eof.side_effect = True
         tap_process.stdout.at_eof.side_effect = (False, False, True)
@@ -592,8 +592,8 @@ class TestExtractLoadBlocks:
 
     def test_custom_run_id(
         self,
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
+        tap,
+        target,
         project_with_environment: Project,
     ) -> None:
         run_id = uuid.UUID("12345678-1234-5678-1234-567812345678")

--- a/tests/meltano/core/block/test_parser.py
+++ b/tests/meltano/core/block/test_parser.py
@@ -4,6 +4,6 @@ from meltano.core.block.parser import is_command_block
 
 
 class TestParserUtils:
-    def test_is_command_block(self, tap, dbt):
+    def test_is_command_block(self, tap, dbt) -> None:  # noqa: ANN001
         assert not is_command_block(tap)
         assert is_command_block(dbt)

--- a/tests/meltano/core/block/test_parser.py
+++ b/tests/meltano/core/block/test_parser.py
@@ -4,6 +4,6 @@ from meltano.core.block.parser import is_command_block
 
 
 class TestParserUtils:
-    def test_is_command_block(self, tap, dbt) -> None:  # noqa: ANN001
+    def test_is_command_block(self, tap, dbt) -> None:
         assert not is_command_block(tap)
         assert is_command_block(dbt)

--- a/tests/meltano/core/block/test_plugin_command.py
+++ b/tests/meltano/core/block/test_plugin_command.py
@@ -9,7 +9,7 @@ from meltano.core.block.plugin_command import plugin_command_invoker
 class TestInvokerCommand:
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("session")
-    async def test_run_passes_command_args_when_required(self, project, dbt) -> None:  # noqa: ANN001
+    async def test_run_passes_command_args_when_required(self, project, dbt) -> None:
         cmd = plugin_command_invoker(
             dbt,
             project,

--- a/tests/meltano/core/block/test_plugin_command.py
+++ b/tests/meltano/core/block/test_plugin_command.py
@@ -9,7 +9,7 @@ from meltano.core.block.plugin_command import plugin_command_invoker
 class TestInvokerCommand:
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("session")
-    async def test_run_passes_command_args_when_required(self, project, dbt):
+    async def test_run_passes_command_args_when_required(self, project, dbt) -> None:  # noqa: ANN001
         cmd = plugin_command_invoker(
             dbt,
             project,

--- a/tests/meltano/core/block/test_singer.py
+++ b/tests/meltano/core/block/test_singer.py
@@ -142,7 +142,7 @@ class TestSingerBlocks:
         )
         await block.start()
 
-        await block.stop(True)
+        await block.stop(kill=True)
         assert block.process_handle.kill.called
         assert block.invoker.cleanup.called
 
@@ -154,7 +154,7 @@ class TestSingerBlocks:
         )
         await block.start()
 
-        await block.stop(False)
+        await block.stop(kill=False)
         assert block.process_handle.terminate.called
         assert block.invoker.cleanup.called
 

--- a/tests/meltano/core/block/test_singer.py
+++ b/tests/meltano/core/block/test_singer.py
@@ -16,17 +16,17 @@ from meltano.core.logging import OutputLogger
 
 class TestSingerBlocks:
     @pytest.fixture()
-    def log(self, tmp_path):
+    def log(self, tmp_path):  # noqa: ANN001, ANN201
         return tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path)
 
     @pytest.fixture()
-    def elt_context(
+    def elt_context(  # noqa: ANN201
         self,
-        project,  # noqa: ARG002
-        session,
-        tap,
-        target,
-        elt_context_builder,
+        project,  # noqa: ANN001, ARG002
+        session,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        elt_context_builder,  # noqa: ANN001
     ):
         job = Job(job_name="pytest_test_runner")
 
@@ -39,8 +39,8 @@ class TestSingerBlocks:
         )
 
     @pytest.fixture()
-    def process_mock_factory(self):
-        def _factory(name):
+    def process_mock_factory(self):  # noqa: ANN201
+        def _factory(name):  # noqa: ANN001, ANN202
             process_mock = Mock()
             process_mock.name = name
             process_mock.wait = AsyncMock(return_value=0)
@@ -49,7 +49,7 @@ class TestSingerBlocks:
         return _factory
 
     @pytest.fixture()
-    def mock_tap_plugin_invoker(self, process_mock_factory, tap):
+    def mock_tap_plugin_invoker(self, process_mock_factory, tap):  # noqa: ANN001, ANN201
         stdout_lines = (b"out1\n", b"out2\n", b"out3\n")
         stderr_lines = (b"err1\n", b"err2\n", b"err3\n")
 
@@ -73,7 +73,7 @@ class TestSingerBlocks:
         return invoker
 
     @pytest.fixture()
-    def mock_target_plugin_invoker(self, process_mock_factory, target):
+    def mock_target_plugin_invoker(self, process_mock_factory, target):  # noqa: ANN001, ANN201
         target_process = process_mock_factory(target)
         target_process.stdin = mock.MagicMock()
         target_process.stdin.wait_closed = AsyncMock(return_value=True)
@@ -87,10 +87,10 @@ class TestSingerBlocks:
     @pytest.mark.asyncio()
     async def test_singer_block_start(
         self,
-        elt_context,
-        mock_tap_plugin_invoker,
-        mock_target_plugin_invoker,
-    ):
+        elt_context,  # noqa: ANN001
+        mock_tap_plugin_invoker,  # noqa: ANN001
+        mock_target_plugin_invoker,  # noqa: ANN001
+    ) -> None:
         block = SingerBlock(
             block_ctx=elt_context,
             project=elt_context.project,
@@ -133,7 +133,11 @@ class TestSingerBlocks:
         )
 
     @pytest.mark.asyncio()
-    async def test_singer_block_stop(self, elt_context, mock_target_plugin_invoker):
+    async def test_singer_block_stop(
+        self,
+        elt_context,  # noqa: ANN001
+        mock_target_plugin_invoker,  # noqa: ANN001
+    ) -> None:
         block = SingerBlock(
             block_ctx=elt_context,
             project=elt_context.project,
@@ -159,7 +163,12 @@ class TestSingerBlocks:
         assert block.invoker.cleanup.called
 
     @pytest.mark.asyncio()
-    async def test_singer_block_io(self, elt_context, mock_tap_plugin_invoker, log):
+    async def test_singer_block_io(
+        self,
+        elt_context,  # noqa: ANN001
+        mock_tap_plugin_invoker,  # noqa: ANN001
+        log,  # noqa: ANN001
+    ) -> None:
         producer = SingerBlock(
             block_ctx=elt_context,
             project=elt_context.project,
@@ -202,10 +211,10 @@ class TestSingerBlocks:
     @pytest.mark.asyncio()
     async def test_singer_block_close_stdin(
         self,
-        elt_context,
-        mock_tap_plugin_invoker,
-        mock_target_plugin_invoker,
-    ):
+        elt_context,  # noqa: ANN001
+        mock_tap_plugin_invoker,  # noqa: ANN001
+        mock_target_plugin_invoker,  # noqa: ANN001
+    ) -> None:
         producer = SingerBlock(
             block_ctx=elt_context,
             project=elt_context.project,

--- a/tests/meltano/core/block/test_singer.py
+++ b/tests/meltano/core/block/test_singer.py
@@ -16,17 +16,17 @@ from meltano.core.logging import OutputLogger
 
 class TestSingerBlocks:
     @pytest.fixture()
-    def log(self, tmp_path):  # noqa: ANN001, ANN201
+    def log(self, tmp_path):
         return tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path)
 
     @pytest.fixture()
-    def elt_context(  # noqa: ANN201
+    def elt_context(
         self,
-        project,  # noqa: ANN001, ARG002
-        session,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        elt_context_builder,  # noqa: ANN001
+        project,  # noqa: ARG002
+        session,
+        tap,
+        target,
+        elt_context_builder,
     ):
         job = Job(job_name="pytest_test_runner")
 
@@ -39,8 +39,8 @@ class TestSingerBlocks:
         )
 
     @pytest.fixture()
-    def process_mock_factory(self):  # noqa: ANN201
-        def _factory(name):  # noqa: ANN001, ANN202
+    def process_mock_factory(self):
+        def _factory(name):
             process_mock = Mock()
             process_mock.name = name
             process_mock.wait = AsyncMock(return_value=0)
@@ -49,7 +49,7 @@ class TestSingerBlocks:
         return _factory
 
     @pytest.fixture()
-    def mock_tap_plugin_invoker(self, process_mock_factory, tap):  # noqa: ANN001, ANN201
+    def mock_tap_plugin_invoker(self, process_mock_factory, tap):
         stdout_lines = (b"out1\n", b"out2\n", b"out3\n")
         stderr_lines = (b"err1\n", b"err2\n", b"err3\n")
 
@@ -73,7 +73,7 @@ class TestSingerBlocks:
         return invoker
 
     @pytest.fixture()
-    def mock_target_plugin_invoker(self, process_mock_factory, target):  # noqa: ANN001, ANN201
+    def mock_target_plugin_invoker(self, process_mock_factory, target):
         target_process = process_mock_factory(target)
         target_process.stdin = mock.MagicMock()
         target_process.stdin.wait_closed = AsyncMock(return_value=True)
@@ -87,9 +87,9 @@ class TestSingerBlocks:
     @pytest.mark.asyncio()
     async def test_singer_block_start(
         self,
-        elt_context,  # noqa: ANN001
-        mock_tap_plugin_invoker,  # noqa: ANN001
-        mock_target_plugin_invoker,  # noqa: ANN001
+        elt_context,
+        mock_tap_plugin_invoker,
+        mock_target_plugin_invoker,
     ) -> None:
         block = SingerBlock(
             block_ctx=elt_context,
@@ -135,8 +135,8 @@ class TestSingerBlocks:
     @pytest.mark.asyncio()
     async def test_singer_block_stop(
         self,
-        elt_context,  # noqa: ANN001
-        mock_target_plugin_invoker,  # noqa: ANN001
+        elt_context,
+        mock_target_plugin_invoker,
     ) -> None:
         block = SingerBlock(
             block_ctx=elt_context,
@@ -165,9 +165,9 @@ class TestSingerBlocks:
     @pytest.mark.asyncio()
     async def test_singer_block_io(
         self,
-        elt_context,  # noqa: ANN001
-        mock_tap_plugin_invoker,  # noqa: ANN001
-        log,  # noqa: ANN001
+        elt_context,
+        mock_tap_plugin_invoker,
+        log,
     ) -> None:
         producer = SingerBlock(
             block_ctx=elt_context,
@@ -211,9 +211,9 @@ class TestSingerBlocks:
     @pytest.mark.asyncio()
     async def test_singer_block_close_stdin(
         self,
-        elt_context,  # noqa: ANN001
-        mock_tap_plugin_invoker,  # noqa: ANN001
-        mock_target_plugin_invoker,  # noqa: ANN001
+        elt_context,
+        mock_tap_plugin_invoker,
+        mock_target_plugin_invoker,
     ) -> None:
         producer = SingerBlock(
             block_ctx=elt_context,

--- a/tests/meltano/core/container/test_container_spec.py
+++ b/tests/meltano/core/container/test_container_spec.py
@@ -62,7 +62,7 @@ class TestContainerService:
         ids=["port-mapping", "custom-entrypoint"],
     )
     @pytest.mark.asyncio()
-    async def test_docker_config(self, spec: ContainerSpec, payload: dict):
+    async def test_docker_config(self, spec: ContainerSpec, payload: dict) -> None:
         """Check Docker container config from container spec."""
         if platform.system() == "Windows":
             pytest.xfail(

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -25,7 +25,7 @@ class TestMeltanoHubService:
         self,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         definition = project.hub_service.find_definition(
             PluginType.EXTRACTORS,
             "tap-mock",
@@ -41,7 +41,7 @@ class TestMeltanoHubService:
         self,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         definition = project.hub_service.find_definition(
             PluginType.EXTRACTORS,
             "tap-mock",
@@ -56,7 +56,7 @@ class TestMeltanoHubService:
         self,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         definition = project.hub_service.find_definition(
             PluginType.EXTRACTORS,
             "tap-mock",
@@ -72,7 +72,7 @@ class TestMeltanoHubService:
         self,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         with pytest.raises(PluginNotFoundError):
             project.hub_service.find_definition(PluginType.EXTRACTORS, "tap-not-found")
 
@@ -83,7 +83,7 @@ class TestMeltanoHubService:
         self,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         with pytest.raises(HubPluginVariantNotFoundError):
             project.hub_service.find_definition(
                 PluginType.EXTRACTORS,
@@ -98,7 +98,7 @@ class TestMeltanoHubService:
         self,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         extractors = project.hub_service.get_plugins_of_type(PluginType.EXTRACTORS)
         assert len(extractors) == 9
         assert len(extractors["tap-mock"].variants) == 2
@@ -108,11 +108,11 @@ class TestMeltanoHubService:
         ]
         assert hub_request_counter["/extractors/index"] == 1
 
-    def test_hub_auth(self, project):
+    def test_hub_auth(self, project) -> None:  # noqa: ANN001
         project.settings.set("hub_url_auth", "Bearer s3cr3t")
         assert project.hub_service.session.headers["Authorization"] == "Bearer s3cr3t"
 
-    def test_server_error(self, project: Project):
+    def test_server_error(self, project: Project) -> None:
         with pytest.raises(
             HubConnectionError,
             match="Could not connect to Meltano Hub. 500 Server Error",
@@ -131,7 +131,7 @@ class TestMeltanoHubService:
             "/this-returns-500--original"
         )
 
-    def test_request_headers(self, project: Project):
+    def test_request_headers(self, project: Project) -> None:
         with mock.patch("click.get_current_context") as get_context:
             get_context.return_value = click.Context(
                 hub,
@@ -146,14 +146,14 @@ class TestMeltanoHubService:
             request = project.hub_service._build_request("GET", "https://example.com")
             assert "X-Meltano-Command" not in request.headers
 
-    def test_custom_ca(self, project, monkeypatch):
+    def test_custom_ca(self, project, monkeypatch) -> None:  # noqa: ANN001
         send_kwargs = {}
 
         class _Adapter(BaseAdapter):
-            def send(
+            def send(  # noqa: ANN202
                 self,
-                request,  # noqa: ARG002
-                **kwargs,
+                request,  # noqa: ANN001, ARG002
+                **kwargs,  # noqa: ANN003
             ):
                 nonlocal send_kwargs
                 send_kwargs = kwargs
@@ -171,14 +171,14 @@ class TestMeltanoHubService:
         hub._get(mock_url)
         assert send_kwargs["verify"] == "/path/to/ca.pem"
 
-    def test_custom_proxy(self, project, monkeypatch):
+    def test_custom_proxy(self, project, monkeypatch) -> None:  # noqa: ANN001
         send_kwargs = {}
 
         class _Adapter(BaseAdapter):
-            def send(
+            def send(  # noqa: ANN202
                 self,
-                request,  # noqa: ARG002
-                **kwargs,
+                request,  # noqa: ANN001, ARG002
+                **kwargs,  # noqa: ANN003
             ):
                 nonlocal send_kwargs
                 send_kwargs = kwargs

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -108,7 +108,7 @@ class TestMeltanoHubService:
         ]
         assert hub_request_counter["/extractors/index"] == 1
 
-    def test_hub_auth(self, project) -> None:  # noqa: ANN001
+    def test_hub_auth(self, project) -> None:
         project.settings.set("hub_url_auth", "Bearer s3cr3t")
         assert project.hub_service.session.headers["Authorization"] == "Bearer s3cr3t"
 
@@ -146,14 +146,14 @@ class TestMeltanoHubService:
             request = project.hub_service._build_request("GET", "https://example.com")
             assert "X-Meltano-Command" not in request.headers
 
-    def test_custom_ca(self, project, monkeypatch) -> None:  # noqa: ANN001
+    def test_custom_ca(self, project, monkeypatch) -> None:
         send_kwargs = {}
 
         class _Adapter(BaseAdapter):
-            def send(  # noqa: ANN202
+            def send(
                 self,
-                request,  # noqa: ANN001, ARG002
-                **kwargs,  # noqa: ANN003
+                request,  # noqa: ARG002
+                **kwargs,
             ):
                 nonlocal send_kwargs
                 send_kwargs = kwargs
@@ -171,14 +171,14 @@ class TestMeltanoHubService:
         hub._get(mock_url)
         assert send_kwargs["verify"] == "/path/to/ca.pem"
 
-    def test_custom_proxy(self, project, monkeypatch) -> None:  # noqa: ANN001
+    def test_custom_proxy(self, project, monkeypatch) -> None:
         send_kwargs = {}
 
         class _Adapter(BaseAdapter):
-            def send(  # noqa: ANN202
+            def send(
                 self,
-                request,  # noqa: ANN001, ARG002
-                **kwargs,  # noqa: ANN003
+                request,  # noqa: ARG002
+                **kwargs,
             ):
                 nonlocal send_kwargs
                 send_kwargs = kwargs

--- a/tests/meltano/core/job/test_finder.py
+++ b/tests/meltano/core/job/test_finder.py
@@ -29,12 +29,12 @@ class TestJobFinder:
     )
     def test_all_stale(
         self,
-        state,
-        started_at_hours_ago,
-        last_heartbeat_at_minutes_ago,
-        is_stale,
-        session,
-    ):
+        state,  # noqa: ANN001
+        started_at_hours_ago,  # noqa: ANN001
+        last_heartbeat_at_minutes_ago,  # noqa: ANN001
+        is_stale,  # noqa: ANN001
+        session,  # noqa: ANN001
+    ) -> None:
         started_at = datetime.now(timezone.utc)
         if started_at_hours_ago:
             started_at -= timedelta(hours=started_at_hours_ago)
@@ -57,7 +57,7 @@ class TestJobFinder:
 
         assert bool(job in JobFinder.all_stale(session)) == is_stale
 
-    def test_stale(self, session):
+    def test_stale(self, session) -> None:  # noqa: ANN001
         job = Job(job_name="test")
         job.start()
         job.last_heartbeat_at = datetime.now(timezone.utc) - timedelta(minutes=10)

--- a/tests/meltano/core/job/test_finder.py
+++ b/tests/meltano/core/job/test_finder.py
@@ -29,11 +29,11 @@ class TestJobFinder:
     )
     def test_all_stale(
         self,
-        state,  # noqa: ANN001
-        started_at_hours_ago,  # noqa: ANN001
-        last_heartbeat_at_minutes_ago,  # noqa: ANN001
-        is_stale,  # noqa: ANN001
-        session,  # noqa: ANN001
+        state,
+        started_at_hours_ago,
+        last_heartbeat_at_minutes_ago,
+        is_stale,
+        session,
     ) -> None:
         started_at = datetime.now(timezone.utc)
         if started_at_hours_ago:
@@ -57,7 +57,7 @@ class TestJobFinder:
 
         assert bool(job in JobFinder.all_stale(session)) == is_stale
 
-    def test_stale(self, session) -> None:  # noqa: ANN001
+    def test_stale(self, session) -> None:
         job = Job(job_name="test")
         job.start()
         job.last_heartbeat_at = datetime.now(timezone.utc) - timedelta(minutes=10)

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -18,19 +18,19 @@ from meltano.core.job.job import (
 
 
 class TestJob:
-    def sample_job(self, payload=None):  # noqa: ANN001, ANN201
+    def sample_job(self, payload=None):
         return Job(
             job_name="meltano:sample-elt",
             state=State.IDLE,
             payload=payload or {},
         )
 
-    def test_save(self, session) -> None:  # noqa: ANN001
+    def test_save(self, session) -> None:
         subject = self.sample_job().save(session)
 
         assert subject.id > 0
 
-    def test_load(self, session) -> None:  # noqa: ANN001
+    def test_load(self, session) -> None:
         for key in range(10):
             session.add(self.sample_job({"key": key}))
 
@@ -39,7 +39,7 @@ class TestJob:
         assert len(subjects.all()) == 10
         session.rollback()
 
-    def test_transit(self, session) -> None:  # noqa: ANN001
+    def test_transit(self, session) -> None:
         subject = self.sample_job().save(session)
 
         transition = subject.transit(State.RUNNING)
@@ -51,7 +51,7 @@ class TestJob:
         subject.ended_at = datetime.now(timezone.utc)
 
     @pytest.mark.asyncio()
-    async def test_run(self, session) -> None:  # noqa: ANN001
+    async def test_run(self, session) -> None:
         subject = self.sample_job().save(session)
 
         # A successful run will mark the subject as SUCCESS and set the `ended_at`
@@ -77,7 +77,7 @@ class TestJob:
         assert subject.ended_at - subject.last_heartbeat_at < timedelta(seconds=2)
 
     @pytest.mark.asyncio()
-    async def test_run_failed(self, session) -> NoReturn:  # noqa: ANN001
+    async def test_run_failed(self, session) -> NoReturn:
         # A failed run will mark the subject as FAILED an set the payload['error']
         subject = self.sample_job({"original_state": 1}).save(session)
         exception = Exception("This is a test.")
@@ -95,7 +95,7 @@ class TestJob:
         assert subject.payload["error"] == "This is a test."
 
     @pytest.mark.asyncio()
-    async def test_run_interrupted(self, session) -> None:  # noqa: ANN001
+    async def test_run_interrupted(self, session) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/2842",
@@ -111,7 +111,7 @@ class TestJob:
         assert subject.payload["error"] == "The process was interrupted"
 
     @pytest.mark.asyncio()
-    async def test_run_terminated(self, session) -> None:  # noqa: ANN001
+    async def test_run_terminated(self, session) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/2842",
@@ -127,7 +127,7 @@ class TestJob:
         assert subject.payload["original_state"] == 1
         assert subject.payload["error"] == "The process was terminated"
 
-    def test_run_id(self, session) -> None:  # noqa: ANN001
+    def test_run_id(self, session) -> None:
         job = Job()
         run_id = job.run_id
         assert isinstance(run_id, uuid.UUID)

--- a/tests/meltano/core/job/test_stale_job_failer.py
+++ b/tests/meltano/core/job/test_stale_job_failer.py
@@ -10,7 +10,7 @@ from meltano.core.job.stale_job_failer import fail_stale_jobs
 
 class TestStaleJobFailer:
     @pytest.fixture()
-    def live_job(self, session):
+    def live_job(self, session):  # noqa: ANN001, ANN201
         job = Job(job_name="test")
         job.start()
         job.save(session)
@@ -18,7 +18,7 @@ class TestStaleJobFailer:
         return job
 
     @pytest.fixture()
-    def stale_job(self, session):
+    def stale_job(self, session):  # noqa: ANN001, ANN201
         job = Job(job_name="test")
         job.start()
         job.last_heartbeat_at = datetime.now(timezone.utc) - timedelta(minutes=10)
@@ -27,7 +27,7 @@ class TestStaleJobFailer:
         return job
 
     @pytest.fixture()
-    def other_stale_job(self, session):
+    def other_stale_job(self, session):  # noqa: ANN001, ANN201
         job = Job(job_name="other")
         job.start()
         job.last_heartbeat_at = datetime.now(timezone.utc) - timedelta(minutes=10)
@@ -36,7 +36,7 @@ class TestStaleJobFailer:
         return job
 
     @pytest.fixture()
-    def complete_job(self, session):
+    def complete_job(self, session):  # noqa: ANN001, ANN201
         job = Job(job_name="other")
         job.start()
         job.success()
@@ -46,12 +46,12 @@ class TestStaleJobFailer:
 
     def test_fail_stale_jobs(
         self,
-        live_job,
-        stale_job,
-        other_stale_job,
-        complete_job,
-        session,
-    ):
+        live_job,  # noqa: ANN001
+        stale_job,  # noqa: ANN001
+        other_stale_job,  # noqa: ANN001
+        complete_job,  # noqa: ANN001
+        session,  # noqa: ANN001
+    ) -> None:
         assert stale_job.is_stale()
         assert other_stale_job.is_stale()
 
@@ -75,12 +75,12 @@ class TestStaleJobFailer:
 
     def test_fail_stale_jobs_with_state_id(
         self,
-        live_job,
-        stale_job,
-        other_stale_job,
-        complete_job,
-        session,
-    ):
+        live_job,  # noqa: ANN001
+        stale_job,  # noqa: ANN001
+        other_stale_job,  # noqa: ANN001
+        complete_job,  # noqa: ANN001
+        session,  # noqa: ANN001
+    ) -> None:
         assert stale_job.is_stale()
         assert other_stale_job.is_stale()
 

--- a/tests/meltano/core/job/test_stale_job_failer.py
+++ b/tests/meltano/core/job/test_stale_job_failer.py
@@ -10,7 +10,7 @@ from meltano.core.job.stale_job_failer import fail_stale_jobs
 
 class TestStaleJobFailer:
     @pytest.fixture()
-    def live_job(self, session):  # noqa: ANN001, ANN201
+    def live_job(self, session):
         job = Job(job_name="test")
         job.start()
         job.save(session)
@@ -18,7 +18,7 @@ class TestStaleJobFailer:
         return job
 
     @pytest.fixture()
-    def stale_job(self, session):  # noqa: ANN001, ANN201
+    def stale_job(self, session):
         job = Job(job_name="test")
         job.start()
         job.last_heartbeat_at = datetime.now(timezone.utc) - timedelta(minutes=10)
@@ -27,7 +27,7 @@ class TestStaleJobFailer:
         return job
 
     @pytest.fixture()
-    def other_stale_job(self, session):  # noqa: ANN001, ANN201
+    def other_stale_job(self, session):
         job = Job(job_name="other")
         job.start()
         job.last_heartbeat_at = datetime.now(timezone.utc) - timedelta(minutes=10)
@@ -36,7 +36,7 @@ class TestStaleJobFailer:
         return job
 
     @pytest.fixture()
-    def complete_job(self, session):  # noqa: ANN001, ANN201
+    def complete_job(self, session):
         job = Job(job_name="other")
         job.start()
         job.success()
@@ -46,11 +46,11 @@ class TestStaleJobFailer:
 
     def test_fail_stale_jobs(
         self,
-        live_job,  # noqa: ANN001
-        stale_job,  # noqa: ANN001
-        other_stale_job,  # noqa: ANN001
-        complete_job,  # noqa: ANN001
-        session,  # noqa: ANN001
+        live_job,
+        stale_job,
+        other_stale_job,
+        complete_job,
+        session,
     ) -> None:
         assert stale_job.is_stale()
         assert other_stale_job.is_stale()
@@ -75,11 +75,11 @@ class TestStaleJobFailer:
 
     def test_fail_stale_jobs_with_state_id(
         self,
-        live_job,  # noqa: ANN001
-        stale_job,  # noqa: ANN001
-        other_stale_job,  # noqa: ANN001
-        complete_job,  # noqa: ANN001
-        session,  # noqa: ANN001
+        live_job,
+        stale_job,
+        other_stale_job,
+        complete_job,
+        session,
     ) -> None:
         assert stale_job.is_stale()
         assert other_stale_job.is_stale()

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -18,7 +18,7 @@ ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 class FakeCode:
     """A fake code object that can be used to test log formatters."""
 
-    def __init__(self, co_filename, co_name) -> None:  # noqa: ANN001
+    def __init__(self, co_filename, co_name) -> None:
         self.co_filename = co_filename
         self.co_name = co_name
 
@@ -26,7 +26,7 @@ class FakeCode:
 class FakeFrame:
     """A fake traceback frame that can be used to test log formatters."""
 
-    def __init__(self, f_code, f_globals, f_locals=None) -> None:  # noqa: ANN001
+    def __init__(self, f_code, f_globals, f_locals=None) -> None:
         self.f_code = f_code
         self.f_globals = f_globals
         self.f_locals = f_locals or {}
@@ -35,7 +35,7 @@ class FakeFrame:
 class FakeTraceback:  # pragma: no cover
     """A fake traceback that can be used to test log formatters."""
 
-    def __init__(self, frames, line_nums) -> None:  # noqa: ANN001
+    def __init__(self, frames, line_nums) -> None:
         if len(frames) != len(line_nums):
             raise ValueError("Ya messed up!")  # noqa: EM101
         self._frames = frames
@@ -44,14 +44,14 @@ class FakeTraceback:  # pragma: no cover
         self.tb_lineno = line_nums[0]
 
     @property
-    def tb_next(self):  # noqa: ANN201
+    def tb_next(self):
         if len(self._frames) > 1:  # noqa: RET503
             return FakeTraceback(self._frames[1:], self._line_nums[1:])
 
 
 class TestLogFormatters:
     @pytest.fixture()
-    def record(self):  # noqa: ANN201
+    def record(self):
         return logging.LogRecord(
             name="test",
             level=logging.INFO,
@@ -63,7 +63,7 @@ class TestLogFormatters:
         )
 
     @pytest.fixture()
-    def record_with_exception(self, tmp_path: Path):  # noqa: ANN201
+    def record_with_exception(self, tmp_path: Path):
         path = tmp_path / "my_module.py"
         path.write_text("cause_an_error()\n")
 
@@ -95,22 +95,22 @@ class TestLogFormatters:
             ),
         )
 
-    def test_console_log_formatter_colors(self, record, monkeypatch) -> None:  # noqa: ANN001
+    def test_console_log_formatter_colors(self, record, monkeypatch) -> None:
         monkeypatch.delenv("NO_COLOR", raising=False)
         formatter = console_log_formatter(colors=True)
         assert ANSI_RE.match(formatter.format(record))
 
-    def test_console_log_formatter_no_colors(self, record) -> None:  # noqa: ANN001
+    def test_console_log_formatter_no_colors(self, record) -> None:
         formatter = console_log_formatter(colors=False)
         assert not ANSI_RE.match(formatter.format(record))
 
-    def test_console_log_formatter_no_locals(self, record_with_exception) -> None:  # noqa: ANN001
+    def test_console_log_formatter_no_locals(self, record_with_exception) -> None:
         formatter = console_log_formatter(show_locals=False)
         output = formatter.format(record_with_exception)
         assert "locals" not in output
         assert "my_var = 'my_value'" not in output
 
-    def test_console_log_formatter_show_locals(self, record_with_exception) -> None:  # noqa: ANN001
+    def test_console_log_formatter_show_locals(self, record_with_exception) -> None:
         formatter = console_log_formatter(show_locals=True)
         output = formatter.format(record_with_exception)
         assert "locals" in output

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -18,7 +18,7 @@ ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 class FakeCode:
     """A fake code object that can be used to test log formatters."""
 
-    def __init__(self, co_filename, co_name):
+    def __init__(self, co_filename, co_name) -> None:  # noqa: ANN001
         self.co_filename = co_filename
         self.co_name = co_name
 
@@ -26,7 +26,7 @@ class FakeCode:
 class FakeFrame:
     """A fake traceback frame that can be used to test log formatters."""
 
-    def __init__(self, f_code, f_globals, f_locals=None):
+    def __init__(self, f_code, f_globals, f_locals=None) -> None:  # noqa: ANN001
         self.f_code = f_code
         self.f_globals = f_globals
         self.f_locals = f_locals or {}
@@ -35,7 +35,7 @@ class FakeFrame:
 class FakeTraceback:  # pragma: no cover
     """A fake traceback that can be used to test log formatters."""
 
-    def __init__(self, frames, line_nums):
+    def __init__(self, frames, line_nums) -> None:  # noqa: ANN001
         if len(frames) != len(line_nums):
             raise ValueError("Ya messed up!")  # noqa: EM101
         self._frames = frames
@@ -44,14 +44,14 @@ class FakeTraceback:  # pragma: no cover
         self.tb_lineno = line_nums[0]
 
     @property
-    def tb_next(self):
+    def tb_next(self):  # noqa: ANN201
         if len(self._frames) > 1:  # noqa: RET503
             return FakeTraceback(self._frames[1:], self._line_nums[1:])
 
 
 class TestLogFormatters:
     @pytest.fixture()
-    def record(self):
+    def record(self):  # noqa: ANN201
         return logging.LogRecord(
             name="test",
             level=logging.INFO,
@@ -63,7 +63,7 @@ class TestLogFormatters:
         )
 
     @pytest.fixture()
-    def record_with_exception(self, tmp_path: Path):
+    def record_with_exception(self, tmp_path: Path):  # noqa: ANN201
         path = tmp_path / "my_module.py"
         path.write_text("cause_an_error()\n")
 
@@ -95,22 +95,22 @@ class TestLogFormatters:
             ),
         )
 
-    def test_console_log_formatter_colors(self, record, monkeypatch):
+    def test_console_log_formatter_colors(self, record, monkeypatch) -> None:  # noqa: ANN001
         monkeypatch.delenv("NO_COLOR", raising=False)
         formatter = console_log_formatter(colors=True)
         assert ANSI_RE.match(formatter.format(record))
 
-    def test_console_log_formatter_no_colors(self, record):
+    def test_console_log_formatter_no_colors(self, record) -> None:  # noqa: ANN001
         formatter = console_log_formatter(colors=False)
         assert not ANSI_RE.match(formatter.format(record))
 
-    def test_console_log_formatter_no_locals(self, record_with_exception):
+    def test_console_log_formatter_no_locals(self, record_with_exception) -> None:  # noqa: ANN001
         formatter = console_log_formatter(show_locals=False)
         output = formatter.format(record_with_exception)
         assert "locals" not in output
         assert "my_var = 'my_value'" not in output
 
-    def test_console_log_formatter_show_locals(self, record_with_exception):
+    def test_console_log_formatter_show_locals(self, record_with_exception) -> None:  # noqa: ANN001
         formatter = console_log_formatter(show_locals=True)
         output = formatter.format(record_with_exception)
         assert "locals" in output

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -19,12 +19,12 @@ class AsyncReader(asyncio.StreamReader):
 
 
 @pytest.mark.asyncio()
-async def test_capture_subprocess_output():
+async def test_capture_subprocess_output() -> None:
     input_lines = [b"LINE\n", b"LINE 2\n", b"\xed\n"]
     output_lines = []
 
     class LineWriter:
-        def writeline(self, line: str):
+        def writeline(self, line: str) -> None:
             output_lines.append(line)
 
     reader = AsyncReader(input_lines)

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -15,28 +15,28 @@ from structlog.testing import LogCapture
 from meltano.core.logging.output_logger import Out, OutputLogger
 
 
-def assert_lines(output, *lines):
+def assert_lines(output, *lines) -> None:  # noqa: ANN001, ANN002
     for line in lines:
         assert line in output
 
 
 class TestOutputLogger:
     @pytest.fixture()
-    def log(self, tmp_path):
+    def log(self, tmp_path):  # noqa: ANN001, ANN201
         file = tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path)
         yield file
         file.close()
 
     @pytest.fixture()
-    def subject(self, log):
+    def subject(self, log):  # noqa: ANN001, ANN201
         return OutputLogger(log.name)
 
     @pytest.fixture(name="log_output")
-    def fixture_log_output(self):
+    def fixture_log_output(self):  # noqa: ANN201
         return LogCapture()
 
     @pytest.fixture(autouse=True)
-    def fixture_configure_structlog(self, log_output):
+    def fixture_configure_structlog(self, log_output):  # noqa: ANN001, ANN201
         original_config = structlog.get_config()
         structlog.configure(
             processors=[log_output],
@@ -64,7 +64,7 @@ class TestOutputLogger:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("log")
-    async def test_stdio_capture(self, subject, log_output):
+    async def test_stdio_capture(self, subject, log_output) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -113,7 +113,7 @@ class TestOutputLogger:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("log")
-    async def test_out_writers(self, subject, log_output):
+    async def test_out_writers(self, subject, log_output) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -167,7 +167,7 @@ class TestOutputLogger:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("log")
-    async def test_set_custom_logger(self, subject, log_output):
+    async def test_set_custom_logger(self, subject, log_output) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -193,7 +193,11 @@ class TestOutputLogger:
     )
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("log", "log_output")
-    async def test_logging_redirect(self, subject: OutputLogger, redirect_handler):
+    async def test_logging_redirect(
+        self,
+        subject: OutputLogger,
+        redirect_handler,  # noqa: ANN001
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -224,7 +228,7 @@ class TestOutputLogger:
         platform.system() == "Windows",
         reason="Test fails if even attempted to be run, xfail can't save us here.",
     )
-    def test_logging_exception(self, log, subject, redirect_handler):
+    def test_logging_exception(self, log, subject, redirect_handler) -> t.NoReturn:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -15,28 +15,28 @@ from structlog.testing import LogCapture
 from meltano.core.logging.output_logger import Out, OutputLogger
 
 
-def assert_lines(output, *lines) -> None:  # noqa: ANN001, ANN002
+def assert_lines(output, *lines) -> None:
     for line in lines:
         assert line in output
 
 
 class TestOutputLogger:
     @pytest.fixture()
-    def log(self, tmp_path):  # noqa: ANN001, ANN201
+    def log(self, tmp_path):
         file = tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path)
         yield file
         file.close()
 
     @pytest.fixture()
-    def subject(self, log):  # noqa: ANN001, ANN201
+    def subject(self, log):
         return OutputLogger(log.name)
 
     @pytest.fixture(name="log_output")
-    def fixture_log_output(self):  # noqa: ANN201
+    def fixture_log_output(self):
         return LogCapture()
 
     @pytest.fixture(autouse=True)
-    def fixture_configure_structlog(self, log_output):  # noqa: ANN001, ANN201
+    def fixture_configure_structlog(self, log_output):
         original_config = structlog.get_config()
         structlog.configure(
             processors=[log_output],
@@ -64,7 +64,7 @@ class TestOutputLogger:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("log")
-    async def test_stdio_capture(self, subject, log_output) -> None:  # noqa: ANN001
+    async def test_stdio_capture(self, subject, log_output) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -113,7 +113,7 @@ class TestOutputLogger:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("log")
-    async def test_out_writers(self, subject, log_output) -> None:  # noqa: ANN001
+    async def test_out_writers(self, subject, log_output) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -167,7 +167,7 @@ class TestOutputLogger:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("log")
-    async def test_set_custom_logger(self, subject, log_output) -> None:  # noqa: ANN001
+    async def test_set_custom_logger(self, subject, log_output) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -196,7 +196,7 @@ class TestOutputLogger:
     async def test_logging_redirect(
         self,
         subject: OutputLogger,
-        redirect_handler,  # noqa: ANN001
+        redirect_handler,
     ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
@@ -228,7 +228,7 @@ class TestOutputLogger:
         platform.system() == "Windows",
         reason="Test fails if even attempted to be run, xfail can't save us here.",
     )
-    def test_logging_exception(self, log, subject, redirect_handler) -> t.NoReturn:  # noqa: ANN001
+    def test_logging_exception(self, log, subject, redirect_handler) -> t.NoReturn:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -685,7 +685,7 @@ CATALOG_PROPERTIES = {
 
 
 @pytest.fixture()
-def select_all_executor():  # noqa: ANN201
+def select_all_executor():
     return SelectExecutor(["*.*"])
 
 
@@ -702,7 +702,7 @@ def select_all_executor():  # noqa: ANN201
         ),
     ),
 )
-def test_path_property(path, prop) -> None:  # noqa: ANN001
+def test_path_property(path, prop) -> None:
     assert path_property(path) == prop
 
 
@@ -830,15 +830,15 @@ class TestCatalogRule:
 
 class TestLegacyCatalogSelectVisitor:
     @pytest.fixture()
-    def catalog(self):  # noqa: ANN201
+    def catalog(self):
         return json.loads(LEGACY_CATALOG)
 
     @classmethod
-    def stream_is_selected(cls, stream):  # noqa: ANN001, ANN206
+    def stream_is_selected(cls, stream):
         return stream.get("selected", False)
 
     @classmethod
-    def metadata_is_selected(cls, metadata):  # noqa: ANN001, ANN206
+    def metadata_is_selected(cls, metadata):
         inclusion = metadata.get("inclusion")
         if inclusion == "automatic":
             return True
@@ -846,7 +846,7 @@ class TestLegacyCatalogSelectVisitor:
         return metadata.get("selected", False)
 
     @classmethod
-    def assert_catalog_is_selected(cls, catalog) -> None:  # noqa: ANN001
+    def assert_catalog_is_selected(cls, catalog) -> None:
         streams = {stream["tap_stream_id"]: stream for stream in catalog["streams"]}
 
         # all streams are selected
@@ -871,7 +871,7 @@ class TestLegacyCatalogSelectVisitor:
                     field_metadata,
                 ), f"{stream}.{metadata['breadcrumb']} is not selected"
 
-    def test_visit(self, catalog, select_all_executor) -> None:  # noqa: ANN001
+    def test_visit(self, catalog, select_all_executor) -> None:
         visit(catalog, select_all_executor)
 
         self.assert_catalog_is_selected(catalog)
@@ -879,11 +879,11 @@ class TestLegacyCatalogSelectVisitor:
 
 class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
     @pytest.fixture()
-    def catalog(self, request):  # noqa: ANN001, ANN201
+    def catalog(self, request):
         return json.loads(globals()[request.param])
 
     @classmethod
-    def stream_is_selected(cls, stream):  # noqa: ANN001, ANN206
+    def stream_is_selected(cls, stream):
         try:
             stream_metadata = next(
                 metadata
@@ -900,7 +900,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ("CATALOG", "JSON_SCHEMA"),
         indirect=["catalog"],
     )
-    def test_visit(self, catalog, select_all_executor) -> None:  # noqa: ANN001
+    def test_visit(self, catalog, select_all_executor) -> None:
         super().test_visit(catalog, select_all_executor)
 
     @pytest.mark.parametrize(
@@ -908,7 +908,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ("CATALOG", "JSON_SCHEMA"),
         indirect=["catalog"],
     )
-    def test_select_all(self, catalog, select_all_executor) -> None:  # noqa: ANN001
+    def test_select_all(self, catalog, select_all_executor) -> None:
         visit(catalog, select_all_executor)
         self.assert_catalog_is_selected(catalog)
 
@@ -942,7 +942,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ),
         indirect=["catalog"],
     )
-    def test_select(self, catalog, attrs) -> None:  # noqa: ANN001
+    def test_select(self, catalog, attrs) -> None:
         selector = SelectExecutor(
             [
                 "UniqueEntitiesName.code",
@@ -975,7 +975,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ),
         indirect=["catalog"],
     )
-    def test_select_escaped(self, catalog, attrs) -> None:  # noqa: ANN001
+    def test_select_escaped(self, catalog, attrs) -> None:
         selector = SelectExecutor(
             [
                 "Unique\\.Entities\\.Name.code",
@@ -1001,7 +1001,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ),
         indirect=["catalog"],
     )
-    def test_select_negated(self, catalog, attrs) -> None:  # noqa: ANN001
+    def test_select_negated(self, catalog, attrs) -> None:
         selector = SelectExecutor(
             [
                 "*.*",
@@ -1110,7 +1110,7 @@ class TestSelectionType:
 
 class TestMetadataExecutor:
     @pytest.fixture()
-    def catalog(self, request):  # noqa: ANN001, ANN201
+    def catalog(self, request):
         return json.loads(globals()[request.param])
 
     @pytest.mark.parametrize(
@@ -1118,7 +1118,7 @@ class TestMetadataExecutor:
         ("CATALOG", "JSON_SCHEMA"),
         indirect=["catalog"],
     )
-    def test_visit(self, catalog) -> None:  # noqa: ANN001
+    def test_visit(self, catalog) -> None:
         executor = MetadataExecutor(
             [
                 MetadataRule(
@@ -1172,7 +1172,7 @@ class TestMetadataExecutor:
 
 class TestSchemaExecutor:
     @pytest.fixture()
-    def catalog(self, request):  # noqa: ANN001, ANN201
+    def catalog(self, request):
         return json.loads(globals()[request.param])
 
     @pytest.mark.parametrize(
@@ -1180,7 +1180,7 @@ class TestSchemaExecutor:
         ("CATALOG", "JSON_SCHEMA", "EMPTY_STREAM_SCHEMA"),
         indirect=["catalog"],
     )
-    def test_visit(self, catalog) -> None:  # noqa: ANN001
+    def test_visit(self, catalog) -> None:
         executor = SchemaExecutor(
             [
                 SchemaRule(
@@ -1243,10 +1243,10 @@ class TestSchemaExecutor:
 
 class TestListExecutor:
     @pytest.fixture()
-    def catalog(self):  # noqa: ANN201
+    def catalog(self):
         return json.loads(CATALOG)
 
-    def test_visit(self, catalog) -> None:  # noqa: ANN001
+    def test_visit(self, catalog) -> None:
         executor = ListExecutor()
         visit(catalog, executor)
 

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -685,7 +685,7 @@ CATALOG_PROPERTIES = {
 
 
 @pytest.fixture()
-def select_all_executor():
+def select_all_executor():  # noqa: ANN201
     return SelectExecutor(["*.*"])
 
 
@@ -702,12 +702,12 @@ def select_all_executor():
         ),
     ),
 )
-def test_path_property(path, prop):
+def test_path_property(path, prop) -> None:  # noqa: ANN001
     assert path_property(path) == prop
 
 
 class TestCatalogRule:
-    def test_match(self):
+    def test_match(self) -> None:
         rule = CatalogRule("tap_stream_id")
 
         # Stream ID matches
@@ -722,7 +722,7 @@ class TestCatalogRule:
         # Stream ID doesn't match
         assert not rule.match("tap_stream")
 
-    def test_match_wildcard(self):
+    def test_match_wildcard(self) -> None:
         rule = CatalogRule("tap_stream*")
 
         # Stream ID pattern matches
@@ -733,7 +733,7 @@ class TestCatalogRule:
         # Stream ID pattern doesn't match
         assert not rule.match("tap_strea")
 
-    def test_match_multiple(self):
+    def test_match_multiple(self) -> None:
         rule = CatalogRule(["tap_stream_id", "other*"])
 
         # Stream ID patterns match
@@ -746,7 +746,7 @@ class TestCatalogRule:
         assert not rule.match("tap_stream")
         assert not rule.match("othe")
 
-    def test_match_negated(self):
+    def test_match_negated(self) -> None:
         rule = CatalogRule("tap_stream_id", negated=True)
 
         # Stream ID doesn't match, so the rule does
@@ -763,7 +763,7 @@ class TestCatalogRule:
         # Stream ID doesn't match (good!), but breadcrumb doesn't match
         assert not rule.match("tap_stream", ["property"])
 
-    def test_match_negated_wildcard(self):
+    def test_match_negated_wildcard(self) -> None:
         rule = CatalogRule("tap_stream*", negated=True)
 
         # Stream ID pattern doesn't match, so the rule does
@@ -774,7 +774,7 @@ class TestCatalogRule:
         assert not rule.match("tap_stream_foo")
         assert not rule.match("tap_stream")
 
-    def test_match_negated_multiple(self):
+    def test_match_negated_multiple(self) -> None:
         rule = CatalogRule(["tap_stream_id", "other*"], negated=True)
 
         # Stream ID pattern doesn't match, so the rule does
@@ -787,7 +787,7 @@ class TestCatalogRule:
         assert not rule.match("other_foo")
         assert not rule.match("other")
 
-    def test_match_breadcrumb(self):
+    def test_match_breadcrumb(self) -> None:
         rule = CatalogRule("tap_stream_id", ["property"])
 
         # Stream ID matches and breadcrumb is not considered
@@ -800,7 +800,7 @@ class TestCatalogRule:
         assert not rule.match("tap_stream_id", [])
         assert not rule.match("tap_stream_id", ["property", "nested"])
 
-    def test_match_wildcard_breadcrumb(self):
+    def test_match_wildcard_breadcrumb(self) -> None:
         rule = CatalogRule("tap_stream_id", ["proper*"])
 
         # Stream ID and breadcrumb pattern match
@@ -814,7 +814,7 @@ class TestCatalogRule:
         assert not rule.match("tap_stream_id", [])
         assert not rule.match("tap_stream_id", ["other"])
 
-    def test_match_negated_breadcrumb(self):
+    def test_match_negated_breadcrumb(self) -> None:
         rule = CatalogRule("tap_stream_id", ["property"], negated=True)
 
         # Stream ID doesn't match (good!) and breadcrumb is not considered
@@ -830,15 +830,15 @@ class TestCatalogRule:
 
 class TestLegacyCatalogSelectVisitor:
     @pytest.fixture()
-    def catalog(self):
+    def catalog(self):  # noqa: ANN201
         return json.loads(LEGACY_CATALOG)
 
     @classmethod
-    def stream_is_selected(cls, stream):
+    def stream_is_selected(cls, stream):  # noqa: ANN001, ANN206
         return stream.get("selected", False)
 
     @classmethod
-    def metadata_is_selected(cls, metadata):
+    def metadata_is_selected(cls, metadata):  # noqa: ANN001, ANN206
         inclusion = metadata.get("inclusion")
         if inclusion == "automatic":
             return True
@@ -846,7 +846,7 @@ class TestLegacyCatalogSelectVisitor:
         return metadata.get("selected", False)
 
     @classmethod
-    def assert_catalog_is_selected(cls, catalog):
+    def assert_catalog_is_selected(cls, catalog) -> None:  # noqa: ANN001
         streams = {stream["tap_stream_id"]: stream for stream in catalog["streams"]}
 
         # all streams are selected
@@ -871,7 +871,7 @@ class TestLegacyCatalogSelectVisitor:
                     field_metadata,
                 ), f"{stream}.{metadata['breadcrumb']} is not selected"
 
-    def test_visit(self, catalog, select_all_executor):
+    def test_visit(self, catalog, select_all_executor) -> None:  # noqa: ANN001
         visit(catalog, select_all_executor)
 
         self.assert_catalog_is_selected(catalog)
@@ -879,11 +879,11 @@ class TestLegacyCatalogSelectVisitor:
 
 class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
     @pytest.fixture()
-    def catalog(self, request):
+    def catalog(self, request):  # noqa: ANN001, ANN201
         return json.loads(globals()[request.param])
 
     @classmethod
-    def stream_is_selected(cls, stream):
+    def stream_is_selected(cls, stream):  # noqa: ANN001, ANN206
         try:
             stream_metadata = next(
                 metadata
@@ -900,7 +900,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ("CATALOG", "JSON_SCHEMA"),
         indirect=["catalog"],
     )
-    def test_visit(self, catalog, select_all_executor):
+    def test_visit(self, catalog, select_all_executor) -> None:  # noqa: ANN001
         super().test_visit(catalog, select_all_executor)
 
     @pytest.mark.parametrize(
@@ -908,7 +908,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ("CATALOG", "JSON_SCHEMA"),
         indirect=["catalog"],
     )
-    def test_select_all(self, catalog, select_all_executor):
+    def test_select_all(self, catalog, select_all_executor) -> None:  # noqa: ANN001
         visit(catalog, select_all_executor)
         self.assert_catalog_is_selected(catalog)
 
@@ -942,7 +942,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ),
         indirect=["catalog"],
     )
-    def test_select(self, catalog, attrs):
+    def test_select(self, catalog, attrs) -> None:  # noqa: ANN001
         selector = SelectExecutor(
             [
                 "UniqueEntitiesName.code",
@@ -975,7 +975,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ),
         indirect=["catalog"],
     )
-    def test_select_escaped(self, catalog, attrs):
+    def test_select_escaped(self, catalog, attrs) -> None:  # noqa: ANN001
         selector = SelectExecutor(
             [
                 "Unique\\.Entities\\.Name.code",
@@ -1001,7 +1001,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ),
         indirect=["catalog"],
     )
-    def test_select_negated(self, catalog, attrs):
+    def test_select_negated(self, catalog, attrs) -> None:  # noqa: ANN001
         selector = SelectExecutor(
             [
                 "*.*",
@@ -1088,13 +1088,13 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
             "no metadata",
         ],
     )
-    def test_node_selection(self, node: dict, selection_type: SelectionType):
+    def test_node_selection(self, node: dict, selection_type: SelectionType) -> None:
         """Test that selection metadata produces the expected selection type member."""
         assert ListSelectedExecutor.node_selection(node) == selection_type
 
 
 class TestSelectionType:
-    def test_selection_type_addition(self):
+    def test_selection_type_addition(self) -> None:
         st = SelectionType
         assert st.EXCLUDED + st.EXCLUDED == st.EXCLUDED
         assert st.SELECTED + st.EXCLUDED == st.EXCLUDED
@@ -1102,7 +1102,7 @@ class TestSelectionType:
         assert st.SELECTED + st.AUTOMATIC == st.AUTOMATIC
         assert st.SELECTED + st.SELECTED == st.SELECTED
 
-    def test_selection_type_repr(self):
+    def test_selection_type_repr(self) -> None:
         assert f"{SelectionType.EXCLUDED}" == "excluded"
         assert f"{SelectionType.AUTOMATIC}" == "automatic"
         assert f"{SelectionType.SELECTED}" == "selected"
@@ -1110,7 +1110,7 @@ class TestSelectionType:
 
 class TestMetadataExecutor:
     @pytest.fixture()
-    def catalog(self, request):
+    def catalog(self, request):  # noqa: ANN001, ANN201
         return json.loads(globals()[request.param])
 
     @pytest.mark.parametrize(
@@ -1118,7 +1118,7 @@ class TestMetadataExecutor:
         ("CATALOG", "JSON_SCHEMA"),
         indirect=["catalog"],
     )
-    def test_visit(self, catalog):
+    def test_visit(self, catalog) -> None:  # noqa: ANN001
         executor = MetadataExecutor(
             [
                 MetadataRule(
@@ -1172,7 +1172,7 @@ class TestMetadataExecutor:
 
 class TestSchemaExecutor:
     @pytest.fixture()
-    def catalog(self, request):
+    def catalog(self, request):  # noqa: ANN001, ANN201
         return json.loads(globals()[request.param])
 
     @pytest.mark.parametrize(
@@ -1180,7 +1180,7 @@ class TestSchemaExecutor:
         ("CATALOG", "JSON_SCHEMA", "EMPTY_STREAM_SCHEMA"),
         indirect=["catalog"],
     )
-    def test_visit(self, catalog):
+    def test_visit(self, catalog) -> None:  # noqa: ANN001
         executor = SchemaExecutor(
             [
                 SchemaRule(
@@ -1243,10 +1243,10 @@ class TestSchemaExecutor:
 
 class TestListExecutor:
     @pytest.fixture()
-    def catalog(self):
+    def catalog(self):  # noqa: ANN201
         return json.loads(CATALOG)
 
-    def test_visit(self, catalog):
+    def test_visit(self, catalog) -> None:  # noqa: ANN001
         executor = ListExecutor()
         visit(catalog, executor)
 

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -1121,18 +1121,23 @@ class TestMetadataExecutor:
     def test_visit(self, catalog):
         executor = MetadataExecutor(
             [
-                MetadataRule("UniqueEntitiesName", [], "replication-key", "created_at"),
+                MetadataRule(
+                    "UniqueEntitiesName",
+                    [],
+                    "replication-key",
+                    value="created_at",
+                ),
                 MetadataRule(
                     "UniqueEntitiesName",
                     ["properties", "created_at"],
                     "is-replication-key",
-                    True,
+                    value=True,
                 ),
                 MetadataRule(
                     "UniqueEntitiesName",
                     ["properties", "payload", "properties", "hash"],
                     "custom-metadata",
-                    "custom-value",
+                    value="custom-value",
                 ),
             ],
         )

--- a/tests/meltano/core/plugin/singer/test_mapper.py
+++ b/tests/meltano/core/plugin/singer/test_mapper.py
@@ -66,7 +66,7 @@ class TestSingerMapper:
         subject: ProjectPlugin,
         session: Session,
         plugin_invoker_factory: t.Callable[[ProjectPlugin], PluginInvoker],
-    ):
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
             assert subject.exec_args(invoker) == ["--config", invoker.files["config"]]
@@ -77,7 +77,7 @@ class TestSingerMapper:
         subject: ProjectPlugin,
         session: Session,
         plugin_invoker_factory: t.Callable[[ProjectPlugin], PluginInvoker],
-    ):
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
 
         async with invoker.prepared(session):
@@ -92,7 +92,7 @@ class TestSingerMapper:
                         "field_id": "author_email",
                         "tap_stream_name": "commits",
                         "type": "MASK-HIDDEN",
-                    }
+                    },
                 ],
                 "parent_mapper_setting": "parent_mapper_setting_value",
             }

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -48,12 +48,12 @@ class CatalogFixture:
 
 class TestSingerTap:
     @pytest.fixture(scope="class")
-    def subject(self, project_add_service):  # noqa: ANN001, ANN201
+    def subject(self, project_add_service):
         return project_add_service.add(PluginType.EXTRACTORS, "tap-mock")
 
     @pytest.mark.order(0)
     @pytest.mark.asyncio()
-    async def test_exec_args(self, subject, session, plugin_invoker_factory) -> None:  # noqa: ANN001
+    async def test_exec_args(self, subject, session, plugin_invoker_factory) -> None:
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
             assert subject.exec_args(invoker) == ["--config", invoker.files["config"]]
@@ -79,7 +79,7 @@ class TestSingerTap:
             ]
 
     @pytest.mark.asyncio()
-    async def test_cleanup(self, subject, session, plugin_invoker_factory) -> None:  # noqa: ANN001
+    async def test_cleanup(self, subject, session, plugin_invoker_factory) -> None:
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
             assert invoker.files["config"].exists()
@@ -89,12 +89,12 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_look_up_state(
         self,
-        subject,  # noqa: ANN001
-        project,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        elt_context_builder,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        subject,
+        project,
+        session,
+        plugin_invoker_factory,
+        elt_context_builder,
+        monkeypatch,
     ) -> None:
         job = Job(job_name="pytest_test_runner")
         elt_context = (
@@ -108,7 +108,7 @@ class TestSingerTap:
         state_service = StateService(session=session)
 
         @contextmanager
-        def create_job():  # noqa: ANN202
+        def create_job():
             new_job = Job(job_name=job.job_name)
             new_job.start()
             yield new_job
@@ -121,7 +121,7 @@ class TestSingerTap:
                         new_job.payload_flags,
                     )
 
-        async def assert_state(state) -> None:  # noqa: ANN001
+        async def assert_state(state) -> None:
             async with invoker.prepared(session):
                 await subject.look_up_state(invoker)
 
@@ -214,17 +214,17 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_discover_catalog(
         self,
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        session,
+        plugin_invoker_factory,
+        subject,
+        monkeypatch,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
 
         catalog_path = invoker.files["catalog"]
         catalog_cache_key_path = invoker.files["catalog_cache_key"]
 
-        def mock_discovery(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        def mock_discovery(*args, **kwargs):  # noqa: ARG001
             future = asyncio.Future()
             future.set_result(catalog_path.open("w").write('{"discovered": true}'))
             return future
@@ -299,11 +299,11 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_discover_catalog_custom(
         self,
-        project,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        project,
+        session,
+        plugin_invoker_factory,
+        subject,
+        monkeypatch,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
 
@@ -325,10 +325,10 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_apply_select(
         self,
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        session,
+        plugin_invoker_factory,
+        subject,
+        monkeypatch,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
 
@@ -337,14 +337,14 @@ class TestSingerTap:
         def reset_catalog() -> None:
             catalog_path.open("w").write('{"rules": []}')
 
-        def assert_rules(*rules) -> None:  # noqa: ANN002
+        def assert_rules(*rules) -> None:
             with catalog_path.open() as catalog_file:
                 catalog = json.load(catalog_file)
 
             assert catalog["rules"] == list(rules)
 
-        def mock_metadata_executor(rules):  # noqa: ANN001, ANN202
-            def visit(catalog) -> None:  # noqa: ANN001
+        def mock_metadata_executor(rules):
+            def visit(catalog) -> None:
                 for rule in rules:
                     catalog["rules"].append(
                         [rule.tap_stream_id, rule.breadcrumb, rule.key, rule.value],
@@ -412,10 +412,10 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_apply_catalog_rules(
         self,
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        session,
+        plugin_invoker_factory,
+        subject,
+        monkeypatch,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
 
@@ -425,14 +425,14 @@ class TestSingerTap:
         def reset_catalog() -> None:
             catalog_path.open("w").write('{"rules": []}')
 
-        def assert_rules(*rules) -> None:  # noqa: ANN002
+        def assert_rules(*rules) -> None:
             with catalog_path.open() as catalog_file:
                 catalog = json.load(catalog_file)
 
             assert catalog["rules"] == list(rules)
 
-        def mock_metadata_executor(rules):  # noqa: ANN001, ANN202
-            def visit(catalog) -> None:  # noqa: ANN001
+        def mock_metadata_executor(rules):
+            def visit(catalog) -> None:
                 for rule in rules:
                     rule_list = [
                         rule.tap_stream_id,
@@ -446,8 +446,8 @@ class TestSingerTap:
 
             return mock.Mock(visit=visit)
 
-        def mock_schema_executor(rules):  # noqa: ANN001, ANN202
-            def visit(catalog) -> None:  # noqa: ANN001
+        def mock_schema_executor(rules):
+            def visit(catalog) -> None:
                 for rule in rules:
                     catalog["rules"].append(
                         [rule.tap_stream_id, rule.breadcrumb, rule.payload],
@@ -579,10 +579,10 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_apply_catalog_rules_select_filter(
         self,
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        session,
+        plugin_invoker_factory,
+        subject,
+        monkeypatch,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
 
@@ -622,7 +622,7 @@ class TestSingerTap:
             ],
         }
 
-        async def selected_properties():  # noqa: ANN202
+        async def selected_properties():
             catalog_path = invoker.files["catalog"]
 
             with catalog_path.open("w") as catalog_file:
@@ -708,9 +708,9 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_apply_catalog_rules_invalid(
         self,
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
+        session,
+        plugin_invoker_factory,
+        subject,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
@@ -722,15 +722,15 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_catalog_cache_key(
         self,
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        session,
+        plugin_invoker_factory,
+        subject,
+        monkeypatch,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
         config_override = invoker.settings_service.config_override
 
-        async def cache_key():  # noqa: ANN202
+        async def cache_key():
             async with invoker.prepared(session):
                 return subject.catalog_cache_key(invoker)
 
@@ -791,8 +791,8 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery(
         self,
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
+        plugin_invoker_factory,
+        subject,
     ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
@@ -823,8 +823,8 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery_failure(
         self,
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
+        plugin_invoker_factory,
+        subject,
     ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
@@ -848,8 +848,8 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery_stderr_output(
         self,
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
+        plugin_invoker_factory,
+        subject,
     ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
@@ -903,8 +903,8 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery_handle_io_exceptions(
         self,
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
+        plugin_invoker_factory,
+        subject,
     ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
@@ -928,8 +928,8 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery_utf8_output(
         self,
-        plugin_invoker_factory,  # noqa: ANN001
-        subject,  # noqa: ANN001
+        plugin_invoker_factory,
+        subject,
     ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -48,12 +48,12 @@ class CatalogFixture:
 
 class TestSingerTap:
     @pytest.fixture(scope="class")
-    def subject(self, project_add_service):
+    def subject(self, project_add_service):  # noqa: ANN001, ANN201
         return project_add_service.add(PluginType.EXTRACTORS, "tap-mock")
 
     @pytest.mark.order(0)
     @pytest.mark.asyncio()
-    async def test_exec_args(self, subject, session, plugin_invoker_factory):
+    async def test_exec_args(self, subject, session, plugin_invoker_factory) -> None:  # noqa: ANN001
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
             assert subject.exec_args(invoker) == ["--config", invoker.files["config"]]
@@ -79,7 +79,7 @@ class TestSingerTap:
             ]
 
     @pytest.mark.asyncio()
-    async def test_cleanup(self, subject, session, plugin_invoker_factory):
+    async def test_cleanup(self, subject, session, plugin_invoker_factory) -> None:  # noqa: ANN001
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
             assert invoker.files["config"].exists()
@@ -89,13 +89,13 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_look_up_state(
         self,
-        subject,
-        project,
-        session,
-        plugin_invoker_factory,
-        elt_context_builder,
-        monkeypatch,
-    ):
+        subject,  # noqa: ANN001
+        project,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        elt_context_builder,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         job = Job(job_name="pytest_test_runner")
         elt_context = (
             elt_context_builder.with_session(session)
@@ -108,7 +108,7 @@ class TestSingerTap:
         state_service = StateService(session=session)
 
         @contextmanager
-        def create_job():
+        def create_job():  # noqa: ANN202
             new_job = Job(job_name=job.job_name)
             new_job.start()
             yield new_job
@@ -121,7 +121,7 @@ class TestSingerTap:
                         new_job.payload_flags,
                     )
 
-        async def assert_state(state):
+        async def assert_state(state) -> None:  # noqa: ANN001
             async with invoker.prepared(session):
                 await subject.look_up_state(invoker)
 
@@ -214,17 +214,17 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_discover_catalog(
         self,
-        session,
-        plugin_invoker_factory,
-        subject,
-        monkeypatch,
-    ):
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
 
         catalog_path = invoker.files["catalog"]
         catalog_cache_key_path = invoker.files["catalog_cache_key"]
 
-        def mock_discovery(*args, **kwargs):  # noqa: ARG001
+        def mock_discovery(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
             future = asyncio.Future()
             future.set_result(catalog_path.open("w").write('{"discovered": true}'))
             return future
@@ -299,12 +299,12 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_discover_catalog_custom(
         self,
-        project,
-        session,
-        plugin_invoker_factory,
-        subject,
-        monkeypatch,
-    ):
+        project,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
 
         custom_catalog_filename = "custom_catalog.json"
@@ -325,26 +325,26 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_apply_select(
         self,
-        session,
-        plugin_invoker_factory,
-        subject,
-        monkeypatch,
-    ):
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
 
         catalog_path = invoker.files["catalog"]
 
-        def reset_catalog():
+        def reset_catalog() -> None:
             catalog_path.open("w").write('{"rules": []}')
 
-        def assert_rules(*rules):
+        def assert_rules(*rules) -> None:  # noqa: ANN002
             with catalog_path.open() as catalog_file:
                 catalog = json.load(catalog_file)
 
             assert catalog["rules"] == list(rules)
 
-        def mock_metadata_executor(rules):
-            def visit(catalog):
+        def mock_metadata_executor(rules):  # noqa: ANN001, ANN202
+            def visit(catalog) -> None:  # noqa: ANN001
                 for rule in rules:
                     catalog["rules"].append(
                         [rule.tap_stream_id, rule.breadcrumb, rule.key, rule.value],
@@ -412,27 +412,27 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_apply_catalog_rules(
         self,
-        session,
-        plugin_invoker_factory,
-        subject,
-        monkeypatch,
-    ):
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
 
         catalog_path = invoker.files["catalog"]
         catalog_cache_key_path = invoker.files["catalog_cache_key"]
 
-        def reset_catalog():
+        def reset_catalog() -> None:
             catalog_path.open("w").write('{"rules": []}')
 
-        def assert_rules(*rules):
+        def assert_rules(*rules) -> None:  # noqa: ANN002
             with catalog_path.open() as catalog_file:
                 catalog = json.load(catalog_file)
 
             assert catalog["rules"] == list(rules)
 
-        def mock_metadata_executor(rules):
-            def visit(catalog):
+        def mock_metadata_executor(rules):  # noqa: ANN001, ANN202
+            def visit(catalog) -> None:  # noqa: ANN001
                 for rule in rules:
                     rule_list = [
                         rule.tap_stream_id,
@@ -446,8 +446,8 @@ class TestSingerTap:
 
             return mock.Mock(visit=visit)
 
-        def mock_schema_executor(rules):
-            def visit(catalog):
+        def mock_schema_executor(rules):  # noqa: ANN001, ANN202
+            def visit(catalog) -> None:  # noqa: ANN001
                 for rule in rules:
                     catalog["rules"].append(
                         [rule.tap_stream_id, rule.breadcrumb, rule.payload],
@@ -579,11 +579,11 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_apply_catalog_rules_select_filter(
         self,
-        session,
-        plugin_invoker_factory,
-        subject,
-        monkeypatch,
-    ):
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
 
         stream_data = {
@@ -622,7 +622,7 @@ class TestSingerTap:
             ],
         }
 
-        async def selected_properties():
+        async def selected_properties():  # noqa: ANN202
             catalog_path = invoker.files["catalog"]
 
             with catalog_path.open("w") as catalog_file:
@@ -708,10 +708,10 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_apply_catalog_rules_invalid(
         self,
-        session,
-        plugin_invoker_factory,
-        subject,
-    ):
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
             invoker.files["catalog"].open("w").write("this is invalid json")
@@ -722,15 +722,15 @@ class TestSingerTap:
     @pytest.mark.asyncio()
     async def test_catalog_cache_key(
         self,
-        session,
-        plugin_invoker_factory,
-        subject,
-        monkeypatch,
-    ):
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         invoker = plugin_invoker_factory(subject)
         config_override = invoker.settings_service.config_override
 
-        async def cache_key():
+        async def cache_key():  # noqa: ANN202
             async with invoker.prepared(session):
                 return subject.catalog_cache_key(invoker)
 
@@ -791,9 +791,9 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery(
         self,
-        plugin_invoker_factory,
-        subject,
-    ):
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+    ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
         process_mock.wait = AsyncMock(return_value=0)
@@ -823,9 +823,9 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery_failure(
         self,
-        plugin_invoker_factory,
-        subject,
-    ):
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+    ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
         process_mock.wait = AsyncMock(return_value=1)
@@ -848,9 +848,9 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery_stderr_output(
         self,
-        plugin_invoker_factory,
-        subject,
-    ):
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+    ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
         # we need to exit successfully to not trigger error handling
@@ -903,9 +903,9 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery_handle_io_exceptions(
         self,
-        plugin_invoker_factory,
-        subject,
-    ):
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+    ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
         process_mock.wait = AsyncMock(return_value=0)
@@ -928,9 +928,9 @@ class TestSingerTap:
     @pytest.mark.usefixtures("session", "elt_context_builder")
     async def test_run_discovery_utf8_output(
         self,
-        plugin_invoker_factory,
-        subject,
-    ):
+        plugin_invoker_factory,  # noqa: ANN001
+        subject,  # noqa: ANN001
+    ) -> None:
         process_mock = mock.Mock()
         process_mock.name = subject.name
         # we need to exit successfully to not trigger error handling
@@ -1049,7 +1049,7 @@ class TestSingerTap:
         rule_pattern: str,
         catalog: CatalogDict,
         message: str | None,
-    ):
+    ) -> None:
         """
         Warning messages should be emitted when a MetadataRule doesn't match.
 

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -276,7 +276,7 @@ class TestSingerTap:
         monkeypatch.setitem(
             invoker.settings_service.config_override,
             "_use_cached_catalog",
-            False,
+            value=False,
         )
 
         async with invoker.prepared(session):

--- a/tests/meltano/core/plugin/singer/test_target.py
+++ b/tests/meltano/core/plugin/singer/test_target.py
@@ -91,7 +91,7 @@ class TestSingerTarget:
             .with_loader(subject.name)
             .with_job(job)
             .with_select_filter(["entity", "!other_entity"])
-            .with_full_refresh(True)
+            .with_full_refresh(full_refresh=True)
             .context()
         )
 

--- a/tests/meltano/core/plugin/singer/test_target.py
+++ b/tests/meltano/core/plugin/singer/test_target.py
@@ -14,14 +14,14 @@ if t.TYPE_CHECKING:
 
 class TestSingerTarget:
     @pytest.fixture()
-    def subject(self, project_add_service: ProjectAddService):  # noqa: ANN201
+    def subject(self, project_add_service: ProjectAddService):
         try:
             return project_add_service.add(PluginType.LOADERS, "target-mock")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.mark.asyncio()
-    async def test_exec_args(self, subject, session, plugin_invoker_factory) -> None:  # noqa: ANN001
+    async def test_exec_args(self, subject, session, plugin_invoker_factory) -> None:
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
             assert subject.exec_args(invoker) == ["--config", invoker.files["config"]]
@@ -29,10 +29,10 @@ class TestSingerTarget:
     @pytest.mark.asyncio()
     async def test_setup_bookmark_writer(
         self,
-        subject,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        elt_context_builder,  # noqa: ANN001
+        subject,
+        session,
+        plugin_invoker_factory,
+        elt_context_builder,
     ) -> None:
         job = Job(job_name="pytest_test_runner")
 

--- a/tests/meltano/core/plugin/singer/test_target.py
+++ b/tests/meltano/core/plugin/singer/test_target.py
@@ -14,14 +14,14 @@ if t.TYPE_CHECKING:
 
 class TestSingerTarget:
     @pytest.fixture()
-    def subject(self, project_add_service: ProjectAddService):
+    def subject(self, project_add_service: ProjectAddService):  # noqa: ANN201
         try:
             return project_add_service.add(PluginType.LOADERS, "target-mock")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.mark.asyncio()
-    async def test_exec_args(self, subject, session, plugin_invoker_factory):
+    async def test_exec_args(self, subject, session, plugin_invoker_factory) -> None:  # noqa: ANN001
         invoker = plugin_invoker_factory(subject)
         async with invoker.prepared(session):
             assert subject.exec_args(invoker) == ["--config", invoker.files["config"]]
@@ -29,11 +29,11 @@ class TestSingerTarget:
     @pytest.mark.asyncio()
     async def test_setup_bookmark_writer(
         self,
-        subject,
-        session,
-        plugin_invoker_factory,
-        elt_context_builder,
-    ):
+        subject,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        elt_context_builder,  # noqa: ANN001
+    ) -> None:
         job = Job(job_name="pytest_test_runner")
 
         # test noop run outside of pipeline context

--- a/tests/meltano/core/plugin/test_airflow.py
+++ b/tests/meltano/core/plugin/test_airflow.py
@@ -20,18 +20,18 @@ AIRFLOW_CONFIG = """
 
 class TestAirflow:
     @pytest.fixture(scope="class")
-    def subject(self, project_add_service):
+    def subject(self, project_add_service):  # noqa: ANN001, ANN201
         with mock.patch.object(PluginInstallService, "install_plugin"):
             return project_add_service.add(PluginType.ORCHESTRATORS, "airflow")
 
     @pytest.mark.asyncio()
     async def test_before_configure(
         self,
-        subject,
-        project,
-        session,
-        plugin_invoker_factory,
-    ):
+        subject,  # noqa: ANN001
+        project,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+    ) -> None:
         run_dir = project.run_dir("airflow")
 
         handle_mock = mock.Mock()
@@ -43,7 +43,7 @@ class TestAirflow:
 
         original_exec = asyncio.create_subprocess_exec
 
-        def popen_mock(cmd, *popen_args, **kwargs):
+        def popen_mock(cmd, *popen_args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
             # first time, it creates the `airflow.cfg`
             if "--help" in popen_args:
                 assert "env" in kwargs
@@ -99,7 +99,7 @@ class TestAirflow:
             assert not run_dir.joinpath("airflow.cfg").exists()
 
     @pytest.mark.asyncio()
-    async def test_before_cleanup(self, subject, plugin_invoker_factory):
+    async def test_before_cleanup(self, subject, plugin_invoker_factory) -> None:  # noqa: ANN001
         invoker: AirflowInvoker = plugin_invoker_factory(subject)
 
         assert not invoker.files["config"].exists()

--- a/tests/meltano/core/plugin/test_airflow.py
+++ b/tests/meltano/core/plugin/test_airflow.py
@@ -20,17 +20,17 @@ AIRFLOW_CONFIG = """
 
 class TestAirflow:
     @pytest.fixture(scope="class")
-    def subject(self, project_add_service):  # noqa: ANN001, ANN201
+    def subject(self, project_add_service):
         with mock.patch.object(PluginInstallService, "install_plugin"):
             return project_add_service.add(PluginType.ORCHESTRATORS, "airflow")
 
     @pytest.mark.asyncio()
     async def test_before_configure(
         self,
-        subject,  # noqa: ANN001
-        project,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
+        subject,
+        project,
+        session,
+        plugin_invoker_factory,
     ) -> None:
         run_dir = project.run_dir("airflow")
 
@@ -43,7 +43,7 @@ class TestAirflow:
 
         original_exec = asyncio.create_subprocess_exec
 
-        def popen_mock(cmd, *popen_args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+        def popen_mock(cmd, *popen_args, **kwargs):
             # first time, it creates the `airflow.cfg`
             if "--help" in popen_args:
                 assert "env" in kwargs
@@ -99,7 +99,7 @@ class TestAirflow:
             assert not run_dir.joinpath("airflow.cfg").exists()
 
     @pytest.mark.asyncio()
-    async def test_before_cleanup(self, subject, plugin_invoker_factory) -> None:  # noqa: ANN001
+    async def test_before_cleanup(self, subject, plugin_invoker_factory) -> None:
         invoker: AirflowInvoker = plugin_invoker_factory(subject)
 
         assert not invoker.files["config"].exists()

--- a/tests/meltano/core/plugin/test_command.py
+++ b/tests/meltano/core/plugin/test_command.py
@@ -8,7 +8,7 @@ from meltano.core.plugin.command import Command, UndefinedEnvVarError
 
 class TestCommand:
     @pytest.fixture()
-    def commands(self):
+    def commands(self):  # noqa: ANN201
         return {
             "foo": {"args": "foo", "description": "foo desc", "executable": "foo"},
             "bar": {"args": "bar"},
@@ -16,7 +16,7 @@ class TestCommand:
             "test": {"args": "--test", "description": "Run tests"},
         }
 
-    def test_serialize(self, commands):
+    def test_serialize(self, commands) -> None:  # noqa: ANN001
         assert Command.parse(commands["foo"]).args == "foo"
         assert Command.parse(commands["bar"]).args == "bar"
         assert Command.parse(commands["baz"]).args == "baz"
@@ -36,7 +36,7 @@ class TestCommand:
         assert serialized["test"].description == "Run tests"
         assert serialized["test"].executable is None
 
-    def test_deserialize(self, commands):
+    def test_deserialize(self, commands) -> None:  # noqa: ANN001
         serialized = Command.parse_all(commands)
 
         assert serialized["foo"].canonical() == commands["foo"]
@@ -46,7 +46,7 @@ class TestCommand:
 
         assert Canonical.as_canonical(serialized) == {**commands, "bar": "bar"}
 
-    def test_expanded_args(self):
+    def test_expanded_args(self) -> None:
         expanded_args = Command.parse("some args --flag $ENV_VAR_ARG").expanded_args(
             name="cmd",
             env={
@@ -56,7 +56,7 @@ class TestCommand:
 
         assert expanded_args == ["some", "args", "--flag", "env-var-arg"]
 
-    def test_undefined_env_var(self):
+    def test_undefined_env_var(self) -> None:
         with pytest.raises(UndefinedEnvVarError):
             Command.parse("some args --flag $ENV_VAR_ARG").expanded_args(
                 name="cmd",

--- a/tests/meltano/core/plugin/test_command.py
+++ b/tests/meltano/core/plugin/test_command.py
@@ -8,7 +8,7 @@ from meltano.core.plugin.command import Command, UndefinedEnvVarError
 
 class TestCommand:
     @pytest.fixture()
-    def commands(self):  # noqa: ANN201
+    def commands(self):
         return {
             "foo": {"args": "foo", "description": "foo desc", "executable": "foo"},
             "bar": {"args": "bar"},
@@ -16,7 +16,7 @@ class TestCommand:
             "test": {"args": "--test", "description": "Run tests"},
         }
 
-    def test_serialize(self, commands) -> None:  # noqa: ANN001
+    def test_serialize(self, commands) -> None:
         assert Command.parse(commands["foo"]).args == "foo"
         assert Command.parse(commands["bar"]).args == "bar"
         assert Command.parse(commands["baz"]).args == "baz"
@@ -36,7 +36,7 @@ class TestCommand:
         assert serialized["test"].description == "Run tests"
         assert serialized["test"].executable is None
 
-    def test_deserialize(self, commands) -> None:  # noqa: ANN001
+    def test_deserialize(self, commands) -> None:
         serialized = Command.parse_all(commands)
 
         assert serialized["foo"].canonical() == commands["foo"]

--- a/tests/meltano/core/plugin/test_plugin.py
+++ b/tests/meltano/core/plugin/test_plugin.py
@@ -156,7 +156,7 @@ class TestPluginDefinition:
         assert not variant.extras
 
     @pytest.mark.parametrize("attrs_key", ATTRS.keys())
-    def test_canonical(self, attrs_key) -> None:  # noqa: ANN001
+    def test_canonical(self, attrs_key) -> None:
         attrs = self.ATTRS[attrs_key]
         plugin_def = PluginDefinition(PluginType.EXTRACTORS, **attrs)
         assert plugin_def.canonical() == attrs
@@ -202,37 +202,37 @@ class TestPluginDefinition:
 
 class TestBasePlugin:
     @pytest.fixture()
-    def plugin_def(self):  # noqa: ANN201
+    def plugin_def(self):
         return PluginDefinition(
             PluginType.EXTRACTORS,
             **TestPluginDefinition.ATTRS["variants"],
         )
 
     @pytest.fixture()
-    def variant(self, plugin_def):  # noqa: ANN001, ANN201
+    def variant(self, plugin_def):
         return plugin_def.find_variant()
 
     @pytest.fixture()
-    def subject(self, plugin_def, variant):  # noqa: ANN001, ANN201
+    def subject(self, plugin_def, variant):
         return BasePlugin(plugin_def, variant)
 
-    def test_getattr(self, subject, plugin_def, variant) -> None:  # noqa: ANN001
+    def test_getattr(self, subject, plugin_def, variant) -> None:
         # Falls back to the plugin def
         assert subject.name == plugin_def.name
 
         # And the variant
         assert subject.pip_url == variant.pip_url
 
-    def test_variant(self, subject, variant) -> None:  # noqa: ANN001
+    def test_variant(self, subject, variant) -> None:
         assert subject.variant == variant.name
 
         variant.name = None
         assert subject.variant is None
 
-    def test_extras(self, subject) -> None:  # noqa: ANN001
+    def test_extras(self, subject) -> None:
         assert subject.extras == {"foo": "bar", "baz": "qux"}
 
-    def test_extra_settings(self, subject) -> None:  # noqa: ANN001
+    def test_extra_settings(self, subject) -> None:
         subject.EXTRA_SETTINGS = [
             SettingDefinition(name="_foo", sensitive=True, value="default"),
             SettingDefinition(name="_bar", kind=SettingKind.INTEGER, value=0),
@@ -364,12 +364,12 @@ class TestProjectPlugin:
         assert plugin.label == plugin.name
 
     @pytest.mark.parametrize("attrs_key", ATTRS.keys())
-    def test_canonical(self, attrs_key) -> None:  # noqa: ANN001
+    def test_canonical(self, attrs_key) -> None:
         attrs = self.ATTRS[attrs_key]
         plugin = ProjectPlugin(PluginType.EXTRACTORS, **attrs)
         assert plugin.canonical() == attrs
 
-    def test_parent(self, inherited_tap) -> None:  # noqa: ANN001
+    def test_parent(self, inherited_tap) -> None:
         tap = inherited_tap.parent
         assert isinstance(tap, ProjectPlugin)
 
@@ -476,7 +476,7 @@ class TestProjectPlugin:
 
         assert plugin.variant == base_plugin.variant == "meltano"
 
-    def test_command_inheritance(self, tap, inherited_tap) -> None:  # noqa: ANN001
+    def test_command_inheritance(self, tap, inherited_tap) -> None:
         # variants
         assert tap.all_commands["cmd"].args == "cmd meltano"
         assert tap.all_commands["cmd"].description == "a description of cmd"
@@ -512,7 +512,7 @@ class TestProjectPlugin:
         assert tap.test_commands["test_extra"].description == "Run extra tests"
         assert tap.test_commands["test_extra"].executable == "test-extra"
 
-    def testenv_prefixes(self, inherited_tap, tap) -> None:  # noqa: ANN001
+    def testenv_prefixes(self, inherited_tap, tap) -> None:
         assert tap.env_prefixes() == ["tap-mock", "tap_mock"]
         assert tap.env_prefixes(for_writing=True) == [
             "tap-mock",
@@ -551,7 +551,7 @@ class TestProjectPlugin:
         assert plugin.config == {"foo": "BAR", "bar": "FOO"}
         assert plugin.extras == {"baz": "QUX", "qux": "BAZ"}
 
-    def test_settings(self, tap) -> None:  # noqa: ANN001
+    def test_settings(self, tap) -> None:
         tap.config["custom"] = "from_meltano_yml"
         tap.config["nested"] = {"custom": True}
 
@@ -566,7 +566,7 @@ class TestProjectPlugin:
         assert "nested.custom" in settings_by_name
         assert settings_by_name["nested.custom"].kind == SettingKind.BOOLEAN
 
-    def test_extra_settings(self, tap) -> None:  # noqa: ANN001
+    def test_extra_settings(self, tap) -> None:
         tap.extras["custom"] = "from_meltano_yml"
         tap.extras["nested"] = {"custom": True}
 

--- a/tests/meltano/core/plugin/test_plugin.py
+++ b/tests/meltano/core/plugin/test_plugin.py
@@ -76,7 +76,7 @@ class TestPluginDefinition:
         },
     }
 
-    def test_init_minimal(self):
+    def test_init_minimal(self) -> None:
         plugin_def = PluginDefinition(PluginType.EXTRACTORS, **self.ATTRS["minimal"])
 
         assert plugin_def.name == "tap-example"
@@ -91,7 +91,7 @@ class TestPluginDefinition:
         variant = plugin_def.variants[0]
         assert variant.name is None
 
-    def test_init_basic(self):
+    def test_init_basic(self) -> None:
         attrs = self.ATTRS["basic"]
         plugin_def = PluginDefinition(PluginType.EXTRACTORS, **attrs)
 
@@ -115,7 +115,7 @@ class TestPluginDefinition:
         assert plugin_def.extras == {"foo": "bar", "baz": "qux"}
         assert not variant.extras
 
-    def test_init_variants(self):
+    def test_init_variants(self) -> None:
         attrs = self.ATTRS["variants"]
         plugin_def = PluginDefinition(PluginType.EXTRACTORS, **attrs)
 
@@ -156,12 +156,12 @@ class TestPluginDefinition:
         assert not variant.extras
 
     @pytest.mark.parametrize("attrs_key", ATTRS.keys())
-    def test_canonical(self, attrs_key):
+    def test_canonical(self, attrs_key) -> None:  # noqa: ANN001
         attrs = self.ATTRS[attrs_key]
         plugin_def = PluginDefinition(PluginType.EXTRACTORS, **attrs)
         assert plugin_def.canonical() == attrs
 
-    def test_find_variant(self):
+    def test_find_variant(self) -> None:
         plugin_def = PluginDefinition(PluginType.EXTRACTORS, **self.ATTRS["variants"])
 
         assert plugin_def.find_variant().name == "meltano"
@@ -172,12 +172,12 @@ class TestPluginDefinition:
 
         assert plugin_def.find_variant(plugin_def.variants[1]).name == "singer-io"
 
-    def test_variant_labels(self):
+    def test_variant_labels(self) -> None:
         plugin_def = PluginDefinition(PluginType.EXTRACTORS, **self.ATTRS["variants"])
 
         assert plugin_def.variant_labels == "meltano (default), singer-io (deprecated)"
 
-    def test_label(self):
+    def test_label(self) -> None:
         plugin_def = PluginDefinition(
             PluginType.EXTRACTORS,
             name="tap-foo",
@@ -188,7 +188,7 @@ class TestPluginDefinition:
         plugin_def.label = "Foo"
         assert plugin_def.label == "Foo"
 
-    def test_logo_url(self):
+    def test_logo_url(self) -> None:
         plugin_def = PluginDefinition(
             PluginType.EXTRACTORS,
             name="tap-foo",
@@ -202,37 +202,37 @@ class TestPluginDefinition:
 
 class TestBasePlugin:
     @pytest.fixture()
-    def plugin_def(self):
+    def plugin_def(self):  # noqa: ANN201
         return PluginDefinition(
             PluginType.EXTRACTORS,
             **TestPluginDefinition.ATTRS["variants"],
         )
 
     @pytest.fixture()
-    def variant(self, plugin_def):
+    def variant(self, plugin_def):  # noqa: ANN001, ANN201
         return plugin_def.find_variant()
 
     @pytest.fixture()
-    def subject(self, plugin_def, variant):
+    def subject(self, plugin_def, variant):  # noqa: ANN001, ANN201
         return BasePlugin(plugin_def, variant)
 
-    def test_getattr(self, subject, plugin_def, variant):
+    def test_getattr(self, subject, plugin_def, variant) -> None:  # noqa: ANN001
         # Falls back to the plugin def
         assert subject.name == plugin_def.name
 
         # And the variant
         assert subject.pip_url == variant.pip_url
 
-    def test_variant(self, subject, variant):
+    def test_variant(self, subject, variant) -> None:  # noqa: ANN001
         assert subject.variant == variant.name
 
         variant.name = None
         assert subject.variant is None
 
-    def test_extras(self, subject):
+    def test_extras(self, subject) -> None:  # noqa: ANN001
         assert subject.extras == {"foo": "bar", "baz": "qux"}
 
-    def test_extra_settings(self, subject):
+    def test_extra_settings(self, subject) -> None:  # noqa: ANN001
         subject.EXTRA_SETTINGS = [
             SettingDefinition(name="_foo", sensitive=True, value="default"),
             SettingDefinition(name="_bar", kind=SettingKind.INTEGER, value=0),
@@ -297,7 +297,7 @@ class TestProjectPlugin:
         },
     }
 
-    def test_init_minimal(self):
+    def test_init_minimal(self) -> None:
         plugin = ProjectPlugin(PluginType.EXTRACTORS, **self.ATTRS["minimal"])
 
         assert plugin.name == "tap-example"
@@ -306,7 +306,7 @@ class TestProjectPlugin:
         assert not plugin.config
         assert not plugin.is_custom()
 
-    def test_init_basic(self):
+    def test_init_basic(self) -> None:
         attrs = self.ATTRS["basic"]
         plugin = ProjectPlugin(PluginType.EXTRACTORS, **attrs)
 
@@ -317,7 +317,7 @@ class TestProjectPlugin:
         assert plugin.extras == {"baz": "qux"}
         assert not plugin.is_custom()
 
-    def test_init_custom(self):
+    def test_init_custom(self) -> None:
         attrs = self.ATTRS["custom"]
         plugin = ProjectPlugin(PluginType.EXTRACTORS, **attrs)
 
@@ -351,7 +351,7 @@ class TestProjectPlugin:
         assert plugin_def.extras == variant.extras
         assert not plugin_def.extras
 
-    def test_init_inherited(self):
+    def test_init_inherited(self) -> None:
         attrs = self.ATTRS["inherited"]
         plugin = ProjectPlugin(PluginType.EXTRACTORS, **attrs)
 
@@ -364,12 +364,12 @@ class TestProjectPlugin:
         assert plugin.label == plugin.name
 
     @pytest.mark.parametrize("attrs_key", ATTRS.keys())
-    def test_canonical(self, attrs_key):
+    def test_canonical(self, attrs_key) -> None:  # noqa: ANN001
         attrs = self.ATTRS[attrs_key]
         plugin = ProjectPlugin(PluginType.EXTRACTORS, **attrs)
         assert plugin.canonical() == attrs
 
-    def test_parent(self, inherited_tap):
+    def test_parent(self, inherited_tap) -> None:  # noqa: ANN001
         tap = inherited_tap.parent
         assert isinstance(tap, ProjectPlugin)
 
@@ -424,7 +424,7 @@ class TestProjectPlugin:
         assert inherited_tap.repo == tap.repo == base_plugin.repo
         assert inherited_tap.docs == tap.docs == base_plugin.docs
 
-    def test_set_parent(self):
+    def test_set_parent(self) -> None:
         plugin_one = ProjectPlugin(
             PluginType.EXTRACTORS,
             name="tap-one",
@@ -447,7 +447,7 @@ class TestProjectPlugin:
         with pytest.raises(CyclicInheritanceError):
             plugin_three.parent = plugin_one
 
-    def test_variant(self, project: Project):
+    def test_variant(self, project: Project) -> None:
         # Without a variant set, the "original" name is used
         plugin: ProjectPlugin = ProjectPlugin(PluginType.EXTRACTORS, name="tap-mock")
         assert plugin.variant == Variant.ORIGINAL_NAME
@@ -476,7 +476,7 @@ class TestProjectPlugin:
 
         assert plugin.variant == base_plugin.variant == "meltano"
 
-    def test_command_inheritance(self, tap, inherited_tap):
+    def test_command_inheritance(self, tap, inherited_tap) -> None:  # noqa: ANN001
         # variants
         assert tap.all_commands["cmd"].args == "cmd meltano"
         assert tap.all_commands["cmd"].description == "a description of cmd"
@@ -501,7 +501,7 @@ class TestProjectPlugin:
             "cmd-inherited",
         ]
 
-    def test_command_test(self, tap: BasePlugin):
+    def test_command_test(self, tap: BasePlugin) -> None:
         """Validate the plugin 'test' command."""
         assert "test" in tap.test_commands
         assert tap.test_commands["test"].args == "--test"
@@ -512,7 +512,7 @@ class TestProjectPlugin:
         assert tap.test_commands["test_extra"].description == "Run extra tests"
         assert tap.test_commands["test_extra"].executable == "test-extra"
 
-    def testenv_prefixes(self, inherited_tap, tap):
+    def testenv_prefixes(self, inherited_tap, tap) -> None:  # noqa: ANN001
         assert tap.env_prefixes() == ["tap-mock", "tap_mock"]
         assert tap.env_prefixes(for_writing=True) == [
             "tap-mock",
@@ -532,7 +532,7 @@ class TestProjectPlugin:
             "meltano_extract",
         ]
 
-    def test_config_with_extras(self):
+    def test_config_with_extras(self) -> None:
         plugin = ProjectPlugin(PluginType.EXTRACTORS, **self.ATTRS["basic"])
 
         # It reads by combining config with extras (prefixed with _)
@@ -551,7 +551,7 @@ class TestProjectPlugin:
         assert plugin.config == {"foo": "BAR", "bar": "FOO"}
         assert plugin.extras == {"baz": "QUX", "qux": "BAZ"}
 
-    def test_settings(self, tap):
+    def test_settings(self, tap) -> None:  # noqa: ANN001
         tap.config["custom"] = "from_meltano_yml"
         tap.config["nested"] = {"custom": True}
 
@@ -566,7 +566,7 @@ class TestProjectPlugin:
         assert "nested.custom" in settings_by_name
         assert settings_by_name["nested.custom"].kind == SettingKind.BOOLEAN
 
-    def test_extra_settings(self, tap):
+    def test_extra_settings(self, tap) -> None:  # noqa: ANN001
         tap.extras["custom"] = "from_meltano_yml"
         tap.extras["nested"] = {"custom": True}
 
@@ -581,7 +581,7 @@ class TestProjectPlugin:
         assert "_nested.custom" in settings_by_name
         assert settings_by_name["_nested.custom"].kind == SettingKind.BOOLEAN
 
-    def test_requirements(self, transformer: ProjectPlugin):
+    def test_requirements(self, transformer: ProjectPlugin) -> None:
         """Validate the plugin requirements."""
         assert transformer.all_requires
         requirement = transformer.all_requires[PluginType.FILES][0]
@@ -593,14 +593,14 @@ class TestProjectPlugin:
 
 
 class TestPluginType:
-    def test_properties(self):
+    def test_properties(self) -> None:
         for plugin_type in PluginType:
             # assert no exceptions raised:
             assert plugin_type.descriptor is not None
             assert plugin_type.singular is not None
             assert plugin_type.verb is not None
 
-    def test_specfic_properties(self):
+    def test_specfic_properties(self) -> None:
         assert PluginType.FILES.descriptor == "file bundle"
         assert PluginType.TRANSFORMS.verb == "transform"
         assert PluginType.UTILITIES.verb == "utilize"
@@ -609,7 +609,7 @@ class TestPluginType:
         assert PluginType.MAPPERS.singular == "mapper"
         assert PluginType.MAPPERS.verb == "map"
 
-    def test_from_cli_argument(self):
+    def test_from_cli_argument(self) -> None:
         for plugin_type in PluginType:
             assert PluginType.from_cli_argument(plugin_type.value) == plugin_type
             assert PluginType.from_cli_argument(plugin_type.singular) == plugin_type

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -75,7 +75,7 @@ def subject(tap, plugin_settings_service_factory) -> PluginSettingsService:
 
 
 @pytest.fixture()
-def environment(project: Project) -> Environment:
+def environment(project: Project) -> t.Generator[Environment, None, None]:
     project.activate_environment("dev")
     try:
         yield project.environment
@@ -310,7 +310,7 @@ class TestPluginSettingsService:
 
     @pytest.mark.usefixtures("tap")
     def test_as_env(self, subject, session, env_var):
-        subject.set("boolean", True, store=SettingValueStore.DOTENV)
+        subject.set("boolean", value=True, store=SettingValueStore.DOTENV)
         subject.set("list", [1, 2, 3, "4"], store=SettingValueStore.DOTENV)
         subject.set("object", {"1": {"2": 3}}, store=SettingValueStore.DOTENV)
 
@@ -515,7 +515,7 @@ class TestPluginSettingsService:
         assert subject.get_with_source("boolean") == (False, SettingValueStore.DOTENV)
         dotenv.unset_key(project.dotenv, "TAP_MOCK_BOOLEAN")
 
-        subject.set("boolean", True, store=store)
+        subject.set("boolean", value=True, store=store)
 
         dotenv_contents = dotenv.dotenv_values(project.dotenv)
         assert dotenv_contents["TAP_MOCK_BOOLEAN"] == "true"
@@ -675,7 +675,7 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("tap")
     def test_custom_setting(self, session, subject, env_var):
         subject.set("custom_string", "from_yml", store=SettingValueStore.MELTANO_YML)
-        subject.set("custom_bool", True, store=SettingValueStore.MELTANO_YML)
+        subject.set("custom_bool", value=True, store=SettingValueStore.MELTANO_YML)
         subject.set("custom_array", [1, 2, 3, "4"], store=SettingValueStore.MELTANO_YML)
 
         assert subject.get_with_source("custom_string", session=session) == (
@@ -998,7 +998,7 @@ class TestPluginSettingsService:
     def test_strict_env_var_mode_on_raises_error(self, subject):
         subject.project_settings_service.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
-            True,
+            value=True,
         )
         subject.set("stacked_env_var", "${NONEXISTENT_ENV_VAR}")
         with pytest.raises(EnvironmentVariableNotSetError):
@@ -1008,7 +1008,7 @@ class TestPluginSettingsService:
     def test_strict_env_var_mode_off_no_raise_error(self, subject):
         subject.project_settings_service.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
-            False,
+            value=False,
         )
         subject.set("stacked_env_var", "${NONEXISTENT_ENV_VAR}")
         assert subject.get("stacked_env_var") is None

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
 
 
 @pytest.mark.order(0)
-def test_create(session) -> None:  # noqa: ANN001
+def test_create(session) -> None:
     setting = Setting(
         name="api_key.test.test",
         namespace="gitlab",
@@ -46,8 +46,8 @@ def test_create(session) -> None:  # noqa: ANN001
 
 
 @pytest.fixture(scope="class")
-def env_var():  # noqa: ANN201
-    def _wrapper(plugin_settings_service, setting_name):  # noqa: ANN001, ANN202
+def env_var():
+    def _wrapper(plugin_settings_service, setting_name):
         setting_def = plugin_settings_service.find_setting(setting_name)
         return plugin_settings_service.setting_env(setting_def)
 
@@ -55,7 +55,7 @@ def env_var():  # noqa: ANN201
 
 
 @pytest.fixture(scope="class")
-def custom_tap(project):  # noqa: ANN001, ANN201
+def custom_tap(project):
     expected = {"test": "custom", "start_date": None, "secure": None}
     tap = ProjectPlugin(
         PluginType.EXTRACTORS,
@@ -70,7 +70,7 @@ def custom_tap(project):  # noqa: ANN001, ANN201
 
 
 @pytest.fixture()
-def subject(tap, plugin_settings_service_factory) -> PluginSettingsService:  # noqa: ANN001
+def subject(tap, plugin_settings_service_factory) -> PluginSettingsService:
     return plugin_settings_service_factory(tap)
 
 
@@ -86,12 +86,12 @@ def environment(project: Project) -> t.Generator[Environment, None, None]:
 class TestPluginSettingsService:
     def test_get_with_source(
         self,
-        session,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        inherited_tap,  # noqa: ANN001
-        env_var,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        session,
+        tap,
+        inherited_tap,
+        env_var,
+        monkeypatch,
+        plugin_settings_service_factory,
     ) -> None:
         subject = plugin_settings_service_factory(inherited_tap)
 
@@ -158,10 +158,10 @@ class TestPluginSettingsService:
 
     def test_get_with_source_casting(
         self,
-        session,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        env_var,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        session,
+        subject,
+        env_var,
+        monkeypatch,
     ) -> None:
         # Verify that integer settings set in env are cast correctly
         monkeypatch.setenv(env_var(subject, "port"), "3333")
@@ -202,7 +202,7 @@ class TestPluginSettingsService:
             SettingValueStore.ENV,
         )
 
-    def test_definitions(self, subject) -> None:  # noqa: ANN001
+    def test_definitions(self, subject) -> None:
         subject.show_hidden = False
         subject._setting_defs = None
 
@@ -217,7 +217,7 @@ class TestPluginSettingsService:
 
     @pytest.mark.order(1)
     @pytest.mark.usefixtures("tap")
-    def test_as_dict(self, subject, session) -> None:  # noqa: ANN001
+    def test_as_dict(self, subject, session) -> None:
         expected = {"test": "mock", "start_date": None, "secure": None}
         full_config = subject.as_dict(session=session)
         redacted_config = subject.as_dict(redacted=True, session=session)
@@ -289,15 +289,15 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("project")
     def test_as_dict_custom(
         self,
-        session,  # noqa: ANN001
-        custom_tap,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        session,
+        custom_tap,
+        plugin_settings_service_factory,
     ) -> None:
         subject = plugin_settings_service_factory(custom_tap)
         assert subject.as_dict(extras=False, session=session) == custom_tap.config
 
     @pytest.mark.usefixtures("tap")
-    def test_as_dict_redacted(self, subject, session) -> None:  # noqa: ANN001
+    def test_as_dict_redacted(self, subject, session) -> None:
         store = SettingValueStore.DB
 
         # ensure values are redacted when they are set
@@ -315,7 +315,7 @@ class TestPluginSettingsService:
         assert config["secure"] == "thisisatest"
 
     @pytest.mark.usefixtures("tap")
-    def test_as_env(self, subject, session, env_var) -> None:  # noqa: ANN001
+    def test_as_env(self, subject, session, env_var) -> None:
         subject.set("boolean", value=True, store=SettingValueStore.DOTENV)
         subject.set("list", [1, 2, 3, "4"], store=SettingValueStore.DOTENV)
         subject.set("object", {"1": {"2": 3}}, store=SettingValueStore.DOTENV)
@@ -342,10 +342,10 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("project")
     def test_as_env_custom(
         self,
-        session,  # noqa: ANN001
-        custom_tap,  # noqa: ANN001
-        env_var,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        session,
+        custom_tap,
+        env_var,
+        plugin_settings_service_factory,
     ) -> None:
         subject = plugin_settings_service_factory(custom_tap)
         config = subject.as_env(session=session)
@@ -357,13 +357,13 @@ class TestPluginSettingsService:
     def test_namespace_as_env_prefix(
         self,
         project: Project,
-        session,  # noqa: ANN001
+        session,
         target: ProjectPlugin,
-        plugin_settings_service_factory,  # noqa: ANN001
+        plugin_settings_service_factory,
     ) -> None:
         subject = plugin_settings_service_factory(target)
 
-        def assert_env_value(value, env_var) -> None:  # noqa: ANN001
+        def assert_env_value(value, env_var) -> None:
             read_value, metadata = subject.get_with_metadata("schema")
             assert value == read_value
             assert metadata["env_var"] == env_var
@@ -397,12 +397,12 @@ class TestPluginSettingsService:
 
     def test_setting_env_vars(
         self,
-        tap,  # noqa: ANN001
-        inherited_tap,  # noqa: ANN001
-        alternative_target,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        tap,
+        inherited_tap,
+        alternative_target,
+        plugin_settings_service_factory,
     ) -> None:
-        def env_vars(service, setting_name, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        def env_vars(service, setting_name, **kwargs):
             return [
                 setting.definition
                 for setting in service.setting_env_vars(
@@ -452,7 +452,7 @@ class TestPluginSettingsService:
         ]
 
     @pytest.mark.usefixtures("tap")
-    def test_store_db(self, session, subject) -> None:  # noqa: ANN001
+    def test_store_db(self, session, subject) -> None:
         store = SettingValueStore.DB
 
         subject.set("test_a", "THIS_IS_FROM_DB", store=store, session=session)
@@ -469,7 +469,7 @@ class TestPluginSettingsService:
         assert session.query(Setting).count() == 0
 
     @pytest.mark.usefixtures("tap")
-    def test_store_meltano_yml(self, subject, project) -> None:  # noqa: ANN001
+    def test_store_meltano_yml(self, subject, project) -> None:
         store = SettingValueStore.MELTANO_YML
 
         subject.set("test_a", "THIS_IS_FROM_YML", store=store)
@@ -562,11 +562,11 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("tap")
     def test_env_var_expansion(
         self,
-        session,  # noqa: ANN001
+        session,
         subject: PluginSettingsService,
         project: Project,
-        monkeypatch,  # noqa: ANN001
-        env_var,  # noqa: ANN001
+        monkeypatch,
+        env_var,
     ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
@@ -622,19 +622,19 @@ class TestPluginSettingsService:
 
     @pytest.mark.order(3)
     @pytest.mark.usefixtures("tap")
-    def test_nested_keys(self, session, subject, project) -> None:  # noqa: ANN001
-        def set_config(path, value) -> None:  # noqa: ANN001
+    def test_nested_keys(self, session, subject, project) -> None:
+        def set_config(path, value) -> None:
             subject.set(path, value, store=SettingValueStore.MELTANO_YML)
 
-        def unset_config(path) -> None:  # noqa: ANN001
+        def unset_config(path) -> None:
             subject.unset(path, store=SettingValueStore.MELTANO_YML)
 
-        def yml_config():  # noqa: ANN202
+        def yml_config():
             with project.meltano_update() as meltano:
                 extractor = meltano.plugins.extractors[0]
                 return extractor.config
 
-        def final_config():  # noqa: ANN202
+        def final_config():
             return subject.as_dict(session=session)
 
         set_config("metadata.stream.replication-key", "created_at")
@@ -683,7 +683,7 @@ class TestPluginSettingsService:
         assert "metadata.stream.replication-key" not in final_config()
 
     @pytest.mark.usefixtures("tap")
-    def test_custom_setting(self, session, subject, env_var) -> None:  # noqa: ANN001
+    def test_custom_setting(self, session, subject, env_var) -> None:
         subject.set("custom_string", "from_yml", store=SettingValueStore.MELTANO_YML)
         subject.set("custom_bool", value=True, store=SettingValueStore.MELTANO_YML)
         subject.set("custom_array", [1, 2, 3, "4"], store=SettingValueStore.MELTANO_YML)
@@ -720,7 +720,7 @@ class TestPluginSettingsService:
             SettingValueStore.ENV,
         )
 
-    def test_date_values(self, subject, monkeypatch) -> None:  # noqa: ANN001
+    def test_date_values(self, subject, monkeypatch) -> None:
         today = datetime.now(timezone.utc).date()
         monkeypatch.setitem(subject.plugin.config, "start_date", today)
         assert subject.get("start_date") == today.isoformat()
@@ -733,8 +733,8 @@ class TestPluginSettingsService:
     def test_kind_object(
         self,
         subject: PluginSettingsService,
-        monkeypatch,  # noqa: ANN001
-        env_var,  # noqa: ANN001
+        monkeypatch,
+        env_var,
     ) -> None:
         assert subject.get_with_source("object") == (
             {"nested": "from_default"},
@@ -812,7 +812,7 @@ class TestPluginSettingsService:
         )
 
     @pytest.mark.usefixtures("tap")
-    def test_extra(self, subject, monkeypatch, env_var) -> None:  # noqa: ANN001
+    def test_extra(self, subject, monkeypatch, env_var) -> None:
         subject._setting_defs = None
 
         assert "_select" in subject.as_dict()
@@ -878,11 +878,11 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("environment")
     def test_extra_object(
         self,
-        subject,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
-        env_var,  # noqa: ANN001
-        project_add_service,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        subject,
+        monkeypatch,
+        env_var,
+        project_add_service,
+        plugin_settings_service_factory,
     ) -> None:
         try:
             transform = project_add_service.add(
@@ -977,9 +977,9 @@ class TestPluginSettingsService:
 
     def test_find_setting_raises_with_conflicting(
         self,
-        tap,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        tap,
+        plugin_settings_service_factory,
+        monkeypatch,
     ) -> None:
         subject = plugin_settings_service_factory(tap)
         monkeypatch.setenv("TAP_MOCK_ALIASED", "value_0")
@@ -989,9 +989,9 @@ class TestPluginSettingsService:
 
     def test_find_setting_raises_with_multiple(
         self,
-        tap,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        tap,
+        plugin_settings_service_factory,
+        monkeypatch,
     ) -> None:
         subject = plugin_settings_service_factory(tap)
         monkeypatch.setenv("TAP_MOCK_ALIASED", "value_0")
@@ -999,13 +999,13 @@ class TestPluginSettingsService:
         with pytest.raises(MultipleEnvVarsSetException):
             subject.get("aliased")
 
-    def test_find_setting_aliases(self, tap, plugin_settings_service_factory) -> None:  # noqa: ANN001
+    def test_find_setting_aliases(self, tap, plugin_settings_service_factory) -> None:
         subject = plugin_settings_service_factory(tap)
         subject.set("aliased_3", "value_3")
         assert subject.get("aliased") == "value_3"
 
     @pytest.mark.order(-1)
-    def test_strict_env_var_mode_on_raises_error(self, subject) -> None:  # noqa: ANN001
+    def test_strict_env_var_mode_on_raises_error(self, subject) -> None:
         subject.project_settings_service.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
             value=True,
@@ -1015,7 +1015,7 @@ class TestPluginSettingsService:
             subject.get("stacked_env_var")
 
     @pytest.mark.order(-1)
-    def test_strict_env_var_mode_off_no_raise_error(self, subject) -> None:  # noqa: ANN001
+    def test_strict_env_var_mode_off_no_raise_error(self, subject) -> None:
         subject.project_settings_service.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
             value=False,

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
 
 
 @pytest.mark.order(0)
-def test_create(session):
+def test_create(session) -> None:  # noqa: ANN001
     setting = Setting(
         name="api_key.test.test",
         namespace="gitlab",
@@ -46,8 +46,8 @@ def test_create(session):
 
 
 @pytest.fixture(scope="class")
-def env_var():
-    def _wrapper(plugin_settings_service, setting_name):
+def env_var():  # noqa: ANN201
+    def _wrapper(plugin_settings_service, setting_name):  # noqa: ANN001, ANN202
         setting_def = plugin_settings_service.find_setting(setting_name)
         return plugin_settings_service.setting_env(setting_def)
 
@@ -55,7 +55,7 @@ def env_var():
 
 
 @pytest.fixture(scope="class")
-def custom_tap(project):
+def custom_tap(project):  # noqa: ANN001, ANN201
     expected = {"test": "custom", "start_date": None, "secure": None}
     tap = ProjectPlugin(
         PluginType.EXTRACTORS,
@@ -70,7 +70,7 @@ def custom_tap(project):
 
 
 @pytest.fixture()
-def subject(tap, plugin_settings_service_factory) -> PluginSettingsService:
+def subject(tap, plugin_settings_service_factory) -> PluginSettingsService:  # noqa: ANN001
     return plugin_settings_service_factory(tap)
 
 
@@ -86,13 +86,13 @@ def environment(project: Project) -> t.Generator[Environment, None, None]:
 class TestPluginSettingsService:
     def test_get_with_source(
         self,
-        session,
-        tap,
-        inherited_tap,
-        env_var,
-        monkeypatch,
-        plugin_settings_service_factory,
-    ):
+        session,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        inherited_tap,  # noqa: ANN001
+        env_var,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         subject = plugin_settings_service_factory(inherited_tap)
 
         # returns the default value when unset
@@ -156,7 +156,13 @@ class TestPluginSettingsService:
             SettingValueStore.CONFIG_OVERRIDE,
         )
 
-    def test_get_with_source_casting(self, session, subject, env_var, monkeypatch):
+    def test_get_with_source_casting(
+        self,
+        session,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        env_var,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         # Verify that integer settings set in env are cast correctly
         monkeypatch.setenv(env_var(subject, "port"), "3333")
 
@@ -196,7 +202,7 @@ class TestPluginSettingsService:
             SettingValueStore.ENV,
         )
 
-    def test_definitions(self, subject):
+    def test_definitions(self, subject) -> None:  # noqa: ANN001
         subject.show_hidden = False
         subject._setting_defs = None
 
@@ -211,7 +217,7 @@ class TestPluginSettingsService:
 
     @pytest.mark.order(1)
     @pytest.mark.usefixtures("tap")
-    def test_as_dict(self, subject, session):
+    def test_as_dict(self, subject, session) -> None:  # noqa: ANN001
         expected = {"test": "mock", "start_date": None, "secure": None}
         full_config = subject.as_dict(session=session)
         redacted_config = subject.as_dict(redacted=True, session=session)
@@ -225,7 +231,7 @@ class TestPluginSettingsService:
         environment: Environment,
         subject: PluginSettingsService,
         project: Project,
-    ):
+    ) -> None:
         subject.set("test_environment", "THIS_IS_FROM_ENVIRONMENT")
         by_name = {sdef.name: sdef for sdef in subject.definitions()}
 
@@ -243,7 +249,7 @@ class TestPluginSettingsService:
             assert env_plugin.config["test_environment"] == "THIS_IS_FROM_ENVIRONMENT"
 
     @pytest.mark.usefixtures("tap")
-    def test_as_dict_process(self, subject: PluginSettingsService):
+    def test_as_dict_process(self, subject: PluginSettingsService) -> None:
         config = subject.as_dict()
         assert config["auth.username"] is None
         assert config["auth.password"] is None
@@ -283,15 +289,15 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("project")
     def test_as_dict_custom(
         self,
-        session,
-        custom_tap,
-        plugin_settings_service_factory,
-    ):
+        session,  # noqa: ANN001
+        custom_tap,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         subject = plugin_settings_service_factory(custom_tap)
         assert subject.as_dict(extras=False, session=session) == custom_tap.config
 
     @pytest.mark.usefixtures("tap")
-    def test_as_dict_redacted(self, subject, session):
+    def test_as_dict_redacted(self, subject, session) -> None:  # noqa: ANN001
         store = SettingValueStore.DB
 
         # ensure values are redacted when they are set
@@ -309,7 +315,7 @@ class TestPluginSettingsService:
         assert config["secure"] == "thisisatest"
 
     @pytest.mark.usefixtures("tap")
-    def test_as_env(self, subject, session, env_var):
+    def test_as_env(self, subject, session, env_var) -> None:  # noqa: ANN001
         subject.set("boolean", value=True, store=SettingValueStore.DOTENV)
         subject.set("list", [1, 2, 3, "4"], store=SettingValueStore.DOTENV)
         subject.set("object", {"1": {"2": 3}}, store=SettingValueStore.DOTENV)
@@ -336,11 +342,11 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("project")
     def test_as_env_custom(
         self,
-        session,
-        custom_tap,
-        env_var,
-        plugin_settings_service_factory,
-    ):
+        session,  # noqa: ANN001
+        custom_tap,  # noqa: ANN001
+        env_var,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         subject = plugin_settings_service_factory(custom_tap)
         config = subject.as_env(session=session)
         for key, value in custom_tap.config.items():
@@ -351,13 +357,13 @@ class TestPluginSettingsService:
     def test_namespace_as_env_prefix(
         self,
         project: Project,
-        session,
+        session,  # noqa: ANN001
         target: ProjectPlugin,
-        plugin_settings_service_factory,
-    ):
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         subject = plugin_settings_service_factory(target)
 
-        def assert_env_value(value, env_var):
+        def assert_env_value(value, env_var) -> None:  # noqa: ANN001
             read_value, metadata = subject.get_with_metadata("schema")
             assert value == read_value
             assert metadata["env_var"] == env_var
@@ -391,12 +397,12 @@ class TestPluginSettingsService:
 
     def test_setting_env_vars(
         self,
-        tap,
-        inherited_tap,
-        alternative_target,
-        plugin_settings_service_factory,
-    ):
-        def env_vars(service, setting_name, **kwargs):
+        tap,  # noqa: ANN001
+        inherited_tap,  # noqa: ANN001
+        alternative_target,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
+        def env_vars(service, setting_name, **kwargs):  # noqa: ANN001, ANN003, ANN202
             return [
                 setting.definition
                 for setting in service.setting_env_vars(
@@ -446,7 +452,7 @@ class TestPluginSettingsService:
         ]
 
     @pytest.mark.usefixtures("tap")
-    def test_store_db(self, session, subject):
+    def test_store_db(self, session, subject) -> None:  # noqa: ANN001
         store = SettingValueStore.DB
 
         subject.set("test_a", "THIS_IS_FROM_DB", store=store, session=session)
@@ -463,7 +469,7 @@ class TestPluginSettingsService:
         assert session.query(Setting).count() == 0
 
     @pytest.mark.usefixtures("tap")
-    def test_store_meltano_yml(self, subject, project):
+    def test_store_meltano_yml(self, subject, project) -> None:  # noqa: ANN001
         store = SettingValueStore.MELTANO_YML
 
         subject.set("test_a", "THIS_IS_FROM_YML", store=store)
@@ -490,7 +496,11 @@ class TestPluginSettingsService:
 
     @pytest.mark.order(2)
     @pytest.mark.usefixtures("tap")
-    def test_store_dotenv(self, subject: PluginSettingsService, project: Project):
+    def test_store_dotenv(
+        self,
+        subject: PluginSettingsService,
+        project: Project,
+    ) -> None:
         store = SettingValueStore.DOTENV
 
         assert not project.dotenv.exists()
@@ -552,12 +562,12 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("tap")
     def test_env_var_expansion(
         self,
-        session,
+        session,  # noqa: ANN001
         subject: PluginSettingsService,
         project: Project,
-        monkeypatch,
-        env_var,
-    ):
+        monkeypatch,  # noqa: ANN001
+        env_var,  # noqa: ANN001
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -612,19 +622,19 @@ class TestPluginSettingsService:
 
     @pytest.mark.order(3)
     @pytest.mark.usefixtures("tap")
-    def test_nested_keys(self, session, subject, project):
-        def set_config(path, value):
+    def test_nested_keys(self, session, subject, project) -> None:  # noqa: ANN001
+        def set_config(path, value) -> None:  # noqa: ANN001
             subject.set(path, value, store=SettingValueStore.MELTANO_YML)
 
-        def unset_config(path):
+        def unset_config(path) -> None:  # noqa: ANN001
             subject.unset(path, store=SettingValueStore.MELTANO_YML)
 
-        def yml_config():
+        def yml_config():  # noqa: ANN202
             with project.meltano_update() as meltano:
                 extractor = meltano.plugins.extractors[0]
                 return extractor.config
 
-        def final_config():
+        def final_config():  # noqa: ANN202
             return subject.as_dict(session=session)
 
         set_config("metadata.stream.replication-key", "created_at")
@@ -673,7 +683,7 @@ class TestPluginSettingsService:
         assert "metadata.stream.replication-key" not in final_config()
 
     @pytest.mark.usefixtures("tap")
-    def test_custom_setting(self, session, subject, env_var):
+    def test_custom_setting(self, session, subject, env_var) -> None:  # noqa: ANN001
         subject.set("custom_string", "from_yml", store=SettingValueStore.MELTANO_YML)
         subject.set("custom_bool", value=True, store=SettingValueStore.MELTANO_YML)
         subject.set("custom_array", [1, 2, 3, "4"], store=SettingValueStore.MELTANO_YML)
@@ -710,7 +720,7 @@ class TestPluginSettingsService:
             SettingValueStore.ENV,
         )
 
-    def test_date_values(self, subject, monkeypatch):
+    def test_date_values(self, subject, monkeypatch) -> None:  # noqa: ANN001
         today = datetime.now(timezone.utc).date()
         monkeypatch.setitem(subject.plugin.config, "start_date", today)
         assert subject.get("start_date") == today.isoformat()
@@ -723,9 +733,9 @@ class TestPluginSettingsService:
     def test_kind_object(
         self,
         subject: PluginSettingsService,
-        monkeypatch,
-        env_var,
-    ):
+        monkeypatch,  # noqa: ANN001
+        env_var,  # noqa: ANN001
+    ) -> None:
         assert subject.get_with_source("object") == (
             {"nested": "from_default"},
             SettingValueStore.DEFAULT,
@@ -802,7 +812,7 @@ class TestPluginSettingsService:
         )
 
     @pytest.mark.usefixtures("tap")
-    def test_extra(self, subject, monkeypatch, env_var):
+    def test_extra(self, subject, monkeypatch, env_var) -> None:  # noqa: ANN001
         subject._setting_defs = None
 
         assert "_select" in subject.as_dict()
@@ -868,12 +878,12 @@ class TestPluginSettingsService:
     @pytest.mark.usefixtures("environment")
     def test_extra_object(
         self,
-        subject,
-        monkeypatch,
-        env_var,
-        project_add_service,
-        plugin_settings_service_factory,
-    ):
+        subject,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+        env_var,  # noqa: ANN001
+        project_add_service,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         try:
             transform = project_add_service.add(
                 PluginType.TRANSFORMS,
@@ -967,10 +977,10 @@ class TestPluginSettingsService:
 
     def test_find_setting_raises_with_conflicting(
         self,
-        tap,
-        plugin_settings_service_factory,
-        monkeypatch,
-    ):
+        tap,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         subject = plugin_settings_service_factory(tap)
         monkeypatch.setenv("TAP_MOCK_ALIASED", "value_0")
         monkeypatch.setenv("TAP_MOCK_ALIASED_1", "value_1")
@@ -979,23 +989,23 @@ class TestPluginSettingsService:
 
     def test_find_setting_raises_with_multiple(
         self,
-        tap,
-        plugin_settings_service_factory,
-        monkeypatch,
-    ):
+        tap,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         subject = plugin_settings_service_factory(tap)
         monkeypatch.setenv("TAP_MOCK_ALIASED", "value_0")
         monkeypatch.setenv("TAP_MOCK_ALIASED_1", "value_0")
         with pytest.raises(MultipleEnvVarsSetException):
             subject.get("aliased")
 
-    def test_find_setting_aliases(self, tap, plugin_settings_service_factory):
+    def test_find_setting_aliases(self, tap, plugin_settings_service_factory) -> None:  # noqa: ANN001
         subject = plugin_settings_service_factory(tap)
         subject.set("aliased_3", "value_3")
         assert subject.get("aliased") == "value_3"
 
     @pytest.mark.order(-1)
-    def test_strict_env_var_mode_on_raises_error(self, subject):
+    def test_strict_env_var_mode_on_raises_error(self, subject) -> None:  # noqa: ANN001
         subject.project_settings_service.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
             value=True,
@@ -1005,7 +1015,7 @@ class TestPluginSettingsService:
             subject.get("stacked_env_var")
 
     @pytest.mark.order(-1)
-    def test_strict_env_var_mode_off_no_raise_error(self, subject):
+    def test_strict_env_var_mode_off_no_raise_error(self, subject) -> None:  # noqa: ANN001
         subject.project_settings_service.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
             value=False,

--- a/tests/meltano/core/plugin/test_superset.py
+++ b/tests/meltano/core/plugin/test_superset.py
@@ -40,18 +40,18 @@ def load_module_from_path(name: str, path: Path) -> ModuleType:
 
 class TestSuperset:
     @pytest.fixture(scope="class")
-    def subject(self, project_add_service):  # noqa: ANN001, ANN201
+    def subject(self, project_add_service):
         with mock.patch.object(PluginInstallService, "install_plugin"):
             return project_add_service.add(PluginType.UTILITIES, "superset")
 
     @pytest.mark.asyncio()
     async def test_hooks(
         self,
-        subject,  # noqa: ANN001
-        project,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        subject,
+        project,
+        session,
+        plugin_invoker_factory,
+        monkeypatch,
     ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
@@ -67,7 +67,7 @@ class TestSuperset:
 
         original_exec = asyncio.create_subprocess_exec
 
-        def popen_mock(cmd, *popen_args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+        def popen_mock(cmd, *popen_args, **kwargs):
             assert kwargs["env"]["SUPERSET_HOME"] == str(run_dir)
             assert kwargs["env"]["SUPERSET_CONFIG_PATH"] == str(config_path)
 
@@ -151,7 +151,7 @@ class TestSuperset:
             assert not run_dir.joinpath("superset_config.py").exists()
 
     @pytest.mark.asyncio()
-    async def test_before_cleanup(self, subject, plugin_invoker_factory) -> None:  # noqa: ANN001
+    async def test_before_cleanup(self, subject, plugin_invoker_factory) -> None:
         invoker: SupersetInvoker = plugin_invoker_factory(subject)
 
         assert not invoker.files["config"].exists()

--- a/tests/meltano/core/plugin/test_superset.py
+++ b/tests/meltano/core/plugin/test_superset.py
@@ -40,19 +40,19 @@ def load_module_from_path(name: str, path: Path) -> ModuleType:
 
 class TestSuperset:
     @pytest.fixture(scope="class")
-    def subject(self, project_add_service):
+    def subject(self, project_add_service):  # noqa: ANN001, ANN201
         with mock.patch.object(PluginInstallService, "install_plugin"):
             return project_add_service.add(PluginType.UTILITIES, "superset")
 
     @pytest.mark.asyncio()
     async def test_hooks(
         self,
-        subject,
-        project,
-        session,
-        plugin_invoker_factory,
-        monkeypatch,
-    ):
+        subject,  # noqa: ANN001
+        project,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -67,7 +67,7 @@ class TestSuperset:
 
         original_exec = asyncio.create_subprocess_exec
 
-        def popen_mock(cmd, *popen_args, **kwargs):
+        def popen_mock(cmd, *popen_args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
             assert kwargs["env"]["SUPERSET_HOME"] == str(run_dir)
             assert kwargs["env"]["SUPERSET_CONFIG_PATH"] == str(config_path)
 
@@ -151,7 +151,7 @@ class TestSuperset:
             assert not run_dir.joinpath("superset_config.py").exists()
 
     @pytest.mark.asyncio()
-    async def test_before_cleanup(self, subject, plugin_invoker_factory):
+    async def test_before_cleanup(self, subject, plugin_invoker_factory) -> None:  # noqa: ANN001
         invoker: SupersetInvoker = plugin_invoker_factory(subject)
 
         assert not invoker.files["config"].exists()

--- a/tests/meltano/core/runner/test_runner.py
+++ b/tests/meltano/core/runner/test_runner.py
@@ -20,17 +20,17 @@ TEST_STATE_ID = "test_job"
 
 
 class AnyInstanceOf:
-    def __init__(self, target_cls) -> None:  # noqa: ANN001
+    def __init__(self, target_cls) -> None:
         self.target_cls = target_cls
 
-    def __eq__(self, other):  # noqa: ANN001, ANN204
+    def __eq__(self, other):
         return isinstance(other, self.target_cls)
 
     def __repr__(self) -> str:
         return f"<Any({self.target_cls}>"
 
 
-def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):  # noqa: ANN201
+def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):
     for file in plugin.config_files.values():
         Path(os.path.join(config_dir, file)).touch()
 
@@ -39,13 +39,13 @@ def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):  # noqa: ANN20
 
 class TestSingerRunner:
     @pytest.fixture()
-    def elt_context(  # noqa: ANN201
+    def elt_context(
         self,
-        project,  # noqa: ANN001, ARG002
-        session,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        elt_context_builder,  # noqa: ANN001
+        project,  # noqa: ARG002
+        session,
+        tap,
+        target,
+        elt_context_builder,
     ):
         job = Job(job_name="pytest_test_runner")
 
@@ -58,17 +58,17 @@ class TestSingerRunner:
         )
 
     @pytest.fixture()
-    def tap_config_dir(self, tmp_path: Path, elt_context) -> Path:  # noqa: ANN001
+    def tap_config_dir(self, tmp_path: Path, elt_context) -> Path:
         create_plugin_files(tmp_path, elt_context.extractor.plugin)
         return tmp_path
 
     @pytest.fixture()
-    def target_config_dir(self, tmp_path: Path, elt_context) -> Path:  # noqa: ANN001
+    def target_config_dir(self, tmp_path: Path, elt_context) -> Path:
         create_plugin_files(tmp_path, elt_context.loader.plugin)
         return tmp_path
 
     @pytest.fixture()
-    def subject(self, session, elt_context):  # noqa: ANN001, ANN201
+    def subject(self, session, elt_context):
         Job(
             job_name=TEST_STATE_ID,
             state=State.SUCCESS,
@@ -79,8 +79,8 @@ class TestSingerRunner:
         return SingerRunner(elt_context)
 
     @pytest.fixture()
-    def process_mock_factory(self):  # noqa: ANN201
-        def _factory(name):  # noqa: ANN001, ANN202
+    def process_mock_factory(self):
+        def _factory(name):
             process_mock = mock.Mock()
             process_mock.name = name
             process_mock.wait = AsyncMock(return_value=0)
@@ -89,25 +89,25 @@ class TestSingerRunner:
         return _factory
 
     @pytest.fixture()
-    def tap_process(self, process_mock_factory, tap):  # noqa: ANN001, ANN201
+    def tap_process(self, process_mock_factory, tap):
         tap = process_mock_factory(tap)
         tap.stdout.readline = AsyncMock(return_value="{}")
         return tap
 
     @pytest.fixture()
-    def target_process(self, process_mock_factory, target):  # noqa: ANN001, ANN201
+    def target_process(self, process_mock_factory, target):
         return process_mock_factory(target)
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("subject")
     async def test_prepare_job(
         self,
-        session,  # noqa: ANN001
-        tap_config_dir,  # noqa: ANN001
-        target_config_dir,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
+        session,
+        tap_config_dir,
+        target_config_dir,
+        tap,
+        target,
+        plugin_invoker_factory,
     ) -> None:
         tap_invoker = plugin_invoker_factory(tap, config_dir=tap_config_dir)
         target_invoker = plugin_invoker_factory(target, config_dir=target_config_dir)
@@ -127,15 +127,15 @@ class TestSingerRunner:
     @pytest.mark.asyncio()
     async def test_invoke(
         self,
-        session,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        tap_config_dir,  # noqa: ANN001
-        target_config_dir,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        tap_process,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
+        session,
+        subject,
+        tap_config_dir,
+        target_config_dir,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        plugin_invoker_factory,
     ) -> None:
         tap_invoker = plugin_invoker_factory(tap, config_dir=tap_config_dir)
         target_invoker = plugin_invoker_factory(target, config_dir=target_config_dir)
@@ -222,17 +222,17 @@ class TestSingerRunner:
     )
     async def test_bookmark(
         self,
-        subject,  # noqa: ANN001
-        session,  # noqa: ANN001
-        target,  # noqa: ANN001
-        target_config_dir,  # noqa: ANN001
-        target_process,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
-        full_refresh,  # noqa: ANN001
-        select_filter,  # noqa: ANN001
-        payload_flag,  # noqa: ANN001
-        elt_context,  # noqa: ANN001
-        merge_state,  # noqa: ANN001
+        subject,
+        session,
+        target,
+        target_config_dir,
+        target_process,
+        plugin_invoker_factory,
+        full_refresh,
+        select_filter,
+        payload_flag,
+        elt_context,
+        merge_state,
     ) -> None:
         lines = (b'{"line": 1}\n', b'{"line": 2}\n', b'{"line": 3}\n')
 
@@ -277,8 +277,8 @@ class TestSingerRunner:
             assert job.payload_flags == payload_flag
 
     @pytest.mark.asyncio()
-    async def test_run(self, subject) -> None:  # noqa: ANN001
-        async def invoke_mock(*args, **kwargs) -> None:  # noqa: ANN002, ANN003, ARG001
+    async def test_run(self, subject) -> None:
+        async def invoke_mock(*args, **kwargs) -> None:  # noqa: ARG001
             pass
 
         with mock.patch.object(

--- a/tests/meltano/core/runner/test_runner.py
+++ b/tests/meltano/core/runner/test_runner.py
@@ -20,17 +20,17 @@ TEST_STATE_ID = "test_job"
 
 
 class AnyInstanceOf:
-    def __init__(self, target_cls):
+    def __init__(self, target_cls) -> None:  # noqa: ANN001
         self.target_cls = target_cls
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # noqa: ANN001, ANN204
         return isinstance(other, self.target_cls)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Any({self.target_cls}>"
 
 
-def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):
+def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):  # noqa: ANN201
     for file in plugin.config_files.values():
         Path(os.path.join(config_dir, file)).touch()
 
@@ -39,13 +39,13 @@ def create_plugin_files(config_dir: Path, plugin: ProjectPlugin):
 
 class TestSingerRunner:
     @pytest.fixture()
-    def elt_context(
+    def elt_context(  # noqa: ANN201
         self,
-        project,  # noqa: ARG002
-        session,
-        tap,
-        target,
-        elt_context_builder,
+        project,  # noqa: ANN001, ARG002
+        session,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        elt_context_builder,  # noqa: ANN001
     ):
         job = Job(job_name="pytest_test_runner")
 
@@ -58,17 +58,17 @@ class TestSingerRunner:
         )
 
     @pytest.fixture()
-    def tap_config_dir(self, tmp_path: Path, elt_context) -> Path:
+    def tap_config_dir(self, tmp_path: Path, elt_context) -> Path:  # noqa: ANN001
         create_plugin_files(tmp_path, elt_context.extractor.plugin)
         return tmp_path
 
     @pytest.fixture()
-    def target_config_dir(self, tmp_path: Path, elt_context) -> Path:
+    def target_config_dir(self, tmp_path: Path, elt_context) -> Path:  # noqa: ANN001
         create_plugin_files(tmp_path, elt_context.loader.plugin)
         return tmp_path
 
     @pytest.fixture()
-    def subject(self, session, elt_context):
+    def subject(self, session, elt_context):  # noqa: ANN001, ANN201
         Job(
             job_name=TEST_STATE_ID,
             state=State.SUCCESS,
@@ -79,8 +79,8 @@ class TestSingerRunner:
         return SingerRunner(elt_context)
 
     @pytest.fixture()
-    def process_mock_factory(self):
-        def _factory(name):
+    def process_mock_factory(self):  # noqa: ANN201
+        def _factory(name):  # noqa: ANN001, ANN202
             process_mock = mock.Mock()
             process_mock.name = name
             process_mock.wait = AsyncMock(return_value=0)
@@ -89,26 +89,26 @@ class TestSingerRunner:
         return _factory
 
     @pytest.fixture()
-    def tap_process(self, process_mock_factory, tap):
+    def tap_process(self, process_mock_factory, tap):  # noqa: ANN001, ANN201
         tap = process_mock_factory(tap)
         tap.stdout.readline = AsyncMock(return_value="{}")
         return tap
 
     @pytest.fixture()
-    def target_process(self, process_mock_factory, target):
+    def target_process(self, process_mock_factory, target):  # noqa: ANN001, ANN201
         return process_mock_factory(target)
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("subject")
     async def test_prepare_job(
         self,
-        session,
-        tap_config_dir,
-        target_config_dir,
-        tap,
-        target,
-        plugin_invoker_factory,
-    ):
+        session,  # noqa: ANN001
+        tap_config_dir,  # noqa: ANN001
+        target_config_dir,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+    ) -> None:
         tap_invoker = plugin_invoker_factory(tap, config_dir=tap_config_dir)
         target_invoker = plugin_invoker_factory(target, config_dir=target_config_dir)
 
@@ -127,16 +127,16 @@ class TestSingerRunner:
     @pytest.mark.asyncio()
     async def test_invoke(
         self,
-        session,
-        subject,
-        tap_config_dir,
-        target_config_dir,
-        tap,
-        target,
-        tap_process,
-        target_process,
-        plugin_invoker_factory,
-    ):
+        session,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        tap_config_dir,  # noqa: ANN001
+        target_config_dir,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        tap_process,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+    ) -> None:
         tap_invoker = plugin_invoker_factory(tap, config_dir=tap_config_dir)
         target_invoker = plugin_invoker_factory(target, config_dir=target_config_dir)
         async with tap_invoker.prepared(
@@ -222,18 +222,18 @@ class TestSingerRunner:
     )
     async def test_bookmark(
         self,
-        subject,
-        session,
-        target,
-        target_config_dir,
-        target_process,
-        plugin_invoker_factory,
-        full_refresh,
-        select_filter,
-        payload_flag,
-        elt_context,
-        merge_state,
-    ):
+        subject,  # noqa: ANN001
+        session,  # noqa: ANN001
+        target,  # noqa: ANN001
+        target_config_dir,  # noqa: ANN001
+        target_process,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+        full_refresh,  # noqa: ANN001
+        select_filter,  # noqa: ANN001
+        payload_flag,  # noqa: ANN001
+        elt_context,  # noqa: ANN001
+        merge_state,  # noqa: ANN001
+    ) -> None:
         lines = (b'{"line": 1}\n', b'{"line": 2}\n', b'{"line": 3}\n')
 
         # testing with a real subprocess proved to be pretty
@@ -277,8 +277,8 @@ class TestSingerRunner:
             assert job.payload_flags == payload_flag
 
     @pytest.mark.asyncio()
-    async def test_run(self, subject):
-        async def invoke_mock(*args, **kwargs):  # noqa: ARG001
+    async def test_run(self, subject) -> None:  # noqa: ANN001
+        async def invoke_mock(*args, **kwargs) -> None:  # noqa: ANN002, ANN003, ARG001
             pass
 
         with mock.patch.object(

--- a/tests/meltano/core/state_store/test_db.py
+++ b/tests/meltano/core/state_store/test_db.py
@@ -10,17 +10,17 @@ from meltano.core.state_store import DBStateStoreManager
 
 class TestDBStateStoreManager:
     @pytest.fixture()
-    def subject(  # noqa: ANN201
+    def subject(
         self,
-        job_history_session,  # noqa: ANN001
-        state_ids_with_jobs,  # noqa: ANN001, ARG002
+        job_history_session,
+        state_ids_with_jobs,  # noqa: ARG002
     ):
         return DBStateStoreManager(session=job_history_session)
 
     def test_get_state(
         self,
         subject: DBStateStoreManager,
-        state_ids_with_expected_states,  # noqa: ANN001
+        state_ids_with_expected_states,
     ) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             assert json.loads(subject.get(state_id).json_merged()) == expected_state
@@ -81,6 +81,6 @@ class TestDBStateStoreManager:
     def test_get_state_ids(
         self,
         subject: DBStateStoreManager,
-        state_ids_with_jobs,  # noqa: ANN001
+        state_ids_with_jobs,
     ) -> None:
         assert set(subject.get_state_ids()) == set(state_ids_with_jobs.keys())

--- a/tests/meltano/core/state_store/test_db.py
+++ b/tests/meltano/core/state_store/test_db.py
@@ -10,22 +10,22 @@ from meltano.core.state_store import DBStateStoreManager
 
 class TestDBStateStoreManager:
     @pytest.fixture()
-    def subject(
+    def subject(  # noqa: ANN201
         self,
-        job_history_session,
-        state_ids_with_jobs,  # noqa: ARG002
+        job_history_session,  # noqa: ANN001
+        state_ids_with_jobs,  # noqa: ANN001, ARG002
     ):
         return DBStateStoreManager(session=job_history_session)
 
     def test_get_state(
         self,
         subject: DBStateStoreManager,
-        state_ids_with_expected_states,
-    ):
+        state_ids_with_expected_states,  # noqa: ANN001
+    ) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             assert json.loads(subject.get(state_id).json_merged()) == expected_state
 
-    def test_set_state(self, subject: DBStateStoreManager):
+    def test_set_state(self, subject: DBStateStoreManager) -> None:
         # New partial is set
         partial_only = JobState(
             state_id="partial_only",
@@ -78,5 +78,9 @@ class TestDBStateStoreManager:
             completed_state={"singer_state": {"complete": 1}},
         )
 
-    def test_get_state_ids(self, subject: DBStateStoreManager, state_ids_with_jobs):
+    def test_get_state_ids(
+        self,
+        subject: DBStateStoreManager,
+        state_ids_with_jobs,  # noqa: ANN001
+    ) -> None:
         assert set(subject.get_state_ids()) == set(state_ids_with_jobs.keys())

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -47,7 +47,7 @@ def encode_if_on_windows(string: str) -> str:
 
 class TestLocalFilesystemStateStoreManager:
     @pytest.fixture()
-    def subject(self, function_scoped_test_dir):
+    def subject(self, function_scoped_test_dir):  # noqa: ANN001, ANN201
         if on_windows():
             yield WindowsFilesystemStateStoreManager(
                 uri=f"file://{function_scoped_test_dir}\\.meltano\\state\\",
@@ -60,9 +60,9 @@ class TestLocalFilesystemStateStoreManager:
             )
 
     @pytest.fixture()
-    def state_path(
+    def state_path(  # noqa: ANN201
         self,
-        function_scoped_test_dir,
+        function_scoped_test_dir,  # noqa: ANN001
         subject: LocalFilesystemStateStoreManager,
     ):
         Path(subject.state_dir).mkdir(parents=True, exist_ok=True)
@@ -72,7 +72,7 @@ class TestLocalFilesystemStateStoreManager:
             ignore_errors=True,
         )
 
-    def test_join_path(self, subject: LocalFilesystemStateStoreManager):
+    def test_join_path(self, subject: LocalFilesystemStateStoreManager) -> None:
         if on_windows():
             assert subject.join_path("a", "b") == "a\\b"
             assert subject.join_path("a", "b", "c", "d", "e") == "a\\b\\c\\d\\e"
@@ -83,8 +83,8 @@ class TestLocalFilesystemStateStoreManager:
     def test_create_state_id_dir_if_not_exists(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,
-    ):
+        state_path,  # noqa: ANN001
+    ) -> None:
         state_id_path = os.path.join(
             state_path,
             encode_if_on_windows("create_state_id_dir"),
@@ -93,13 +93,21 @@ class TestLocalFilesystemStateStoreManager:
         subject.create_state_id_dir_if_not_exists("create_state_id_dir")
         assert os.path.exists(state_id_path)
 
-    def test_get_reader(self, subject: LocalFilesystemStateStoreManager, state_path):
+    def test_get_reader(
+        self,
+        subject: LocalFilesystemStateStoreManager,
+        state_path,  # noqa: ANN001
+    ) -> None:
         filepath = os.path.join(state_path, "get_reader")
         open(filepath, "a").close()
         with subject.get_reader(path=filepath) as reader:
             assert reader.name == filepath
 
-    def test_get_writer(self, subject: LocalFilesystemStateStoreManager, state_path):
+    def test_get_writer(
+        self,
+        subject: LocalFilesystemStateStoreManager,
+        state_path,  # noqa: ANN001
+    ) -> None:
         filepath = os.path.join(state_path, "get_writer")
         with subject.get_writer(path=filepath) as writer:
             assert writer.name == filepath
@@ -107,33 +115,41 @@ class TestLocalFilesystemStateStoreManager:
     def test_get_state_path(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,
-    ):
+        state_path,  # noqa: ANN001
+    ) -> None:
         assert subject.get_state_path("get_state_path") == os.path.join(
             state_path,
             encode_if_on_windows("get_state_path"),
             "state.json",
         )
 
-    def test_get_lock_path(self, subject: LocalFilesystemStateStoreManager, state_path):
+    def test_get_lock_path(
+        self,
+        subject: LocalFilesystemStateStoreManager,
+        state_path,  # noqa: ANN001
+    ) -> None:
         assert subject.get_lock_path("some_state_id") == os.path.join(
             state_path,
             encode_if_on_windows("some_state_id"),
             "lock",
         )
 
-    def test_acquire_lock(self, subject: LocalFilesystemStateStoreManager, state_path):
+    def test_acquire_lock(
+        self,
+        subject: LocalFilesystemStateStoreManager,
+        state_path,  # noqa: ANN001
+    ) -> None:
         dir_path = os.path.join(state_path, encode_if_on_windows("acquire_lock"))
         with subject.acquire_lock("acquire_lock"):
             assert os.path.exists(os.path.join(dir_path, "lock"))
 
-    def test_lock_timeout(self, subject: LocalFilesystemStateStoreManager):
+    def test_lock_timeout(self, subject: LocalFilesystemStateStoreManager) -> None:
         state_id = "is_locked"
         timeout = subject.lock_timeout_seconds
 
         initial_dt = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
         with time_machine.travel(initial_dt) as frozen_datetime, subject.acquire_lock(
-            state_id
+            state_id,
         ):
             frozen_datetime.shift(datetime.timedelta(seconds=timeout / 2))
             assert subject.is_locked(state_id)
@@ -143,7 +159,7 @@ class TestLocalFilesystemStateStoreManager:
                 assert not subject.is_locked(state_id)
 
     @pytest.mark.usefixtures("state_path")
-    def test_get_state_ids(self, subject: LocalFilesystemStateStoreManager):
+    def test_get_state_ids(self, subject: LocalFilesystemStateStoreManager) -> None:
         dev_ids = [f"dev:{letter}-to-{letter}" for letter in string.ascii_lowercase]
         prod_ids = [f"prod:{letter}-to-{letter}" for letter in string.ascii_lowercase]
         for state_id in dev_ids + prod_ids:
@@ -158,9 +174,9 @@ class TestLocalFilesystemStateStoreManager:
     def test_get(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,
-        state_ids_with_expected_states,
-    ):
+        state_path,  # noqa: ANN001
+        state_ids_with_expected_states,  # noqa: ANN001
+    ) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             state_dir = os.path.join(state_path, encode_if_on_windows(state_id))
             Path(state_dir).mkdir(parents=True)
@@ -179,9 +195,9 @@ class TestLocalFilesystemStateStoreManager:
     def test_set(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,
-        state_ids_with_expected_states,
-    ):
+        state_path,  # noqa: ANN001
+        state_ids_with_expected_states,  # noqa: ANN001
+    ) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             subject.set(
                 JobState.from_json(state_id, json.dumps({"completed": expected_state})),
@@ -199,8 +215,8 @@ class TestLocalFilesystemStateStoreManager:
         self,
         subject: LocalFilesystemStateStoreManager,
         state_path: str,
-        state_ids_with_expected_states,
-    ):
+        state_ids_with_expected_states,  # noqa: ANN001
+    ) -> None:
         def _get_state_path(state_id: str) -> str:
             return os.path.join(
                 state_path,
@@ -228,9 +244,9 @@ class TestLocalFilesystemStateStoreManager:
     def test_delete(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,
-        state_ids_with_expected_states,
-    ):
+        state_path,  # noqa: ANN001
+        state_ids_with_expected_states,  # noqa: ANN001
+    ) -> None:
         # Delete files
         state_id, expected_state = state_ids_with_expected_states[0]
         state_dir = os.path.join(state_path, encode_if_on_windows(state_id))
@@ -254,9 +270,9 @@ class TestLocalFilesystemStateStoreManager:
     def test_clear(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,
-        state_ids_with_expected_states,
-    ):
+        state_path,  # noqa: ANN001
+        state_ids_with_expected_states,  # noqa: ANN001
+    ) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             state_dir = os.path.join(state_path, encode_if_on_windows(state_id))
             Path(state_dir).mkdir(parents=True)
@@ -272,9 +288,9 @@ class TestLocalFilesystemStateStoreManager:
 
 class TestAZStorageStateStoreManager:
     @pytest.fixture()
-    def subject(
+    def subject(  # noqa: ANN201
         self,
-        function_scoped_test_dir,  # noqa: ARG002
+        function_scoped_test_dir,  # noqa: ANN001, ARG002
     ):
         return AZStorageStateStoreManager(
             uri="azure://meltano/state/",
@@ -283,13 +299,13 @@ class TestAZStorageStateStoreManager:
         )
 
     @pytest.fixture()
-    def mock_client(self):
+    def mock_client(self):  # noqa: ANN201
         with patch(
             "meltano.core.state_store.azure.BlobServiceClient",
         ) as mock_client:
             yield mock_client
 
-    def test_client(self, subject: AZStorageStateStoreManager, mock_client):
+    def test_client(self, subject: AZStorageStateStoreManager, mock_client) -> None:  # noqa: ANN001
         # Call twice to assure memoization
         _ = subject.client
         _ = subject.client
@@ -301,7 +317,7 @@ class TestAZStorageStateStoreManager:
     def test_is_file_not_found_error_true(
         self,
         subject: AZStorageStateStoreManager,
-    ):
+    ) -> None:
         got_reader = False
         mock_container_client = MagicMock()
         mock_container_client.container_name = subject.container_name
@@ -321,7 +337,7 @@ class TestAZStorageStateStoreManager:
     def test_is_file_not_found_error_false(
         self,
         subject: AZStorageStateStoreManager,
-    ):
+    ) -> None:
         got_reader = False
         mock_container_client = MagicMock()
         mock_container_client.container_name = subject.container_name
@@ -337,18 +353,18 @@ class TestAZStorageStateStoreManager:
             assert not subject.is_file_not_found_error(e)  # noqa: PT017
         assert not got_reader
 
-    def test_state_path(self, subject: AZStorageStateStoreManager):
+    def test_state_path(self, subject: AZStorageStateStoreManager) -> None:
         assert subject.state_dir == "state"
 
     @pytest.mark.usefixtures("mock_client")
-    def test_delete(self, subject):
+    def test_delete(self, subject) -> None:  # noqa: ANN001
         mock_blob_client = MagicMock()
         subject.client.get_blob_client.return_value = mock_blob_client
         subject.delete("some_path")
         mock_blob_client.delete_blob.assert_called_once()
 
     @pytest.mark.usefixtures("mock_client")
-    def test_get_state_ids(self, subject):
+    def test_get_state_ids(self, subject) -> None:  # noqa: ANN001
         mock_container_client = MagicMock()
         mock_container_client.list_blobs.return_value = (
             BlobProperties(name=f"state/state_id_{i}/state.json") for i in range(10)
@@ -372,9 +388,9 @@ class TestS3StateStoreManager:
                 yield stubber
 
     @pytest.fixture()
-    def subject(
+    def subject(  # noqa: ANN201
         self,
-        function_scoped_test_dir,  # noqa: ARG002
+        function_scoped_test_dir,  # noqa: ANN001, ARG002
     ):
         return S3StateStoreManager(
             uri="s3://test_access_key_id:test_secret_access_key@meltano/state",
@@ -382,7 +398,7 @@ class TestS3StateStoreManager:
             lock_timeout_seconds=10,
         )
 
-    def test_is_file_not_found_error_true(self, subject: S3StateStoreManager):
+    def test_is_file_not_found_error_true(self, subject: S3StateStoreManager) -> None:
         got_reader = False
         with self.stubber() as stubber:
             stubber.add_client_error("get_object", service_error_code="NoSuchKey")
@@ -393,7 +409,7 @@ class TestS3StateStoreManager:
                 assert subject.is_file_not_found_error(e)  # noqa: PT017
         assert not got_reader
 
-    def test_is_file_not_found_error_false(self, subject: S3StateStoreManager):
+    def test_is_file_not_found_error_false(self, subject: S3StateStoreManager) -> None:
         got_reader = False
         with self.stubber() as stubber:
             stubber.add_client_error("get_object", service_error_code="NoSuchBucket")
@@ -404,7 +420,7 @@ class TestS3StateStoreManager:
                 assert not subject.is_file_not_found_error(e)  # noqa: PT017
         assert not got_reader
 
-    def test_client_session(self, subject: S3StateStoreManager):
+    def test_client_session(self, subject: S3StateStoreManager) -> None:
         with patch("boto3.Session") as mock_session:
             _ = subject.client
             _ = subject.client
@@ -413,16 +429,16 @@ class TestS3StateStoreManager:
                 aws_secret_access_key=subject.aws_secret_access_key,
             )
 
-    def test_client_client(self, subject: S3StateStoreManager):
+    def test_client_client(self, subject: S3StateStoreManager) -> None:
         with patch("boto3.Session.client") as mock_client:
             _ = subject.client
             _ = subject.client
             mock_client.assert_called_once_with("s3", endpoint_url=subject.endpoint_url)
 
-    def test_state_path(self, subject: S3StateStoreManager):
+    def test_state_path(self, subject: S3StateStoreManager) -> None:
         assert subject.state_dir == "state"
 
-    def test_delete(self, subject: S3StateStoreManager):
+    def test_delete(self, subject: S3StateStoreManager) -> None:
         response = {
             "ResponseMetadata": {
                 "RequestId": "test_delete",
@@ -458,7 +474,7 @@ class TestS3StateStoreManager:
             )
             subject.delete("/state/test_delete")
 
-    def test_get_state_ids(self, subject: S3StateStoreManager):
+    def test_get_state_ids(self, subject: S3StateStoreManager) -> None:
         response = {
             "ResponseMetadata": {
                 "RequestId": "test_get_state_ids",
@@ -559,9 +575,9 @@ class TestS3StateStoreManager:
 
 class TestGCSStateStoreManager:
     @pytest.fixture()
-    def subject(
+    def subject(  # noqa: ANN201
         self,
-        function_scoped_test_dir,  # noqa: ARG002
+        function_scoped_test_dir,  # noqa: ANN001, ARG002
     ):
         return GCSStateStoreManager(
             uri="gs://meltano/state/",
@@ -570,13 +586,13 @@ class TestGCSStateStoreManager:
         )
 
     @pytest.fixture()
-    def mock_client(self):
+    def mock_client(self):  # noqa: ANN201
         with patch(
             "google.cloud.storage.Client",
         ) as mock_client:
             yield mock_client
 
-    def test_client(self, subject: GCSStateStoreManager, mock_client):
+    def test_client(self, subject: GCSStateStoreManager, mock_client) -> None:  # noqa: ANN001
         # Call twice to assure memoization
         _ = subject.client
         _ = subject.client
@@ -588,7 +604,7 @@ class TestGCSStateStoreManager:
     def test_is_file_not_found_error_true(
         self,
         subject: GCSStateStoreManager,
-    ):
+    ) -> None:
         got_reader = False
         mock_bucket = MagicMock()
         mock_bucket.get_blob.return_value = None
@@ -604,7 +620,7 @@ class TestGCSStateStoreManager:
     def test_is_file_not_found_error_false(
         self,
         subject: GCSStateStoreManager,
-    ):
+    ) -> None:
         got_reader = False
         mock_blob = MagicMock()
         mock_blob.open.side_effect = ValueError("Some other error")
@@ -618,11 +634,11 @@ class TestGCSStateStoreManager:
             assert not subject.is_file_not_found_error(e)  # noqa: PT017
         assert not got_reader
 
-    def test_state_path(self, subject: GCSStateStoreManager):
+    def test_state_path(self, subject: GCSStateStoreManager) -> None:
         assert subject.state_dir == "state"
 
     @pytest.mark.usefixtures("mock_client")
-    def test_delete(self, subject: GCSStateStoreManager):
+    def test_delete(self, subject: GCSStateStoreManager) -> None:
         mock_blob = MagicMock()
         mock_bucket = MagicMock()
         mock_bucket.blob.return_value = mock_blob
@@ -631,20 +647,22 @@ class TestGCSStateStoreManager:
         mock_blob.delete.assert_called_once()
 
     @pytest.mark.usefixtures("mock_client")
-    def test_get_state_ids(self, subject: GCSStateStoreManager):
+    def test_get_state_ids(self, subject: GCSStateStoreManager) -> None:
         subject.client.list_blobs.return_value = (
             Blob(bucket=Bucket("meltano"), name=f"state/state_id_{i}/state.json")
             for i in range(10)
         )
         assert set(subject.get_state_ids()) == {f"state_id_{i}" for i in range(10)}
         subject.client.list_blobs.assert_called_once_with(
-            bucket_or_name="meltano", prefix="state"
+            bucket_or_name="meltano",
+            prefix="state",
         )
 
     @pytest.mark.usefixtures("mock_client")
     def test_get_state_ids_when_any_files_was_located_in_root(
-        self, subject: GCSStateStoreManager
-    ):
+        self,
+        subject: GCSStateStoreManager,
+    ) -> None:
         subject.client.list_blobs.return_value = itertools.chain(
             (Blob(bucket=Bucket("meltano"), name="my-file.txt") for _ in range(2)),
             (
@@ -654,5 +672,6 @@ class TestGCSStateStoreManager:
         )
         assert len(set(subject.get_state_ids())) == 10
         subject.client.list_blobs.assert_called_once_with(
-            bucket_or_name="meltano", prefix="state"
+            bucket_or_name="meltano",
+            prefix="state",
         )

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -47,7 +47,7 @@ def encode_if_on_windows(string: str) -> str:
 
 class TestLocalFilesystemStateStoreManager:
     @pytest.fixture()
-    def subject(self, function_scoped_test_dir):  # noqa: ANN001, ANN201
+    def subject(self, function_scoped_test_dir):
         if on_windows():
             yield WindowsFilesystemStateStoreManager(
                 uri=f"file://{function_scoped_test_dir}\\.meltano\\state\\",
@@ -60,9 +60,9 @@ class TestLocalFilesystemStateStoreManager:
             )
 
     @pytest.fixture()
-    def state_path(  # noqa: ANN201
+    def state_path(
         self,
-        function_scoped_test_dir,  # noqa: ANN001
+        function_scoped_test_dir,
         subject: LocalFilesystemStateStoreManager,
     ):
         Path(subject.state_dir).mkdir(parents=True, exist_ok=True)
@@ -83,7 +83,7 @@ class TestLocalFilesystemStateStoreManager:
     def test_create_state_id_dir_if_not_exists(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
+        state_path,
     ) -> None:
         state_id_path = os.path.join(
             state_path,
@@ -96,7 +96,7 @@ class TestLocalFilesystemStateStoreManager:
     def test_get_reader(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
+        state_path,
     ) -> None:
         filepath = os.path.join(state_path, "get_reader")
         open(filepath, "a").close()
@@ -106,7 +106,7 @@ class TestLocalFilesystemStateStoreManager:
     def test_get_writer(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
+        state_path,
     ) -> None:
         filepath = os.path.join(state_path, "get_writer")
         with subject.get_writer(path=filepath) as writer:
@@ -115,7 +115,7 @@ class TestLocalFilesystemStateStoreManager:
     def test_get_state_path(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
+        state_path,
     ) -> None:
         assert subject.get_state_path("get_state_path") == os.path.join(
             state_path,
@@ -126,7 +126,7 @@ class TestLocalFilesystemStateStoreManager:
     def test_get_lock_path(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
+        state_path,
     ) -> None:
         assert subject.get_lock_path("some_state_id") == os.path.join(
             state_path,
@@ -137,7 +137,7 @@ class TestLocalFilesystemStateStoreManager:
     def test_acquire_lock(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
+        state_path,
     ) -> None:
         dir_path = os.path.join(state_path, encode_if_on_windows("acquire_lock"))
         with subject.acquire_lock("acquire_lock"):
@@ -174,8 +174,8 @@ class TestLocalFilesystemStateStoreManager:
     def test_get(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
-        state_ids_with_expected_states,  # noqa: ANN001
+        state_path,
+        state_ids_with_expected_states,
     ) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             state_dir = os.path.join(state_path, encode_if_on_windows(state_id))
@@ -195,8 +195,8 @@ class TestLocalFilesystemStateStoreManager:
     def test_set(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
-        state_ids_with_expected_states,  # noqa: ANN001
+        state_path,
+        state_ids_with_expected_states,
     ) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             subject.set(
@@ -215,7 +215,7 @@ class TestLocalFilesystemStateStoreManager:
         self,
         subject: LocalFilesystemStateStoreManager,
         state_path: str,
-        state_ids_with_expected_states,  # noqa: ANN001
+        state_ids_with_expected_states,
     ) -> None:
         def _get_state_path(state_id: str) -> str:
             return os.path.join(
@@ -244,8 +244,8 @@ class TestLocalFilesystemStateStoreManager:
     def test_delete(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
-        state_ids_with_expected_states,  # noqa: ANN001
+        state_path,
+        state_ids_with_expected_states,
     ) -> None:
         # Delete files
         state_id, expected_state = state_ids_with_expected_states[0]
@@ -270,8 +270,8 @@ class TestLocalFilesystemStateStoreManager:
     def test_clear(
         self,
         subject: LocalFilesystemStateStoreManager,
-        state_path,  # noqa: ANN001
-        state_ids_with_expected_states,  # noqa: ANN001
+        state_path,
+        state_ids_with_expected_states,
     ) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             state_dir = os.path.join(state_path, encode_if_on_windows(state_id))
@@ -288,9 +288,9 @@ class TestLocalFilesystemStateStoreManager:
 
 class TestAZStorageStateStoreManager:
     @pytest.fixture()
-    def subject(  # noqa: ANN201
+    def subject(
         self,
-        function_scoped_test_dir,  # noqa: ANN001, ARG002
+        function_scoped_test_dir,  # noqa: ARG002
     ):
         return AZStorageStateStoreManager(
             uri="azure://meltano/state/",
@@ -299,13 +299,13 @@ class TestAZStorageStateStoreManager:
         )
 
     @pytest.fixture()
-    def mock_client(self):  # noqa: ANN201
+    def mock_client(self):
         with patch(
             "meltano.core.state_store.azure.BlobServiceClient",
         ) as mock_client:
             yield mock_client
 
-    def test_client(self, subject: AZStorageStateStoreManager, mock_client) -> None:  # noqa: ANN001
+    def test_client(self, subject: AZStorageStateStoreManager, mock_client) -> None:
         # Call twice to assure memoization
         _ = subject.client
         _ = subject.client
@@ -357,14 +357,14 @@ class TestAZStorageStateStoreManager:
         assert subject.state_dir == "state"
 
     @pytest.mark.usefixtures("mock_client")
-    def test_delete(self, subject) -> None:  # noqa: ANN001
+    def test_delete(self, subject) -> None:
         mock_blob_client = MagicMock()
         subject.client.get_blob_client.return_value = mock_blob_client
         subject.delete("some_path")
         mock_blob_client.delete_blob.assert_called_once()
 
     @pytest.mark.usefixtures("mock_client")
-    def test_get_state_ids(self, subject) -> None:  # noqa: ANN001
+    def test_get_state_ids(self, subject) -> None:
         mock_container_client = MagicMock()
         mock_container_client.list_blobs.return_value = (
             BlobProperties(name=f"state/state_id_{i}/state.json") for i in range(10)
@@ -388,9 +388,9 @@ class TestS3StateStoreManager:
                 yield stubber
 
     @pytest.fixture()
-    def subject(  # noqa: ANN201
+    def subject(
         self,
-        function_scoped_test_dir,  # noqa: ANN001, ARG002
+        function_scoped_test_dir,  # noqa: ARG002
     ):
         return S3StateStoreManager(
             uri="s3://test_access_key_id:test_secret_access_key@meltano/state",
@@ -575,9 +575,9 @@ class TestS3StateStoreManager:
 
 class TestGCSStateStoreManager:
     @pytest.fixture()
-    def subject(  # noqa: ANN201
+    def subject(
         self,
-        function_scoped_test_dir,  # noqa: ANN001, ARG002
+        function_scoped_test_dir,  # noqa: ARG002
     ):
         return GCSStateStoreManager(
             uri="gs://meltano/state/",
@@ -586,13 +586,13 @@ class TestGCSStateStoreManager:
         )
 
     @pytest.fixture()
-    def mock_client(self):  # noqa: ANN201
+    def mock_client(self):
         with patch(
             "google.cloud.storage.Client",
         ) as mock_client:
             yield mock_client
 
-    def test_client(self, subject: GCSStateStoreManager, mock_client) -> None:  # noqa: ANN001
+    def test_client(self, subject: GCSStateStoreManager, mock_client) -> None:
         # Call twice to assure memoization
         _ = subject.client
         _ = subject.client

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -37,7 +37,7 @@ class TestSystemDBStateBackend:
 
 class TestLocalFilesystemStateBackend:
     @pytest.fixture()
-    def state_path(self, tmp_path: Path):  # noqa: ANN201
+    def state_path(self, tmp_path: Path):
         path = tmp_path / ".meltano" / "state"
         try:
             yield str(path)

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -28,7 +28,7 @@ if t.TYPE_CHECKING:
 
 
 class TestSystemDBStateBackend:
-    def test_manager_from_settings(self, project: Project):
+    def test_manager_from_settings(self, project: Project) -> None:
         project.settings.set(["state_backend", "uri"], StateBackend.SYSTEMDB)
         project.settings.set(["state_backend", "lock_timeout_seconds"], 10)
         db_state_store = state_store_manager_from_project_settings(project.settings)
@@ -37,14 +37,14 @@ class TestSystemDBStateBackend:
 
 class TestLocalFilesystemStateBackend:
     @pytest.fixture()
-    def state_path(self, tmp_path: Path):
+    def state_path(self, tmp_path: Path):  # noqa: ANN201
         path = tmp_path / ".meltano" / "state"
         try:
             yield str(path)
         finally:
             shutil.rmtree(path)
 
-    def test_manager_from_settings(self, project: Project, state_path: str):
+    def test_manager_from_settings(self, project: Project, state_path: str) -> None:
         project.settings.set(["state_backend", "uri"], f"file://{state_path}")
         file_state_store = state_store_manager_from_project_settings(project.settings)
         assert isinstance(file_state_store, LocalFilesystemStateStoreManager)
@@ -52,7 +52,7 @@ class TestLocalFilesystemStateBackend:
 
 
 class TestAzureStateBackend:
-    def test_manager_from_settings(self, project: Project):
+    def test_manager_from_settings(self, project: Project) -> None:
         # Azure
         project.settings.set(
             ["state_backend", "uri"],
@@ -119,7 +119,7 @@ class TestAzureStateBackend:
 
 
 class TestGCSStateBackend:
-    def test_manager_from_settings(self, project: Project):
+    def test_manager_from_settings(self, project: Project) -> None:
         # GCS
         project.settings.set(["state_backend", "uri"], "gs://some_container/some/path")
         gs_state_store = state_store_manager_from_project_settings(project.settings)
@@ -129,7 +129,7 @@ class TestGCSStateBackend:
 
 
 class TestS3StateBackend:
-    def test_manager_from_settings(self, project: Project):
+    def test_manager_from_settings(self, project: Project) -> None:
         # AWS S3 (credentials in URI)
         project.settings.set(
             ["state_backend", "uri"],

--- a/tests/meltano/core/test_db_compat.py
+++ b/tests/meltano/core/test_db_compat.py
@@ -39,7 +39,7 @@ class TestDatabaseCompatibility:
             ),
         ),
     )
-    def test_db_compatibility(self, dialect, version, expected) -> None:  # noqa: ANN001
+    def test_db_compatibility(self, dialect, version, expected) -> None:
         engine_mock = Mock()
         engine_mock.dialect.name = dialect
         engine_mock.dialect.server_version_info = version

--- a/tests/meltano/core/test_db_compat.py
+++ b/tests/meltano/core/test_db_compat.py
@@ -39,7 +39,7 @@ class TestDatabaseCompatibility:
             ),
         ),
     )
-    def test_db_compatibility(self, dialect, version, expected):
+    def test_db_compatibility(self, dialect, version, expected) -> None:  # noqa: ANN001
         engine_mock = Mock()
         engine_mock.dialect.name = dialect
         engine_mock.dialect.server_version_info = version

--- a/tests/meltano/core/test_db_connection.py
+++ b/tests/meltano/core/test_db_connection.py
@@ -15,7 +15,7 @@ if t.TYPE_CHECKING:
 
 
 class TestConnectionRetries:
-    def test_ping_failure(self):
+    def test_ping_failure(self) -> None:
         engine_mock = Mock()
 
         # check if OperationalError is raised if a connection can't be made
@@ -45,7 +45,7 @@ class TestProjectEngine:
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
-    ):
+    ) -> None:
         with tmp_path.joinpath("meltano.yml").open("w") as meltano_yml:
             yaml.dump(
                 {

--- a/tests/meltano/core/test_elt_context.py
+++ b/tests/meltano/core/test_elt_context.py
@@ -8,7 +8,7 @@ from meltano.core.plugin import PluginType, Variant
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
 
 
-def assert_extractor_env(extractor, env) -> None:  # noqa: ANN001
+def assert_extractor_env(extractor, env) -> None:
     assert env["MELTANO_EXTRACTOR_NAME"] == extractor.name
     assert env["MELTANO_EXTRACTOR_NAMESPACE"] == extractor.namespace
     assert env["MELTANO_EXTRACTOR_VARIANT"] == extractor.variant
@@ -17,7 +17,7 @@ def assert_extractor_env(extractor, env) -> None:  # noqa: ANN001
     assert env["MELTANO_EXTRACT__SELECT"] == env["TAP_MOCK__SELECT"] == '["*.*"]'
 
 
-def assert_loader_env(loader, env) -> None:  # noqa: ANN001
+def assert_loader_env(loader, env) -> None:
     assert env["MELTANO_LOADER_NAME"] == loader.name
     assert env["MELTANO_LOADER_NAMESPACE"] == loader.namespace
     assert env["MELTANO_LOADER_VARIANT"] == loader.variant
@@ -31,13 +31,13 @@ def assert_loader_env(loader, env) -> None:  # noqa: ANN001
     )
 
 
-def assert_transform_env(transform, env) -> None:  # noqa: ANN001
+def assert_transform_env(transform, env) -> None:
     assert env["MELTANO_TRANSFORM_NAME"] == transform.name
     assert env["MELTANO_TRANSFORM_NAMESPACE"] == transform.namespace
     assert env["MELTANO_TRANSFORM_VARIANT"] == Variant.ORIGINAL_NAME
 
 
-def assert_transformer_env(transformer, env) -> None:  # noqa: ANN001
+def assert_transformer_env(transformer, env) -> None:
     assert env["MELTANO_TRANSFORMER_NAME"] == transformer.name
     assert env["MELTANO_TRANSFORMER_NAMESPACE"] == transformer.namespace
     assert env["MELTANO_TRANSFORMER_VARIANT"] == "dbt-labs"
@@ -62,28 +62,28 @@ def assert_transformer_env(transformer, env) -> None:  # noqa: ANN001
 
 class TestELTContext:
     @pytest.fixture()
-    def target_postgres(self, project_add_service):  # noqa: ANN001, ANN201
+    def target_postgres(self, project_add_service):
         try:
             return project_add_service.add(PluginType.LOADERS, "target-postgres")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.fixture()
-    def tap_mock_transform(self, project_add_service):  # noqa: ANN001, ANN201
+    def tap_mock_transform(self, project_add_service):
         try:
             return project_add_service.add(PluginType.TRANSFORMS, "tap-mock-transform")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.fixture()
-    def elt_context(  # noqa: ANN201
+    def elt_context(
         self,
-        elt_context_builder,  # noqa: ANN001
-        session,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target_postgres,  # noqa: ANN001
-        tap_mock_transform,  # noqa: ANN001
-        dbt,  # noqa: ANN001, ARG002
+        elt_context_builder,
+        session,
+        tap,
+        target_postgres,
+        tap_mock_transform,
+        dbt,  # noqa: ARG002
     ):
         return (
             elt_context_builder.with_session(session)
@@ -95,7 +95,7 @@ class TestELTContext:
         )
 
     @pytest.mark.asyncio()
-    async def test_extractor(self, elt_context, session, tap) -> None:  # noqa: ANN001
+    async def test_extractor(self, elt_context, session, tap) -> None:
         extractor = elt_context.extractor
         assert extractor.type == PluginType.EXTRACTORS
         assert extractor.name == tap.name
@@ -107,7 +107,7 @@ class TestELTContext:
         assert_extractor_env(extractor, env)
 
     @pytest.mark.asyncio()
-    async def test_loader(self, elt_context, session, target_postgres) -> None:  # noqa: ANN001
+    async def test_loader(self, elt_context, session, target_postgres) -> None:
         loader = elt_context.loader
         assert loader.type == PluginType.LOADERS
         assert loader.name == target_postgres.name
@@ -123,10 +123,10 @@ class TestELTContext:
     @pytest.mark.usefixtures("target_postgres")
     async def test_transformer(
         self,
-        elt_context,  # noqa: ANN001
-        session,  # noqa: ANN001
-        tap_mock_transform,  # noqa: ANN001
-        dbt,  # noqa: ANN001
+        elt_context,
+        session,
+        tap_mock_transform,
+        dbt,
     ) -> None:
         transformer = elt_context.transformer
         assert transformer.type == PluginType.TRANSFORMERS
@@ -147,7 +147,7 @@ class TestELTContext:
         assert_transformer_env(transformer, env)
 
     @pytest.mark.asyncio()
-    async def test_select_filter(self, elt_context, session) -> None:  # noqa: ANN001
+    async def test_select_filter(self, elt_context, session) -> None:
         assert elt_context.select_filter
 
         invoker = elt_context.extractor_invoker()

--- a/tests/meltano/core/test_elt_context.py
+++ b/tests/meltano/core/test_elt_context.py
@@ -8,7 +8,7 @@ from meltano.core.plugin import PluginType, Variant
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
 
 
-def assert_extractor_env(extractor, env):
+def assert_extractor_env(extractor, env) -> None:  # noqa: ANN001
     assert env["MELTANO_EXTRACTOR_NAME"] == extractor.name
     assert env["MELTANO_EXTRACTOR_NAMESPACE"] == extractor.namespace
     assert env["MELTANO_EXTRACTOR_VARIANT"] == extractor.variant
@@ -17,7 +17,7 @@ def assert_extractor_env(extractor, env):
     assert env["MELTANO_EXTRACT__SELECT"] == env["TAP_MOCK__SELECT"] == '["*.*"]'
 
 
-def assert_loader_env(loader, env):
+def assert_loader_env(loader, env) -> None:  # noqa: ANN001
     assert env["MELTANO_LOADER_NAME"] == loader.name
     assert env["MELTANO_LOADER_NAMESPACE"] == loader.namespace
     assert env["MELTANO_LOADER_VARIANT"] == loader.variant
@@ -31,13 +31,13 @@ def assert_loader_env(loader, env):
     )
 
 
-def assert_transform_env(transform, env):
+def assert_transform_env(transform, env) -> None:  # noqa: ANN001
     assert env["MELTANO_TRANSFORM_NAME"] == transform.name
     assert env["MELTANO_TRANSFORM_NAMESPACE"] == transform.namespace
     assert env["MELTANO_TRANSFORM_VARIANT"] == Variant.ORIGINAL_NAME
 
 
-def assert_transformer_env(transformer, env):
+def assert_transformer_env(transformer, env) -> None:  # noqa: ANN001
     assert env["MELTANO_TRANSFORMER_NAME"] == transformer.name
     assert env["MELTANO_TRANSFORMER_NAMESPACE"] == transformer.namespace
     assert env["MELTANO_TRANSFORMER_VARIANT"] == "dbt-labs"
@@ -62,28 +62,28 @@ def assert_transformer_env(transformer, env):
 
 class TestELTContext:
     @pytest.fixture()
-    def target_postgres(self, project_add_service):
+    def target_postgres(self, project_add_service):  # noqa: ANN001, ANN201
         try:
             return project_add_service.add(PluginType.LOADERS, "target-postgres")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.fixture()
-    def tap_mock_transform(self, project_add_service):
+    def tap_mock_transform(self, project_add_service):  # noqa: ANN001, ANN201
         try:
             return project_add_service.add(PluginType.TRANSFORMS, "tap-mock-transform")
         except PluginAlreadyAddedException as err:
             return err.plugin
 
     @pytest.fixture()
-    def elt_context(
+    def elt_context(  # noqa: ANN201
         self,
-        elt_context_builder,
-        session,
-        tap,
-        target_postgres,
-        tap_mock_transform,
-        dbt,  # noqa: ARG002
+        elt_context_builder,  # noqa: ANN001
+        session,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target_postgres,  # noqa: ANN001
+        tap_mock_transform,  # noqa: ANN001
+        dbt,  # noqa: ANN001, ARG002
     ):
         return (
             elt_context_builder.with_session(session)
@@ -95,7 +95,7 @@ class TestELTContext:
         )
 
     @pytest.mark.asyncio()
-    async def test_extractor(self, elt_context, session, tap):
+    async def test_extractor(self, elt_context, session, tap) -> None:  # noqa: ANN001
         extractor = elt_context.extractor
         assert extractor.type == PluginType.EXTRACTORS
         assert extractor.name == tap.name
@@ -107,7 +107,7 @@ class TestELTContext:
         assert_extractor_env(extractor, env)
 
     @pytest.mark.asyncio()
-    async def test_loader(self, elt_context, session, target_postgres):
+    async def test_loader(self, elt_context, session, target_postgres) -> None:  # noqa: ANN001
         loader = elt_context.loader
         assert loader.type == PluginType.LOADERS
         assert loader.name == target_postgres.name
@@ -123,11 +123,11 @@ class TestELTContext:
     @pytest.mark.usefixtures("target_postgres")
     async def test_transformer(
         self,
-        elt_context,
-        session,
-        tap_mock_transform,
-        dbt,
-    ):
+        elt_context,  # noqa: ANN001
+        session,  # noqa: ANN001
+        tap_mock_transform,  # noqa: ANN001
+        dbt,  # noqa: ANN001
+    ) -> None:
         transformer = elt_context.transformer
         assert transformer.type == PluginType.TRANSFORMERS
         assert transformer.name == dbt.name
@@ -147,7 +147,7 @@ class TestELTContext:
         assert_transformer_env(transformer, env)
 
     @pytest.mark.asyncio()
-    async def test_select_filter(self, elt_context, session):
+    async def test_select_filter(self, elt_context, session) -> None:  # noqa: ANN001
         assert elt_context.select_filter
 
         invoker = elt_context.extractor_invoker()

--- a/tests/meltano/core/test_environment_service.py
+++ b/tests/meltano/core/test_environment_service.py
@@ -18,7 +18,7 @@ from meltano.core.utils import NotFound
 
 class TestEnvironmentService:
     @pytest.fixture()
-    def subject(self, environment_service):  # noqa: ANN001, ANN201
+    def subject(self, environment_service):
         return environment_service
 
     @pytest.fixture()

--- a/tests/meltano/core/test_environment_service.py
+++ b/tests/meltano/core/test_environment_service.py
@@ -18,7 +18,7 @@ from meltano.core.utils import NotFound
 
 class TestEnvironmentService:
     @pytest.fixture()
-    def subject(self, environment_service):
+    def subject(self, environment_service):  # noqa: ANN001, ANN201
         return environment_service
 
     @pytest.fixture()
@@ -26,7 +26,7 @@ class TestEnvironmentService:
         return environment_service.add("test-environment")
 
     @pytest.mark.order(0)
-    def test_add_environment(self, subject: EnvironmentService):
+    def test_add_environment(self, subject: EnvironmentService) -> None:
         count = 10
         environments = [Environment(f"environment_{idx}") for idx in range(count)]
         for environment in environments:
@@ -51,7 +51,7 @@ class TestEnvironmentService:
         self,
         subject: EnvironmentService,
         environment: Environment,
-    ):
+    ) -> None:
         assert subject.list_environments() == [environment]
         subject.remove(environment.name)
         assert not subject.list_environments()
@@ -66,7 +66,7 @@ class TestEnvironmentService:
     def test_list_environments(
         self,
         subject: EnvironmentService,
-    ):
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -77,6 +77,6 @@ class TestEnvironmentService:
     def test_add_name_contains_state_id_component_delimiter(
         self,
         subject: EnvironmentService,
-    ):
+    ) -> None:
         with pytest.raises(EnvironmentNameContainsStateIdDelimiterError):
             subject.add(f"test{STATE_ID_COMPONENT_DELIMITER}")

--- a/tests/meltano/core/test_environment_variables.py
+++ b/tests/meltano/core/test_environment_variables.py
@@ -19,6 +19,7 @@ class EnvVarResolutionExpectation(t.NamedTuple):
 
 
 def _meltanofile_update_dict(
+    *,
     top_level_plugin_setting=True,
     top_level_plugin_config=False,
     top_level_env=False,
@@ -348,7 +349,7 @@ def test_environment_variable_inheritance_meltano_env_only(
 def test_strict_env_var_mode_raises_full_replace(cli_runner, project):
     project.settings.set(
         [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
-        True,
+        value=True,
     )
     with project.meltano_update() as meltanofile:
         meltanofile.update(_meltanofile_update_dict())
@@ -373,7 +374,7 @@ def test_strict_env_var_mode_raises_full_replace(cli_runner, project):
 def test_strict_env_var_mode_raises_partial_replace(cli_runner, project):
     project.settings.set(
         [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
-        True,
+        value=True,
     )
     with project.meltano_update() as meltanofile:
         meltanofile.update(_meltanofile_update_dict())

--- a/tests/meltano/core/test_environment_variables.py
+++ b/tests/meltano/core/test_environment_variables.py
@@ -18,16 +18,16 @@ class EnvVarResolutionExpectation(t.NamedTuple):
     terminal_env: t.ClassVar[dict] = {}
 
 
-def _meltanofile_update_dict(
+def _meltanofile_update_dict(  # noqa: ANN202
     *,
-    top_level_plugin_setting=True,
-    top_level_plugin_config=False,
-    top_level_env=False,
-    top_level_plugin_env=False,
-    environment_level_env=False,
-    environment_level_plugin_env=False,
-    environment_level_plugin_config=False,
-    environment_level_plugin_config_indirected=False,
+    top_level_plugin_setting=True,  # noqa: ANN001
+    top_level_plugin_config=False,  # noqa: ANN001
+    top_level_env=False,  # noqa: ANN001
+    top_level_plugin_env=False,  # noqa: ANN001
+    environment_level_env=False,  # noqa: ANN001
+    environment_level_plugin_env=False,  # noqa: ANN001
+    environment_level_plugin_config=False,  # noqa: ANN001
+    environment_level_plugin_config_indirected=False,  # noqa: ANN001
 ):
     plugin_name = "test-env-var-resolution"
     plugin_namespace = plugin_name.replace("-", "_")
@@ -227,12 +227,12 @@ class TestEnvVarResolution:
     @pytest.mark.usefixtures("cli_runner")
     def test_env_var_resolution(
         self,
-        expected_env_values,
-        meltanofile_updates,
-        terminal_env,
-        project,
-        monkeypatch,
-    ):
+        expected_env_values,  # noqa: ANN001
+        meltanofile_updates,  # noqa: ANN001
+        terminal_env,  # noqa: ANN001
+        project,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -260,7 +260,7 @@ class TestEnvVarResolution:
         ]
 
 
-def test_environment_variable_inheritance(cli_runner, project, monkeypatch):
+def test_environment_variable_inheritance(cli_runner, project, monkeypatch) -> None:  # noqa: ANN001
     monkeypatch.setenv("STACKED", "1")
     with project.meltano_update() as meltanofile:
         meltanofile.update(
@@ -308,10 +308,10 @@ def test_environment_variable_inheritance(cli_runner, project, monkeypatch):
 
 
 def test_environment_variable_inheritance_meltano_env_only(
-    cli_runner,
-    project,
-    monkeypatch,
-):
+    cli_runner,  # noqa: ANN001
+    project,  # noqa: ANN001
+    monkeypatch,  # noqa: ANN001
+) -> None:
     monkeypatch.setenv("STACKED", "1")
     with project.meltano_update() as meltanofile:
         meltanofile.update(
@@ -346,7 +346,7 @@ def test_environment_variable_inheritance_meltano_env_only(
     assert result.stdout.strip() == "STACKED=12"
 
 
-def test_strict_env_var_mode_raises_full_replace(cli_runner, project):
+def test_strict_env_var_mode_raises_full_replace(cli_runner, project) -> None:  # noqa: ANN001
     project.settings.set(
         [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
         value=True,
@@ -371,7 +371,7 @@ def test_strict_env_var_mode_raises_full_replace(cli_runner, project):
     assert result.exception.instruction == "Make sure the environment variable is set"
 
 
-def test_strict_env_var_mode_raises_partial_replace(cli_runner, project):
+def test_strict_env_var_mode_raises_partial_replace(cli_runner, project) -> None:  # noqa: ANN001
     project.settings.set(
         [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
         value=True,

--- a/tests/meltano/core/test_environment_variables.py
+++ b/tests/meltano/core/test_environment_variables.py
@@ -18,16 +18,16 @@ class EnvVarResolutionExpectation(t.NamedTuple):
     terminal_env: t.ClassVar[dict] = {}
 
 
-def _meltanofile_update_dict(  # noqa: ANN202
+def _meltanofile_update_dict(
     *,
-    top_level_plugin_setting=True,  # noqa: ANN001
-    top_level_plugin_config=False,  # noqa: ANN001
-    top_level_env=False,  # noqa: ANN001
-    top_level_plugin_env=False,  # noqa: ANN001
-    environment_level_env=False,  # noqa: ANN001
-    environment_level_plugin_env=False,  # noqa: ANN001
-    environment_level_plugin_config=False,  # noqa: ANN001
-    environment_level_plugin_config_indirected=False,  # noqa: ANN001
+    top_level_plugin_setting=True,
+    top_level_plugin_config=False,
+    top_level_env=False,
+    top_level_plugin_env=False,
+    environment_level_env=False,
+    environment_level_plugin_env=False,
+    environment_level_plugin_config=False,
+    environment_level_plugin_config_indirected=False,
 ):
     plugin_name = "test-env-var-resolution"
     plugin_namespace = plugin_name.replace("-", "_")
@@ -227,11 +227,11 @@ class TestEnvVarResolution:
     @pytest.mark.usefixtures("cli_runner")
     def test_env_var_resolution(
         self,
-        expected_env_values,  # noqa: ANN001
-        meltanofile_updates,  # noqa: ANN001
-        terminal_env,  # noqa: ANN001
-        project,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        expected_env_values,
+        meltanofile_updates,
+        terminal_env,
+        project,
+        monkeypatch,
     ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
@@ -260,7 +260,7 @@ class TestEnvVarResolution:
         ]
 
 
-def test_environment_variable_inheritance(cli_runner, project, monkeypatch) -> None:  # noqa: ANN001
+def test_environment_variable_inheritance(cli_runner, project, monkeypatch) -> None:
     monkeypatch.setenv("STACKED", "1")
     with project.meltano_update() as meltanofile:
         meltanofile.update(
@@ -308,9 +308,9 @@ def test_environment_variable_inheritance(cli_runner, project, monkeypatch) -> N
 
 
 def test_environment_variable_inheritance_meltano_env_only(
-    cli_runner,  # noqa: ANN001
-    project,  # noqa: ANN001
-    monkeypatch,  # noqa: ANN001
+    cli_runner,
+    project,
+    monkeypatch,
 ) -> None:
     monkeypatch.setenv("STACKED", "1")
     with project.meltano_update() as meltanofile:
@@ -346,7 +346,7 @@ def test_environment_variable_inheritance_meltano_env_only(
     assert result.stdout.strip() == "STACKED=12"
 
 
-def test_strict_env_var_mode_raises_full_replace(cli_runner, project) -> None:  # noqa: ANN001
+def test_strict_env_var_mode_raises_full_replace(cli_runner, project) -> None:
     project.settings.set(
         [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
         value=True,
@@ -371,7 +371,7 @@ def test_strict_env_var_mode_raises_full_replace(cli_runner, project) -> None:  
     assert result.exception.instruction == "Make sure the environment variable is set"
 
 
-def test_strict_env_var_mode_raises_partial_replace(cli_runner, project) -> None:  # noqa: ANN001
+def test_strict_env_var_mode_raises_partial_replace(cli_runner, project) -> None:
     project.settings.set(
         [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
         value=True,

--- a/tests/meltano/core/test_locked_definition_service.py
+++ b/tests/meltano/core/test_locked_definition_service.py
@@ -13,13 +13,13 @@ HTTP_STATUS_TEAPOT = 418
 
 
 @pytest.fixture()
-def subject(project):  # noqa: ANN001, ANN201
+def subject(project):
     return LockedDefinitionService(project)
 
 
 class TestLockedDefinitionService:
     @pytest.fixture()
-    def locked_plugin(self, subject: LockedDefinitionService):  # noqa: ANN201
+    def locked_plugin(self, subject: LockedDefinitionService):
         """Locked plugin definition.
 
         Yields:

--- a/tests/meltano/core/test_locked_definition_service.py
+++ b/tests/meltano/core/test_locked_definition_service.py
@@ -13,13 +13,13 @@ HTTP_STATUS_TEAPOT = 418
 
 
 @pytest.fixture()
-def subject(project):
+def subject(project):  # noqa: ANN001, ANN201
     return LockedDefinitionService(project)
 
 
 class TestLockedDefinitionService:
     @pytest.fixture()
-    def locked_plugin(self, subject: LockedDefinitionService):
+    def locked_plugin(self, subject: LockedDefinitionService):  # noqa: ANN201
         """Locked plugin definition.
 
         Yields:
@@ -44,7 +44,7 @@ class TestLockedDefinitionService:
         path.unlink()
 
     @pytest.mark.usefixtures("locked_plugin")
-    def test_definition(self, subject: LockedDefinitionService):
+    def test_definition(self, subject: LockedDefinitionService) -> None:
         with pytest.raises(PluginNotFoundError):
             subject.find_definition(PluginType.EXTRACTORS, "unknown")
 
@@ -60,7 +60,7 @@ class TestLockedDefinitionService:
         assert len(plugin_def.variants) == 1
 
     @pytest.mark.usefixtures("locked_plugin")
-    def test_find_base_plugin(self, subject: LockedDefinitionService):
+    def test_find_base_plugin(self, subject: LockedDefinitionService) -> None:
         base_plugin = subject.find_base_plugin(
             PluginType.EXTRACTORS,
             "tap-locked",

--- a/tests/meltano/core/test_meltano_file.py
+++ b/tests/meltano/core/test_meltano_file.py
@@ -7,12 +7,12 @@ from meltano.core.meltano_file import MeltanoFile
 
 class TestMeltanoFile:
     @pytest.mark.usefixtures("tap", "target")
-    def test_load(self, project) -> None:  # noqa: ANN001
+    def test_load(self, project) -> None:
         meltano_file = MeltanoFile.parse(project.meltano)
         assert meltano_file
 
     @pytest.mark.usefixtures("mapper")
-    def test_get_plugins_for_mappings(self, project) -> None:  # noqa: ANN001
+    def test_get_plugins_for_mappings(self, project) -> None:
         meltano_file = MeltanoFile.parse(project.meltano)
 
         test_config = {

--- a/tests/meltano/core/test_meltano_file.py
+++ b/tests/meltano/core/test_meltano_file.py
@@ -7,12 +7,12 @@ from meltano.core.meltano_file import MeltanoFile
 
 class TestMeltanoFile:
     @pytest.mark.usefixtures("tap", "target")
-    def test_load(self, project):
+    def test_load(self, project) -> None:  # noqa: ANN001
         meltano_file = MeltanoFile.parse(project.meltano)
         assert meltano_file
 
     @pytest.mark.usefixtures("mapper")
-    def test_get_plugins_for_mappings(self, project):
+    def test_get_plugins_for_mappings(self, project) -> None:  # noqa: ANN001
         meltano_file = MeltanoFile.parse(project.meltano)
 
         test_config = {

--- a/tests/meltano/core/test_meltano_invoker.py
+++ b/tests/meltano/core/test_meltano_invoker.py
@@ -20,10 +20,10 @@ if t.TYPE_CHECKING:
 
 class TestMeltanoInvoker:
     @pytest.fixture()
-    def subject(self, project):
+    def subject(self, project):  # noqa: ANN001, ANN201
         return MeltanoInvoker(project)
 
-    def test_invoke(self, subject: MeltanoInvoker):
+    def test_invoke(self, subject: MeltanoInvoker) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -32,7 +32,11 @@ class TestMeltanoInvoker:
         assert process.returncode == 0
         assert meltano.__version__ in str(process.stdout)
 
-    def test_env(self, subject: MeltanoInvoker, monkeypatch: pytest.MonkeyPatch):
+    def test_env(
+        self,
+        subject: MeltanoInvoker,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         # Process env vars are injected
         monkeypatch.setenv("ENV_VAR_KEY", "ENV_VAR_VALUE_1")
         assert subject._executable_env()["ENV_VAR_KEY"] == "ENV_VAR_VALUE_1"
@@ -47,7 +51,7 @@ class TestMeltanoInvoker:
             == environment_context.data["context_uuid"]
         )
 
-    def test_invoke_executable(self, subject: MeltanoInvoker, project: Project):
+    def test_invoke_executable(self, subject: MeltanoInvoker, project: Project) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",

--- a/tests/meltano/core/test_meltano_invoker.py
+++ b/tests/meltano/core/test_meltano_invoker.py
@@ -20,7 +20,7 @@ if t.TYPE_CHECKING:
 
 class TestMeltanoInvoker:
     @pytest.fixture()
-    def subject(self, project):  # noqa: ANN001, ANN201
+    def subject(self, project):
         return MeltanoInvoker(project)
 
     def test_invoke(self, subject: MeltanoInvoker) -> None:

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -21,7 +21,7 @@ class TestPluginInstallService:
         params=({}, {"parallelism": -1}, {"parallelism": 2}),
         ids=("default", "-p=-1", "-p=2"),
     )
-    def subject(self, project: Project, request):  # noqa: ANN001, ANN201
+    def subject(self, project: Project, request):
         with open(project.meltanofile, "w") as file:
             file.write(
                 yaml.dump(
@@ -52,10 +52,10 @@ class TestPluginInstallService:
         project.refresh()
         return PluginInstallService(project, **request.param)
 
-    def test_default_init_should_not_fail(self, subject) -> None:  # noqa: ANN001
+    def test_default_init_should_not_fail(self, subject) -> None:
         assert subject
 
-    def test_remove_duplicates(self, subject) -> None:  # noqa: ANN001
+    def test_remove_duplicates(self, subject) -> None:
         states, deduped_plugins = subject.remove_duplicates(
             plugins=subject.project.plugins.plugins(),
             reason=PluginInstallReason.INSTALL,
@@ -72,7 +72,7 @@ class TestPluginInstallService:
         ]
 
     @pytest.mark.slow()
-    async def test_install_all(self, subject) -> None:  # noqa: ANN001
+    async def test_install_all(self, subject) -> None:
         all_plugins = await subject.install_all_plugins()
         assert len(all_plugins) == 3
 
@@ -91,7 +91,7 @@ class TestPluginInstallService:
         assert all_plugins[0].plugin.venv_name == all_plugins[1].plugin.venv_name
         assert all_plugins[0].plugin.executable == all_plugins[1].plugin.executable
 
-    def test_get_quoted_pip_install_args(self, project) -> None:  # noqa: ANN001
+    def test_get_quoted_pip_install_args(self, project) -> None:
         with open(project.meltanofile, "w") as file:
             file.write(
                 yaml.dump(

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -21,7 +21,7 @@ class TestPluginInstallService:
         params=({}, {"parallelism": -1}, {"parallelism": 2}),
         ids=("default", "-p=-1", "-p=2"),
     )
-    def subject(self, project: Project, request):
+    def subject(self, project: Project, request):  # noqa: ANN001, ANN201
         with open(project.meltanofile, "w") as file:
             file.write(
                 yaml.dump(
@@ -52,10 +52,10 @@ class TestPluginInstallService:
         project.refresh()
         return PluginInstallService(project, **request.param)
 
-    def test_default_init_should_not_fail(self, subject):
+    def test_default_init_should_not_fail(self, subject) -> None:  # noqa: ANN001
         assert subject
 
-    def test_remove_duplicates(self, subject):
+    def test_remove_duplicates(self, subject) -> None:  # noqa: ANN001
         states, deduped_plugins = subject.remove_duplicates(
             plugins=subject.project.plugins.plugins(),
             reason=PluginInstallReason.INSTALL,
@@ -72,7 +72,7 @@ class TestPluginInstallService:
         ]
 
     @pytest.mark.slow()
-    async def test_install_all(self, subject):
+    async def test_install_all(self, subject) -> None:  # noqa: ANN001
         all_plugins = await subject.install_all_plugins()
         assert len(all_plugins) == 3
 
@@ -91,7 +91,7 @@ class TestPluginInstallService:
         assert all_plugins[0].plugin.venv_name == all_plugins[1].plugin.venv_name
         assert all_plugins[0].plugin.executable == all_plugins[1].plugin.executable
 
-    def test_get_quoted_pip_install_args(self, project):
+    def test_get_quoted_pip_install_args(self, project) -> None:  # noqa: ANN001
         with open(project.meltanofile, "w") as file:
             file.write(
                 yaml.dump(
@@ -121,7 +121,7 @@ class TestPluginInstallService:
         self,
         project: Project,
         subject: PluginInstallService,
-    ):
+    ) -> None:
         plugin = next(project.plugins.plugins())
         state = await subject.install_plugin_async(
             plugin,

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -13,19 +13,19 @@ from meltano.core.venv_service import VirtualEnv
 
 class TestPluginInvoker:
     @pytest.fixture()
-    async def plugin_invoker(self, utility, session, plugin_invoker_factory):
+    async def plugin_invoker(self, utility, session, plugin_invoker_factory):  # noqa: ANN001, ANN201
         subject = plugin_invoker_factory(utility)
         async with subject.prepared(session):
             yield subject
 
     @pytest.fixture()
-    async def nonpip_plugin_invoker(self, nonpip_tap, session, plugin_invoker_factory):
+    async def nonpip_plugin_invoker(self, nonpip_tap, session, plugin_invoker_factory):  # noqa: ANN001, ANN201
         subject = plugin_invoker_factory(nonpip_tap)
         async with subject.prepared(session):
             yield subject
 
     @pytest.mark.asyncio()
-    async def test_env(self, project, tap, session, plugin_invoker_factory):
+    async def test_env(self, project, tap, session, plugin_invoker_factory) -> None:  # noqa: ANN001
         project.dotenv.touch()
         dotenv.set_key(project.dotenv, "DUMMY_ENV_VAR", "from_dotenv")
         dotenv.set_key(project.dotenv, "TAP_MOCK_TEST", "from_dotenv")
@@ -66,11 +66,11 @@ class TestPluginInvoker:
     @pytest.mark.asyncio()
     async def test_environment_env(
         self,
-        project_with_environment,
-        tap,
-        session,
-        plugin_invoker_factory,
-    ):
+        project_with_environment,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+    ) -> None:
         subject = plugin_invoker_factory(tap)
         async with subject.prepared(session):
             env = subject.env()
@@ -81,11 +81,11 @@ class TestPluginInvoker:
     @pytest.mark.asyncio()
     async def test_expanded_environment_env(
         self,
-        project_with_environment,
-        tap,
-        session,
-        plugin_invoker_factory,
-    ):
+        project_with_environment,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        session,  # noqa: ANN001
+        plugin_invoker_factory,  # noqa: ANN001
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -99,14 +99,14 @@ class TestPluginInvoker:
         )
 
     @pytest.mark.asyncio()
-    async def test_unknown_command(self, plugin_invoker):
+    async def test_unknown_command(self, plugin_invoker) -> None:  # noqa: ANN001
         with pytest.raises(UnknownCommandError) as err:
             await plugin_invoker.invoke_async(command="foo")
 
         assert err.value.command == "foo"
         assert "supports the following commands" in str(err.value)
 
-    def test_expand_exec_args(self, plugin_invoker):
+    def test_expand_exec_args(self, plugin_invoker) -> None:  # noqa: ANN001
         exec_args = plugin_invoker.exec_args(
             "extra",
             "args",
@@ -119,7 +119,7 @@ class TestPluginInvoker:
         assert exec_args[0].endswith("utility-mock")
         assert exec_args[1:] == ["--option", "env-var-arg", "extra", "args"]
 
-    def test_expand_command_exec_args(self, plugin_invoker):
+    def test_expand_command_exec_args(self, plugin_invoker) -> None:  # noqa: ANN001
         exec_args = plugin_invoker.exec_args(
             "extra",
             "args",
@@ -133,7 +133,7 @@ class TestPluginInvoker:
         assert exec_args[1:] == ["--option", "env-var-arg", "extra", "args"]
 
     @pytest.mark.asyncio()
-    async def test_undefined_env_var(self, plugin_invoker):
+    async def test_undefined_env_var(self, plugin_invoker) -> None:  # noqa: ANN001
         with pytest.raises(UndefinedEnvVarError) as err:
             await plugin_invoker.invoke_async(command="cmd")
 
@@ -142,7 +142,7 @@ class TestPluginInvoker:
             "variable '$ENV_VAR_ARG' in an argument"
         ) in str(err.value)
 
-    def test_alternate_command_executable(self, plugin_invoker):
+    def test_alternate_command_executable(self, plugin_invoker) -> None:  # noqa: ANN001
         exec_args = plugin_invoker.exec_args(
             "extra",
             "args",
@@ -166,11 +166,11 @@ class TestPluginInvoker:
     @pytest.mark.asyncio()
     async def test_expand_nonpip_command_exec_args(
         self,
-        nonpip_plugin_invoker,
-        session,
-        executable_str,
-        assert_fn,
-    ):
+        nonpip_plugin_invoker,  # noqa: ANN001
+        session,  # noqa: ANN001
+        executable_str,  # noqa: ANN001
+        assert_fn,  # noqa: ANN001
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -13,19 +13,19 @@ from meltano.core.venv_service import VirtualEnv
 
 class TestPluginInvoker:
     @pytest.fixture()
-    async def plugin_invoker(self, utility, session, plugin_invoker_factory):  # noqa: ANN001, ANN201
+    async def plugin_invoker(self, utility, session, plugin_invoker_factory):
         subject = plugin_invoker_factory(utility)
         async with subject.prepared(session):
             yield subject
 
     @pytest.fixture()
-    async def nonpip_plugin_invoker(self, nonpip_tap, session, plugin_invoker_factory):  # noqa: ANN001, ANN201
+    async def nonpip_plugin_invoker(self, nonpip_tap, session, plugin_invoker_factory):
         subject = plugin_invoker_factory(nonpip_tap)
         async with subject.prepared(session):
             yield subject
 
     @pytest.mark.asyncio()
-    async def test_env(self, project, tap, session, plugin_invoker_factory) -> None:  # noqa: ANN001
+    async def test_env(self, project, tap, session, plugin_invoker_factory) -> None:
         project.dotenv.touch()
         dotenv.set_key(project.dotenv, "DUMMY_ENV_VAR", "from_dotenv")
         dotenv.set_key(project.dotenv, "TAP_MOCK_TEST", "from_dotenv")
@@ -66,10 +66,10 @@ class TestPluginInvoker:
     @pytest.mark.asyncio()
     async def test_environment_env(
         self,
-        project_with_environment,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
+        project_with_environment,
+        tap,
+        session,
+        plugin_invoker_factory,
     ) -> None:
         subject = plugin_invoker_factory(tap)
         async with subject.prepared(session):
@@ -81,10 +81,10 @@ class TestPluginInvoker:
     @pytest.mark.asyncio()
     async def test_expanded_environment_env(
         self,
-        project_with_environment,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        session,  # noqa: ANN001
-        plugin_invoker_factory,  # noqa: ANN001
+        project_with_environment,
+        tap,
+        session,
+        plugin_invoker_factory,
     ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
@@ -99,14 +99,14 @@ class TestPluginInvoker:
         )
 
     @pytest.mark.asyncio()
-    async def test_unknown_command(self, plugin_invoker) -> None:  # noqa: ANN001
+    async def test_unknown_command(self, plugin_invoker) -> None:
         with pytest.raises(UnknownCommandError) as err:
             await plugin_invoker.invoke_async(command="foo")
 
         assert err.value.command == "foo"
         assert "supports the following commands" in str(err.value)
 
-    def test_expand_exec_args(self, plugin_invoker) -> None:  # noqa: ANN001
+    def test_expand_exec_args(self, plugin_invoker) -> None:
         exec_args = plugin_invoker.exec_args(
             "extra",
             "args",
@@ -119,7 +119,7 @@ class TestPluginInvoker:
         assert exec_args[0].endswith("utility-mock")
         assert exec_args[1:] == ["--option", "env-var-arg", "extra", "args"]
 
-    def test_expand_command_exec_args(self, plugin_invoker) -> None:  # noqa: ANN001
+    def test_expand_command_exec_args(self, plugin_invoker) -> None:
         exec_args = plugin_invoker.exec_args(
             "extra",
             "args",
@@ -133,7 +133,7 @@ class TestPluginInvoker:
         assert exec_args[1:] == ["--option", "env-var-arg", "extra", "args"]
 
     @pytest.mark.asyncio()
-    async def test_undefined_env_var(self, plugin_invoker) -> None:  # noqa: ANN001
+    async def test_undefined_env_var(self, plugin_invoker) -> None:
         with pytest.raises(UndefinedEnvVarError) as err:
             await plugin_invoker.invoke_async(command="cmd")
 
@@ -142,7 +142,7 @@ class TestPluginInvoker:
             "variable '$ENV_VAR_ARG' in an argument"
         ) in str(err.value)
 
-    def test_alternate_command_executable(self, plugin_invoker) -> None:  # noqa: ANN001
+    def test_alternate_command_executable(self, plugin_invoker) -> None:
         exec_args = plugin_invoker.exec_args(
             "extra",
             "args",
@@ -166,10 +166,10 @@ class TestPluginInvoker:
     @pytest.mark.asyncio()
     async def test_expand_nonpip_command_exec_args(
         self,
-        nonpip_plugin_invoker,  # noqa: ANN001
-        session,  # noqa: ANN001
-        executable_str,  # noqa: ANN001
-        assert_fn,  # noqa: ANN001
+        nonpip_plugin_invoker,
+        session,
+        executable_str,
+        assert_fn,
     ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(

--- a/tests/meltano/core/test_plugin_lock_service.py
+++ b/tests/meltano/core/test_plugin_lock_service.py
@@ -18,7 +18,7 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture()
-def plugin():
+def plugin():  # noqa: ANN201
     plugin_definition = PluginDefinition(
         PluginType.EXTRACTORS,
         name="tap-locked",
@@ -61,10 +61,10 @@ def plugin():
 
 class TestPluginLock:
     @pytest.fixture()
-    def subject(self, project: Project, plugin: ProjectPlugin):
+    def subject(self, project: Project, plugin: ProjectPlugin):  # noqa: ANN201
         return PluginLock(project, plugin)
 
-    def test_path(self, subject: PluginLock):
+    def test_path(self, subject: PluginLock) -> None:
         assert subject.path.parts[-3:] == (
             "plugins",
             "extractors",
@@ -72,12 +72,12 @@ class TestPluginLock:
         )
 
     @pytest.mark.order(before="test_load")
-    def test_save(self, subject: PluginLock):
+    def test_save(self, subject: PluginLock) -> None:
         assert not subject.path.exists()
         subject.save()
         assert subject.path.exists()
 
-    def test_load(self, subject: PluginLock, plugin: ProjectPlugin):
+    def test_load(self, subject: PluginLock, plugin: ProjectPlugin) -> None:
         subject.save()
         loaded = subject.load()
         assert loaded.name == plugin.inherit_from
@@ -87,7 +87,7 @@ class TestPluginLock:
 
 class TestPluginLockService:
     @pytest.fixture()
-    def subject(self, project: Project):
+    def subject(self, project: Project):  # noqa: ANN201
         return PluginLockService(project)
 
     def test_save(
@@ -95,7 +95,7 @@ class TestPluginLockService:
         subject: PluginLockService,
         project: Project,
         plugin: ProjectPlugin,
-    ):
+    ) -> None:
         plugin_lock = PluginLock(project, plugin)
         assert not plugin_lock.path.exists()
 

--- a/tests/meltano/core/test_plugin_lock_service.py
+++ b/tests/meltano/core/test_plugin_lock_service.py
@@ -18,7 +18,7 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture()
-def plugin():  # noqa: ANN201
+def plugin():
     plugin_definition = PluginDefinition(
         PluginType.EXTRACTORS,
         name="tap-locked",
@@ -61,7 +61,7 @@ def plugin():  # noqa: ANN201
 
 class TestPluginLock:
     @pytest.fixture()
-    def subject(self, project: Project, plugin: ProjectPlugin):  # noqa: ANN201
+    def subject(self, project: Project, plugin: ProjectPlugin):
         return PluginLock(project, plugin)
 
     def test_path(self, subject: PluginLock) -> None:
@@ -87,7 +87,7 @@ class TestPluginLock:
 
 class TestPluginLockService:
     @pytest.fixture()
-    def subject(self, project: Project):  # noqa: ANN201
+    def subject(self, project: Project):
         return PluginLockService(project)
 
     def test_save(

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import os
+from typing import NoReturn  # noqa: ICN003
 
 import mock
 import pytest
@@ -13,11 +14,11 @@ from meltano.core.plugin_remove_service import PluginRemoveService
 
 class TestPluginRemoveService:
     @pytest.fixture()
-    def subject(self, project):
+    def subject(self, project):  # noqa: ANN001, ANN201
         return PluginRemoveService(project)
 
     @pytest.fixture()
-    def add(self, subject: PluginRemoveService):
+    def add(self, subject: PluginRemoveService) -> None:
         with open(subject.project.meltanofile, "w") as meltano_yml:
             meltano_yml.write(
                 yaml.dump(
@@ -41,7 +42,7 @@ class TestPluginRemoveService:
             )
 
     @pytest.fixture()
-    def install(self, subject: PluginRemoveService):
+    def install(self, subject: PluginRemoveService) -> None:
         tap_gitlab_installation = subject.project.meltano_dir().joinpath(
             "extractors",
             "tap-gitlab",
@@ -54,7 +55,7 @@ class TestPluginRemoveService:
         os.makedirs(target_csv_installation, exist_ok=True)
 
     @pytest.fixture()
-    def lock(self, subject: PluginRemoveService):
+    def lock(self, subject: PluginRemoveService) -> None:
         tap_gitlab_lockfile = subject.project.plugin_lock_path(
             "extractors",
             "tap-gitlab",
@@ -68,11 +69,11 @@ class TestPluginRemoveService:
         tap_gitlab_lockfile.touch()
         target_csv_lockfile.touch()
 
-    def test_default_init_should_not_fail(self, subject):
+    def test_default_init_should_not_fail(self, subject) -> None:  # noqa: ANN001
         assert subject
 
     @pytest.mark.usefixtures("add", "install", "lock")
-    def test_remove(self, subject: PluginRemoveService):
+    def test_remove(self, subject: PluginRemoveService) -> None:
         plugins = list(subject.project.plugins.plugins())
         removed_plugins, total_plugins = subject.remove_plugins(plugins)
 
@@ -99,14 +100,14 @@ class TestPluginRemoveService:
             )
             assert all(not path.exists() for path in lock_file_paths)
 
-    def test_remove_not_added_or_installed(self, subject: PluginRemoveService):
+    def test_remove_not_added_or_installed(self, subject: PluginRemoveService) -> None:
         plugins = list(subject.project.plugins.plugins())
         removed_plugins, total_plugins = subject.remove_plugins(plugins)
 
         assert removed_plugins == 0
 
     @pytest.mark.usefixtures("add", "install", "lock")
-    def test_remove_db_error(self, subject: PluginRemoveService):
+    def test_remove_db_error(self, subject: PluginRemoveService) -> None:
         plugins = list(subject.project.plugins.plugins())
 
         with mock.patch(
@@ -122,8 +123,8 @@ class TestPluginRemoveService:
         assert removed_plugins == 0
 
     @pytest.mark.usefixtures("add", "install", "lock")
-    def test_remove_meltano_yml_error(self, subject: PluginRemoveService):
-        def raise_permissionerror(filename):
+    def test_remove_meltano_yml_error(self, subject: PluginRemoveService) -> None:
+        def raise_permissionerror(filename) -> NoReturn:  # noqa: ANN001
             raise OSError(errno.EACCES, os.strerror(errno.ENOENT), filename)
 
         plugins = list(subject.project.plugins.plugins())
@@ -137,8 +138,8 @@ class TestPluginRemoveService:
         assert removed_plugins == 0
 
     @pytest.mark.usefixtures("add", "install", "lock")
-    def test_remove_installation_error(self, subject: PluginRemoveService):
-        def raise_permissionerror(filename):
+    def test_remove_installation_error(self, subject: PluginRemoveService) -> None:
+        def raise_permissionerror(filename) -> NoReturn:  # noqa: ANN001
             raise OSError(errno.EACCES, os.strerror(errno.ENOENT), filename)
 
         plugins = list(subject.project.plugins.plugins())
@@ -150,7 +151,7 @@ class TestPluginRemoveService:
         assert removed_plugins == 0
 
     @pytest.mark.usefixtures("add", "install")
-    def test_remove_lockfile_not_found(self, subject: PluginRemoveService):
+    def test_remove_lockfile_not_found(self, subject: PluginRemoveService) -> None:
         plugins = list(subject.project.plugins.plugins())
         removed_plugins, _ = subject.remove_plugins(plugins)
 

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -14,7 +14,7 @@ from meltano.core.plugin_remove_service import PluginRemoveService
 
 class TestPluginRemoveService:
     @pytest.fixture()
-    def subject(self, project):  # noqa: ANN001, ANN201
+    def subject(self, project):
         return PluginRemoveService(project)
 
     @pytest.fixture()
@@ -69,7 +69,7 @@ class TestPluginRemoveService:
         tap_gitlab_lockfile.touch()
         target_csv_lockfile.touch()
 
-    def test_default_init_should_not_fail(self, subject) -> None:  # noqa: ANN001
+    def test_default_init_should_not_fail(self, subject) -> None:
         assert subject
 
     @pytest.mark.usefixtures("add", "install", "lock")
@@ -124,7 +124,7 @@ class TestPluginRemoveService:
 
     @pytest.mark.usefixtures("add", "install", "lock")
     def test_remove_meltano_yml_error(self, subject: PluginRemoveService) -> None:
-        def raise_permissionerror(filename) -> NoReturn:  # noqa: ANN001
+        def raise_permissionerror(filename) -> NoReturn:
             raise OSError(errno.EACCES, os.strerror(errno.ENOENT), filename)
 
         plugins = list(subject.project.plugins.plugins())
@@ -139,7 +139,7 @@ class TestPluginRemoveService:
 
     @pytest.mark.usefixtures("add", "install", "lock")
     def test_remove_installation_error(self, subject: PluginRemoveService) -> None:
-        def raise_permissionerror(filename) -> NoReturn:  # noqa: ANN001
+        def raise_permissionerror(filename) -> NoReturn:
             raise OSError(errno.EACCES, os.strerror(errno.ENOENT), filename)
 
         plugins = list(subject.project.plugins.plugins())

--- a/tests/meltano/core/test_plugin_test_service.py
+++ b/tests/meltano/core/test_plugin_test_service.py
@@ -23,16 +23,16 @@ MOCK_RECORD_MESSAGE = json.dumps({"type": "RECORD"})
 class TestPluginTestServiceFactory:
     @pytest.fixture(autouse=True)
     @patch("meltano.core.plugin_invoker.PluginInvoker")
-    def setup(self, mock_invoker):
+    def setup(self, mock_invoker) -> None:  # noqa: ANN001
         self.mock_invoker = mock_invoker
 
-    def test_extractor_plugin(self, tap: ProjectPlugin):
+    def test_extractor_plugin(self, tap: ProjectPlugin) -> None:
         self.mock_invoker.plugin = tap
 
         test_service = PluginTestServiceFactory(self.mock_invoker).get_test_service()
         assert isinstance(test_service, ExtractorTestService)
 
-    def test_loader_plugin(self, target: ProjectPlugin):
+    def test_loader_plugin(self, target: ProjectPlugin) -> None:
         self.mock_invoker.plugin = target
 
         with pytest.raises(
@@ -47,7 +47,7 @@ class TestPluginTestServiceFactory:
 class TestExtractorTestService:
     @pytest.fixture(autouse=True)
     @patch("meltano.core.plugin_invoker.PluginInvoker")
-    def setup(self, mock_invoker):
+    def setup(self, mock_invoker) -> None:  # noqa: ANN001
         self.mock_invoke = Mock()
         self.mock_invoke.name = "utility-mock"
         self.mock_invoke.wait = AsyncMock(return_value=-SIGTERM)
@@ -56,7 +56,7 @@ class TestExtractorTestService:
         self.mock_invoker.invoke_async = AsyncMock(return_value=self.mock_invoke)
 
     @pytest.mark.asyncio()
-    async def test_validate_success(self):
+    async def test_validate_success(self) -> None:
         self.mock_invoke.stderr.at_eof.side_effect = True
         self.mock_invoke.stdout.at_eof.side_effect = (False, True)
         self.mock_invoke.stdout.readline = AsyncMock(
@@ -69,7 +69,7 @@ class TestExtractorTestService:
         assert detail == MOCK_RECORD_MESSAGE
 
     @pytest.mark.asyncio()
-    async def test_validate_success_ignore_non_json(self):
+    async def test_validate_success_ignore_non_json(self) -> None:
         self.mock_invoke.stderr.at_eof.side_effect = True
         self.mock_invoke.stdout.at_eof.side_effect = (False, False, True)
         self.mock_invoke.stdout.readline = AsyncMock(
@@ -82,7 +82,7 @@ class TestExtractorTestService:
         assert detail == MOCK_RECORD_MESSAGE
 
     @pytest.mark.asyncio()
-    async def test_validate_success_ignore_non_record_msg(self):
+    async def test_validate_success_ignore_non_record_msg(self) -> None:
         self.mock_invoke.stderr.at_eof.side_effect = True
         self.mock_invoke.stdout.at_eof.side_effect = (False, False, True)
         self.mock_invoke.stdout.readline = AsyncMock(
@@ -98,7 +98,7 @@ class TestExtractorTestService:
         assert detail == MOCK_RECORD_MESSAGE
 
     @pytest.mark.asyncio()
-    async def test_validate_success_stop_after_record_msg(self):
+    async def test_validate_success_stop_after_record_msg(self) -> None:
         self.mock_invoke.stderr.at_eof.side_effect = True
         self.mock_invoke.stdout.at_eof.side_effect = (False, False, False, True)
         self.mock_invoke.stdout.readline = AsyncMock(
@@ -117,7 +117,7 @@ class TestExtractorTestService:
         assert self.mock_invoke.stdout.readline.call_count == 2
 
     @pytest.mark.asyncio()
-    async def test_validate_failure_no_record_msg(self):
+    async def test_validate_failure_no_record_msg(self) -> None:
         self.mock_invoke.stderr.at_eof.side_effect = True
         self.mock_invoke.stdout.at_eof.side_effect = (False, True)
         self.mock_invoke.stdout.readline = AsyncMock(
@@ -134,7 +134,7 @@ class TestExtractorTestService:
         assert "No RECORD or BATCH message received" in detail
 
     @pytest.mark.asyncio()
-    async def test_validate_failure_subprocess_err(self):
+    async def test_validate_failure_subprocess_err(self) -> None:
         self.mock_invoke.stderr.at_eof.side_effect = True
         self.mock_invoke.stdout.at_eof.side_effect = (False, False, True)
         self.mock_invoke.stdout.readline = AsyncMock(
@@ -153,7 +153,7 @@ class TestExtractorTestService:
         assert "A subprocess error occurred" in detail
 
     @pytest.mark.asyncio()
-    async def test_validate_failure_plugin_invoke_exception(self):
+    async def test_validate_failure_plugin_invoke_exception(self) -> None:
         mock_exception = Exception("An exception occurred on plugin invocation")
         self.mock_invoker.invoke_async.side_effect = mock_exception
 

--- a/tests/meltano/core/test_plugin_test_service.py
+++ b/tests/meltano/core/test_plugin_test_service.py
@@ -23,7 +23,7 @@ MOCK_RECORD_MESSAGE = json.dumps({"type": "RECORD"})
 class TestPluginTestServiceFactory:
     @pytest.fixture(autouse=True)
     @patch("meltano.core.plugin_invoker.PluginInvoker")
-    def setup(self, mock_invoker) -> None:  # noqa: ANN001
+    def setup(self, mock_invoker) -> None:
         self.mock_invoker = mock_invoker
 
     def test_extractor_plugin(self, tap: ProjectPlugin) -> None:
@@ -47,7 +47,7 @@ class TestPluginTestServiceFactory:
 class TestExtractorTestService:
     @pytest.fixture(autouse=True)
     @patch("meltano.core.plugin_invoker.PluginInvoker")
-    def setup(self, mock_invoker) -> None:  # noqa: ANN001
+    def setup(self, mock_invoker) -> None:
         self.mock_invoke = Mock()
         self.mock_invoke.name = "utility-mock"
         self.mock_invoke.wait = AsyncMock(return_value=-SIGTERM)

--- a/tests/meltano/core/test_project.py
+++ b/tests/meltano/core/test_project.py
@@ -14,13 +14,13 @@ from meltano.core.project import PROJECT_ROOT_ENV, Project
 
 
 @pytest.fixture()
-def deactivate_project(project):  # noqa: ANN001, ANN201
+def deactivate_project(project):
     Project.deactivate()
     yield
     Project.activate(project)
 
 
-def update(payload) -> None:  # noqa: ANN001
+def update(payload) -> None:
     project = Project.find()
 
     with project.meltano_update() as meltano:
@@ -39,7 +39,7 @@ class IndefiniteThread(threading.Thread):
     def stop(self) -> None:
         self._stop_event.set()
 
-    def run(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+    def run(self, *args, **kwargs) -> None:
         while not self._stop_event.is_set():
             self.do(*args, **kwargs)
 
@@ -47,7 +47,7 @@ class IndefiniteThread(threading.Thread):
 class ProjectReader(IndefiniteThread):
     """Project using a never ending thread."""
 
-    def __init__(self, project) -> None:  # noqa: ANN001
+    def __init__(self, project) -> None:
         """Set the project."""
         self.project = project
         super().__init__()
@@ -59,7 +59,7 @@ class ProjectReader(IndefiniteThread):
 
 class TestProject:
     @pytest.mark.usefixtures("deactivate_project")
-    def test_find(self, project, tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    def test_find(self, project, tmp_path, monkeypatch) -> None:
         # defaults to the cwd
         found = Project.find(activate=False)
         assert found == project
@@ -86,7 +86,7 @@ class TestProject:
         with pytest.raises(ProjectNotFound):
             Project.find(tmp_path)
 
-    def test_activate(self, project) -> None:  # noqa: ANN001
+    def test_activate(self, project) -> None:
         Project.deactivate()
         assert Project._default is None
 
@@ -95,13 +95,13 @@ class TestProject:
         assert Project._default is project
         assert Project.find() is project
 
-    def test_find_threadsafe(self, project, concurrency) -> None:  # noqa: ANN001
+    def test_find_threadsafe(self, project, concurrency) -> None:
         workers = ThreadPool(concurrency["threads"])
         projects = workers.map(Project.find, range(concurrency["cases"]))
         assert all(x is project for x in projects)
 
     @pytest.mark.concurrent()
-    def test_meltano_concurrency(self, project, concurrency) -> None:  # noqa: ANN001
+    def test_meltano_concurrency(self, project, concurrency) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -139,7 +139,7 @@ class TestProject:
 
 class TestIncompatibleProject:
     @pytest.fixture()
-    def increase_version(self, project):  # noqa: ANN001, ANN201
+    def increase_version(self, project):
         with project.meltano_update() as meltano:
             meltano["version"] += 1
         yield
@@ -147,6 +147,6 @@ class TestIncompatibleProject:
             meltano["version"] -= 1
 
     @pytest.mark.usefixtures("increase_version")
-    def test_incompatible(self, project) -> None:  # noqa: ANN001
+    def test_incompatible(self, project) -> None:
         with pytest.raises(IncompatibleVersionError):
             Project.activate(project)

--- a/tests/meltano/core/test_project.py
+++ b/tests/meltano/core/test_project.py
@@ -14,13 +14,13 @@ from meltano.core.project import PROJECT_ROOT_ENV, Project
 
 
 @pytest.fixture()
-def deactivate_project(project):
+def deactivate_project(project):  # noqa: ANN001, ANN201
     Project.deactivate()
     yield
     Project.activate(project)
 
 
-def update(payload):
+def update(payload) -> None:  # noqa: ANN001
     project = Project.find()
 
     with project.meltano_update() as meltano:
@@ -31,15 +31,15 @@ def update(payload):
 class IndefiniteThread(threading.Thread):
     """Never ending thread."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Set stop event."""
         super().__init__()
         self._stop_event = threading.Event()
 
-    def stop(self):
+    def stop(self) -> None:
         self._stop_event.set()
 
-    def run(self, *args, **kwargs):
+    def run(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         while not self._stop_event.is_set():
             self.do(*args, **kwargs)
 
@@ -47,19 +47,19 @@ class IndefiniteThread(threading.Thread):
 class ProjectReader(IndefiniteThread):
     """Project using a never ending thread."""
 
-    def __init__(self, project):
+    def __init__(self, project) -> None:  # noqa: ANN001
         """Set the project."""
         self.project = project
         super().__init__()
 
-    def do(self):
+    def do(self) -> None:
         assert self.project.meltano
         time.sleep(50 / 1000)  # 50ms
 
 
 class TestProject:
     @pytest.mark.usefixtures("deactivate_project")
-    def test_find(self, project, tmp_path, monkeypatch):
+    def test_find(self, project, tmp_path, monkeypatch) -> None:  # noqa: ANN001
         # defaults to the cwd
         found = Project.find(activate=False)
         assert found == project
@@ -86,7 +86,7 @@ class TestProject:
         with pytest.raises(ProjectNotFound):
             Project.find(tmp_path)
 
-    def test_activate(self, project):
+    def test_activate(self, project) -> None:  # noqa: ANN001
         Project.deactivate()
         assert Project._default is None
 
@@ -95,13 +95,13 @@ class TestProject:
         assert Project._default is project
         assert Project.find() is project
 
-    def test_find_threadsafe(self, project, concurrency):
+    def test_find_threadsafe(self, project, concurrency) -> None:  # noqa: ANN001
         workers = ThreadPool(concurrency["threads"])
         projects = workers.map(Project.find, range(concurrency["cases"]))
         assert all(x is project for x in projects)
 
     @pytest.mark.concurrent()
-    def test_meltano_concurrency(self, project, concurrency):
+    def test_meltano_concurrency(self, project, concurrency) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -123,7 +123,7 @@ class TestProject:
         for key, val in unpacked_items:
             assert meltano.extras[key] == val
 
-    def test_preserve_comments(self, project: Project):
+    def test_preserve_comments(self, project: Project) -> None:
         original_contents = project.meltanofile.read_text()
 
         new_contents = f"# Please don't delete me :)\n{original_contents}"
@@ -139,7 +139,7 @@ class TestProject:
 
 class TestIncompatibleProject:
     @pytest.fixture()
-    def increase_version(self, project):
+    def increase_version(self, project):  # noqa: ANN001, ANN201
         with project.meltano_update() as meltano:
             meltano["version"] += 1
         yield
@@ -147,6 +147,6 @@ class TestIncompatibleProject:
             meltano["version"] -= 1
 
     @pytest.mark.usefixtures("increase_version")
-    def test_incompatible(self, project):
+    def test_incompatible(self, project) -> None:  # noqa: ANN001
         with pytest.raises(IncompatibleVersionError):
             Project.activate(project)

--- a/tests/meltano/core/test_project_add_service.py
+++ b/tests/meltano/core/test_project_add_service.py
@@ -21,10 +21,10 @@ if t.TYPE_CHECKING:
 
 class TestProjectAddService:
     @pytest.fixture()
-    def subject(self, project_add_service):  # noqa: ANN001, ANN201
+    def subject(self, project_add_service):
         return project_add_service
 
-    def test_missing_plugin_exception(self, subject, hub_request_counter) -> None:  # noqa: ANN001
+    def test_missing_plugin_exception(self, subject, hub_request_counter) -> None:
         with pytest.raises(PluginDefinitionNotFoundError):
             subject.add(PluginType.EXTRACTORS, "tap-missing")
 
@@ -83,10 +83,10 @@ class TestProjectAddService:
 
     def test_add_inherited(
         self,
-        tap,  # noqa: ANN001
-        subject,  # noqa: ANN001
+        tap,
+        subject,
         project: Project,
-        hub_request_counter,  # noqa: ANN001
+        hub_request_counter,
     ) -> None:
         # Make sure tap-mock is not in the project as a project plugin
         project.plugins.remove_from_file(tap)
@@ -187,7 +187,7 @@ class TestProjectAddService:
     def test_add_update(
         self,
         lock_save: mock.MagicMock,
-        target,  # noqa: ANN001
+        target,
         subject: ProjectAddService,
         project: Project,
         hub_request_counter: Counter,

--- a/tests/meltano/core/test_project_add_service.py
+++ b/tests/meltano/core/test_project_add_service.py
@@ -21,10 +21,10 @@ if t.TYPE_CHECKING:
 
 class TestProjectAddService:
     @pytest.fixture()
-    def subject(self, project_add_service):
+    def subject(self, project_add_service):  # noqa: ANN001, ANN201
         return project_add_service
 
-    def test_missing_plugin_exception(self, subject, hub_request_counter):
+    def test_missing_plugin_exception(self, subject, hub_request_counter) -> None:  # noqa: ANN001
         with pytest.raises(PluginDefinitionNotFoundError):
             subject.add(PluginType.EXTRACTORS, "tap-missing")
 
@@ -51,7 +51,7 @@ class TestProjectAddService:
         subject: ProjectAddService,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         used_variant = variant or default_variant
         lockfile_path = project.plugin_lock_path(
             plugin_type,
@@ -83,11 +83,11 @@ class TestProjectAddService:
 
     def test_add_inherited(
         self,
-        tap,
-        subject,
+        tap,  # noqa: ANN001
+        subject,  # noqa: ANN001
         project: Project,
-        hub_request_counter,
-    ):
+        hub_request_counter,  # noqa: ANN001
+    ) -> None:
         # Make sure tap-mock is not in the project as a project plugin
         project.plugins.remove_from_file(tap)
 
@@ -124,7 +124,7 @@ class TestProjectAddService:
         self,
         subject: ProjectAddService,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         child = subject.add(
             PluginType.EXTRACTORS,
             "tap-mock-inherited-new",
@@ -176,7 +176,7 @@ class TestProjectAddService:
     def test_add_name_contains_state_id_component_delimiter(
         self,
         subject: ProjectAddService,
-    ):
+    ) -> None:
         with pytest.raises(PluginRefNameContainsStateIdDelimiterError):
             subject.add(
                 PluginType.EXTRACTORS,
@@ -187,11 +187,11 @@ class TestProjectAddService:
     def test_add_update(
         self,
         lock_save: mock.MagicMock,
-        target,
+        target,  # noqa: ANN001
         subject: ProjectAddService,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         target.config = {
             "username": "meltano",
             "password": "meltano",
@@ -235,7 +235,7 @@ class TestProjectAddService:
         subject: ProjectAddService,
         project: Project,
         hub_request_counter: Counter,
-    ):
+    ) -> None:
         custom_plugin = subject.add(
             PluginType.EXTRACTORS,
             "tap-custom",

--- a/tests/meltano/core/test_project_files.py
+++ b/tests/meltano/core/test_project_files.py
@@ -13,7 +13,7 @@ from meltano.core.utils import deep_merge
 
 
 @pytest.fixture()
-def cd_temp_subdir():  # noqa: ANN201
+def cd_temp_subdir():
     original_dir = Path.cwd()
     with tempfile.TemporaryDirectory(dir=original_dir) as name, cd(
         Path(name).resolve(),
@@ -22,7 +22,7 @@ def cd_temp_subdir():  # noqa: ANN201
 
 
 @pytest.fixture()
-def cd_temp_dir():  # noqa: ANN201
+def cd_temp_dir():
     with tempfile.TemporaryDirectory() as name, cd(Path(name).resolve()) as new_dir:
         yield new_dir
 
@@ -38,13 +38,13 @@ def cd_temp_dir():  # noqa: ANN201
         ({"a": "A", "b": "B"}, [{"a": "Z"}], {"a": "Z", "b": "B"}),
     ),
 )
-def test_deep_merge(parent, children, expected) -> None:  # noqa: ANN001
+def test_deep_merge(parent, children, expected) -> None:
     assert deep_merge(parent, *children) == expected
 
 
 class TestProjectFiles:
     @pytest.mark.order(1)
-    def test_resolve_subfiles(self, project_files) -> None:  # noqa: ANN001
+    def test_resolve_subfiles(self, project_files) -> None:
         assert project_files._meltano_file_path == (project_files.root / "meltano.yml")
         assert project_files.meltano == {
             "version": 1,
@@ -115,7 +115,7 @@ class TestProjectFiles:
         platform.system() == "Windows",
         reason="Test fails if even attempted to be run, xfail can't save us here.",
     )
-    def test_resolve_from_subdir(self, project_files, cd_temp_subdir) -> None:  # noqa: ANN001
+    def test_resolve_from_subdir(self, project_files, cd_temp_subdir) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -133,7 +133,7 @@ class TestProjectFiles:
         platform.system() == "Windows",
         reason="Test fails if even attempted to be run, xfail can't save us here.",
     )
-    def test_resolve_from_any_dir(self, project_files, cd_temp_dir) -> None:  # noqa: ANN001
+    def test_resolve_from_any_dir(self, project_files, cd_temp_dir) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -146,7 +146,7 @@ class TestProjectFiles:
         ]
 
     @pytest.mark.order(5)
-    def test_load(self, project_files) -> None:  # noqa: ANN001
+    def test_load(self, project_files) -> None:
         expected_result = {
             "version": 1,
             "default_environment": "test-meltano-environment",
@@ -248,7 +248,7 @@ class TestProjectFiles:
         assert read_result == expected_result
 
     @pytest.mark.order(6)
-    def test_update(self, project_files) -> None:  # noqa: ANN001
+    def test_update(self, project_files) -> None:
         meltano_config = project_files.load()
         meltano_config["version"] = 2
         meltano_config["plugins"]["extractors"][1]["name"] = (
@@ -361,7 +361,7 @@ class TestProjectFiles:
         assert read_result == expected_result
 
     @pytest.mark.order(7)
-    def test_preserve_format(self, project_files) -> None:  # noqa: ANN001
+    def test_preserve_format(self, project_files) -> None:
         meltano_config = project_files.load()
         meltano_config["version"] = 3
         meltano_config["schedules"][0]["transform"] = "only"
@@ -464,7 +464,7 @@ class TestProjectFiles:
         assert included_path.read_text() == dedent(expected_subconfig_2_contents)
 
     @pytest.mark.order(-1)
-    def test_remove_all_file_contents(self, project_files) -> None:  # noqa: ANN001
+    def test_remove_all_file_contents(self, project_files) -> None:
         meltano_config = project_files.load()
         meltano_config["plugins"]["extractors"] = [
             entry

--- a/tests/meltano/core/test_project_files.py
+++ b/tests/meltano/core/test_project_files.py
@@ -13,7 +13,7 @@ from meltano.core.utils import deep_merge
 
 
 @pytest.fixture()
-def cd_temp_subdir():
+def cd_temp_subdir():  # noqa: ANN201
     original_dir = Path.cwd()
     with tempfile.TemporaryDirectory(dir=original_dir) as name, cd(
         Path(name).resolve(),
@@ -22,7 +22,7 @@ def cd_temp_subdir():
 
 
 @pytest.fixture()
-def cd_temp_dir():
+def cd_temp_dir():  # noqa: ANN201
     with tempfile.TemporaryDirectory() as name, cd(Path(name).resolve()) as new_dir:
         yield new_dir
 
@@ -38,13 +38,13 @@ def cd_temp_dir():
         ({"a": "A", "b": "B"}, [{"a": "Z"}], {"a": "Z", "b": "B"}),
     ),
 )
-def test_deep_merge(parent, children, expected):
+def test_deep_merge(parent, children, expected) -> None:  # noqa: ANN001
     assert deep_merge(parent, *children) == expected
 
 
 class TestProjectFiles:
     @pytest.mark.order(1)
-    def test_resolve_subfiles(self, project_files):
+    def test_resolve_subfiles(self, project_files) -> None:  # noqa: ANN001
         assert project_files._meltano_file_path == (project_files.root / "meltano.yml")
         assert project_files.meltano == {
             "version": 1,
@@ -115,7 +115,7 @@ class TestProjectFiles:
         platform.system() == "Windows",
         reason="Test fails if even attempted to be run, xfail can't save us here.",
     )
-    def test_resolve_from_subdir(self, project_files, cd_temp_subdir):
+    def test_resolve_from_subdir(self, project_files, cd_temp_subdir) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -133,7 +133,7 @@ class TestProjectFiles:
         platform.system() == "Windows",
         reason="Test fails if even attempted to be run, xfail can't save us here.",
     )
-    def test_resolve_from_any_dir(self, project_files, cd_temp_dir):
+    def test_resolve_from_any_dir(self, project_files, cd_temp_dir) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -146,7 +146,7 @@ class TestProjectFiles:
         ]
 
     @pytest.mark.order(5)
-    def test_load(self, project_files):
+    def test_load(self, project_files) -> None:  # noqa: ANN001
         expected_result = {
             "version": 1,
             "default_environment": "test-meltano-environment",
@@ -248,7 +248,7 @@ class TestProjectFiles:
         assert read_result == expected_result
 
     @pytest.mark.order(6)
-    def test_update(self, project_files):
+    def test_update(self, project_files) -> None:  # noqa: ANN001
         meltano_config = project_files.load()
         meltano_config["version"] = 2
         meltano_config["plugins"]["extractors"][1]["name"] = (
@@ -361,7 +361,7 @@ class TestProjectFiles:
         assert read_result == expected_result
 
     @pytest.mark.order(7)
-    def test_preserve_format(self, project_files):
+    def test_preserve_format(self, project_files) -> None:  # noqa: ANN001
         meltano_config = project_files.load()
         meltano_config["version"] = 3
         meltano_config["schedules"][0]["transform"] = "only"
@@ -464,7 +464,7 @@ class TestProjectFiles:
         assert included_path.read_text() == dedent(expected_subconfig_2_contents)
 
     @pytest.mark.order(-1)
-    def test_remove_all_file_contents(self, project_files):
+    def test_remove_all_file_contents(self, project_files) -> None:  # noqa: ANN001
         meltano_config = project_files.load()
         meltano_config["plugins"]["extractors"] = [
             entry

--- a/tests/meltano/core/test_project_init_service.py
+++ b/tests/meltano/core/test_project_init_service.py
@@ -28,7 +28,7 @@ def test_project_init_success(
     *,
     create_project_dir: bool,
     tmp_path: Path,
-    pushd,  # noqa: ANN001
+    pushd,
 ) -> None:
     projects_dir = tmp_path.joinpath("success")
     projects_dir.mkdir()
@@ -49,7 +49,7 @@ def test_project_init_success(
     ProjectInitService(project_dir.absolute()).init(activate=False)
 
 
-def test_project_init_non_empty_directory(tmp_path: Path, pushd) -> None:  # noqa: ANN001
+def test_project_init_non_empty_directory(tmp_path: Path, pushd) -> None:
     projects_dir = tmp_path.joinpath("exists")
     projects_dir.mkdir()
     pushd(projects_dir)
@@ -59,7 +59,7 @@ def test_project_init_non_empty_directory(tmp_path: Path, pushd) -> None:  # noq
     ProjectInitService(project_dir).init(activate=False)
 
 
-def test_project_init_existing_meltano_yml(tmp_path: Path, pushd) -> None:  # noqa: ANN001
+def test_project_init_existing_meltano_yml(tmp_path: Path, pushd) -> None:
     projects_dir = tmp_path.joinpath("exists")
     projects_dir.mkdir()
     pushd(projects_dir)
@@ -80,7 +80,7 @@ def test_project_init_existing_meltano_yml(tmp_path: Path, pushd) -> None:  # no
     ProjectInitService(project_dir).init(activate=False, force=True)
 
 
-def test_project_init_no_write_permission(tmp_path: Path, pushd) -> None:  # noqa: ANN001
+def test_project_init_no_write_permission(tmp_path: Path, pushd) -> None:
     if platform.system() == "Windows":
         pytest.xfail(
             "Windows can still create new directories inside a read-only directory.",
@@ -101,7 +101,7 @@ def test_project_init_no_write_permission(tmp_path: Path, pushd) -> None:  # noq
         ProjectInitService(project_dir).init(activate=False)
 
 
-def test_project_init_missing_parent_directory(tmp_path: Path, pushd) -> None:  # noqa: ANN001
+def test_project_init_missing_parent_directory(tmp_path: Path, pushd) -> None:
     if platform.system() == "Windows":
         pytest.xfail(
             "Windows can't remove a directory that is in use. "

--- a/tests/meltano/core/test_project_init_service.py
+++ b/tests/meltano/core/test_project_init_service.py
@@ -24,7 +24,7 @@ from meltano.core.project_init_service import (
         "empty directory",
     ),
 )
-def test_project_init_success(create_project_dir: bool, tmp_path: Path, pushd):
+def test_project_init_success(*, create_project_dir: bool, tmp_path: Path, pushd):
     projects_dir = tmp_path.joinpath("success")
     projects_dir.mkdir()
     pushd(projects_dir)

--- a/tests/meltano/core/test_project_init_service.py
+++ b/tests/meltano/core/test_project_init_service.py
@@ -24,7 +24,12 @@ from meltano.core.project_init_service import (
         "empty directory",
     ),
 )
-def test_project_init_success(*, create_project_dir: bool, tmp_path: Path, pushd):
+def test_project_init_success(
+    *,
+    create_project_dir: bool,
+    tmp_path: Path,
+    pushd,  # noqa: ANN001
+) -> None:
     projects_dir = tmp_path.joinpath("success")
     projects_dir.mkdir()
     pushd(projects_dir)
@@ -44,7 +49,7 @@ def test_project_init_success(*, create_project_dir: bool, tmp_path: Path, pushd
     ProjectInitService(project_dir.absolute()).init(activate=False)
 
 
-def test_project_init_non_empty_directory(tmp_path: Path, pushd):
+def test_project_init_non_empty_directory(tmp_path: Path, pushd) -> None:  # noqa: ANN001
     projects_dir = tmp_path.joinpath("exists")
     projects_dir.mkdir()
     pushd(projects_dir)
@@ -54,7 +59,7 @@ def test_project_init_non_empty_directory(tmp_path: Path, pushd):
     ProjectInitService(project_dir).init(activate=False)
 
 
-def test_project_init_existing_meltano_yml(tmp_path: Path, pushd):
+def test_project_init_existing_meltano_yml(tmp_path: Path, pushd) -> None:  # noqa: ANN001
     projects_dir = tmp_path.joinpath("exists")
     projects_dir.mkdir()
     pushd(projects_dir)
@@ -75,7 +80,7 @@ def test_project_init_existing_meltano_yml(tmp_path: Path, pushd):
     ProjectInitService(project_dir).init(activate=False, force=True)
 
 
-def test_project_init_no_write_permission(tmp_path: Path, pushd):
+def test_project_init_no_write_permission(tmp_path: Path, pushd) -> None:  # noqa: ANN001
     if platform.system() == "Windows":
         pytest.xfail(
             "Windows can still create new directories inside a read-only directory.",
@@ -96,7 +101,7 @@ def test_project_init_no_write_permission(tmp_path: Path, pushd):
         ProjectInitService(project_dir).init(activate=False)
 
 
-def test_project_init_missing_parent_directory(tmp_path: Path, pushd):
+def test_project_init_missing_parent_directory(tmp_path: Path, pushd) -> None:  # noqa: ANN001
     if platform.system() == "Windows":
         pytest.xfail(
             "Windows can't remove a directory that is in use. "

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -21,7 +21,7 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture()
-def modified_lockfile(project: Project):  # noqa: ANN201
+def modified_lockfile(project: Project):
     lockfile_path = project.plugin_lock_path(
         PluginType.EXTRACTORS,
         "tap-mock",
@@ -44,12 +44,12 @@ def modified_lockfile(project: Project):  # noqa: ANN201
 
 class TestProjectPluginsService:
     @pytest.fixture(autouse=True)
-    def setup(self, project: Project, tap) -> None:  # noqa: ANN001
+    def setup(self, project: Project, tap) -> None:
         project.plugins.lock_service.save(tap, exists_ok=True)
         project.plugins._prefer_source = DefinitionSource.ANY
 
     @pytest.mark.order(0)
-    def test_plugins(self, project) -> None:  # noqa: ANN001
+    def test_plugins(self, project) -> None:
         assert all(
             isinstance(plugin.parent, BasePlugin)
             for plugin in project.plugins.plugins()
@@ -57,11 +57,11 @@ class TestProjectPluginsService:
 
     def test_get_plugin(
         self,
-        project,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        alternative_tap,  # noqa: ANN001
-        inherited_tap,  # noqa: ANN001
-        alternative_target,  # noqa: ANN001
+        project,
+        tap,
+        alternative_tap,
+        inherited_tap,
+        alternative_target,
     ) -> None:
         # name="tap-mock", variant="meltano"
         plugin = project.plugins.get_plugin(tap)
@@ -132,10 +132,10 @@ class TestProjectPluginsService:
     def test_get_parent_no_lockfiles(
         self,
         project: Project,
-        tap,  # noqa: ANN001
-        alternative_tap,  # noqa: ANN001
-        inherited_tap,  # noqa: ANN001
-        alternative_target,  # noqa: ANN001
+        tap,
+        alternative_tap,
+        inherited_tap,
+        alternative_target,
     ) -> None:
         # The behavior being tested here assumes that no lockfiles exist.
         shutil.rmtree(project.plugins.project.root_dir("plugins"), ignore_errors=True)
@@ -185,7 +185,7 @@ class TestProjectPluginsService:
 
         assert isinstance(excinfo.value.__cause__, PluginParentNotFoundError)
 
-    def test_update_plugin(self, project: Project, tap) -> None:  # noqa: ANN001
+    def test_update_plugin(self, project: Project, tap) -> None:
         # update a tap with a random value
         tap.config["test"] = 42
         tap, outdated = project.plugins.update_plugin(tap)
@@ -208,7 +208,7 @@ class TestProjectPluginsService:
         with pytest.raises(PluginNotFoundError):
             project.plugins.update_plugin(nonexistent_plugin)
 
-    def test_find_plugins_by_mapping_name(self, project: Project, mapper) -> None:  # noqa: ANN001
+    def test_find_plugins_by_mapping_name(self, project: Project, mapper) -> None:
         assert project.plugins.find_plugins_by_mapping_name("mock-mapping-1") == [
             mapper,
         ]
@@ -218,7 +218,7 @@ class TestProjectPluginsService:
         with pytest.raises(PluginNotFoundError):
             project.plugins.find_plugins_by_mapping_name("non-existent-mapping")
 
-    def test_find_plugins(self, project: Project, mapper) -> None:  # noqa: ANN001
+    def test_find_plugins(self, project: Project, mapper) -> None:
         assert project.plugins.find_plugin("mock-mapping-1") == mapper
         assert project.plugins.find_plugin("mock-mapping-0") == mapper
         with pytest.raises(PluginNotFoundError):

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -21,7 +21,7 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture()
-def modified_lockfile(project: Project):
+def modified_lockfile(project: Project):  # noqa: ANN201
     lockfile_path = project.plugin_lock_path(
         PluginType.EXTRACTORS,
         "tap-mock",
@@ -44,12 +44,12 @@ def modified_lockfile(project: Project):
 
 class TestProjectPluginsService:
     @pytest.fixture(autouse=True)
-    def setup(self, project: Project, tap):
+    def setup(self, project: Project, tap) -> None:  # noqa: ANN001
         project.plugins.lock_service.save(tap, exists_ok=True)
         project.plugins._prefer_source = DefinitionSource.ANY
 
     @pytest.mark.order(0)
-    def test_plugins(self, project):
+    def test_plugins(self, project) -> None:  # noqa: ANN001
         assert all(
             isinstance(plugin.parent, BasePlugin)
             for plugin in project.plugins.plugins()
@@ -57,12 +57,12 @@ class TestProjectPluginsService:
 
     def test_get_plugin(
         self,
-        project,
-        tap,
-        alternative_tap,
-        inherited_tap,
-        alternative_target,
-    ):
+        project,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        alternative_tap,  # noqa: ANN001
+        inherited_tap,  # noqa: ANN001
+        alternative_target,  # noqa: ANN001
+    ) -> None:
         # name="tap-mock", variant="meltano"
         plugin = project.plugins.get_plugin(tap)
         assert plugin.type == PluginType.EXTRACTORS
@@ -105,7 +105,7 @@ class TestProjectPluginsService:
         project: Project,
         tap: ProjectPlugin,
         locked_definition_service: LockedDefinitionService,
-    ):
+    ) -> None:
         expected = locked_definition_service.find_base_plugin(
             plugin_type=PluginType.EXTRACTORS,
             plugin_name="tap-mock",
@@ -123,7 +123,7 @@ class TestProjectPluginsService:
         self,
         project: Project,
         tap: ProjectPlugin,
-    ):
+    ) -> None:
         with project.plugins.use_preferred_source(DefinitionSource.NONE), pytest.raises(
             PluginDefinitionNotFoundError,
         ):
@@ -132,11 +132,11 @@ class TestProjectPluginsService:
     def test_get_parent_no_lockfiles(
         self,
         project: Project,
-        tap,
-        alternative_tap,
-        inherited_tap,
-        alternative_target,
-    ):
+        tap,  # noqa: ANN001
+        alternative_tap,  # noqa: ANN001
+        inherited_tap,  # noqa: ANN001
+        alternative_target,  # noqa: ANN001
+    ) -> None:
         # The behavior being tested here assumes that no lockfiles exist.
         shutil.rmtree(project.plugins.project.root_dir("plugins"), ignore_errors=True)
         # name="tap-mock", variant="meltano"
@@ -185,7 +185,7 @@ class TestProjectPluginsService:
 
         assert isinstance(excinfo.value.__cause__, PluginParentNotFoundError)
 
-    def test_update_plugin(self, project: Project, tap):
+    def test_update_plugin(self, project: Project, tap) -> None:  # noqa: ANN001
         # update a tap with a random value
         tap.config["test"] = 42
         tap, outdated = project.plugins.update_plugin(tap)
@@ -199,7 +199,7 @@ class TestProjectPluginsService:
             project.plugins.get_plugin(tap).config == {}  # (OK compare with falsy)
         )
 
-    def test_update_plugin_not_found(self, project: Project):
+    def test_update_plugin_not_found(self, project: Project) -> None:
         nonexistent_plugin = ProjectPlugin(
             PluginType.EXTRACTORS,
             name="tap-foo",
@@ -208,7 +208,7 @@ class TestProjectPluginsService:
         with pytest.raises(PluginNotFoundError):
             project.plugins.update_plugin(nonexistent_plugin)
 
-    def test_find_plugins_by_mapping_name(self, project: Project, mapper):
+    def test_find_plugins_by_mapping_name(self, project: Project, mapper) -> None:  # noqa: ANN001
         assert project.plugins.find_plugins_by_mapping_name("mock-mapping-1") == [
             mapper,
         ]
@@ -218,7 +218,7 @@ class TestProjectPluginsService:
         with pytest.raises(PluginNotFoundError):
             project.plugins.find_plugins_by_mapping_name("non-existent-mapping")
 
-    def test_find_plugins(self, project: Project, mapper):
+    def test_find_plugins(self, project: Project, mapper) -> None:  # noqa: ANN001
         assert project.plugins.find_plugin("mock-mapping-1") == mapper
         assert project.plugins.find_plugin("mock-mapping-0") == mapper
         with pytest.raises(PluginNotFoundError):

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -19,7 +19,7 @@ from meltano.core.utils import EnvironmentVariableNotSetError
 
 
 @pytest.fixture()
-def config_override():  # noqa: ANN201
+def config_override():
     try:
         ProjectSettingsService.config_override["project_id"] = "from_config_override"
 
@@ -29,23 +29,23 @@ def config_override():  # noqa: ANN201
 
 
 @pytest.fixture()
-def subject(project):  # noqa: ANN001, ANN201
+def subject(project):
     return ProjectSettingsService(project)
 
 
 class TestProjectSettingsService:
     @pytest.fixture()
-    def environment(self):  # noqa: ANN201
+    def environment(self):
         return Environment("testing", {})
 
-    def test_get_with_source(self, subject, monkeypatch) -> None:  # noqa: ANN001
+    def test_get_with_source(self, subject, monkeypatch) -> None:
         # A warning is raised because the setting does not exist.
         with pytest.warns(RuntimeWarning):
             assert subject.get_with_source(
                 "and_now_for_something_completely_different",
             ) == (None, SettingValueStore.DEFAULT)
 
-        def assert_value_source(value, source) -> None:  # noqa: ANN001
+        def assert_value_source(value, source) -> None:
             assert subject.get_with_source("project_id") == (value, source)
 
         subject.set(
@@ -67,27 +67,27 @@ class TestProjectSettingsService:
             assert_value_source("from_env", SettingValueStore.ENV)
 
     @pytest.mark.usefixtures("config_override")
-    def test_get_with_source_config_override(self, subject) -> None:  # noqa: ANN001
+    def test_get_with_source_config_override(self, subject) -> None:
         assert subject.get_with_source("project_id") == (
             "from_config_override",
             SettingValueStore.CONFIG_OVERRIDE,
         )
 
-    def test_experimental_on(self, subject, monkeypatch) -> None:  # noqa: ANN001
+    def test_experimental_on(self, subject, monkeypatch) -> None:
         changed = []
         monkeypatch.setenv("MELTANO_EXPERIMENTAL", "true")
         with subject.feature_flag(EXPERIMENTAL):
             changed.append(True)
         assert changed
 
-    def test_experimental_off_by_default(self, subject) -> None:  # noqa: ANN001
+    def test_experimental_off_by_default(self, subject) -> None:
         changed = []
         with pytest.raises(FeatureNotAllowedException), subject.feature_flag(
             EXPERIMENTAL,
         ):
             changed.append(True)
 
-    def test_feature_flag_allowed(self, subject) -> None:  # noqa: ANN001
+    def test_feature_flag_allowed(self, subject) -> None:
         changed = []
         subject.set([FEATURE_FLAG_PREFIX, "allowed"], value=True)
 
@@ -98,7 +98,7 @@ class TestProjectSettingsService:
         should_run()
         assert changed
 
-    def test_feature_flag_disallowed(self, subject) -> None:  # noqa: ANN001
+    def test_feature_flag_disallowed(self, subject) -> None:
         changed = []
         subject.set([FEATURE_FLAG_PREFIX, "disallowed"], value=False)
 
@@ -109,7 +109,7 @@ class TestProjectSettingsService:
         with pytest.raises(FeatureNotAllowedException):
             should_not_run()
 
-    def test_strict_env_var_mode_on_raises_error(self, subject) -> None:  # noqa: ANN001
+    def test_strict_env_var_mode_on_raises_error(self, subject) -> None:
         subject.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
             value=True,
@@ -121,7 +121,7 @@ class TestProjectSettingsService:
         with pytest.raises(EnvironmentVariableNotSetError):
             subject.get("stacked_env_var")
 
-    def test_strict_env_var_mode_off_no_raise_error(self, subject) -> None:  # noqa: ANN001
+    def test_strict_env_var_mode_off_no_raise_error(self, subject) -> None:
         subject.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
             value=False,
@@ -132,7 +132,7 @@ class TestProjectSettingsService:
         )
         assert subject.get("stacked_env_var") == "@nonexistent_1"
 
-    def test_warn_if_default_setting_is_used(self, subject, monkeypatch) -> None:  # noqa: ANN001
+    def test_warn_if_default_setting_is_used(self, subject, monkeypatch) -> None:
         # Assert that warnings are not raised in the following cases:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
@@ -169,9 +169,9 @@ class TestProjectSettingsService:
 
     def test_meltano_settings_with_active_environment(
         self,
-        subject,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
-        environment,  # noqa: ANN001
+        subject,
+        monkeypatch,
+        environment,
     ) -> None:
         # make sure that meltano setting values are written to the root of `meltano.yml`
         # even if there is an active environment

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -89,7 +89,7 @@ class TestProjectSettingsService:
 
     def test_feature_flag_allowed(self, subject):
         changed = []
-        subject.set([FEATURE_FLAG_PREFIX, "allowed"], True)
+        subject.set([FEATURE_FLAG_PREFIX, "allowed"], value=True)
 
         @subject.feature_flag("allowed")
         def should_run():
@@ -100,7 +100,7 @@ class TestProjectSettingsService:
 
     def test_feature_flag_disallowed(self, subject):
         changed = []
-        subject.set([FEATURE_FLAG_PREFIX, "disallowed"], False)
+        subject.set([FEATURE_FLAG_PREFIX, "disallowed"], value=False)
 
         @subject.feature_flag("disallowed")
         def should_not_run():
@@ -110,7 +110,9 @@ class TestProjectSettingsService:
             should_not_run()
 
     def test_strict_env_var_mode_on_raises_error(self, subject):
-        subject.set([FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], True)
+        subject.set(
+            [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], value=True
+        )
         subject.set(
             "stacked_env_var",
             "${NONEXISTENT_ENV_VAR}@nonexistent",
@@ -119,7 +121,9 @@ class TestProjectSettingsService:
             subject.get("stacked_env_var")
 
     def test_strict_env_var_mode_off_no_raise_error(self, subject):
-        subject.set([FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], False)
+        subject.set(
+            [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], value=False
+        )
         subject.set(
             "stacked_env_var",
             "${NONEXISTENT_ENV_VAR}@nonexistent_1",
@@ -180,7 +184,9 @@ class TestProjectSettingsService:
         self,
         subject: ProjectSettingsService,
     ):
-        subject.set([FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], False)
+        subject.set(
+            [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], value=False
+        )
         # https://github.com/meltano/meltano/issues/7189#issuecomment-1396112167
         with pytest.warns(RuntimeWarning, match="Unknown setting 'port'"):
             subject.set("port", "${UNSET_PORT_ENV_VAR}")
@@ -203,7 +209,9 @@ class TestProjectSettingsService:
             setting_def=setting_def,
         )
 
-        subject.set([FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], False)
+        subject.set(
+            [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)], value=False
+        )
         assert subject.get(name) is None
 
         subject.env_override["DB_MAX_RETRIES_TEST"] = "7"

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -20,8 +20,8 @@ from meltano.core.schedule_service import (
 
 
 @pytest.fixture(scope="session")
-def create_elt_schedule():  # noqa: ANN201
-    def make(name, **kwargs):  # noqa: ANN001, ANN003, ANN202
+def create_elt_schedule():
+    def make(name, **kwargs):
         attrs = {
             "extractor": "tap-mock",
             "loader": "target-mock",
@@ -38,8 +38,8 @@ def create_elt_schedule():  # noqa: ANN201
 
 
 @pytest.fixture(scope="session")
-def create_job_schedule():  # noqa: ANN201
-    def make(name, **kwargs):  # noqa: ANN001, ANN003, ANN202
+def create_job_schedule():
+    def make(name, **kwargs):
         attrs = {
             "job": "job-mock",
             "interval": "@daily",
@@ -54,7 +54,7 @@ def create_job_schedule():  # noqa: ANN201
 
 
 @pytest.fixture(scope="class")
-def custom_tap(project):  # noqa: ANN001, ANN201
+def custom_tap(project):
     tap = ProjectPlugin(
         PluginType.EXTRACTORS,
         name="tap-custom",
@@ -68,15 +68,15 @@ def custom_tap(project):  # noqa: ANN001, ANN201
 
 class TestScheduleService:
     @pytest.fixture()
-    def subject(self, schedule_service):  # noqa: ANN001, ANN201
+    def subject(self, schedule_service):
         return schedule_service
 
     @pytest.mark.order(0)
     def test_add_schedules(
         self,
-        subject,  # noqa: ANN001
-        create_elt_schedule,  # noqa: ANN001
-        create_job_schedule,  # noqa: ANN001
+        subject,
+        create_elt_schedule,
+        create_job_schedule,
     ) -> None:
         intervals = [
             "@once",
@@ -116,7 +116,7 @@ class TestScheduleService:
         assert excinfo.value.reason == "Invalid Cron expression or alias: 'bad_cron'"
         assert excinfo.value.instruction == "Please use a valid cron expression"
 
-    def test_remove_schedule(self, subject) -> None:  # noqa: ANN001
+    def test_remove_schedule(self, subject) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -140,7 +140,7 @@ class TestScheduleService:
         with pytest.raises(ScheduleDoesNotExistError):
             subject.remove_schedule(target_name)
 
-    def test_schedule_update(self, subject) -> None:  # noqa: ANN001
+    def test_schedule_update(self, subject) -> None:
         schedule = subject.schedules()[0]
 
         yearly_intervals = sum(sbj.interval == "@yearly" for sbj in subject.schedules())
@@ -167,14 +167,14 @@ class TestScheduleService:
 
     def test_schedule_start_date(
         self,
-        subject,  # noqa: ANN001
-        session,  # noqa: ANN001
-        tap,  # noqa: ANN001
-        target,  # noqa: ANN001
-        plugin_settings_service_factory,  # noqa: ANN001
+        subject,
+        session,
+        tap,
+        target,
+        plugin_settings_service_factory,
     ) -> None:
         # curry the `add_elt` method to remove some arguments
-        def add_elt(name, start_date):  # noqa: ANN001, ANN202
+        def add_elt(name, start_date):
             return subject.add_elt(
                 session,
                 name,
@@ -205,7 +205,7 @@ class TestScheduleService:
             schedule = add_elt("with_no_start_date", None)
             assert schedule.start_date
 
-    def test_run_elt_schedule(self, subject, session, tap, target) -> None:  # noqa: ANN001
+    def test_run_elt_schedule(self, subject, session, tap, target) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -250,7 +250,7 @@ class TestScheduleService:
             )
 
     @pytest.mark.usefixtures("session", "tap", "target")
-    def test_run_job_schedule(self, subject) -> None:  # noqa: ANN001
+    def test_run_job_schedule(self, subject) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -290,7 +290,7 @@ class TestScheduleService:
                 },
             )
 
-    def test_find_namespace_schedule(self, subject, tap, create_elt_schedule) -> None:  # noqa: ANN001
+    def test_find_namespace_schedule(self, subject, tap, create_elt_schedule) -> None:
         schedule = create_elt_schedule(tap.name)
         subject.add_schedule(schedule)
         found_schedule = subject.find_namespace_schedule(tap.namespace)
@@ -299,8 +299,8 @@ class TestScheduleService:
     @pytest.mark.usefixtures("create_elt_schedule")
     def test_find_namespace_schedule_custom_extractor(
         self,
-        subject,  # noqa: ANN001
-        custom_tap,  # noqa: ANN001
+        subject,
+        custom_tap,
     ) -> None:
         schedule = Schedule(
             name="tap-custom",
@@ -311,6 +311,6 @@ class TestScheduleService:
         found_schedule = subject.find_namespace_schedule(custom_tap.namespace)
         assert found_schedule.extractor == custom_tap.name
 
-    def test_find_namespace_schedule_not_found(self, subject) -> None:  # noqa: ANN001
+    def test_find_namespace_schedule_not_found(self, subject) -> None:
         with pytest.raises(ScheduleNotFoundError):
             subject.find_namespace_schedule("no-such-namespace")

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -20,8 +20,8 @@ from meltano.core.schedule_service import (
 
 
 @pytest.fixture(scope="session")
-def create_elt_schedule():
-    def make(name, **kwargs):
+def create_elt_schedule():  # noqa: ANN201
+    def make(name, **kwargs):  # noqa: ANN001, ANN003, ANN202
         attrs = {
             "extractor": "tap-mock",
             "loader": "target-mock",
@@ -38,8 +38,8 @@ def create_elt_schedule():
 
 
 @pytest.fixture(scope="session")
-def create_job_schedule():
-    def make(name, **kwargs):
+def create_job_schedule():  # noqa: ANN201
+    def make(name, **kwargs):  # noqa: ANN001, ANN003, ANN202
         attrs = {
             "job": "job-mock",
             "interval": "@daily",
@@ -54,7 +54,7 @@ def create_job_schedule():
 
 
 @pytest.fixture(scope="class")
-def custom_tap(project):
+def custom_tap(project):  # noqa: ANN001, ANN201
     tap = ProjectPlugin(
         PluginType.EXTRACTORS,
         name="tap-custom",
@@ -68,11 +68,16 @@ def custom_tap(project):
 
 class TestScheduleService:
     @pytest.fixture()
-    def subject(self, schedule_service):
+    def subject(self, schedule_service):  # noqa: ANN001, ANN201
         return schedule_service
 
     @pytest.mark.order(0)
-    def test_add_schedules(self, subject, create_elt_schedule, create_job_schedule):
+    def test_add_schedules(
+        self,
+        subject,  # noqa: ANN001
+        create_elt_schedule,  # noqa: ANN001
+        create_job_schedule,  # noqa: ANN001
+    ) -> None:
         intervals = [
             "@once",
             "@manual",
@@ -111,7 +116,7 @@ class TestScheduleService:
         assert excinfo.value.reason == "Invalid Cron expression or alias: 'bad_cron'"
         assert excinfo.value.instruction == "Please use a valid cron expression"
 
-    def test_remove_schedule(self, subject):
+    def test_remove_schedule(self, subject) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -135,7 +140,7 @@ class TestScheduleService:
         with pytest.raises(ScheduleDoesNotExistError):
             subject.remove_schedule(target_name)
 
-    def test_schedule_update(self, subject):
+    def test_schedule_update(self, subject) -> None:  # noqa: ANN001
         schedule = subject.schedules()[0]
 
         yearly_intervals = sum(sbj.interval == "@yearly" for sbj in subject.schedules())
@@ -162,14 +167,14 @@ class TestScheduleService:
 
     def test_schedule_start_date(
         self,
-        subject,
-        session,
-        tap,
-        target,
-        plugin_settings_service_factory,
-    ):
+        subject,  # noqa: ANN001
+        session,  # noqa: ANN001
+        tap,  # noqa: ANN001
+        target,  # noqa: ANN001
+        plugin_settings_service_factory,  # noqa: ANN001
+    ) -> None:
         # curry the `add_elt` method to remove some arguments
-        def add_elt(name, start_date):
+        def add_elt(name, start_date):  # noqa: ANN001, ANN202
             return subject.add_elt(
                 session,
                 name,
@@ -200,7 +205,7 @@ class TestScheduleService:
             schedule = add_elt("with_no_start_date", None)
             assert schedule.start_date
 
-    def test_run_elt_schedule(self, subject, session, tap, target):
+    def test_run_elt_schedule(self, subject, session, tap, target) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -245,7 +250,7 @@ class TestScheduleService:
             )
 
     @pytest.mark.usefixtures("session", "tap", "target")
-    def test_run_job_schedule(self, subject):
+    def test_run_job_schedule(self, subject) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -285,7 +290,7 @@ class TestScheduleService:
                 },
             )
 
-    def test_find_namespace_schedule(self, subject, tap, create_elt_schedule):
+    def test_find_namespace_schedule(self, subject, tap, create_elt_schedule) -> None:  # noqa: ANN001
         schedule = create_elt_schedule(tap.name)
         subject.add_schedule(schedule)
         found_schedule = subject.find_namespace_schedule(tap.namespace)
@@ -294,9 +299,9 @@ class TestScheduleService:
     @pytest.mark.usefixtures("create_elt_schedule")
     def test_find_namespace_schedule_custom_extractor(
         self,
-        subject,
-        custom_tap,
-    ):
+        subject,  # noqa: ANN001
+        custom_tap,  # noqa: ANN001
+    ) -> None:
         schedule = Schedule(
             name="tap-custom",
             extractor="tap-custom",
@@ -306,6 +311,6 @@ class TestScheduleService:
         found_schedule = subject.find_namespace_schedule(custom_tap.namespace)
         assert found_schedule.extractor == custom_tap.name
 
-    def test_find_namespace_schedule_not_found(self, subject):
+    def test_find_namespace_schedule_not_found(self, subject) -> None:  # noqa: ANN001
         with pytest.raises(ScheduleNotFoundError):
             subject.find_namespace_schedule("no-such-namespace")

--- a/tests/meltano/core/test_select_service.py
+++ b/tests/meltano/core/test_select_service.py
@@ -22,7 +22,7 @@ async def test_select_service_list_all(
     project: Project,
     session: Session,
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     catalog = {
         "streams": [
             {
@@ -34,15 +34,15 @@ async def test_select_service_list_all(
                 "schema": {
                     "properties": {
                         "id": {"type": "integer"},
-                    }
+                    },
                 },
-            }
-        ]
+            },
+        ],
     }
     extractor = "tap-mock"
     service = SelectService(project, extractor)
 
-    async def mock_run_discovery(tap, plugin_invoker, catalog_path):  # noqa: ARG001
+    async def mock_run_discovery(tap, plugin_invoker, catalog_path) -> None:  # noqa: ANN001, ARG001
         with catalog_path.open("w") as catalog_file:
             json.dump(catalog, catalog_file)
 
@@ -58,7 +58,7 @@ async def test_select_service_list_all(
         SelectedNode(
             key="users",
             selection=SelectionType.SELECTED,
-        )
+        ),
     }
     assert list_all.properties == OrderedDict(
         {
@@ -67,8 +67,8 @@ async def test_select_service_list_all(
                     key="id",
                     selection=SelectionType.AUTOMATIC,
                 ),
-            }
-        }
+            },
+        },
     )
 
     # Update the catalog to include a new property
@@ -83,8 +83,8 @@ async def test_select_service_list_all(
                     key="id",
                     selection=SelectionType.AUTOMATIC,
                 ),
-            }
-        }
+            },
+        },
     )
 
     # Refreshing the catalog should include the new property
@@ -100,6 +100,6 @@ async def test_select_service_list_all(
                     key="name",
                     selection=SelectionType.AUTOMATIC,
                 ),
-            }
-        }
+            },
+        },
     )

--- a/tests/meltano/core/test_select_service.py
+++ b/tests/meltano/core/test_select_service.py
@@ -42,7 +42,7 @@ async def test_select_service_list_all(
     extractor = "tap-mock"
     service = SelectService(project, extractor)
 
-    async def mock_run_discovery(tap, plugin_invoker, catalog_path) -> None:  # noqa: ANN001, ARG001
+    async def mock_run_discovery(tap, plugin_invoker, catalog_path) -> None:  # noqa: ARG001
         with catalog_path.open("w") as catalog_file:
             json.dump(catalog, catalog_file)
 

--- a/tests/meltano/core/test_setting_definition.py
+++ b/tests/meltano/core/test_setting_definition.py
@@ -47,7 +47,7 @@ class TestSettingDefinition:
     def test_cast_value_array(
         self,
         setting_definition: SettingDefinition,
-        uncast_expected_pairs,  # noqa: ANN001
+        uncast_expected_pairs,
     ) -> None:
         for uncast, expected in uncast_expected_pairs:
             if isinstance(expected, type) and issubclass(expected, Exception):

--- a/tests/meltano/core/test_setting_definition.py
+++ b/tests/meltano/core/test_setting_definition.py
@@ -47,8 +47,8 @@ class TestSettingDefinition:
     def test_cast_value_array(
         self,
         setting_definition: SettingDefinition,
-        uncast_expected_pairs,
-    ):
+        uncast_expected_pairs,  # noqa: ANN001
+    ) -> None:
         for uncast, expected in uncast_expected_pairs:
             if isinstance(expected, type) and issubclass(expected, Exception):
                 with pytest.raises(expected):
@@ -56,7 +56,7 @@ class TestSettingDefinition:
             else:
                 assert setting_definition.cast_value(uncast) == expected
 
-    def test_cast_options(self):
+    def test_cast_options(self) -> None:
         setting_definition = SettingDefinition(
             name="test_setting",
             kind=SettingKind.OPTIONS,
@@ -173,6 +173,6 @@ class TestSettingDefinition:
         *,
         sensitive: bool,
         kind: SettingKind,
-    ):
+    ) -> None:
         assert setting_definition.sensitive is sensitive
         assert setting_definition.kind is kind

--- a/tests/meltano/core/test_setting_definition.py
+++ b/tests/meltano/core/test_setting_definition.py
@@ -10,7 +10,7 @@ class TestSettingDefinition:
         ("setting_definition", "uncast_expected_pairs"),
         (
             (
-                SettingDefinition("test_setting", kind=SettingKind.ARRAY),
+                SettingDefinition(name="test_setting", kind=SettingKind.ARRAY),
                 (
                     ('["abc", "xyz"]', ["abc", "xyz"]),
                     ('["abc", "xyz",]', ["abc", "xyz"]),
@@ -25,7 +25,7 @@ class TestSettingDefinition:
                 ),
             ),
             (
-                SettingDefinition("test_setting", kind=SettingKind.OBJECT),
+                SettingDefinition(name="test_setting", kind=SettingKind.OBJECT),
                 (
                     (
                         '{"key_1": "value_1", "key_2": "value_2"}',
@@ -58,7 +58,7 @@ class TestSettingDefinition:
 
     def test_cast_options(self):
         setting_definition = SettingDefinition(
-            "test_setting",
+            name="test_setting",
             kind=SettingKind.OPTIONS,
             options=[
                 {"value": "abc", "label": "ABC"},
@@ -77,7 +77,7 @@ class TestSettingDefinition:
         (
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=True,
                     kind=SettingKind.STRING,
                 ),
@@ -87,7 +87,7 @@ class TestSettingDefinition:
             ),
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=True,
                     kind=SettingKind.PASSWORD,
                 ),
@@ -97,7 +97,7 @@ class TestSettingDefinition:
             ),
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=False,
                     kind=None,
                 ),
@@ -107,7 +107,7 @@ class TestSettingDefinition:
             ),
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=False,
                     kind=SettingKind.STRING,
                 ),
@@ -117,7 +117,7 @@ class TestSettingDefinition:
             ),
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=False,
                     kind=SettingKind.PASSWORD,
                 ),
@@ -127,7 +127,7 @@ class TestSettingDefinition:
             ),
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=False,
                     kind=None,
                 ),
@@ -137,7 +137,7 @@ class TestSettingDefinition:
             ),
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=None,
                     kind=SettingKind.STRING,
                 ),
@@ -147,7 +147,7 @@ class TestSettingDefinition:
             ),
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=None,
                     kind=SettingKind.PASSWORD,
                 ),
@@ -157,7 +157,7 @@ class TestSettingDefinition:
             ),
             pytest.param(
                 SettingDefinition(
-                    "test_setting",
+                    name="test_setting",
                     sensitive=None,
                     kind=None,
                 ),
@@ -170,6 +170,7 @@ class TestSettingDefinition:
     def test_parse(
         self,
         setting_definition: SettingDefinition,
+        *,
         sensitive: bool,
         kind: SettingKind,
     ):

--- a/tests/meltano/core/test_settings_store.py
+++ b/tests/meltano/core/test_settings_store.py
@@ -26,7 +26,7 @@ Store = SettingValueStore
 class DummySettingsService(SettingsService):
     """Dummy SettingsService for testing."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Instantiate new DummySettingsService instance.
 
         Args:
@@ -45,44 +45,44 @@ class DummySettingsService(SettingsService):
         self._inherited_settings = None
 
     @property
-    def label(self):
+    def label(self) -> str:
         return "Dummy"
 
     @property
-    def project_settings_service(self):
+    def project_settings_service(self):  # noqa: ANN201
         return ProjectSettingsService(Project.find())
 
     @property
-    def docs_url(self):
+    def docs_url(self) -> str:
         return "https://docs.meltano.com/"
 
     @property
-    def env_prefixes(self):
+    def env_prefixes(self):  # noqa: ANN201
         return ["dummy"]
 
     @property
-    def db_namespace(self):
+    def db_namespace(self) -> str:
         return "dummy"
 
     @property
-    def setting_definitions(self):
+    def setting_definitions(self):  # noqa: ANN201
         return self.__definitions
 
     @property
-    def meltano_yml_config(self):
+    def meltano_yml_config(self):  # noqa: ANN201
         return self.__meltano_yml_config
 
-    def update_meltano_yml_config(self, config):
+    def update_meltano_yml_config(self, config) -> None:  # noqa: ANN001
         self.__meltano_yml_config = config
 
-    def update_meltano_environment_config(self, config):
+    def update_meltano_environment_config(self, config) -> None:  # noqa: ANN001
         self._meltano_environment_config = config
 
     @property
-    def inherited_settings_service(self):
+    def inherited_settings_service(self):  # noqa: ANN201
         return self._inherited_settings
 
-    def process_config(self, config):
+    def process_config(self, config):  # noqa: ANN001, ANN201
         return config
 
     @property
@@ -91,14 +91,14 @@ class DummySettingsService(SettingsService):
 
 
 @pytest.fixture()
-def dummy_settings_service(project):
+def dummy_settings_service(project):  # noqa: ANN001, ANN201
     return DummySettingsService(project)
 
 
 @pytest.fixture()
-def unsupported():
+def unsupported():  # noqa: ANN201
     @contextmanager
-    def _unsupported(store):
+    def _unsupported(store):  # noqa: ANN001, ANN202
         with mock.patch.object(
             store.manager,
             "ensure_supported",
@@ -123,14 +123,14 @@ def unsupported():
 
 class TestAutoStoreManager:
     @pytest.fixture()
-    def subject(self, dummy_settings_service, session):
+    def subject(self, dummy_settings_service, session):  # noqa: ANN001, ANN201
         manager = AutoStoreManager(dummy_settings_service, session=session, cache=False)
         yield manager
         manager.reset()
 
     @pytest.fixture()
-    def set_value_store(self, subject):
-        def _set_value_store(value, store, name="regular"):
+    def set_value_store(self, subject):  # noqa: ANN001, ANN201
+        def _set_value_store(value, store, name="regular") -> None:  # noqa: ANN001
             subject.manager_for(store).set(
                 name,
                 [name],
@@ -141,12 +141,12 @@ class TestAutoStoreManager:
         return _set_value_store
 
     @pytest.fixture()
-    def environment(self):
+    def environment(self):  # noqa: ANN201
         return Environment("testing", {})
 
     @pytest.fixture()
-    def assert_value_source(self, subject):
-        def _assert_value_source(value, source, name="regular"):
+    def assert_value_source(self, subject):  # noqa: ANN001, ANN201
+        def _assert_value_source(value, source, name="regular") -> None:  # noqa: ANN001
             new_value, metadata = subject.get(
                 name,
                 setting_def=subject.find_setting(name),
@@ -167,14 +167,14 @@ class TestAutoStoreManager:
     )
     def test_auto_store(
         self,
-        setting_name,
-        preferred_store,
-        subject,
-        project,
-        unsupported,
-        environment,
-        monkeypatch,
-    ):
+        setting_name,  # noqa: ANN001
+        preferred_store,  # noqa: ANN001
+        subject,  # noqa: ANN001
+        project,  # noqa: ANN001
+        unsupported,  # noqa: ANN001
+        environment,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         assert subject.auto_store(setting_name) == preferred_store
 
         # Meltano environment is selected only when there's an active environment
@@ -217,13 +217,13 @@ class TestAutoStoreManager:
     @pytest.mark.usefixtures("assert_value_source")
     def test_get(
         self,
-        subject,
-        project,
-        dummy_settings_service,
-        set_value_store,
-        monkeypatch,
-        environment,
-    ):
+        subject,  # noqa: ANN001
+        project,  # noqa: ANN001
+        dummy_settings_service,  # noqa: ANN001
+        set_value_store,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+        environment,  # noqa: ANN001
+    ) -> None:
         value, metadata = subject.get("regular")
         assert value == "from_default"
         assert metadata["source"] == Store.DEFAULT
@@ -306,13 +306,13 @@ class TestAutoStoreManager:
     def test_set(
         self,
         subject: SettingsStoreManager,
-        project,
-        unsupported,
-        assert_value_source,
-        monkeypatch,
-        environment,
-    ):
-        def set_value(value):
+        project,  # noqa: ANN001
+        unsupported,  # noqa: ANN001
+        assert_value_source,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+        environment,  # noqa: ANN001
+    ) -> None:
+        def set_value(value):  # noqa: ANN001, ANN202
             return subject.set("regular", ["regular"], value)
 
         # Allow setting to a default value
@@ -379,14 +379,14 @@ class TestAutoStoreManager:
 
     def test_unset(
         self,
-        subject,
-        project,
-        unsupported,
-        set_value_store,
-        assert_value_source,
-        monkeypatch,
-        environment,
-    ):
+        subject,  # noqa: ANN001
+        project,  # noqa: ANN001
+        unsupported,  # noqa: ANN001
+        set_value_store,  # noqa: ANN001
+        assert_value_source,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+        environment,  # noqa: ANN001
+    ) -> None:
         set_value_store("from_dotenv", Store.DOTENV, name="password")
 
         set_value_store("from_dotenv", Store.DOTENV)
@@ -441,14 +441,14 @@ class TestAutoStoreManager:
 
     def test_reset(
         self,
-        subject,
-        unsupported,
-        set_value_store,
-        assert_value_source,
-        project,
-        environment,
-        monkeypatch,
-    ):
+        subject,  # noqa: ANN001
+        unsupported,  # noqa: ANN001
+        set_value_store,  # noqa: ANN001
+        assert_value_source,  # noqa: ANN001
+        project,  # noqa: ANN001
+        environment,  # noqa: ANN001
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
         set_value_store("from_db", Store.DB)
         set_value_store("from_meltano_yml", Store.MELTANO_YML, name="unknown")
         set_value_store("from_dotenv", Store.DOTENV, name="password")
@@ -515,13 +515,13 @@ class TestAutoStoreManager:
 
 class TestMeltanoYmlStoreManager:
     @pytest.fixture()
-    def subject(self, dummy_settings_service):
+    def subject(self, dummy_settings_service):  # noqa: ANN001, ANN201
         manager = MeltanoYmlStoreManager(dummy_settings_service)
         yield manager
         manager.reset()
 
-    def test_get(self, subject):
-        def get():
+    def test_get(self, subject) -> None:  # noqa: ANN001
+        def get():  # noqa: ANN202
             return subject.get(
                 "regular",
                 setting_def=subject.settings_service.find_setting("regular"),
@@ -538,8 +538,8 @@ class TestMeltanoYmlStoreManager:
 
         assert get() == ("value", {"expandable": True, "key": "regular"})
 
-    def test_set(self, subject):
-        def set_value(key, value):
+    def test_set(self, subject) -> None:  # noqa: ANN001
+        def set_value(key, value):  # noqa: ANN001, ANN202
             return subject.set(
                 key,
                 [key],
@@ -559,15 +559,15 @@ class TestMeltanoYmlStoreManager:
         assert "basic" not in subject.flat_config
         assert subject.flat_config["regular"] == "new_value"
 
-    def test_unset(self, subject):
-        def unset_value(key):
+    def test_unset(self, subject) -> None:  # noqa: ANN001
+        def unset_value(key):  # noqa: ANN001, ANN202
             return subject.unset(
                 key,
                 [key],
                 setting_def=subject.settings_service.find_setting(key),
             )
 
-        def set_values():
+        def set_values() -> None:
             subject.flat_config["regular"] = "value"
             subject.flat_config["basic"] = "alias_value"
 
@@ -586,7 +586,7 @@ class TestMeltanoYmlStoreManager:
 
 class TestMeltanoEnvironmentStoreManager(TestMeltanoYmlStoreManager):
     @pytest.fixture()
-    def subject(self, dummy_settings_service, project):
+    def subject(self, dummy_settings_service, project):  # noqa: ANN001, ANN201
         project.refresh(environment=Environment("testing", {}))
         manager = MeltanoEnvStoreManager(dummy_settings_service)
         try:
@@ -598,11 +598,11 @@ class TestMeltanoEnvironmentStoreManager(TestMeltanoYmlStoreManager):
 
 class TestInheritedStoreManager:
     @pytest.fixture()
-    def subject(self, dummy_settings_service):
+    def subject(self, dummy_settings_service):  # noqa: ANN001, ANN201
         return InheritedStoreManager(dummy_settings_service)
 
-    def test_get(self, subject, project):
-        def get(key="regular"):
+    def test_get(self, subject, project) -> None:  # noqa: ANN001
+        def get(key="regular"):  # noqa: ANN001, ANN202
             return subject.get(
                 key,
                 setting_def=subject.settings_service.find_setting(key),

--- a/tests/meltano/core/test_settings_store.py
+++ b/tests/meltano/core/test_settings_store.py
@@ -38,9 +38,9 @@ class DummySettingsService(SettingsService):
         self.__meltano_yml_config = {}
         self._meltano_environment_config = {}
         self.__definitions = [
-            SettingDefinition("regular", aliases=["basic"], value="from_default"),
-            SettingDefinition("password", sensitive=True),
-            SettingDefinition("env_specific", env_specific=True),
+            SettingDefinition(name="regular", aliases=["basic"], value="from_default"),
+            SettingDefinition(name="password", sensitive=True),
+            SettingDefinition(name="env_specific", env_specific=True),
         ]
         self._inherited_settings = None
 

--- a/tests/meltano/core/test_settings_store.py
+++ b/tests/meltano/core/test_settings_store.py
@@ -26,7 +26,7 @@ Store = SettingValueStore
 class DummySettingsService(SettingsService):
     """Dummy SettingsService for testing."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+    def __init__(self, *args, **kwargs) -> None:
         """Instantiate new DummySettingsService instance.
 
         Args:
@@ -49,7 +49,7 @@ class DummySettingsService(SettingsService):
         return "Dummy"
 
     @property
-    def project_settings_service(self):  # noqa: ANN201
+    def project_settings_service(self):
         return ProjectSettingsService(Project.find())
 
     @property
@@ -57,7 +57,7 @@ class DummySettingsService(SettingsService):
         return "https://docs.meltano.com/"
 
     @property
-    def env_prefixes(self):  # noqa: ANN201
+    def env_prefixes(self):
         return ["dummy"]
 
     @property
@@ -65,24 +65,24 @@ class DummySettingsService(SettingsService):
         return "dummy"
 
     @property
-    def setting_definitions(self):  # noqa: ANN201
+    def setting_definitions(self):
         return self.__definitions
 
     @property
-    def meltano_yml_config(self):  # noqa: ANN201
+    def meltano_yml_config(self):
         return self.__meltano_yml_config
 
-    def update_meltano_yml_config(self, config) -> None:  # noqa: ANN001
+    def update_meltano_yml_config(self, config) -> None:
         self.__meltano_yml_config = config
 
-    def update_meltano_environment_config(self, config) -> None:  # noqa: ANN001
+    def update_meltano_environment_config(self, config) -> None:
         self._meltano_environment_config = config
 
     @property
-    def inherited_settings_service(self):  # noqa: ANN201
+    def inherited_settings_service(self):
         return self._inherited_settings
 
-    def process_config(self, config):  # noqa: ANN001, ANN201
+    def process_config(self, config):
         return config
 
     @property
@@ -91,14 +91,14 @@ class DummySettingsService(SettingsService):
 
 
 @pytest.fixture()
-def dummy_settings_service(project):  # noqa: ANN001, ANN201
+def dummy_settings_service(project):
     return DummySettingsService(project)
 
 
 @pytest.fixture()
-def unsupported():  # noqa: ANN201
+def unsupported():
     @contextmanager
-    def _unsupported(store):  # noqa: ANN001, ANN202
+    def _unsupported(store):
         with mock.patch.object(
             store.manager,
             "ensure_supported",
@@ -123,14 +123,14 @@ def unsupported():  # noqa: ANN201
 
 class TestAutoStoreManager:
     @pytest.fixture()
-    def subject(self, dummy_settings_service, session):  # noqa: ANN001, ANN201
+    def subject(self, dummy_settings_service, session):
         manager = AutoStoreManager(dummy_settings_service, session=session, cache=False)
         yield manager
         manager.reset()
 
     @pytest.fixture()
-    def set_value_store(self, subject):  # noqa: ANN001, ANN201
-        def _set_value_store(value, store, name="regular") -> None:  # noqa: ANN001
+    def set_value_store(self, subject):
+        def _set_value_store(value, store, name="regular") -> None:
             subject.manager_for(store).set(
                 name,
                 [name],
@@ -141,12 +141,12 @@ class TestAutoStoreManager:
         return _set_value_store
 
     @pytest.fixture()
-    def environment(self):  # noqa: ANN201
+    def environment(self):
         return Environment("testing", {})
 
     @pytest.fixture()
-    def assert_value_source(self, subject):  # noqa: ANN001, ANN201
-        def _assert_value_source(value, source, name="regular") -> None:  # noqa: ANN001
+    def assert_value_source(self, subject):
+        def _assert_value_source(value, source, name="regular") -> None:
             new_value, metadata = subject.get(
                 name,
                 setting_def=subject.find_setting(name),
@@ -167,13 +167,13 @@ class TestAutoStoreManager:
     )
     def test_auto_store(
         self,
-        setting_name,  # noqa: ANN001
-        preferred_store,  # noqa: ANN001
-        subject,  # noqa: ANN001
-        project,  # noqa: ANN001
-        unsupported,  # noqa: ANN001
-        environment,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        setting_name,
+        preferred_store,
+        subject,
+        project,
+        unsupported,
+        environment,
+        monkeypatch,
     ) -> None:
         assert subject.auto_store(setting_name) == preferred_store
 
@@ -217,12 +217,12 @@ class TestAutoStoreManager:
     @pytest.mark.usefixtures("assert_value_source")
     def test_get(
         self,
-        subject,  # noqa: ANN001
-        project,  # noqa: ANN001
-        dummy_settings_service,  # noqa: ANN001
-        set_value_store,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
-        environment,  # noqa: ANN001
+        subject,
+        project,
+        dummy_settings_service,
+        set_value_store,
+        monkeypatch,
+        environment,
     ) -> None:
         value, metadata = subject.get("regular")
         assert value == "from_default"
@@ -306,13 +306,13 @@ class TestAutoStoreManager:
     def test_set(
         self,
         subject: SettingsStoreManager,
-        project,  # noqa: ANN001
-        unsupported,  # noqa: ANN001
-        assert_value_source,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
-        environment,  # noqa: ANN001
+        project,
+        unsupported,
+        assert_value_source,
+        monkeypatch,
+        environment,
     ) -> None:
-        def set_value(value):  # noqa: ANN001, ANN202
+        def set_value(value):
             return subject.set("regular", ["regular"], value)
 
         # Allow setting to a default value
@@ -379,13 +379,13 @@ class TestAutoStoreManager:
 
     def test_unset(
         self,
-        subject,  # noqa: ANN001
-        project,  # noqa: ANN001
-        unsupported,  # noqa: ANN001
-        set_value_store,  # noqa: ANN001
-        assert_value_source,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
-        environment,  # noqa: ANN001
+        subject,
+        project,
+        unsupported,
+        set_value_store,
+        assert_value_source,
+        monkeypatch,
+        environment,
     ) -> None:
         set_value_store("from_dotenv", Store.DOTENV, name="password")
 
@@ -441,13 +441,13 @@ class TestAutoStoreManager:
 
     def test_reset(
         self,
-        subject,  # noqa: ANN001
-        unsupported,  # noqa: ANN001
-        set_value_store,  # noqa: ANN001
-        assert_value_source,  # noqa: ANN001
-        project,  # noqa: ANN001
-        environment,  # noqa: ANN001
-        monkeypatch,  # noqa: ANN001
+        subject,
+        unsupported,
+        set_value_store,
+        assert_value_source,
+        project,
+        environment,
+        monkeypatch,
     ) -> None:
         set_value_store("from_db", Store.DB)
         set_value_store("from_meltano_yml", Store.MELTANO_YML, name="unknown")
@@ -515,13 +515,13 @@ class TestAutoStoreManager:
 
 class TestMeltanoYmlStoreManager:
     @pytest.fixture()
-    def subject(self, dummy_settings_service):  # noqa: ANN001, ANN201
+    def subject(self, dummy_settings_service):
         manager = MeltanoYmlStoreManager(dummy_settings_service)
         yield manager
         manager.reset()
 
-    def test_get(self, subject) -> None:  # noqa: ANN001
-        def get():  # noqa: ANN202
+    def test_get(self, subject) -> None:
+        def get():
             return subject.get(
                 "regular",
                 setting_def=subject.settings_service.find_setting("regular"),
@@ -538,8 +538,8 @@ class TestMeltanoYmlStoreManager:
 
         assert get() == ("value", {"expandable": True, "key": "regular"})
 
-    def test_set(self, subject) -> None:  # noqa: ANN001
-        def set_value(key, value):  # noqa: ANN001, ANN202
+    def test_set(self, subject) -> None:
+        def set_value(key, value):
             return subject.set(
                 key,
                 [key],
@@ -559,8 +559,8 @@ class TestMeltanoYmlStoreManager:
         assert "basic" not in subject.flat_config
         assert subject.flat_config["regular"] == "new_value"
 
-    def test_unset(self, subject) -> None:  # noqa: ANN001
-        def unset_value(key):  # noqa: ANN001, ANN202
+    def test_unset(self, subject) -> None:
+        def unset_value(key):
             return subject.unset(
                 key,
                 [key],
@@ -586,7 +586,7 @@ class TestMeltanoYmlStoreManager:
 
 class TestMeltanoEnvironmentStoreManager(TestMeltanoYmlStoreManager):
     @pytest.fixture()
-    def subject(self, dummy_settings_service, project):  # noqa: ANN001, ANN201
+    def subject(self, dummy_settings_service, project):
         project.refresh(environment=Environment("testing", {}))
         manager = MeltanoEnvStoreManager(dummy_settings_service)
         try:
@@ -598,11 +598,11 @@ class TestMeltanoEnvironmentStoreManager(TestMeltanoYmlStoreManager):
 
 class TestInheritedStoreManager:
     @pytest.fixture()
-    def subject(self, dummy_settings_service):  # noqa: ANN001, ANN201
+    def subject(self, dummy_settings_service):
         return InheritedStoreManager(dummy_settings_service)
 
-    def test_get(self, subject, project) -> None:  # noqa: ANN001
-        def get(key="regular"):  # noqa: ANN001, ANN202
+    def test_get(self, subject, project) -> None:
+        def get(key="regular"):
             return subject.get(
                 key,
                 setting_def=subject.settings_service.find_setting(key),

--- a/tests/meltano/core/test_sqlalchemy.py
+++ b/tests/meltano/core/test_sqlalchemy.py
@@ -52,7 +52,7 @@ class TestSQLAlchemyModels:
         table: sa.Table,
         inserted: datetime | None,
         expected: datetime | None,
-    ):
+    ) -> None:
         select_stmt = table.select()
         insert_stmt = table.insert().values(created_at=inserted)
 

--- a/tests/meltano/core/test_state_service.py
+++ b/tests/meltano/core/test_state_service.py
@@ -10,7 +10,7 @@ from meltano.core.utils import merge
 
 
 class TestStateService:
-    def test_validate_state(self, state_service) -> None:  # noqa: ANN001
+    def test_validate_state(self, state_service) -> None:
         with pytest.raises(InvalidJobStateError):
             state_service.validate_state(
                 json.loads('{"root key not singer_state": {}}'),
@@ -24,14 +24,14 @@ class TestStateService:
             is None
         )
 
-    def test_get_state(self, state_service, state_ids_with_expected_states) -> None:  # noqa: ANN001
+    def test_get_state(self, state_service, state_ids_with_expected_states) -> None:
         for state_id, expected_state in state_ids_with_expected_states:
             assert state_service.get_state(state_id) == expected_state
 
-    def test_list_state(self, state_service, state_ids_with_expected_states) -> None:  # noqa: ANN001
+    def test_list_state(self, state_service, state_ids_with_expected_states) -> None:
         assert state_service.list_state() == dict(state_ids_with_expected_states)
 
-    def test_add_state(self, state_service, payloads) -> None:  # noqa: ANN001
+    def test_add_state(self, state_service, payloads) -> None:
         mock_state_id = "nonexistent"
         state_service.add_state(
             mock_state_id,
@@ -40,7 +40,7 @@ class TestStateService:
         assert state_service.get_state(mock_state_id) == payloads.mock_state_payloads[0]
 
     @pytest.mark.usefixtures("job_history_session")
-    def test_set_state(self, jobs, payloads, state_service) -> None:  # noqa: ANN001
+    def test_set_state(self, jobs, payloads, state_service) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -52,13 +52,13 @@ class TestStateService:
                 assert state_service.get_state(job.job_name) == state
 
     @pytest.mark.usefixtures("job_history_session")
-    def test_clear_state(self, jobs, payloads, state_service) -> None:  # noqa: ANN001
+    def test_clear_state(self, jobs, payloads, state_service) -> None:
         for job in jobs:
             state_service.clear_state(job.job_name)
             assert state_service.get_state(job.job_name) == payloads.mock_empty_payload
 
     @pytest.mark.usefixtures("job_history_session")
-    def test_merge_state(self, jobs, state_service) -> None:  # noqa: ANN001
+    def test_merge_state(self, jobs, state_service) -> None:
         job_pairs = [(jobs[idx], jobs[idx + 1]) for idx in range(0, len(jobs) - 1, 2)]
         for job_src, job_dst in job_pairs:
             state_src = state_service.get_state(job_src.job_name)
@@ -67,7 +67,7 @@ class TestStateService:
             state_service.merge_state(job_src.job_name, job_dst.job_name)
             assert merged_dst == state_service.get_state(job_dst.job_name)
 
-    def test_copy(self, state_ids, state_service) -> None:  # noqa: ANN001
+    def test_copy(self, state_ids, state_service) -> None:
         state_id_pairs = [
             (state_ids[idx], state_ids[idx + 1])
             for idx in range(0, len(state_ids) - 1, 2)
@@ -77,7 +77,7 @@ class TestStateService:
             state_service.copy_state(state_id_src, state_id_dst)
             assert state_service.get_state(state_id_dst) == state_src
 
-    def test_move(self, state_ids, state_service) -> None:  # noqa: ANN001
+    def test_move(self, state_ids, state_service) -> None:
         state_id_pairs = [
             (state_ids[idx], state_ids[idx + 1])
             for idx in range(0, len(state_ids) - 1, 2)

--- a/tests/meltano/core/test_state_service.py
+++ b/tests/meltano/core/test_state_service.py
@@ -10,7 +10,7 @@ from meltano.core.utils import merge
 
 
 class TestStateService:
-    def test_validate_state(self, state_service):
+    def test_validate_state(self, state_service) -> None:  # noqa: ANN001
         with pytest.raises(InvalidJobStateError):
             state_service.validate_state(
                 json.loads('{"root key not singer_state": {}}'),
@@ -24,14 +24,14 @@ class TestStateService:
             is None
         )
 
-    def test_get_state(self, state_service, state_ids_with_expected_states):
+    def test_get_state(self, state_service, state_ids_with_expected_states) -> None:  # noqa: ANN001
         for state_id, expected_state in state_ids_with_expected_states:
             assert state_service.get_state(state_id) == expected_state
 
-    def test_list_state(self, state_service, state_ids_with_expected_states):
+    def test_list_state(self, state_service, state_ids_with_expected_states) -> None:  # noqa: ANN001
         assert state_service.list_state() == dict(state_ids_with_expected_states)
 
-    def test_add_state(self, state_service, payloads):
+    def test_add_state(self, state_service, payloads) -> None:  # noqa: ANN001
         mock_state_id = "nonexistent"
         state_service.add_state(
             mock_state_id,
@@ -40,7 +40,7 @@ class TestStateService:
         assert state_service.get_state(mock_state_id) == payloads.mock_state_payloads[0]
 
     @pytest.mark.usefixtures("job_history_session")
-    def test_set_state(self, jobs, payloads, state_service):
+    def test_set_state(self, jobs, payloads, state_service) -> None:  # noqa: ANN001
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -52,13 +52,13 @@ class TestStateService:
                 assert state_service.get_state(job.job_name) == state
 
     @pytest.mark.usefixtures("job_history_session")
-    def test_clear_state(self, jobs, payloads, state_service):
+    def test_clear_state(self, jobs, payloads, state_service) -> None:  # noqa: ANN001
         for job in jobs:
             state_service.clear_state(job.job_name)
             assert state_service.get_state(job.job_name) == payloads.mock_empty_payload
 
     @pytest.mark.usefixtures("job_history_session")
-    def test_merge_state(self, jobs, state_service):
+    def test_merge_state(self, jobs, state_service) -> None:  # noqa: ANN001
         job_pairs = [(jobs[idx], jobs[idx + 1]) for idx in range(0, len(jobs) - 1, 2)]
         for job_src, job_dst in job_pairs:
             state_src = state_service.get_state(job_src.job_name)
@@ -67,7 +67,7 @@ class TestStateService:
             state_service.merge_state(job_src.job_name, job_dst.job_name)
             assert merged_dst == state_service.get_state(job_dst.job_name)
 
-    def test_copy(self, state_ids, state_service):
+    def test_copy(self, state_ids, state_service) -> None:  # noqa: ANN001
         state_id_pairs = [
             (state_ids[idx], state_ids[idx + 1])
             for idx in range(0, len(state_ids) - 1, 2)
@@ -77,7 +77,7 @@ class TestStateService:
             state_service.copy_state(state_id_src, state_id_dst)
             assert state_service.get_state(state_id_dst) == state_src
 
-    def test_move(self, state_ids, state_service):
+    def test_move(self, state_ids, state_service) -> None:  # noqa: ANN001
         state_id_pairs = [
             (state_ids[idx], state_ids[idx + 1])
             for idx in range(0, len(state_ids) - 1, 2)

--- a/tests/meltano/core/test_task_sets.py
+++ b/tests/meltano/core/test_task_sets.py
@@ -6,7 +6,7 @@ from meltano.core.task_sets import InvalidTasksError, TaskSets, tasks_from_yaml_
 
 
 class TestTaskSets:
-    def test_squash(self):
+    def test_squash(self) -> None:
         tset = TaskSets(name="test", tasks=["tap target", "tap2 target2"])
         assert tset._as_args() == ["tap", "target", "tap2", "target2"]
 
@@ -25,7 +25,7 @@ class TestTaskSets:
             ["tap2", "target2"],
         ]
 
-    def test_tasks_from_yaml_str(self):
+    def test_tasks_from_yaml_str(self) -> None:
         cases = [
             ("generic", "tap target", TaskSets(name="generic", tasks=["tap target"])),
             (

--- a/tests/meltano/core/test_task_sets_service.py
+++ b/tests/meltano/core/test_task_sets_service.py
@@ -11,8 +11,8 @@ from meltano.core.task_sets_service import (
 
 
 @pytest.fixture(scope="session")
-def create_task_set():
-    def make(name):
+def create_task_set():  # noqa: ANN201
+    def make(name):  # noqa: ANN001, ANN202
         return TaskSets(name=name, tasks=["tap-mock target-mock"])
 
     return make
@@ -20,11 +20,11 @@ def create_task_set():
 
 class TestTaskSetsService:
     @pytest.fixture()
-    def subject(self, task_sets_service):
+    def subject(self, task_sets_service):  # noqa: ANN001, ANN201
         return task_sets_service
 
     @pytest.mark.order(0)
-    def test_add(self, subject: TaskSetsService, create_task_set):
+    def test_add(self, subject: TaskSetsService, create_task_set) -> None:  # noqa: ANN001
         count = 10
         jobs = [create_task_set(f"test_job_{idx}") for idx in range(count)]
 
@@ -37,7 +37,7 @@ class TestTaskSetsService:
         with pytest.raises(JobAlreadyExistsError):
             subject.add(jobs[0])
 
-    def test_update(self, subject: TaskSetsService, create_task_set):
+    def test_update(self, subject: TaskSetsService, create_task_set) -> None:  # noqa: ANN001
         job = subject.list()[0]
         job.tasks = ["tap-mock target-mock updated:addition"]
         subject.update(job)
@@ -49,7 +49,7 @@ class TestTaskSetsService:
             subject.update(nonexistent)
 
     @pytest.mark.usefixtures("create_task_set")
-    def test_remove(self, subject: TaskSetsService):
+    def test_remove(self, subject: TaskSetsService) -> None:
         jobs = subject.list()
         subject.remove(jobs[0].name)
         assert subject.list() == jobs[1:]
@@ -60,7 +60,7 @@ class TestTaskSetsService:
             subject.remove(jobs[0].name)
 
     @pytest.mark.usefixtures("create_task_set")
-    def test_get(self, subject: TaskSetsService):
+    def test_get(self, subject: TaskSetsService) -> None:
         jobs = subject.list()
 
         assert subject.get(jobs[0].name) == jobs[0]
@@ -70,12 +70,12 @@ class TestTaskSetsService:
             subject.get("non-existent")
 
     @pytest.mark.usefixtures("create_task_set")
-    def test_exists(self, subject: TaskSetsService):
+    def test_exists(self, subject: TaskSetsService) -> None:
         job = subject.list()[0]
         assert subject.exists(job.name)
         assert not subject.exists("non-existent")
 
-    def test_list(self, subject: TaskSetsService, create_task_set):
+    def test_list(self, subject: TaskSetsService, create_task_set) -> None:  # noqa: ANN001
         expected_jobs = [create_task_set(f"test_list_{idx}") for idx in range(3)]
 
         for job in expected_jobs:

--- a/tests/meltano/core/test_task_sets_service.py
+++ b/tests/meltano/core/test_task_sets_service.py
@@ -11,8 +11,8 @@ from meltano.core.task_sets_service import (
 
 
 @pytest.fixture(scope="session")
-def create_task_set():  # noqa: ANN201
-    def make(name):  # noqa: ANN001, ANN202
+def create_task_set():
+    def make(name):
         return TaskSets(name=name, tasks=["tap-mock target-mock"])
 
     return make
@@ -20,11 +20,11 @@ def create_task_set():  # noqa: ANN201
 
 class TestTaskSetsService:
     @pytest.fixture()
-    def subject(self, task_sets_service):  # noqa: ANN001, ANN201
+    def subject(self, task_sets_service):
         return task_sets_service
 
     @pytest.mark.order(0)
-    def test_add(self, subject: TaskSetsService, create_task_set) -> None:  # noqa: ANN001
+    def test_add(self, subject: TaskSetsService, create_task_set) -> None:
         count = 10
         jobs = [create_task_set(f"test_job_{idx}") for idx in range(count)]
 
@@ -37,7 +37,7 @@ class TestTaskSetsService:
         with pytest.raises(JobAlreadyExistsError):
             subject.add(jobs[0])
 
-    def test_update(self, subject: TaskSetsService, create_task_set) -> None:  # noqa: ANN001
+    def test_update(self, subject: TaskSetsService, create_task_set) -> None:
         job = subject.list()[0]
         job.tasks = ["tap-mock target-mock updated:addition"]
         subject.update(job)
@@ -75,7 +75,7 @@ class TestTaskSetsService:
         assert subject.exists(job.name)
         assert not subject.exists("non-existent")
 
-    def test_list(self, subject: TaskSetsService, create_task_set) -> None:  # noqa: ANN001
+    def test_list(self, subject: TaskSetsService, create_task_set) -> None:
         expected_jobs = [create_task_set(f"test_list_{idx}") for idx in range(3)]
 
         for job in expected_jobs:

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -183,7 +183,7 @@ def test_flatten() -> None:
         ),
     ),
 )
-def test_expand_env_vars(input_value, env, kwargs, expected_output) -> None:  # noqa: ANN001
+def test_expand_env_vars(input_value, env, kwargs, expected_output) -> None:
     assert expand_env_vars(input_value, env, **kwargs) == expected_output
 
 
@@ -265,7 +265,7 @@ def test_expand_env_vars_nested() -> None:
         ),
     ),
 )
-def test_expand_env_vars_array_nested(input_array, env, expected_output) -> None:  # noqa: ANN001
+def test_expand_env_vars_array_nested(input_array, env, expected_output) -> None:
     assert expand_env_vars(input_array, env) == expected_output
 
 
@@ -275,16 +275,16 @@ def test_remove_suffix() -> None:
     assert remove_suffix("a_string", "gni") == "a_string"
 
 
-def test_makedirs_decorator(tmp_path) -> None:  # noqa: ANN001
-    def root(*paths):  # noqa: ANN002, ANN202
+def test_makedirs_decorator(tmp_path) -> None:
+    def root(*paths):
         return tmp_path.joinpath(*paths)
 
     @makedirs
-    def hierarchy(*ranks, make_dirs: bool = True):  # noqa: ANN002, ANN202, ARG001
+    def hierarchy(*ranks, make_dirs: bool = True):  # noqa: ARG001
         return root(*ranks)
 
     @makedirs
-    def species(genus_name, species_name, *, make_dirs: bool = True):  # noqa: ANN001, ANN202
+    def species(genus_name, species_name, *, make_dirs: bool = True):
         return hierarchy(genus_name, species_name, make_dirs=make_dirs)
 
     cat = species("felis", "catus")

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -16,7 +16,7 @@ from meltano.core.utils import (
 )
 
 
-def test_nest():
+def test_nest() -> None:
     subject = {}
 
     one_deep = nest(subject, "a.b")
@@ -55,7 +55,7 @@ def test_nest():
     }
 
 
-def test_pop_at_path():
+def test_pop_at_path() -> None:
     subject = {}
     pop_at_path(subject, "a.b.c")
     assert not subject
@@ -79,7 +79,7 @@ def test_pop_at_path():
     assert not subject
 
 
-def test_set_at_path():
+def test_set_at_path() -> None:
     subject = {}
 
     set_at_path(subject, "a.b.c", "value")
@@ -101,7 +101,7 @@ def test_set_at_path():
     assert subject == {"a": {"b": {"c": "value"}, "d.e": "value"}}
 
 
-def test_flatten():
+def test_flatten() -> None:
     example_config = {"_update": {"orchestrate/dags/meltano.py": False}}
     expected_flat = {"_update.orchestrate/dags/meltano.py": False}
     result = flatten(example_config, "dot")
@@ -183,11 +183,11 @@ def test_flatten():
         ),
     ),
 )
-def test_expand_env_vars(input_value, env, kwargs, expected_output):
+def test_expand_env_vars(input_value, env, kwargs, expected_output) -> None:  # noqa: ANN001
     assert expand_env_vars(input_value, env, **kwargs) == expected_output
 
 
-def test_expand_env_vars_nested():
+def test_expand_env_vars_nested() -> None:
     input_dict = {
         "some_key": 12,
         "some_var": "${ENV_VAR_1}",
@@ -265,26 +265,26 @@ def test_expand_env_vars_nested():
         ),
     ),
 )
-def test_expand_env_vars_array_nested(input_array, env, expected_output):
+def test_expand_env_vars_array_nested(input_array, env, expected_output) -> None:  # noqa: ANN001
     assert expand_env_vars(input_array, env) == expected_output
 
 
-def test_remove_suffix():
+def test_remove_suffix() -> None:
     assert remove_suffix("a_string", "ing") == "a_str"
     assert remove_suffix("a_string", "in") == "a_string"
     assert remove_suffix("a_string", "gni") == "a_string"
 
 
-def test_makedirs_decorator(tmp_path):
-    def root(*paths):
+def test_makedirs_decorator(tmp_path) -> None:  # noqa: ANN001
+    def root(*paths):  # noqa: ANN002, ANN202
         return tmp_path.joinpath(*paths)
 
     @makedirs
-    def hierarchy(*ranks, make_dirs: bool = True):  # noqa: ARG001
+    def hierarchy(*ranks, make_dirs: bool = True):  # noqa: ANN002, ANN202, ARG001
         return root(*ranks)
 
     @makedirs
-    def species(genus_name, species_name, *, make_dirs: bool = True):
+    def species(genus_name, species_name, *, make_dirs: bool = True):  # noqa: ANN001, ANN202
         return hierarchy(genus_name, species_name, make_dirs=make_dirs)
 
     cat = species("felis", "catus")

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -284,7 +284,7 @@ def test_makedirs_decorator(tmp_path):
         return root(*ranks)
 
     @makedirs
-    def species(genus_name, species_name, make_dirs: bool = True):
+    def species(genus_name, species_name, *, make_dirs: bool = True):
         return hierarchy(genus_name, species_name, make_dirs=make_dirs)
 
     cat = species("felis", "catus")

--- a/tests/meltano/core/test_validation_service.py
+++ b/tests/meltano/core/test_validation_service.py
@@ -19,7 +19,7 @@ class MockValidationsRunner(ValidationsRunner):
 
 class TestValidationsRunner:
     @pytest.mark.asyncio()
-    async def test_run_all(self, session, dbt, plugin_invoker_factory) -> None:  # noqa: ANN001
+    async def test_run_all(self, session, dbt, plugin_invoker_factory) -> None:
         invoker = plugin_invoker_factory(dbt)
         runner = MockValidationsRunner(
             invoker,

--- a/tests/meltano/core/test_validation_service.py
+++ b/tests/meltano/core/test_validation_service.py
@@ -13,13 +13,13 @@ if t.TYPE_CHECKING:
 
 
 class MockValidationsRunner(ValidationsRunner):
-    async def run_test(self, name: str):  # noqa: ARG002
+    async def run_test(self, name: str) -> int:  # noqa: ARG002
         return 1
 
 
 class TestValidationsRunner:
     @pytest.mark.asyncio()
-    async def test_run_all(self, session, dbt, plugin_invoker_factory):
+    async def test_run_all(self, session, dbt, plugin_invoker_factory) -> None:  # noqa: ANN001
         invoker = plugin_invoker_factory(dbt)
         runner = MockValidationsRunner(
             invoker,
@@ -48,7 +48,7 @@ class TestValidationsRunner:
         assert noop_runner.invoker.call_count == 0
 
     @pytest.mark.order(after="test_run_all")
-    def test_collect_tests(self, project: Project):
+    def test_collect_tests(self, project: Project) -> None:
         collected = MockValidationsRunner.collect(project, select_all=False)
 
         assert collected["dbt"].invoker.plugin.type == PluginType.TRANSFORMERS

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -42,7 +42,7 @@ async def _check_venv_created_with_python_for_plugin(
 
 class TestVenvService:
     @pytest.fixture()
-    def subject(self, project):  # noqa: ANN001, ANN201
+    def subject(self, project):
         return VenvService(project=project, namespace="namespace", name="name")
 
     def test_clean_run_files(self, project: Project, subject: VenvService) -> None:
@@ -298,7 +298,7 @@ class TestVirtualEnv:
 
 class TestUvVenvService:
     @pytest.fixture()
-    def subject(self, project):  # noqa: ANN001, ANN201
+    def subject(self, project):
         find_uv.cache_clear()
         return UvVenvService(project=project, namespace="namespace", name="name")
 

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -22,7 +22,7 @@ if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 
-def _check_venv_created_with_python(project: Project, python: str | None):
+def _check_venv_created_with_python(project: Project, python: str | None) -> None:
     with mock.patch("meltano.core.venv_service._resolve_python_path") as venv_mock:
         VenvService(project=project)
         venv_mock.assert_called_once_with(python)
@@ -32,9 +32,9 @@ async def _check_venv_created_with_python_for_plugin(
     project: Project,
     plugin: ProjectPlugin,
     python: str | None,
-):
+) -> None:
     with mock.patch(
-        "meltano.core.venv_service._resolve_python_path"
+        "meltano.core.venv_service._resolve_python_path",
     ) as venv_mock, mock.patch("meltano.core.venv_service.VenvService.install"):
         await install_pip_plugin(project=project, plugin=plugin)
         venv_mock.assert_called_once_with(python)
@@ -42,10 +42,10 @@ async def _check_venv_created_with_python_for_plugin(
 
 class TestVenvService:
     @pytest.fixture()
-    def subject(self, project):
+    def subject(self, project):  # noqa: ANN001, ANN201
         return VenvService(project=project, namespace="namespace", name="name")
 
-    def test_clean_run_files(self, project: Project, subject: VenvService):
+    def test_clean_run_files(self, project: Project, subject: VenvService) -> None:
         run_dir = project.run_dir("name")
 
         file = run_dir / "test.file.txt"
@@ -70,7 +70,7 @@ class TestVenvService:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("project")
-    async def test_clean_install(self, subject: VenvService):
+    async def test_clean_install(self, subject: VenvService) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -129,7 +129,7 @@ class TestVenvService:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("project")
-    async def test_install(self, subject: VenvService):
+    async def test_install(self, subject: VenvService) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -153,7 +153,7 @@ class TestVenvService:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("project")
-    async def test_requires_clean_install(self, subject: VenvService):
+    async def test_requires_clean_install(self, subject: VenvService) -> None:
         # Make sure the venv exists already
         await subject.install(["example"], clean=True)
 
@@ -175,13 +175,13 @@ class TestVenvService:
         assert subject.requires_clean_install(["example==0.1.0"])
         assert subject.requires_clean_install(["example", "another-package"])
 
-    def test_top_level_python_setting(self, project: Project):
+    def test_top_level_python_setting(self, project: Project) -> None:
         project.settings.set("python", "test-python-executable-project-level")
         _check_venv_created_with_python(project, "test-python-executable-project-level")
         project.settings.unset("python")
         _check_venv_created_with_python(project, None)
 
-    async def test_plugin_python_setting(self, project: Project):
+    async def test_plugin_python_setting(self, project: Project) -> None:
         plugin = ProjectPlugin(
             PluginType.EXTRACTORS,
             name="tap-mock",
@@ -229,19 +229,19 @@ class TestVirtualEnv:
             ("Windows", "Lib"),
         ),
     )
-    def test_cross_platform(self, system: str, lib_dir: str, project: Project):
+    def test_cross_platform(self, system: str, lib_dir: str, project: Project) -> None:
         with mock.patch("platform.system", return_value=system):
             subject = VirtualEnv(project.venvs_dir("pytest", "pytest"))
             assert subject.lib_dir == subject.root / lib_dir
 
-    def test_unknown_platform(self, project: Project):
+    def test_unknown_platform(self, project: Project) -> None:
         with mock.patch("platform.system", return_value="commodore64"), pytest.raises(
             MeltanoError,
             match="(?i)Platform 'commodore64'.*?not supported.",
         ):
             VirtualEnv(project.venvs_dir("pytest", "pytest"))
 
-    def test_different_python_versions(self, project: Project):
+    def test_different_python_versions(self, project: Project) -> None:
         root = project.venvs_dir("pytest", "pytest")
 
         assert (
@@ -298,19 +298,19 @@ class TestVirtualEnv:
 
 class TestUvVenvService:
     @pytest.fixture()
-    def subject(self, project):
+    def subject(self, project):  # noqa: ANN001, ANN201
         find_uv.cache_clear()
         return UvVenvService(project=project, namespace="namespace", name="name")
 
-    def test_find_uv_builtin(self, monkeypatch: pytest.MonkeyPatch):
+    def test_find_uv_builtin(self, monkeypatch: pytest.MonkeyPatch) -> None:
         find_uv.cache_clear()
         monkeypatch.setattr("uv.find_uv_bin", lambda: "/usr/bin/uv")
         assert find_uv() == "/usr/bin/uv"
 
-    def test_find_uv_global(self, monkeypatch: pytest.MonkeyPatch):
+    def test_find_uv_global(self, monkeypatch: pytest.MonkeyPatch) -> None:
         find_uv.cache_clear()
 
-        def raise_import_error():
+        def raise_import_error() -> t.NoReturn:
             raise ImportError
 
         monkeypatch.setattr("uv.find_uv_bin", raise_import_error)
@@ -318,10 +318,10 @@ class TestUvVenvService:
 
         assert find_uv() == "/usr/bin/uv"
 
-    def test_find_uv_not_found(self, monkeypatch: pytest.MonkeyPatch):
+    def test_find_uv_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
         find_uv.cache_clear()
 
-        def raise_import_error():
+        def raise_import_error() -> t.NoReturn:
             raise ImportError
 
         monkeypatch.setattr("uv.find_uv_bin", raise_import_error)
@@ -332,7 +332,7 @@ class TestUvVenvService:
 
     @pytest.mark.asyncio()
     @pytest.mark.usefixtures("project")
-    async def test_install(self, subject: UvVenvService):
+    async def test_install(self, subject: UvVenvService) -> None:
         # Make sure the venv exists already
         await subject.install(["cowsay"], clean=True)
 
@@ -353,7 +353,7 @@ class TestUvVenvService:
         )
         assert "cowsay" in str(run.stdout)
 
-    async def test_handle_installation_error(self, subject: UvVenvService):
+    async def test_handle_installation_error(self, subject: UvVenvService) -> None:
         process = mock.Mock(spec=Process)
         process.stderr = "Some error"
 

--- a/tests/meltano/core/tracking/test_environment_context.py
+++ b/tests/meltano/core/tracking/test_environment_context.py
@@ -10,7 +10,7 @@ if t.TYPE_CHECKING:
     import pytest
 
 
-def test_notable_flag_env_vars(monkeypatch: pytest.MonkeyPatch):
+def test_notable_flag_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     for notable_flag_env_var in EnvironmentContext.notable_flag_env_vars:
         monkeypatch.delenv(notable_flag_env_var, raising=False)
 
@@ -33,7 +33,7 @@ def test_notable_flag_env_vars(monkeypatch: pytest.MonkeyPatch):
     check(("trew", "Fallse", "nah", "si", "okay", "01"), expected=None)
 
 
-def test_notable_hashed_env_vars(monkeypatch: pytest.MonkeyPatch):
+def test_notable_hashed_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     for notable_hashed_env_var in EnvironmentContext.notable_hashed_env_vars:
         monkeypatch.delenv(notable_hashed_env_var, raising=False)
     assert EnvironmentContext().data["notable_hashed_env_vars"] == {}

--- a/tests/meltano/core/tracking/test_environment_context.py
+++ b/tests/meltano/core/tracking/test_environment_context.py
@@ -28,9 +28,9 @@ def test_notable_flag_env_vars(monkeypatch: pytest.MonkeyPatch):
             expected,
         )
 
-    check(("Yes", "TRUE", "1", "true", "y", "on", "t"), True)
-    check(("No", "FALSE", "0", "false", "n", "off", "f"), False)
-    check(("trew", "Fallse", "nah", "si", "okay", "01"), None)
+    check(("Yes", "TRUE", "1", "true", "y", "on", "t"), expected=True)
+    check(("No", "FALSE", "0", "false", "n", "off", "f"), expected=False)
+    check(("trew", "Fallse", "nah", "si", "okay", "01"), expected=None)
 
 
 def test_notable_hashed_env_vars(monkeypatch: pytest.MonkeyPatch):

--- a/tests/meltano/core/tracking/test_exception.py
+++ b/tests/meltano/core/tracking/test_exception.py
@@ -49,7 +49,7 @@ def is_valid_exception_context(instance: dict[str, t.Any]) -> bool:
     return True
 
 
-def test_null_exception_context():
+def test_null_exception_context() -> None:
     ctx = ExceptionContext()
     assert isinstance(ctx.data, dict)
     assert isinstance(ctx.data["context_uuid"], str)
@@ -57,7 +57,7 @@ def test_null_exception_context():
     assert ctx.data["exception"] is None
 
 
-def test_simple_exception_context():
+def test_simple_exception_context() -> None:
     msg = "The error message"
 
     ex = ValueError(msg)
@@ -93,7 +93,7 @@ def test_simple_exception_context():
         assert key in tb_data[0]
 
 
-def test_complex_exception_context():
+def test_complex_exception_context() -> None:
     if platform.system() == "Windows":
         pytest.xfail("Fails on Windows: https://github.com/meltano/meltano/issues/3444")
 

--- a/tests/meltano/core/tracking/test_plugins.py
+++ b/tests/meltano/core/tracking/test_plugins.py
@@ -17,7 +17,7 @@ class TestPluginsTrackingContext:
         self,
         project: Project,
         dbt: ProjectPlugin,
-    ):
+    ) -> None:
         plugin_ctx = PluginsTrackingContext.from_block(
             plugin_command_invoker(
                 dbt,
@@ -31,7 +31,11 @@ class TestPluginsTrackingContext:
         self.assert_plugin_attributes(plugin_dict, dbt)
         assert plugin_dict.get("command") == "test"
 
-    def test_plugins_tracking_context(self, tap: ProjectPlugin, dbt: ProjectPlugin):
+    def test_plugins_tracking_context(
+        self,
+        tap: ProjectPlugin,
+        dbt: ProjectPlugin,
+    ) -> None:
         plugin_ctx = PluginsTrackingContext([(tap, None), (dbt, "test")])
         assert plugin_ctx.schema == PluginsContextSchema.url
         assert len(plugin_ctx.data.get("plugins")) == 2
@@ -58,7 +62,10 @@ class TestPluginsTrackingContext:
         assert not plugin_with_no_parent.get("parent_name_hash")
 
     @staticmethod
-    def assert_plugin_attributes(plugin_dict: dict[str, t.Any], plugin: ProjectPlugin):
+    def assert_plugin_attributes(
+        plugin_dict: dict[str, t.Any],
+        plugin: ProjectPlugin,
+    ) -> None:
         for dict_key, plugin_key in (
             ("name_hash", "name"),
             ("namespace_hash", "namespace"),

--- a/tests/meltano/core/tracking/test_project_context.py
+++ b/tests/meltano/core/tracking/test_project_context.py
@@ -36,7 +36,7 @@ def test_environment_name_hash(
     expected: str,
     snowplow: SnowplowMicro,
     cli_runner: MeltanoCliRunner,
-):
+) -> None:
     results = cli_runner.invoke(cli, cmd.split())
     assert_cli_runner(results)
     for event in snowplow.good():

--- a/tests/meltano/core/tracking/test_schemas.py
+++ b/tests/meltano/core/tracking/test_schemas.py
@@ -29,5 +29,5 @@ versions_available = {
 }
 
 
-def test_using_latest_schemas():
+def test_using_latest_schemas() -> None:
     assert versions_in_use == versions_available

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -54,7 +54,7 @@ def delete_analytics_json(project: Project) -> t.Generator[None, None, None]:
 
 class TestTracker:
     @pytest.fixture(autouse=True)
-    def clear_telemetry_settings(self, project, monkeypatch: pytest.MonkeyPatch):  # noqa: ANN001, ANN201
+    def clear_telemetry_settings(self, project, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("MELTANO_SEND_ANONYMOUS_USAGE_STATS", raising=False)
         config = project.settings.meltano_yml_config
         config.pop("send_anonymous_usage_stats", None)
@@ -267,7 +267,7 @@ class TestTracker:
         project.settings.set("send_anonymous_usage_stats", send_stats)
         assert Tracker(project).can_track() is expected
 
-    def test_send_anonymous_usage_stats(self, project: Project, monkeypatch) -> None:  # noqa: ANN001
+    def test_send_anonymous_usage_stats(self, project: Project, monkeypatch) -> None:
         monkeypatch.setenv("MELTANO_SEND_ANONYMOUS_USAGE_STATS", "True")
         assert Tracker(project).send_anonymous_usage_stats is True
 
@@ -366,8 +366,8 @@ class TestTracker:
     def test_timeout_if_endpoint_unavailable(
         self,
         project: Project,
-        sleep_duration,  # noqa: ANN001
-        timeout_should_occur,  # noqa: ANN001
+        sleep_duration,
+        timeout_should_occur,
     ) -> None:
         """Test to ensure that the default tracker timeout is respected.
 
@@ -413,9 +413,9 @@ class TestTracker:
     def test_project_context_send_anonymous_usage_stats_source(
         self,
         project: Project,
-        monkeypatch,  # noqa: ANN001
+        monkeypatch,
     ) -> None:
-        def get_source():  # noqa: ANN202
+        def get_source():
             return ProjectContext(project, uuid.uuid4()).to_json()["data"][
                 "send_anonymous_usage_stats_source"
             ]

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -54,7 +54,7 @@ def delete_analytics_json(project: Project) -> t.Generator[None, None, None]:
 
 class TestTracker:
     @pytest.fixture(autouse=True)
-    def clear_telemetry_settings(self, project, monkeypatch: pytest.MonkeyPatch):
+    def clear_telemetry_settings(self, project, monkeypatch: pytest.MonkeyPatch):  # noqa: ANN001, ANN201
         monkeypatch.delenv("MELTANO_SEND_ANONYMOUS_USAGE_STATS", raising=False)
         config = project.settings.meltano_yml_config
         config.pop("send_anonymous_usage_stats", None)
@@ -74,7 +74,7 @@ class TestTracker:
                 project.settings.config_override,
             ) = original_config_override
 
-    def test_telemetry_state_change_check(self, project: Project):
+    def test_telemetry_state_change_check(self, project: Project) -> None:
         with mock.patch.object(
             Tracker,
             "save_telemetry_settings",
@@ -82,7 +82,7 @@ class TestTracker:
             Tracker(project)
             assert mocked.call_count == 1
 
-    def test_update_analytics_json(self, project: Project):
+    def test_update_analytics_json(self, project: Project) -> None:
         tracker = Tracker(project)
         inital_send_anonymous_usage_stats = tracker.send_anonymous_usage_stats
 
@@ -110,7 +110,7 @@ class TestTracker:
             != analytics_json_post["send_anonymous_usage_stats"]
         )
 
-    def test_restore_project_id_from_analytics_json(self, project: Project):
+    def test_restore_project_id_from_analytics_json(self, project: Project) -> None:
         Tracker(project)  # Ensure `analytics.json` exists and is valid
 
         original_project_id = project.settings.get("project_id")
@@ -133,7 +133,10 @@ class TestTracker:
             str(uuid.UUID(hash_sha256(original_project_id)[::2])) == restored_project_id
         )
 
-    def test_no_project_id_state_change_if_tracking_disabled(self, project: Project):
+    def test_no_project_id_state_change_if_tracking_disabled(
+        self,
+        project: Project,
+    ) -> None:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
@@ -150,7 +153,10 @@ class TestTracker:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 0
 
-    def test_no_state_change_event_without_analytics_json(self, project: Project):
+    def test_no_state_change_event_without_analytics_json(
+        self,
+        project: Project,
+    ) -> None:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
@@ -163,7 +169,7 @@ class TestTracker:
                 Tracker(project)
                 assert mocked.call_count == 0
 
-    def test_analytics_json_is_created(self, project: Project):
+    def test_analytics_json_is_created(self, project: Project) -> None:
         Tracker(project)
         check_analytics_json(project)
         with delete_analytics_json(project):
@@ -185,7 +191,7 @@ class TestTracker:
         self,
         project: Project,
         analytics_json_content: str,
-    ):
+    ) -> None:
         with delete_analytics_json(project):
             # Use `delete_analytics_json` to ensure `analytics.json` is restored after
             analytics_json_path = project.meltano_dir() / "analytics.json"
@@ -199,7 +205,10 @@ class TestTracker:
 
             check_analytics_json(project)
 
-    def test_restore_project_id_and_telemetry_state_change(self, project: Project):
+    def test_restore_project_id_and_telemetry_state_change(
+        self,
+        project: Project,
+    ) -> None:
         """
         Test that `project_id` is restored from `analytics.json`, and a telemetry state
         change event is fired because `send_anonymous_usage_stats` is negated.
@@ -253,12 +262,12 @@ class TestTracker:
         snowplow_endpoints: list[str],
         send_stats: bool,
         expected: bool,
-    ):
+    ) -> None:
         project.settings.set("snowplow.collector_endpoints", snowplow_endpoints)
         project.settings.set("send_anonymous_usage_stats", send_stats)
         assert Tracker(project).can_track() is expected
 
-    def test_send_anonymous_usage_stats(self, project: Project, monkeypatch):
+    def test_send_anonymous_usage_stats(self, project: Project, monkeypatch) -> None:  # noqa: ANN001
         monkeypatch.setenv("MELTANO_SEND_ANONYMOUS_USAGE_STATS", "True")
         assert Tracker(project).send_anonymous_usage_stats is True
 
@@ -279,15 +288,15 @@ class TestTracker:
         project: Project,
         *,
         setting_value: bool,
-    ):
+    ) -> None:
         project.settings.set("send_anonymous_usage_stats", setting_value)
         assert Tracker(project).send_anonymous_usage_stats is setting_value
 
-    def test_default_send_anonymous_usage_stats(self, project: Project):
+    def test_default_send_anonymous_usage_stats(self, project: Project) -> None:
         assert Tracker(project).send_anonymous_usage_stats
 
     @pytest.mark.usefixtures("project")
-    def test_exit_event_is_fired(self, snowplow: SnowplowMicro):
+    def test_exit_event_is_fired(self, snowplow: SnowplowMicro) -> None:
         subprocess.run(("meltano", "invoke", "alpha-beta-fox"))
 
         event_summary = snowplow.all()
@@ -307,14 +316,14 @@ class TestTracker:
         project: Project,
         *,
         send_anonymous_usage_stats: bool,
-    ):
+    ) -> None:
         tracker = Tracker(project)
         tracker.send_anonymous_usage_stats = send_anonymous_usage_stats
 
         passed = False
 
         class MockSnowplowTracker:
-            def track(self, event: SelfDescribing):
+            def track(self, event: SelfDescribing) -> None:
                 # Can't put asserts in here because this method is executed
                 # withing a try-except block that catches all exceptions.
                 nonlocal passed
@@ -357,9 +366,9 @@ class TestTracker:
     def test_timeout_if_endpoint_unavailable(
         self,
         project: Project,
-        sleep_duration,
-        timeout_should_occur,
-    ):
+        sleep_duration,  # noqa: ANN001
+        timeout_should_occur,  # noqa: ANN001
+    ) -> None:
         """Test to ensure that the default tracker timeout is respected.
 
         An HTTP sever is run on another thread, which handles request sent from
@@ -404,9 +413,9 @@ class TestTracker:
     def test_project_context_send_anonymous_usage_stats_source(
         self,
         project: Project,
-        monkeypatch,
-    ):
-        def get_source():
+        monkeypatch,  # noqa: ANN001
+    ) -> None:
+        def get_source():  # noqa: ANN202
             return ProjectContext(project, uuid.uuid4()).to_json()["data"][
                 "send_anonymous_usage_stats_source"
             ]
@@ -428,7 +437,7 @@ class TestTracker:
         project: Project,
         monkeypatch: pytest.MonkeyPatch,
         log: pytest_structlog.StructuredLogCapture,
-    ):
+    ) -> None:
         endpoints = """
             [
                 "notvalid:8080",
@@ -471,7 +480,7 @@ class TestTracker:
         self,
         project: Project,
         monkeypatch: pytest.MonkeyPatch,
-    ):
+    ) -> None:
         with delete_analytics_json(project):
             monkeypatch.setenv("MELTANO_CLIENT_ID", "invalid-context-uuid")
             with pytest.warns(RuntimeWarning, match="Invalid telemetry client UUID"):


### PR DESCRIPTION
For this rule I applied the available auto-fixes, which seems to have just added `-> None` to functions that don't have a return statement. Then I used `ruff check . --add-noqa` to ignore the rest of the issues, since addressing them all in one go is impractical. We can chip away at them as we naturally work on parts of the codebase.

Relates to:
- #7383
