### PR TITLE
fix: A mapper is now auto-installed when one its mappings is used in a command

### DIFF
--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -84,7 +84,7 @@ async def install(
             plugin_type = PluginType.from_cli_argument(plugin_type)
             plugins = project.plugins.get_plugins_of_type(plugin_type)
         else:
-            plugins = list(project.plugins.plugins())
+            plugins = [p for p in project.plugins.plugins() if not p.is_mapping()]
 
         if plugin_name:
             plugins = [plugin for plugin in plugins if plugin.name in plugin_name]

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -454,3 +454,18 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
             for plugin_type, deps in self.all_requires.items()
             for dep in deps
         ]
+
+    def is_mapping(self) -> bool:
+        """Check if the plugin is a mapping, as mappings are not installed.
+
+        Mappings are `PluginType.MAPPERS` with extra attribute of `_mapping`
+        which will indicate that this instance of the plugin is actually a
+        mapping - and should not be installed.
+
+        Returns:
+            A boolean determining if the plugin is a mapping (of type
+            `PluginType.MAPPERS`).
+        """
+        return self.type is PluginType.MAPPERS and bool(
+            self.extra_config.get("_mapping")
+        )

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -310,14 +310,7 @@ class PluginInstallService:
         """
         env = self.plugin_installation_env(plugin)
 
-        if (
-            (
-                reason == PluginInstallReason.AUTO
-                and not self._requires_install(plugin, env=env)
-            )
-            or not plugin.is_installable()
-            or self._is_mapping(plugin)
-        ):
+        if not self._requires_install(plugin, reason, env=env):
             state = PluginInstallState(
                 plugin=plugin,
                 reason=reason,
@@ -395,9 +388,16 @@ class PluginInstallService:
     def _requires_install(
         self,
         plugin: ProjectPlugin,
+        reason: PluginInstallReason,
         *,
         env: t.Mapping[str, str] | None = None,
     ) -> bool:
+        if not plugin.is_installable():
+            return False
+
+        if reason is not PluginInstallReason.AUTO:
+            return not self._is_mapping(plugin)
+
         try:
             pip_install_args = get_pip_install_args(
                 self.project,

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -21,7 +21,6 @@ from meltano.core.error import (
     PluginInstallError,
     PluginInstallWarning,
 )
-from meltano.core.plugin import PluginType
 from meltano.core.plugin.settings_service import PluginSettingsService
 from meltano.core.settings_service import FeatureFlags
 from meltano.core.utils import (
@@ -396,7 +395,7 @@ class PluginInstallService:
             return False
 
         if reason is not PluginInstallReason.AUTO:
-            return not self._is_mapping(plugin)
+            return not plugin.is_mapping()
 
         try:
             pip_install_args = get_pip_install_args(
@@ -418,25 +417,6 @@ class PluginInstallService:
 
         venv = VirtualEnv(self.project.plugin_dir(plugin, "venv", make_dirs=False))
         return fingerprint(pip_install_args) != venv.read_fingerprint()
-
-    @staticmethod
-    def _is_mapping(plugin: ProjectPlugin) -> bool:
-        """Check if a plugin is a mapping, as mappings are not installed.
-
-        Mappings are `PluginType.MAPPERS` with extra attribute of `_mapping`
-        which will indicate that this instance of the plugin is actually a
-        mapping - and should not be installed.
-
-        Args:
-            plugin: ProjectPlugin to evaluate.
-
-        Returns:
-            A boolean determining if the given plugin is a mapping (of type
-            `PluginType.MAPPERS`).
-        """
-        return plugin.type == PluginType.MAPPERS and bool(
-            plugin.extra_config.get("_mapping")
-        )
 
     def plugin_installation_env(self, plugin: ProjectPlugin) -> dict[str, str]:
         """Environment variables to use during plugin installation.

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -238,7 +238,7 @@ class TestCliInstall:
             assert not kwargs["clean"]
 
             mappers = [m for m in commands[0][1] if m == mapper]
