### PR TITLE
fix: Failure message is now correctly printed when a plugin can not be removed from the system database

### DIFF
--- a/src/meltano/cli/remove.py
+++ b/src/meltano/cli/remove.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing as t
+
 import click
 
 from meltano.cli.params import pass_project
@@ -14,12 +16,19 @@ from meltano.core.plugin_location_remove import (
 )
 from meltano.core.plugin_remove_service import PluginRemoveService
 
+if t.TYPE_CHECKING:
+    from meltano.core.project import Project
+
 
 @click.command(cls=InstrumentedCmd, short_help="Remove plugins from your project.")
 @click.argument("plugin_type", type=click.Choice(PluginType.cli_arguments()))
 @click.argument("plugin_names", nargs=-1, required=True)
 @pass_project()
-def remove(project, plugin_type, plugin_names) -> None:  # noqa: ANN001
+def remove(
+    project: Project,
+    plugin_type: PluginType,
+    plugin_names: tuple[str, ...],
+) -> None:
     """Remove plugins from your project.
 
     \b
@@ -32,7 +41,7 @@ def remove(project, plugin_type, plugin_names) -> None:  # noqa: ANN001
     remove_plugins(project, plugins)
 
 
-def remove_plugins(project, plugins) -> None:  # noqa: ANN001
+def remove_plugins(project: Project, plugins: t.Sequence[ProjectPlugin]) -> None:
     """Invoke PluginRemoveService and output CLI removal overview."""
     remove_service = PluginRemoveService(project)
 
@@ -49,7 +58,7 @@ def remove_plugins(project, plugins) -> None:  # noqa: ANN001
         click.echo()
 
 
-def remove_plugin_status_update(plugin) -> None:  # noqa: ANN001
+def remove_plugin_status_update(plugin: ProjectPlugin) -> None:
     """Print remove status message for a plugin."""
     plugin_descriptor = f"{plugin.type.descriptor} '{plugin.name}'"
 
@@ -63,7 +72,7 @@ def removal_manager_status_update(removal_manager: PluginLocationRemoveManager) 
     plugin_descriptor = removal_manager.plugin_descriptor
     location = removal_manager.location
     if removal_manager.plugin_error:
-        message = removal_manager.remove_message
+        message = removal_manager.message
 
         click.secho(
             f"Error removing plugin {plugin_descriptor} from {location}: {message}",

--- a/src/meltano/core/plugin_remove_service.py
+++ b/src/meltano/core/plugin_remove_service.py
@@ -32,8 +32,11 @@ class PluginRemoveService:
     def remove_plugins(
         self,
         plugins: t.Sequence[ProjectPlugin],
-        plugin_status_cb=noop,  # noqa: ANN001
-        removal_manager_status_cb=noop,  # noqa: ANN001
+        plugin_status_cb: t.Callable[[ProjectPlugin], None] = noop,
+        removal_manager_status_cb: t.Callable[
+            [PluginLocationRemoveManager],
+            None,
+        ] = noop,
     ) -> tuple[int, int]:
         """Remove multiple plugins.
 

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -177,7 +177,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
             The removed plugin.
         """
         # Will raise if the plugin isn't actually in the file
-        self.get_plugin(plugin)
+        self.get_plugin(plugin, ensure_parent=False)
 
         with self.update_plugins() as plugins:
             plugins[plugin.type].remove(plugin)
@@ -308,11 +308,17 @@ class ProjectPluginsService:  # (too many methods, attributes)
             return found
         raise PluginNotFoundError(mapping_name)
 
-    def get_plugin(self, plugin_ref: PluginRef) -> ProjectPlugin:
+    def get_plugin(
+        self,
+        plugin_ref: PluginRef,
+        *,
+        ensure_parent: bool = True,
+    ) -> ProjectPlugin:
         """Get a plugin using its PluginRef.
 
         Args:
             plugin_ref: The plugin reference to use.
+            ensure_parent: If True, ensure that plugin has a parent plugin set.
 
         Returns:
             The plugin if found.
@@ -327,7 +333,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
                 if plugin == plugin_ref
             )
 
-            return self.ensure_parent(plugin)
+            return self.ensure_parent(plugin) if ensure_parent else plugin
         except StopIteration as stop:
             raise PluginNotFoundError(plugin_ref) from stop
 

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -127,6 +127,7 @@ class TestPluginRemoveService:
 
     @pytest.mark.usefixtures("add", "install", "lock")
     def test_remove(self, subject: PluginRemoveService) -> None:
+        subject.project.refresh()
         plugins = list(subject.project.plugins.plugins())
         removed_plugins, total_plugins = subject.remove_plugins(plugins)
 
@@ -154,6 +155,7 @@ class TestPluginRemoveService:
 
     @pytest.mark.usefixtures("no_plugins")
     def test_remove_not_added_or_installed(self, subject: PluginRemoveService) -> None:
+        subject.project.refresh()
         plugins = list(subject.project.plugins.plugins())
         removed_plugins, total_plugins = subject.remove_plugins(plugins)
 
@@ -189,6 +191,8 @@ class TestPluginRemoveService:
 
     @pytest.mark.usefixtures("add", "install", "lock")
     def test_remove_meltano_yml_error(self, subject: PluginRemoveService) -> None:
+        subject.project.refresh()
+
         def raise_permissionerror(filename) -> t.NoReturn:
             raise OSError(errno.EACCES, os.strerror(errno.ENOENT), filename)
 
@@ -204,6 +208,8 @@ class TestPluginRemoveService:
 
     @pytest.mark.usefixtures("add", "install", "lock")
     def test_remove_installation_error(self, subject: PluginRemoveService) -> None:
+        subject.project.refresh()
+
         def raise_permissionerror(filename) -> t.NoReturn:
             raise OSError(errno.EACCES, os.strerror(errno.ENOENT), filename)
 
@@ -217,7 +223,8 @@ class TestPluginRemoveService:
 
     @pytest.mark.usefixtures("add", "install")
     def test_remove_lockfile_not_found(self, subject: PluginRemoveService) -> None:
-        plugins = list(subject.project.plugins.plugins())
+        subject.project.refresh()
+        plugins = list(subject.project.plugins.plugins(ensure_parent=False))
         removed_plugins, _ = subject.remove_plugins(plugins)
 
         assert removed_plugins == 0


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

The detailed error message was missing when a plugin couldn't be removed from the db.

## Related Issues

* Closes #XXXX
