### PR TITLE
fix: Inheriting plugins are no longer always auto-installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,6 @@ module = [
   "meltano.core.plugin.command",
   "meltano.core.plugin.dbt.*",
   "meltano.core.plugin.factory",
-  "meltano.core.plugin.file",
   "meltano.core.plugin.meltano_file",
   "meltano.core.plugin.project_plugin",
   "meltano.core.plugin.settings_service",

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -188,6 +188,8 @@ class PluginType(YAMLEnum):
 class PluginRef(Canonical):
     """A reference to a plugin."""
 
+    name: str
+
     def __init__(self, plugin_type: str | PluginType, name: str, **kwargs):  # noqa: ANN003
         """Create a new PluginRef.
 
@@ -219,6 +221,15 @@ class PluginRef(Canonical):
             The type of the plugin.
         """
         return self._type
+
+    @property
+    def plugin_dir_name(self) -> str:
+        """Return the plugin directory name.
+
+        Returns:
+            The plugin directory name.
+        """
+        return self.name
 
     def __eq__(self, other: PluginRef) -> bool:
         """Compare two plugin references.
@@ -665,7 +676,7 @@ class BasePlugin(HookObject):
     def env_prefixes(
         self,
         *,
-        for_writing=False,  # noqa: ANN001, ARG002
+        for_writing: bool = False,  # noqa: ARG002
     ) -> list[str]:
         """Return environment variable prefixes to use for settings.
 

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -66,7 +66,8 @@ class FilePlugin(BasePlugin):
         Returns:
             A dictionary of file names and their contents.
         """
-        venv = VirtualEnv(project.plugin_dir(self, "venv"))
+        plugin = project.plugins.get_plugin(self)
+        venv = VirtualEnv(project.plugin_dir(plugin, "venv"))
         bundle_dir = venv.site_packages_dir / "bundle"
 
         return {

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -8,6 +8,7 @@ import structlog
 
 from meltano.core.behavior.hookable import hook
 from meltano.core.plugin import BasePlugin, PluginType
+from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin.settings_service import PluginSettingsService
 from meltano.core.plugin_install_service import (
     PluginInstallReason,
@@ -20,7 +21,6 @@ if t.TYPE_CHECKING:
     from os import PathLike
     from pathlib import Path
 
-    from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
 
 
@@ -66,7 +66,7 @@ class FilePlugin(BasePlugin):
         Returns:
             A dictionary of file names and their contents.
         """
-        plugin = project.plugins.get_plugin(self)
+        plugin = ProjectPlugin(PluginType.FILES, self.name)
         venv = VirtualEnv(project.plugin_dir(plugin, "venv"))
         bundle_dir = venv.site_packages_dir / "bundle"
 

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -399,7 +399,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
             return self.name
 
         if not self.pip_url or (self.parent.pip_url == self.pip_url):
-            return self.parent.name
+            return self.parent.venv_name
 
         return self.name
 

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -225,7 +225,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         return self.is_attr_set(self.VARIANT_ATTR)
 
     @property
-    def info(self) -> dict[str, str]:
+    def info(self) -> dict[str, str | None]:
         """Plugin info dict.
 
         Returns:
@@ -276,7 +276,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         """
         return list(self.all_commands.keys())
 
-    def env_prefixes(self, *, for_writing=False) -> list[str]:  # noqa: ANN001
+    def env_prefixes(self, *, for_writing: bool = False) -> list[str]:
         """Return environment variable prefixes.
 
         Args:
@@ -388,8 +388,11 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         return not self.inherit_from
 
     @property
-    def venv_name(self) -> str:
-        """Return the venv name this plugin should use.
+    def plugin_dir_name(self) -> str:
+        """Return the plugin directory name this plugin should use.
+
+        This directory is where the plugin's Python virtual environment will be
+        created, among other things.
 
         Returns:
             The name of this plugins parent if both pip urls are the same, else
@@ -399,7 +402,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
             return self.name
 
         if not self.pip_url or (self.parent.pip_url == self.pip_url):
-            return self.parent.venv_name
+            return self.parent.plugin_dir_name
 
         return self.name
 

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -212,9 +212,9 @@ class PluginInstallService:
         deduped_plugins: list[ProjectPlugin] = []
         states: list[PluginInstallState] = []
         for plugin in plugins:
-            if (plugin.type, plugin.venv_name) not in seen_venvs:
+            if (plugin.type, plugin.plugin_dir_name) not in seen_venvs:
                 deduped_plugins.append(plugin)
-                seen_venvs.add((plugin.type, plugin.venv_name))
+                seen_venvs.add((plugin.type, plugin.plugin_dir_name))
             else:
                 states.append(
                     PluginInstallState(
@@ -644,14 +644,14 @@ async def install_pip_plugin(
             project=project,
             python=plugin.python,
             namespace=plugin.type,
-            name=plugin.venv_name,
+            name=plugin.plugin_dir_name,
         )
     elif backend == "uv":  # pragma: no cover
         service = UvVenvService(
             project=project,
             python=plugin.python,
             namespace=plugin.type,
-            name=plugin.venv_name,
+            name=plugin.plugin_dir_name,
         )
     else:  # pragma: no cover
         msg = f"Unsupported venv backend: {backend}"

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -160,7 +160,7 @@ class PluginInvoker:
             self.venv_service = VenvService(
                 project=project,
                 python=self.plugin.python,
-                name=plugin.venv_name,
+                name=plugin.plugin_dir_name,
                 namespace=plugin.type,
             )
         else:

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -25,6 +25,7 @@ from meltano.core.error import (
     ProjectReadonly,
 )
 from meltano.core.hub import MeltanoHubService
+from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project_files import ProjectFiles
 from meltano.core.project_plugins_service import ProjectPluginsService
 from meltano.core.project_settings_service import ProjectSettingsService
@@ -32,7 +33,7 @@ from meltano.core.utils import makedirs, sanitize_filename, truthy
 
 if t.TYPE_CHECKING:
     from meltano.core.meltano_file import MeltanoFile as MeltanoFileTypeHint
-    from meltano.core.plugin.project_plugin import ProjectPlugin
+    from meltano.core.plugin.base import PluginRef
 
     if sys.version_info < (3, 10):
         from typing import TypeAlias  # noqa: ICN003
@@ -547,7 +548,7 @@ class Project(Versioned):
     @makedirs
     def plugin_dir(
         self,
-        plugin: ProjectPlugin,
+        plugin: PluginRef,
         *joinpaths: StrPath,
         make_dirs: bool = True,
     ) -> Path:
@@ -563,7 +564,7 @@ class Project(Versioned):
         """
         return self.meltano_dir(
             plugin.type,
-            plugin.venv_name,
+            plugin.venv_name if isinstance(plugin, ProjectPlugin) else plugin.name,
             *joinpaths,
             make_dirs=make_dirs,
         )

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -32,7 +32,7 @@ from meltano.core.utils import makedirs, sanitize_filename, truthy
 
 if t.TYPE_CHECKING:
     from meltano.core.meltano_file import MeltanoFile as MeltanoFileTypeHint
-    from meltano.core.plugin.base import PluginRef
+    from meltano.core.plugin.project_plugin import ProjectPlugin
 
     if sys.version_info < (3, 10):
         from typing import TypeAlias  # noqa: ICN003
@@ -547,7 +547,7 @@ class Project(Versioned):
     @makedirs
     def plugin_dir(
         self,
-        plugin: PluginRef,
+        plugin: ProjectPlugin,
         *joinpaths: StrPath,
         make_dirs: bool = True,
     ) -> Path:
@@ -563,7 +563,7 @@ class Project(Versioned):
         """
         return self.meltano_dir(
             plugin.type,
-            self.plugins.get_progenitor(plugin).name,
+            plugin.venv_name,
             *joinpaths,
             make_dirs=make_dirs,
         )

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -32,7 +32,7 @@ from meltano.core.utils import makedirs, sanitize_filename, truthy
 
 if t.TYPE_CHECKING:
     from meltano.core.meltano_file import MeltanoFile as MeltanoFileTypeHint
-    from meltano.core.plugin.project_plugin import ProjectPlugin
+    from meltano.core.plugin.base import PluginRef
 
     if sys.version_info < (3, 10):
         from typing import TypeAlias  # noqa: ICN003
@@ -547,7 +547,7 @@ class Project(Versioned):
     @makedirs
     def plugin_dir(
         self,
-        plugin: ProjectPlugin,
+        plugin: PluginRef,
         *joinpaths: StrPath,
         make_dirs: bool = True,
     ) -> Path:
@@ -563,7 +563,7 @@ class Project(Versioned):
         """
         return self.meltano_dir(
             plugin.type,
-            plugin.venv_name,
+            plugin.plugin_dir_name,
             *joinpaths,
             make_dirs=make_dirs,
         )

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -563,7 +563,7 @@ class Project(Versioned):
         """
         return self.meltano_dir(
             plugin.type,
-            plugin.name,
+            self.plugins.get_progenitor(plugin).name,
             *joinpaths,
             make_dirs=make_dirs,
         )

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -25,7 +25,6 @@ from meltano.core.error import (
     ProjectReadonly,
 )
 from meltano.core.hub import MeltanoHubService
-from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project_files import ProjectFiles
 from meltano.core.project_plugins_service import ProjectPluginsService
 from meltano.core.project_settings_service import ProjectSettingsService
@@ -33,7 +32,7 @@ from meltano.core.utils import makedirs, sanitize_filename, truthy
 
 if t.TYPE_CHECKING:
     from meltano.core.meltano_file import MeltanoFile as MeltanoFileTypeHint
-    from meltano.core.plugin.base import PluginRef
+    from meltano.core.plugin.project_plugin import ProjectPlugin
 
     if sys.version_info < (3, 10):
         from typing import TypeAlias  # noqa: ICN003
@@ -548,7 +547,7 @@ class Project(Versioned):
     @makedirs
     def plugin_dir(
         self,
-        plugin: PluginRef,
+        plugin: ProjectPlugin,
         *joinpaths: StrPath,
         make_dirs: bool = True,
     ) -> Path:
@@ -564,7 +563,7 @@ class Project(Versioned):
         """
         return self.meltano_dir(
             plugin.type,
-            plugin.venv_name if isinstance(plugin, ProjectPlugin) else plugin.name,
+            plugin.venv_name,
             *joinpaths,
             make_dirs=make_dirs,
         )

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -540,21 +540,6 @@ class ProjectPluginsService:  # (too many methods, attributes)
         )
         return parent
 
