### PR TITLE
chore: Filter "Unknown setting" warnings in tests

### DIFF
--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -231,6 +231,7 @@ class TestCliConfigSet:
         ) in result.stdout
 
     @pytest.mark.usefixtures("project")
+    @pytest.mark.filterwarnings("ignore:Unknown setting 'private_key':RuntimeWarning")
     def test_config_set_from_file(self, cli_runner, tap, tmp_path: Path) -> None:
         result = cli_runner.invoke(
             cli,

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -226,6 +226,7 @@ class TestPluginSettingsService:
             assert full_config.get(key) == value
             assert redacted_config.get(key) == value
 
+    @pytest.mark.filterwarnings("ignore:Unknown setting:RuntimeWarning")
     def test_environment_only_config(
         self,
         environment: Environment,
@@ -452,6 +453,7 @@ class TestPluginSettingsService:
         ]
 
     @pytest.mark.usefixtures("tap")
+    @pytest.mark.filterwarnings("ignore:Unknown setting:RuntimeWarning")
     def test_store_db(self, session, subject) -> None:
         store = SettingValueStore.DB
 
@@ -469,6 +471,7 @@ class TestPluginSettingsService:
         assert session.query(Setting).count() == 0
 
     @pytest.mark.usefixtures("tap")
+    @pytest.mark.filterwarnings("ignore:Unknown setting:RuntimeWarning")
     def test_store_meltano_yml(self, subject, project) -> None:
         store = SettingValueStore.MELTANO_YML
 
@@ -622,6 +625,7 @@ class TestPluginSettingsService:
 
     @pytest.mark.order(3)
     @pytest.mark.usefixtures("tap")
+    @pytest.mark.filterwarnings("ignore:Unknown setting:RuntimeWarning")
     def test_nested_keys(self, session, subject, project) -> None:
         def set_config(path, value) -> None:
             subject.set(path, value, store=SettingValueStore.MELTANO_YML)
@@ -683,6 +687,7 @@ class TestPluginSettingsService:
         assert "metadata.stream.replication-key" not in final_config()
 
     @pytest.mark.usefixtures("tap")
+    @pytest.mark.filterwarnings("ignore:Unknown setting:RuntimeWarning")
     def test_custom_setting(self, session, subject, env_var) -> None:
         subject.set("custom_string", "from_yml", store=SettingValueStore.MELTANO_YML)
         subject.set("custom_bool", value=True, store=SettingValueStore.MELTANO_YML)
@@ -730,6 +735,7 @@ class TestPluginSettingsService:
         assert subject.get("start_date") == now.isoformat()
 
     @pytest.mark.usefixtures("tap")
+    @pytest.mark.filterwarnings("ignore:Unknown setting:RuntimeWarning")
     def test_kind_object(
         self,
         subject: PluginSettingsService,

--- a/tests/meltano/core/plugin/test_superset.py
+++ b/tests/meltano/core/plugin/test_superset.py
@@ -45,6 +45,9 @@ class TestSuperset:
             return project_add_service.add(PluginType.UTILITIES, "superset")
 
     @pytest.mark.asyncio()
+    @pytest.mark.filterwarnings(
+        "ignore:Unknown setting 'SUPERSET_WEBSERVER_PORT':RuntimeWarning",
+    )
     async def test_hooks(
         self,
         subject,

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -87,6 +87,7 @@ class TestProjectSettingsService:
         ):
             changed.append(True)
 
+    @pytest.mark.filterwarnings("ignore:Unknown setting 'ff.allowed':RuntimeWarning")
     def test_feature_flag_allowed(self, subject) -> None:
         changed = []
         subject.set([FEATURE_FLAG_PREFIX, "allowed"], value=True)
@@ -98,6 +99,7 @@ class TestProjectSettingsService:
         should_run()
         assert changed
 
+    @pytest.mark.filterwarnings("ignore:Unknown setting 'ff.disallowed':RuntimeWarning")
     def test_feature_flag_disallowed(self, subject) -> None:
         changed = []
         subject.set([FEATURE_FLAG_PREFIX, "disallowed"], value=False)
@@ -109,6 +111,9 @@ class TestProjectSettingsService:
         with pytest.raises(FeatureNotAllowedException):
             should_not_run()
 
+    @pytest.mark.filterwarnings(
+        "ignore:Unknown setting 'stacked_env_var':RuntimeWarning",
+    )
     def test_strict_env_var_mode_on_raises_error(self, subject) -> None:
         subject.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],
@@ -121,6 +126,9 @@ class TestProjectSettingsService:
         with pytest.raises(EnvironmentVariableNotSetError):
             subject.get("stacked_env_var")
 
+    @pytest.mark.filterwarnings(
+        "ignore:Unknown setting 'stacked_env_var':RuntimeWarning",
+    )
     def test_strict_env_var_mode_off_no_raise_error(self, subject) -> None:
         subject.set(
             [FEATURE_FLAG_PREFIX, str(FeatureFlags.STRICT_ENV_VAR_MODE)],


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Ignores 'Unknown setting...' warnings in tests that use dummy setting names. Now there are only warnings on Python 3.12 coming from `time-machine`, which we can either wait for them to fix upstream (I prefer this) or silence them here.

## Test results

| PYTHON | OS     | DB     | PASSED | FAILED | XPASSED | XFAILED | SKIPPED | DESELECTED | WARNINGS | ERRORS | DURATION |
|--------|--------|--------|--------|--------|---------|---------|---------|------------|----------|--------|----------|
| 3.8 | Linux x64 | sqlite | 781 | 0 | 0 | 1 | 1 | 0 | 0 | 0 | 367s |
| 3.9 | Linux x64 | sqlite | 781 | 0 | 0 | 1 | 1 | 0 | 0 | 0 | 368s |
| 3.10 | Linux x64 | sqlite | 781 | 0 | 0 | 1 | 1 | 0 | 0 | 0 | 320s |
| 3.11 | Linux x64 | sqlite | 781 | 0 | 0 | 1 | 1 | 0 | 0 | 0 | 474s |
| 3.12 | Linux x64 | sqlite | 781 | 0 | 0 | 1 | 1 | 0 | 23 | 0 | 631s |
| 3.8 | Linux x64 | postgresql | 736 | 0 | 0 | 1 | 46 | 0 | 0 | 0 | 237s |
| 3.9 | Linux x64 | postgresql | 742 | 0 | 0 | 1 | 40 | 0 | 0 | 0 | 229s |
| 3.10 | Linux x64 | postgresql | 742 | 0 | 0 | 1 | 40 | 0 | 0 | 0 | 202s |
| 3.11 | Linux x64 | postgresql | 742 | 0 | 0 | 1 | 40 | 0 | 0 | 0 | 231s |
| 3.12 | Linux x64 | postgresql | 742 | 0 | 0 | 1 | 40 | 0 | 23 | 0 | 333s |
| 3.8 | Linux x64 | mssql | 742 | 0 | 0 | 1 | 40 | 0 | 0 | 0 | 357s |
| 3.9 | Linux x64 | mssql | 742 | 0 | 0 | 1 | 40 | 0 | 0 | 0 | 344s |
| 3.10 | Linux x64 | mssql | 742 | 0 | 0 | 1 | 40 | 0 | 0 | 0 | 313s |
| 3.11 | Linux x64 | mssql | 742 | 0 | 0 | 1 | 40 | 0 | 0 | 0 | 356s |
| 3.12 | Linux x64 | mssql | 742 | 0 | 0 | 1 | 40 | 0 | 23 | 0 | 448s |
| 3.9 | Windows x64 | sqlite | 683 | 0 | 0 | 51 | 49 | 0 | 0 | 0 | 402s |
| 3.10 | Windows x64 | sqlite | 683 | 0 | 0 | 51 | 49 | 0 | 0 | 0 | 407s |
| 3.11 | Windows x64 | sqlite | 683 | 0 | 0 | 51 | 49 | 0 | 0 | 0 | 624s |
| 3.12 | Windows x64 | sqlite | 683 | 0 | 0 | 51 | 49 | 0 | 23 | 0 | 771s |

## Related Issues

* Closes https://github.com/meltano/meltano/issues/6973
