### PR TITLE
fix: No longer fail on uploading state to S3 when the object does not initially exist

### DIFF
--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -329,7 +329,8 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
                 except Exception as e:
                     if self.is_file_not_found_error(e):
                         state_to_write = state
-                    raise e
+                    else:
+                        raise e
             with self.get_writer(filepath) as writer:
                 writer.write(state_to_write.json())
 

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -137,7 +137,7 @@ class EventMatcher:
         for line in result_output.splitlines():
             try:
                 parsed_line = json.loads(line)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError:  # pragma: no cover
                 self.seen_raw.append(line)
                 continue
             self.seen_events.append(parsed_line)

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -455,6 +455,32 @@ class TestS3StateStoreManager:
             store_manager.client.create_bucket(Bucket=store_manager.bucket)
             store_manager.set(JobState(state_id=state_id, completed_state={}))
 
+    def test_set_fail_object_in_glacier(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        state_id = uuid.uuid4().hex
+        with moto.mock_aws():
+            store_manager = S3StateStoreManager(
+                uri="s3://test_access_key_id:test_secret_access_key@meltano/state",
+                lock_timeout_seconds=10,
+            )
+            store_manager.client.create_bucket(Bucket=store_manager.bucket)
+            store_manager.client.put_object(
+                Bucket=store_manager.bucket,
+                Key=f"state/{state_id}/state.json",
+                Body=json.dumps({}).encode(),
+                StorageClass="GLACIER",
+            )
+            with pytest.raises(OSError, match="unable to access") as exc_info:
+                store_manager.set(JobState(state_id=state_id, completed_state={}))
+
+            exc = exc_info.value
+            assert isinstance(exc.__cause__, botocore.exceptions.ClientError)
+            assert exc.__cause__.response["Error"]["Code"] == "InvalidObjectState"
+
     def test_set_fail_bucket_does_not_exist(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -442,11 +442,6 @@ class TestS3StateStoreManager:
     def test_state_path(self, subject: S3StateStoreManager) -> None:
         assert subject.state_dir == "state"
 
-    @pytest.mark.xfail(
-        reason="Fails the first time because the object does not exist",
-        raises=OSError,
-        strict=True,
-    )
     def test_set_first_time(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         monkeypatch.delenv("AWS_PROFILE", raising=False)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

- To make testing simpler, I used `moto` instead of `boto3`'s stubber.

## Related Issues

* Closes https://github.com/meltano/meltano/issues/8801