-    def get_progenitor(self, plugin: ProjectPlugin) -> ProjectPlugin:
-        """Get plugin's progenitor plugin.
-
-        Args:
-            plugin: The plugin to get the progenitor of.
-
-        Returns:
-            The progenitor plugin.
-        """
-        if not plugin.inherit_from:
-            return plugin
-
-        parent = self.get_parent(plugin)
-        return self.get_progenitor(parent)
-
     def ensure_parent(self, plugin: ProjectPlugin) -> ProjectPlugin:
         """Ensure that plugin has a parent set.
 

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -540,6 +540,21 @@ class ProjectPluginsService:  # (too many methods, attributes)
         )
         return parent
 
+    def get_progenitor(self, plugin: ProjectPlugin) -> ProjectPlugin:
+        """Get plugin's progenitor plugin.
+
+        Args:
+            plugin: The plugin to get the progenitor of.
+
+        Returns:
+            The progenitor plugin.
+        """
+        if not plugin.inherit_from:
+            return plugin
+
+        parent = self.get_parent(plugin)
+        return self.get_progenitor(parent)
+
     def ensure_parent(self, plugin: ProjectPlugin) -> ProjectPlugin:
         """Ensure that plugin has a parent set.
 

--- a/tests/meltano/core/plugin/test_plugin.py
+++ b/tests/meltano/core/plugin/test_plugin.py
@@ -591,17 +591,17 @@ class TestProjectPlugin:
         # Plugin doesn't have any utility requirements
         assert not transformer.all_requires[PluginType.UTILITIES]
 
