### PR TITLE
fix: Install plugins correctly given multiple levels of inheritance

### DIFF
--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -399,7 +399,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
             return self.name
 
         if not self.pip_url or (self.parent.pip_url == self.pip_url):
-            return self.parent.name
+            return self.parent.venv_name
 
         return self.name
 

--- a/tests/meltano/core/plugin/test_plugin.py
+++ b/tests/meltano/core/plugin/test_plugin.py
@@ -591,6 +591,52 @@ class TestProjectPlugin:
         # Plugin doesn't have any utility requirements
         assert not transformer.all_requires[PluginType.UTILITIES]
 
+    def test_venv_name(self):
+        """Validate the virtual environment name.
+
+        - If the plugin has a pip_url, the venv name is the plugin name.
+        - If the plugin is an inherited plugin without a custom pip_url, the venv name
+          is the parent plugin name.
+        - For multiple levels of inheritance, the venv name is the name of the first
+          plugin in the inheritance chain that has a pip_url.
+        """
+        base: ProjectPlugin = ProjectPlugin(PluginType.EXTRACTORS, name="tap-mock")
+        assert base.venv_name == "tap-mock"
+
+        inherited: ProjectPlugin = ProjectPlugin(
+            PluginType.EXTRACTORS,
+            name="tap-mock--inherited",
+            inherit_from="tap-mock",
+        )
+        inherited.parent = base
+        assert inherited.venv_name == "tap-mock"
+
+        inception: ProjectPlugin = ProjectPlugin(
+            PluginType.EXTRACTORS,
+            name="tap-mock--inception",
+            inherit_from="tap-mock--inherited",
+        )
+        inception.parent = inherited
+        assert inception.venv_name == "tap-mock"
+
+        inherited_custom: ProjectPlugin = ProjectPlugin(
+            PluginType.EXTRACTORS,
+            name="tap-mock--inherited-custom",
+            inherit_from="tap-mock",
+            pip_url="tap-mock--inherited-custom",
+        )
+        inherited_custom.parent = base
+        assert inherited_custom.venv_name == "tap-mock--inherited-custom"
+
+        inception_custom: ProjectPlugin = ProjectPlugin(
+            PluginType.EXTRACTORS,
+            name="tap-mock--inception-custom",
+            inherit_from="tap-mock--inherited",
+            pip_url="tap-mock--inception-custom",
+        )
+        inception_custom.parent = inherited
+        assert inception_custom.venv_name == "tap-mock--inception-custom"
+
 
 class TestPluginType:
     def test_properties(self) -> None:


### PR DESCRIPTION
The `venv_name` property of a plugin is used to determine if it installed or skipped based on whether or not the venv directory has been "seen".

https://github.com/meltano/meltano/blob/28bc90be783123655e837e23175db4cf64724393/src/meltano/core/plugin_install_service.py#L215

Previously, for an inherited plugin (i.e. defines `inherits_from`) only its immediate parent was taken into account when resolving the venv name. For one level of inheritance this is fine, but at soon as you start inheriting from inherited plugins the venv name is resolved as the parent inherited plugin name, **not the base plugin name**.

The fix is actually super simple - instead of getting the parent  `name`, get its `venv_name` to recursively resolve the base plugin name.

---

Given `meltano.yml` from https://meltano.slack.com/archives/C0695LLCGVC/p1726488890814789:

```yml
version: 1
default_environment: dev
project_id: 805c9ea1-931b-4722-9761-d6074594b175
environments:
- name: dev
- name: staging
- name: prod
plugins:
  extractors:
  - name: tap-oracle
    variant: s7clarke10
    pip_url:
      git+https://github.com/s7clarke10/pipelinewise-tap-oracle.git@53bb75ed27d7796d2f492e74cec87f10f1bce4d4
    config:
      use_ora_rowscn: false
      ora_python_driver_type: thick
      use_singer_decimal: true

  - name: tap-oracle-demo_foo
    inherit_from: tap-oracle
    config:
      user: demo
      host: 123
      port: 420
      service_name: foo

  - name: tap-oracle-demo_foo-full_table
    inherit_from: tap-oracle-demo_foo
    config:
      default_replication_method: FULL_TABLE

  - name: tap-oracle-demo_foo-full_table-bar_baz
    inherit_from: tap-oracle-demo_foo-full_table
    select:
     - bar-baz.*

  - name: tap-oracle-demo_foo-full_table-asd_qwe
    inherit_from: tap-oracle-demo_foo-full_table
    select:
      - asd-qwe.*
```

Before fix:

![image](https://github.com/user-attachments/assets/eee07284-d3e0-44e1-b4fd-0e60438bc8fd)

After fix:

![image](https://github.com/user-attachments/assets/91710d0f-169e-4c7a-b4f8-2e332800613c)

---

Related to #8783