### PR TITLE
test: Bump to latest Snowplow Micro (2.1.0) and use distroless image

### DIFF
--- a/tests/fixtures/docker/docker-compose.yml
+++ b/tests/fixtures/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   snowplow:
-    image: "snowplow/snowplow-micro:1.3.1"
+    image: "snowplow/snowplow-micro:2.1.0-distroless"
     user: "1000:0"
     command: --collector-config /config/micro.conf --iglu /config/iglu.json
     ports:


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

<blockquote>

We also provide a _distroless_ image of Micro. Because it only includes the bare minimum, it’s smaller and more secure. However, the downside of using the distroless image is that basic utilities (such as a shell) are not available.

</blockquote>

https://docs.snowplow.io/docs/testing-debugging/snowplow-micro/basic-usage/

## Related Issues

* Closes #XXXX