-    def test_venv_name(self):
+    def test_plugin_dir_name(self):
         """Validate the virtual environment name.
 
-        - If the plugin has a pip_url, the venv name is the plugin name.
-        - If the plugin is an inherited plugin without a custom pip_url, the venv name
-          is the parent plugin name.
-        - For multiple levels of inheritance, the venv name is the name of the first
-          plugin in the inheritance chain that has a pip_url.
+        - If the plugin has a pip_url, the plugin dir name is the plugin name.
+        - If the plugin is an inherited plugin without a custom pip_url, the plugin dir
+          name is the parent plugin name.
+        - For multiple levels of inheritance, the plugin dir name is the name of the
+          first plugin in the inheritance chain that has a pip_url.
         """
         base: ProjectPlugin = ProjectPlugin(PluginType.EXTRACTORS, name="tap-mock")
-        assert base.venv_name == "tap-mock"
+        assert base.plugin_dir_name == "tap-mock"
 
         inherited: ProjectPlugin = ProjectPlugin(
             PluginType.EXTRACTORS,
@@ -609,7 +609,7 @@ class TestProjectPlugin:
             inherit_from="tap-mock",
         )
         inherited.parent = base
-        assert inherited.venv_name == "tap-mock"
+        assert inherited.plugin_dir_name == "tap-mock"
 
         inception: ProjectPlugin = ProjectPlugin(
             PluginType.EXTRACTORS,
@@ -617,7 +617,7 @@ class TestProjectPlugin:
             inherit_from="tap-mock--inherited",
         )
         inception.parent = inherited
