### PR TITLE
fix: Show the correct value in the "Current value is still" warning for `meltano config set`

### DIFF
--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -433,7 +433,7 @@ class InteractiveConfig:
 
         current_value, source = settings.get_with_source(name, session=self.session)
         if source != store:
-            current_value = REDACTED_VALUE if is_redacted else f"{value!r}"
+            current_value = REDACTED_VALUE if is_redacted else f"{current_value!r}"
 
             click.secho(
                 f"Current value is still: {current_value} (from {source.label})",


### PR DESCRIPTION
Closes #8827

Blame doesn't lie, I'll hold my hands up https://github.com/meltano/meltano/commit/f3f9b9da4f4a5dde04e0155d85363ad63f3fee19#diff-21e668e8c7b63006703a98a074109ca3d1661504976324336a75512129a6d7c4R433