### PR TITLE
ci: Use `include-hidden-files: true` to upload coverage artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,6 +201,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
+        include-hidden-files: true
         name: coverage-data-${{ matrix.id }}
         path: ".coverage.*"
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Version [v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) of actions/upload-artifact broke uploading (silently) and combining coverage files.

## Related Issues

* Closes #XXXX