-        assert inception.venv_name == "tap-mock"
+        assert inception.plugin_dir_name == "tap-mock"
 
         inherited_custom: ProjectPlugin = ProjectPlugin(
             PluginType.EXTRACTORS,
@@ -626,7 +626,7 @@ class TestProjectPlugin:
             pip_url="tap-mock--inherited-custom",
         )
         inherited_custom.parent = base
-        assert inherited_custom.venv_name == "tap-mock--inherited-custom"
+        assert inherited_custom.plugin_dir_name == "tap-mock--inherited-custom"
 
         inception_custom: ProjectPlugin = ProjectPlugin(
             PluginType.EXTRACTORS,
@@ -635,7 +635,7 @@ class TestProjectPlugin:
             pip_url="tap-mock--inception-custom",
         )
         inception_custom.parent = inherited
-        assert inception_custom.venv_name == "tap-mock--inception-custom"
+        assert inception_custom.plugin_dir_name == "tap-mock--inception-custom"
 
 
 class TestPluginType:

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -6,11 +6,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import yaml
 
+from meltano.core.plugin import PluginType
 from meltano.core.plugin_install_service import (
     PluginInstallReason,
     PluginInstallService,
     get_pip_install_args,
 )
+from meltano.core.project_plugins_service import PluginAlreadyAddedException
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -51,6 +53,39 @@ class TestPluginInstallService:
             )
         project.refresh()
         return PluginInstallService(project, **request.param)
+
+    @pytest.fixture()
+    def tap(self, project_add_service):
+        try:
+            return project_add_service.add(
+                PluginType.EXTRACTORS,
+                "tap-mock",
+                variant="meltano",
+            )
+        except PluginAlreadyAddedException as err:
+            return err.plugin
+
+    @pytest.fixture()
+    def inherited_tap(self, project_add_service, tap):
+        try:
+            return project_add_service.add(
+                PluginType.EXTRACTORS,
+                "tap-mock-inherited",
+                inherit_from=tap.name,
+            )
+        except PluginAlreadyAddedException as err:
+            return err.plugin
+
+    @pytest.fixture()
+    def inherited_inherited_tap(self, project_add_service, inherited_tap):
+        try:
+            return project_add_service.add(
+                PluginType.EXTRACTORS,
+                "tap-mock-inherited-inherited",
+                inherit_from=inherited_tap.name,
+            )
+        except PluginAlreadyAddedException as err:
+            return err.plugin
 
     def test_default_init_should_not_fail(self, subject) -> None:
         assert subject
