### PR TITLE
refactor: Move `install_plugins` to `meltano.core.plugin_install_service`

### DIFF
--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -8,9 +8,10 @@ import click
 import structlog
 
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliError, PartialInstrumentedCmd, install_plugins
+from meltano.cli.utils import CliError, PartialInstrumentedCmd
 from meltano.core.block.parser import BlockParser
 from meltano.core.plugin import PluginType
+from meltano.core.plugin_install_service import install_plugins
 from meltano.core.schedule_service import ScheduleService
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 from meltano.core.utils import run_async

--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -7,10 +7,10 @@ import typing as t
 
 import click
 
-from meltano.cli.utils import AutoInstallBehavior, CliError, install_plugins
+from meltano.cli.utils import AutoInstallBehavior, CliError
 from meltano.core.db import project_engine
 from meltano.core.migration_service import MigrationError
-from meltano.core.plugin_install_service import PluginInstallReason
+from meltano.core.plugin_install_service import PluginInstallReason, install_plugins
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.utils import async_noop
 

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import logging
 import os
 import shlex
 import sys
@@ -535,6 +536,82 @@ def get_pip_install_args(
             )
             or "",
         )
+
+
+def install_status_update(install_state: PluginInstallState) -> None:
+    """Print the status of plugin installation.
+
+    Used as the callback for PluginInstallService.
+    """
+    plugin = install_state.plugin
+    desc = plugin.type.descriptor
+
+    if install_state.status is PluginInstallStatus.SKIPPED:
+        level = (
+            logging.DEBUG
+            if install_state.reason == PluginInstallReason.AUTO
+            else logging.INFO
+        )
+        logger.log(level, "%s %s '%s'", install_state.verb, desc, plugin.name)
+    elif install_state.status in {
+        PluginInstallStatus.RUNNING,
+        PluginInstallStatus.SUCCESS,
+    }:
+        logger.info("%s %s '%s'", install_state.verb, desc, plugin.name)
+    elif install_state.status is PluginInstallStatus.ERROR:
+        logger.error(install_state.message)
+        logger.info(install_state.details)
+    elif install_state.status is PluginInstallStatus.WARNING:  # pragma: no cover
+        logger.warning(install_state.message)
+
+
+async def install_plugins(
+    project: Project,
+    plugins: t.Sequence[ProjectPlugin],
+    *,
+    reason: PluginInstallReason = PluginInstallReason.INSTALL,
+    parallelism: int | None = None,
+    clean: bool = False,
+    force: bool = False,
+) -> bool:
+    """Install the provided plugins and report results to the console."""
+    install_service = PluginInstallService(
+        project,
+        status_cb=install_status_update,
+        parallelism=parallelism,
+        clean=clean,
+        force=force,
+    )
+    install_results = await install_service.install_plugins(plugins, reason=reason)
+    num_successful = len([status for status in install_results if status.successful])
+    num_skipped = len([status for status in install_results if status.skipped])
+    num_failed = len(install_results) - num_successful
+
+    level = logging.INFO
+    if num_failed >= 0 and num_successful == 0:
+        level = logging.ERROR
+    elif num_failed > 0 and num_successful > 0:
+        level = logging.WARNING
+    elif reason == PluginInstallReason.AUTO and num_skipped == len(plugins):
+        level = logging.DEBUG
+
+    if len(plugins) > 1:
+        logger.log(
+            level,
+            "%s %d/%d plugins",
+            "Updated" if reason == PluginInstallReason.UPGRADE else "Installed",
+            num_successful - num_skipped,
+            num_successful + num_failed,
+        )
+    if num_skipped:  # pragma: no cover
+        logger.log(
+            level,
+            "Skipped installing %d/%d plugins",
+            num_skipped,
+            num_successful + num_failed,
+        )
+
+    return num_failed == 0
 
 
 async def install_pip_plugin(

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -11,8 +11,8 @@ import typing as t
 import click
 
 import meltano
-from meltano.cli.utils import PluginInstallReason, install_plugins
 from meltano.core.error import MeltanoError
+from meltano.core.plugin_install_service import PluginInstallReason, install_plugins
 from meltano.core.project_plugins_service import PluginType
 from meltano.core.state_service import StateService
 from meltano.core.state_store.filesystem import CloudStateStoreManager


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This lets us eliminate one dependency on `meltano.cli` in `meltano.core`, though there's still
https://github.com/meltano/meltano/blob/4efb91d68bb8e5c2364ea7ae2f032a937959d3f2/src/meltano/core/tracking/tracker.py#L520-L569

which I'm not sure yet how to decouple.

## Related Issues

* Closes #XXXX