-            assert len(mappers) == 3
+            assert len(mappers) == 1
 
     def test_clean_install(
         self,
@@ -274,7 +274,7 @@ class TestCliInstall:
             assert kwargs["clean"]
 
             mappers = [m for m in commands[0][1] if m == mapper]
-            assert len(mappers) == 3
+            assert len(mappers) == 1
 
     @pytest.mark.usefixtures("tap_gitlab", "target")
     def test_install_schedule(

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -122,7 +122,7 @@ class TestPluginInstallService:
                     },
                 ],
             )
-        except PluginAlreadyAddedException as err:
+        except PluginAlreadyAddedException as err:  # pragma: no cover
             return err.plugin
 
     @pytest.fixture()

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -15,6 +15,7 @@ from meltano.core.plugin_install_service import (
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
 
 if t.TYPE_CHECKING:
+    from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
 
 
@@ -86,6 +87,48 @@ class TestPluginInstallService:
             )
         except PluginAlreadyAddedException as err:  # pragma: no cover
             return err.plugin
+
+    @pytest.fixture()
+    def mapper(self, project_add_service):
+        try:
+            return project_add_service.add(
+                PluginType.MAPPERS,
+                "mapper-mock",
+                variant="meltano",
+                mappings=[
+                    {
+                        "name": "mock-mapping-0",
+                        "config": {
+                            "transformations": [
+                                {
+                                    "field_id": "author_email",
+                                    "tap_stream_name": "commits",
+                                    "type": "MASK-HIDDEN",
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        "name": "mock-mapping-1",
+                        "config": {
+                            "transformations": [
+                                {
+                                    "field_id": "given_name",
+                                    "tap_stream_name": "users",
+                                    "type": "lowercase",
+                                },
+                            ],
+                        },
+                    },
+                ],
+            )
+        except PluginAlreadyAddedException as err:
+            return err.plugin
+
+    @pytest.fixture()
+    def mapping(self, project: Project, mapper: ProjectPlugin):
+        name: str = mapper.extra_config["_mappings"][0]["name"]
+        return project.plugins.find_plugin(name)
 
     def test_default_init_should_not_fail(self, subject) -> None:
         assert subject
@@ -221,3 +264,32 @@ class TestPluginInstallService:
         assert (
             state.skipped
         ), "Expected plugin with missing env var in pip URL to not be installed"
+
+    @patch("meltano.core.venv_service.VenvService.install_pip_args", AsyncMock())
+    @pytest.mark.usefixtures("reset_project_context")
+    async def test_auto_install_mapper_by_mapping(
+        self,
+        subject: PluginInstallService,
+        mapper,
+        mapping,
+    ) -> None:
+        state = await subject.install_plugin_async(
+            mapping,
+            reason=PluginInstallReason.AUTO,
+        )
+
+        assert not state.skipped, "Expected mapper defining mapping to be installed"
+
+        state = await subject.install_plugin_async(
+            mapper,
+            reason=PluginInstallReason.AUTO,
+        )
+
+        assert state.skipped, "Expected mapper to not be installed"
+
+        state = await subject.install_plugin_async(
+            mapping,
+            reason=PluginInstallReason.AUTO,
+        )
+
+        assert state.skipped, "Expected mapper defining mapping to not be installed"


### PR DESCRIPTION
Closes #8660
Closes #3442

Could also use this PR to address #3442, although not sure what the consensus on that actually is. Do we treat mappings as plugins and update the install logging to show

```
reuben@reuben-Inspiron-14-5425:/tmp/p$ meltano install
2024-09-30T16:05:44.928766Z [info     ] Installing 2 plugins          
2024-09-30T16:05:44.929202Z [info     ] Skipped installing mapping 'my-mapping'
2024-09-30T16:05:44.945050Z [info     ] Installing mapper 'meltano-map-transformer'
2024-09-30T16:05:58.131879Z [info     ] Installed mapper 'meltano-map-transformer'
2024-09-30T16:05:58.132364Z [info     ] Installed 1/2 plugins         
2024-09-30T16:05:58.132468Z [info     ] Skipped installing 1/2 plugins
```

or filter out mappings from plugins beforehand in https://github.com/meltano/meltano/blob/b8d68748075ec8e5e464da79a694164d0c62eeca/src/meltano/cli/install.py#L87 i.e.

```py
plugins = [p for p in project.plugins.plugins() if not plugin_install_service._is_mapping(p)]
```

?