@@ -119,10 +154,15 @@ class TestPluginInstallService:
     @pytest.mark.usefixtures("reset_project_context")
     async def test_auto_install(
         self,
-        project: Project,
         subject: PluginInstallService,
+        tap,
+        inherited_tap,
+        inherited_inherited_tap,
     ) -> None:
-        plugin = next(project.plugins.plugins())
+        plugin = tap
+        inherited_plugin = inherited_tap
+        inherited_inherited_plugin = inherited_inherited_tap
+
         state = await subject.install_plugin_async(
             plugin,
             reason=PluginInstallReason.AUTO,
@@ -138,6 +178,26 @@ class TestPluginInstallService:
         assert (
             state.skipped
         ), "Expected plugin with venv and matching fingerprint to not be installed"
+
+        state = await subject.install_plugin_async(
+            inherited_plugin,
+            reason=PluginInstallReason.AUTO,
+        )
+
+        assert state.skipped, (
+            "Expected plugin inheriting from another plugin with venv and matching"
+            " fingerprint to not be installed"
+        )
+
+        state = await subject.install_plugin_async(
+            inherited_inherited_plugin,
+            reason=PluginInstallReason.AUTO,
+        )
+
+        assert state.skipped, (
+            "Expected plugin inheriting from another inherited plugin with venv and"
+            " matching fingerprint to not be installed"
+        )
 
         plugin.pip_url = "changed"
         state = await subject.install_plugin_async(

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -62,7 +62,7 @@ class TestPluginInstallService:
                 "tap-mock",
                 variant="meltano",
             )
-        except PluginAlreadyAddedException as err:
+        except PluginAlreadyAddedException as err:  # pragma: no cover
             return err.plugin
 
     @pytest.fixture()
@@ -73,7 +73,7 @@ class TestPluginInstallService:
                 "tap-mock-inherited",
                 inherit_from=tap.name,
             )
-        except PluginAlreadyAddedException as err:
+        except PluginAlreadyAddedException as err:  # pragma: no cover
             return err.plugin
 
     @pytest.fixture()
@@ -84,7 +84,7 @@ class TestPluginInstallService:
                 "tap-mock-inherited-inherited",
                 inherit_from=inherited_tap.name,
             )
-        except PluginAlreadyAddedException as err:
+        except PluginAlreadyAddedException as err:  # pragma: no cover
             return err.plugin
 
     def test_default_init_should_not_fail(self, subject) -> None:

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -123,7 +123,10 @@ class TestPluginInstallService:
         assert all_plugins[1].successful
         assert not all_plugins[1].skipped
 
-        assert all_plugins[0].plugin.venv_name == all_plugins[1].plugin.venv_name
+        assert (
+            all_plugins[0].plugin.plugin_dir_name
+            == all_plugins[1].plugin.plugin_dir_name
+        )
         assert all_plugins[0].plugin.executable == all_plugins[1].plugin.executable
 
     def test_get_quoted_pip_install_args(self, project) -> None:


### PR DESCRIPTION
Culprit of this issue is that the `plugin_dir` method does not respect plugin inheritance, so would reference a plugin directory by the inheriting plugin name, rather than its progenitor plugin.

In the case of auto-install, the check to determine whether or not an install is required calls `plugin_dir`, resolves an incorrect directory, and then goes on to install reusing the parent plugin directory later on. Since the venv in the inherited plugin directory is never created, auto-install is always attempted.

Worth confirming that there is a separate but related issue here around install logic and multiple inheritance as discussed in [this Slack thread](https://meltano.slack.com/archives/C0695LLCGVC/p1726488890814789). ~A fix for that might benefit from reusing `get_progenitor`.~ EDIT: never mind, it's simpler than that (see #8785)!

---

Related to #8783