### PR TITLE
chore: Update log formatter tests to accomodate changes in the Rich library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3265,19 +3265,19 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "rich"
-version = "13.8.1"
+version = "13.9.2"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 files = [
-    {file = "rich-13.8.1-py3-none-any.whl", hash = "sha256:1760a3c0848469b97b558fc61c85233e3dafb69c7a071b4d60c38099d3cd4c06"},
-    {file = "rich-13.8.1.tar.gz", hash = "sha256:8260cda28e3db6bf04d2d1ef4dbc03ba80a824c88b0e7668a0f23126a424844a"},
+    {file = "rich-13.9.2-py3-none-any.whl", hash = "sha256:8c82a3d3f8dcfe9e734771313e606b39d8247bb6b826e196f4914b333b743cf1"},
+    {file = "rich-13.9.2.tar.gz", hash = "sha256:51a2c62057461aaf7152b4d611168f93a9fc73068f8ded2790f29fe2b5366d0c"},
 ]
 
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
 pygments = ">=2.13.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -22,6 +22,9 @@ class FakeCode:
         self.co_filename = co_filename
         self.co_name = co_name
 
+    def co_positions(self):
+        yield 0, 10, 0, 40
+
 
 class FakeFrame:
     """A fake traceback frame that can be used to test log formatters."""
@@ -30,6 +33,7 @@ class FakeFrame:
         self.f_code = f_code
         self.f_globals = f_globals
         self.f_locals = f_locals or {}
+        self.f_lasti = 0
 
 
 class FakeTraceback:  # pragma: no cover


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

The Rich library[^1] recently made changes[^2] that add support for PEP 657[^3] on Python 3.11+.

This might make the Rich tracebacks more useful, but currently breaks our tests because our codeobject and frame stubs only implement a subset of the interface.

## Related Issues

* Closes #XXXX

[^1]: https://github.com/textualize/rich
[^2]: https://github.com/Textualize/rich/pull/3486
[^3]: https://peps.python.org/pep-0657/