### PR TITLE
fix: Addressed `structlog` warning by removing `format_exc_info` from the processor chain

### DIFF
--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -150,7 +150,6 @@ def setup_logging(
             structlog.stdlib.PositionalArgumentsFormatter(),
             TIMESTAMPER,
             structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

See https://github.com/hynek/structlog/blob/main/CHANGELOG.md#2120---2021-10-12.

<blockquote>

[ConsoleRenderer](https://www.structlog.org/en/stable/api.html#structlog.dev.ConsoleRenderer) now handles the exc_info event dict key itself. Do not use the [structlog.processors.format_exc_info](https://www.structlog.org/en/stable/api.html#structlog.processors.format_exc_info) processor together with [ConsoleRenderer](https://www.structlog.org/en/stable/api.html#structlog.dev.ConsoleRenderer) anymore! It will keep working, but you can’t have customize exception formatting and a warning will be raised if you ask for it.

</blockquote>

## Related Issues

* Closes #XXXX
