### PR TITLE
feat: Added `exceptions` to the log message when using the JSON formatter

### DIFF
--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -55,6 +55,7 @@ formatters:
   json: # log format for json formatted logs
     (): meltano.core.logging.json_formatter
     callsite_parameters: true # adds `pathname`, `lineno`, and `func_name` to each log entry
+    dict_tracebacks: true # adds an `exception` object to each log entry
 
 handlers:
   console: # log to the console (stderr) using structured_colored formatter, logging everything at DEBUG level and up

--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -55,7 +55,7 @@ formatters:
   json: # log format for json formatted logs
     (): meltano.core.logging.json_formatter
     callsite_parameters: true # adds `pathname`, `lineno`, and `func_name` to each log entry
-    dict_tracebacks: true # adds an `exception` object to each log entry
+    dict_tracebacks: false # removes the `exception` object that is added to each log entry
 
 handlers:
   console: # log to the console (stderr) using structured_colored formatter, logging everything at DEBUG level and up

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -203,6 +203,7 @@ def json_formatter(
     Returns:
         A configured JSON formatter.
     """
+    features.setdefault("dict_tracebacks", True)
     return _process_formatter(
         *_processors_from_kwargs(**features),
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -43,6 +43,11 @@ class LoggingFeatures(t.TypedDict, total=False):
     https://www.structlog.org/en/stable/api.html#structlog.processors.CallsiteParameter.
     """
 
+    dict_tracebacks: bool
+    """Enable tracebacks dictionaries in log entries.
+    https://www.structlog.org/en/stable/api.html#structlog.processors.dict_tracebacks.
+    """
+
 
 # Convert boolean kwargs to LoggingFeatures enum.
 def _processors_from_kwargs(
@@ -56,6 +61,9 @@ def _processors_from_kwargs(
                 structlog.processors.CallsiteParameter.FUNC_NAME,
             ),
         )
+
+    if features.get("dict_tracebacks", False):
+        yield structlog.processors.dict_tracebacks
 
 
 def rich_exception_formatter_factory(

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -131,7 +131,7 @@ class TestLogFormatters:
         assert message_dict["func_name"] == "my_func"
 
     def test_json_formatter_exception(self, record_with_exception) -> None:
-        formatter = formatters.json_formatter(dict_tracebacks=True)
+        formatter = formatters.json_formatter()
         output = formatter.format(record_with_exception)
         message_dict = json.loads(output)
 
@@ -142,3 +142,9 @@ class TestLogFormatters:
         assert len(exception_list) == 1
         assert exception_list[0]["exc_type"] == "Exception"
         assert exception_list[0]["exc_value"] == "test"
+
+        formatter = formatters.json_formatter(dict_tracebacks=False)
+        output = formatter.format(record_with_exception)
+        message_dict = json.loads(output)
+
+        assert "exception" not in message_dict

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -129,3 +129,16 @@ class TestLogFormatters:
         assert message_dict["pathname"] == "/path/to/my_module.py"
         assert message_dict["lineno"] == 1
         assert message_dict["func_name"] == "my_func"
+
+    def test_json_formatter_exception(self, record_with_exception) -> None:
+        formatter = formatters.json_formatter(dict_tracebacks=True)
+        output = formatter.format(record_with_exception)
+        message_dict = json.loads(output)
+
+        assert "exception" in message_dict
+
+        exception_list = message_dict["exception"]
+        assert isinstance(exception_list, list)
+        assert len(exception_list) == 1
+        assert exception_list[0]["exc_type"] == "Exception"
+        assert exception_list[0]["exc_value"] == "test"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

- https://www.structlog.org/en/stable/api.html#structlog.processors.JSONRenderer
- https://www.structlog.org/en/stable/api.html#structlog.processors.dict_tracebacks

<details><summary>JSON log example with <code>structlog.processors.dict_tracebacks</code></summary>
<p>

```json
{
    "event": "Block run completed.",
    "level": "error",
    "logger": "meltano.cli.run",
    "timestamp": "2024-08-31T03:49:48.740752Z",
    "exception": [
        {
            "exc_type": "RunnerError",
            "exc_value": "Cannot start plugin tap-getpocket: '' is not a valid StateBackend",
            "syntax_error": null,
            "is_cause": false,
            "frames": [
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/cli/run.py",
                    "lineno": 224,
                    "name": "_run_blocks",
                    "locals": {
                        "tracker": "<meltano.core.tracking.tracker.Tracker object at 0x11ac22900>",
                        "parsed_blocks": "[<meltano.core.block.extract_load.ExtractLoadBlocks object at 0x11b63f050>]",
                        "dry_run": "False",
                        "idx": "0",
                        "blk": "<meltano.core.block.extract_load.ExtractLoadBlocks object at 0x11b63f050>",
                        "blk_name": "'ExtractLoadBlocks'",
                        "tracking_ctx": "<meltano.core.tracking.contexts.plugins.PluginsTrackingContext object at 0x11b63f350>",
                        "err": "RunnerError(\"Cannot start plugin tap-getpocket: '' is not a valid StateBackend\")",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/block/extract_load.py",
                    "lineno": 506,
                    "name": "run",
                    "locals": {
                        "self": "<meltano.core.block.extract_load.ExtractLoadBlocks object at 0x11b63f050>",
                        "legacy_log_handler": "<meltano.core.logging.output_logger.Out object at 0x11abec2c0>",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/block/extract_load.py",
                    "lineno": 538,
                    "name": "run_with_job",
                    "locals": {
                        "self": "<meltano.core.block.extract_load.ExtractLoadBlocks object at 0x11b63f050>",
                        "job": "<repr-error 'Instance <Job at 0x11b63f290> is not bound to a Session; attribute refresh operation cannot proceed (Background on this error at: https://sqlalche.me/e/20/bhk3)'>",
                        "existing": "None",
                        "session": "<sqlalchemy.orm.session.Session object at 0x11ac33e60>",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/block/extract_load.py",
                    "lineno": 495,
                    "name": "execute",
                    "locals": {
                        "self": "<meltano.core.block.extract_load.ExtractLoadBlocks object at 0x11b63f050>"
                    },
                },
                {
                    "filename": "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py",
                    "lineno": 210,
                    "name": "__aenter__",
                    "locals": {
                        "self": "<contextlib._AsyncGeneratorContextManager object at 0x11abd53a0>"
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/block/extract_load.py",
                    "lineno": 627,
                    "name": "_start_blocks",
                    "locals": {
                        "self": "<meltano.core.block.extract_load.ExtractLoadBlocks object at 0x11b63f050>",
                        "block": "<meltano.core.block.singer.SingerBlock object at 0x11a461dc0>",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/block/singer.py",
                    "lineno": 339,
                    "name": "start",
                    "locals": {
                        "self": "<meltano.core.block.singer.SingerBlock object at 0x11a461dc0>",
                        "stream_buffer_size": "10485760",
                        "line_length_limit": "5242880",
                        "stdin": "None",
                    },
                },
            ],
        },
        {
            "exc_type": "ValueError",
            "exc_value": "'' is not a valid StateBackend",
            "syntax_error": null,
            "is_cause": true,
            "frames": [
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/block/singer.py",
                    "lineno": 332,
                    "name": "start",
                    "locals": {
                        "self": "<meltano.core.block.singer.SingerBlock object at 0x11a461dc0>",
                        "stream_buffer_size": "10485760",
                        "line_length_limit": "5242880",
                        "stdin": "None",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/plugin_invoker.py",
                    "lineno": 452,
                    "name": "invoke_async",
                    "locals": {
                        "self": "<meltano.core.plugin_invoker.PluginInvoker object at 0x11ac9bb30>",
                        "args": "()",
                        "kwargs": "{'limit': 5242880, 'stdin': None, 'stdout': -1, 'stderr': -1}",
                    },
                },
                {
                    "filename": "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py",
                    "lineno": 210,
                    "name": "__aenter__",
                    "locals": {
                        "self": "<contextlib._AsyncGeneratorContextManager object at 0x11b690560>"
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/plugin_invoker.py",
                    "lineno": 428,
                    "name": "_invoke",
                    "locals": {
                        "self": "<meltano.core.plugin_invoker.PluginInvoker object at 0x11ac9bb30>",
                        "require_preparation": "True",
                        "env": "{}",
                        "command": "None",
                        "args": "()",
                        "kwargs": "{'limit': 5242880, 'stdin': None, 'stdout': -1, 'stderr': -1}",
                    },
                },
                {
                    "filename": "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py",
                    "lineno": 210,
                    "name": "__aenter__",
                    "locals": {
                        "self": "<contextlib._AsyncGeneratorContextManager object at 0x11b693b60>"
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/behavior/hookable.py",
                    "lineno": 94,
                    "name": "trigger_hooks",
                    "locals": {
                        "self": "<meltano.core.plugin.singer.tap.SingerTap object at 0x11abd6750>",
                        "hook_name": "'invoke'",
                        "args": "(<meltano.core.plugin_invoker.PluginInvoker object at 0x11ac9bb30>, ())",
                        "kwargs": "{}",
                        "already_triggering": "False",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/behavior/hookable.py",
                    "lineno": 122,
                    "name": "trigger",
                    "locals": {
                        "cls": "<class 'meltano.core.plugin.singer.tap.SingerTap'>",
                        "target": "<meltano.core.plugin.singer.tap.SingerTap object at 0x11abd6750>",
                        "hook_name": "'before_invoke'",
                        "args": "(<meltano.core.plugin_invoker.PluginInvoker object at 0x11ac9bb30>, ())",
                        "kwargs": "{}",
                        "hooks": "[\n    <function SingerTap.look_up_state_hook at 0x11ab83ba0>,\n    <function SingerTap.discover_catalog_hook at 0x11ab83ce0>,\n    <function SingerTap.apply_catalog_rules_hook at 0x11ab83ec0>\n]",
                        "hook_func": "<function SingerTap.look_up_state_hook at 0x11ab83ba0>",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/behavior/hookable.py",
                    "lineno": 114,
                    "name": "trigger",
                    "locals": {
                        "cls": "<class 'meltano.core.plugin.singer.tap.SingerTap'>",
                        "target": "<meltano.core.plugin.singer.tap.SingerTap object at 0x11abd6750>",
                        "hook_name": "'before_invoke'",
                        "args": "(<meltano.core.plugin_invoker.PluginInvoker object at 0x11ac9bb30>, ())",
                        "kwargs": "{}",
                        "hooks": "[\n    <function SingerTap.look_up_state_hook at 0x11ab83ba0>,\n    <function SingerTap.discover_catalog_hook at 0x11ab83ce0>,\n    <function SingerTap.apply_catalog_rules_hook at 0x11ab83ec0>\n]",
                        "hook_func": "<function SingerTap.look_up_state_hook at 0x11ab83ba0>",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/plugin/singer/tap.py",
                    "lineno": 266,
                    "name": "look_up_state_hook",
                    "locals": {
                        "self": "<meltano.core.plugin.singer.tap.SingerTap object at 0x11abd6750>",
                        "plugin_invoker": "<meltano.core.plugin_invoker.PluginInvoker object at 0x11ac9bb30>",
                        "exec_args": "()",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/plugin/singer/tap.py",
                    "lineno": 332,
                    "name": "look_up_state",
                    "locals": {
                        "self": "<meltano.core.plugin.singer.tap.SingerTap object at 0x11abd6750>",
                        "plugin_invoker": "<meltano.core.plugin_invoker.PluginInvoker object at 0x11ac9bb30>",
                        "state_path": "PosixPath('/Users/edgarramirez/Code/edgarrmondragon/meltano-dataops/.meltano/run/tap-getpocket/state.json')",
                        "elt_context": "<meltano.core.block.extract_load.ELBContext object at 0x11b63fec0>",
                        "custom_state_filename": "None",
                        "state_service": "<meltano.core.state_service.StateService object at 0x11b693650>",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/state_service.py",
                    "lineno": 94,
                    "name": "state_store_manager",
                    "locals": {
                        "self": "<meltano.core.state_service.StateService object at 0x11b693650>"
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/state_store/__init__.py",
                    "lineno": 110,
                    "name": "state_store_manager_from_project_settings",
                    "locals": {
                        "settings_service": "<meltano.core.project_settings_service.ProjectSettingsService object at 0x11abec6b0>",
                        "session": "<sqlalchemy.orm.session.Session object at 0x11ac33e60>",
                        "state_backend_uri": "''",
                        "parsed": "ParseResult(scheme='', netloc='', path='', params='', query='', fragment='')",
                        "setting_defs": "<filter object at 0x11b6dc1c0>",
                        "settings": "<generator object state_store_manager_from_project_settings.<locals>.<genexpr> at 0x11b698c40>",
                        "scheme": "''",
                    },
                },
                {
                    "filename": "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/enum.py",
                    "lineno": 757,
                    "name": "__call__",
                    "locals": {
                        "cls": "<enum 'StateBackend'>",
                        "value": "''",
                        "names": "<not given>",
                        "module": "None",
                        "qualname": "None",
                        "type": "None",
                        "start": "1",
                        "boundary": "None",
                        "values": "()",
                    },
                },
                {
                    "filename": "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/enum.py",
                    "lineno": 1171,
                    "name": "__new__",
                    "locals": {
                        "cls": "<enum 'StateBackend'>",
                        "value": "''",
                        "exc": "None",
                        "result": "None",
                        "ve_exc": "None",
                    },
                },
            ],
        },
        {
            "exc_type": "ValueError",
            "exc_value": "'' is not a valid StateBackend",
            "syntax_error": null,
            "is_cause": false,
            "frames": [
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/plugin/singer/tap.py",
                    "lineno": 328,
                    "name": "look_up_state",
                    "locals": {
                        "self": "<meltano.core.plugin.singer.tap.SingerTap object at 0x11abd6750>",
                        "plugin_invoker": "<meltano.core.plugin_invoker.PluginInvoker object at 0x11ac9bb30>",
                        "state_path": "PosixPath('/Users/edgarramirez/Code/edgarrmondragon/meltano-dataops/.meltano/run/tap-getpocket/state.json')",
                        "elt_context": "<meltano.core.block.extract_load.ELBContext object at 0x11b63fec0>",
                        "custom_state_filename": "None",
                        "state_service": "<meltano.core.state_service.StateService object at 0x11b693650>",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/state_service.py",
                    "lineno": 162,
                    "name": "get_state",
                    "locals": {
                        "self": "<meltano.core.state_service.StateService object at 0x11b693650>",
                        "state_id": "'dev:tap-getpocket-to-target-jsonl'",
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/state_service.py",
                    "lineno": 94,
                    "name": "state_store_manager",
                    "locals": {
                        "self": "<meltano.core.state_service.StateService object at 0x11b693650>"
                    },
                },
                {
                    "filename": "/Users/edgarramirez/Code/meltano/meltano/src/meltano/core/state_store/__init__.py",
                    "lineno": 110,
                    "name": "state_store_manager_from_project_settings",
                    "locals": {
                        "settings_service": "<meltano.core.project_settings_service.ProjectSettingsService object at 0x11abec6b0>",
                        "session": "<sqlalchemy.orm.session.Session object at 0x11ac33e60>",
                        "state_backend_uri": "''",
                        "parsed": "ParseResult(scheme='', netloc='', path='', params='', query='', fragment='')",
                        "setting_defs": "<filter object at 0x11b63fbe0>",
                        "settings": "<generator object state_store_manager_from_project_settings.<locals>.<genexpr> at 0x11b698100>",
                        "scheme": "''",
                    },
                },
                {
                    "filename": "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/enum.py",
                    "lineno": 757,
                    "name": "__call__",
                    "locals": {
                        "cls": "<enum 'StateBackend'>",
                        "value": "''",
                        "names": "<not given>",
                        "module": "None",
                        "qualname": "None",
                        "type": "None",
                        "start": "1",
                        "boundary": "None",
                        "values": "()",
                    },
                },
                {
                    "filename": "/opt/homebrew/Cellar/python@3.12/3.12.5/Frameworks/Python.framework/Versions/3.12/lib/python3.12/enum.py",
                    "lineno": 1171,
                    "name": "__new__",
                    "locals": {
                        "cls": "<enum 'StateBackend'>",
                        "value": "''",
                        "exc": "None",
                        "result": "None",
                        "ve_exc": "None",
                    },
                },
            ],
        },
    ],
}
```

</p>
</details> 

## Related Issues

* Requires: https://github.com/meltano/meltano/pull/8494
