### PR TITLE
fix: Using the `--force` flag of `meltano install` no longer causes plugin installation to crash

### DIFF
--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -646,7 +646,7 @@ async def install_pip_plugin(
 
     await service.install(
         pip_install_args=("--ignore-requires-python", *pip_install_args)
-        if force
+        if force and backend == "virtualenv"
         else pip_install_args,
         clean=clean,
         env={


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

Because `uv pip install` doesn't support this flag and its default behavior is to ignore upper limits in `Requires-Python` during resolution.

<details><summary>Full output of `uv pip install --help` for uv 0.4.26</summary>
<p>

```
Install packages into an environment

Usage: uv pip install [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>|--editable <EDITABLE>>

Arguments:
  [PACKAGE]...  Install all listed packages

Options:
  -r, --requirement <REQUIREMENT>            Install all packages listed in the given `requirements.txt` files
  -e, --editable <EDITABLE>                  Install the editable package based on the provided local file path
  -c, --constraint <CONSTRAINT>              Constrain versions using the given requirements files [env: UV_CONSTRAINT=]
      --override <OVERRIDE>                  Override versions using the given requirements files [env: UV_OVERRIDE=]
  -b, --build-constraint <BUILD_CONSTRAINT>  Constrain build dependencies using the given requirements files when building source distributions [env: UV_BUILD_CONSTRAINT=]
      --extra <EXTRA>                        Include optional dependencies from the extra group name; may be provided more than once
      --all-extras                           Include all optional dependencies
      --no-deps                              Ignore package dependencies, instead only installing those packages explicitly listed on the command line or in the requirements files
      --require-hashes                       Require a matching hash for each requirement [env: UV_REQUIRE_HASHES=]
      --verify-hashes                        Validate any hashes provided in the requirements file [env: UV_VERIFY_HASHES=]
      --system                               Install packages into the system Python environment [env: UV_SYSTEM_PYTHON=]
      --break-system-packages                Allow uv to modify an `EXTERNALLY-MANAGED` Python installation [env: UV_BREAK_SYSTEM_PACKAGES=]
      --no-break-system-packages             
      --target <TARGET>                      Install packages into the specified directory, rather than into the virtual or system Python environment. The packages will be installed at the top-level of the directory
      --prefix <PREFIX>                      Install packages into `lib`, `bin`, and other top-level folders under the specified directory, as if a virtual environment were present at that location
      --no-build                             Don't build source distributions
      --no-binary <NO_BINARY>                Don't install pre-built wheels
      --only-binary <ONLY_BINARY>            Only use pre-built wheels; don't build source distributions
      --python-version <PYTHON_VERSION>      The minimum Python version that should be supported by the requirements (e.g., `3.7` or `3.7.9`)
      --python-platform <PYTHON_PLATFORM>    The platform for which requirements should be installed [possible values: windows, linux, macos, x86_64-pc-windows-msvc, i686-pc-windows-msvc, x86_64-unknown-linux-gnu, aarch64-apple-darwin, x86_64-apple-darwin,
                                             aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, x86_64-unknown-linux-musl, x86_64-manylinux_2_17, x86_64-manylinux_2_28, x86_64-manylinux_2_31, aarch64-manylinux_2_17, aarch64-manylinux_2_28, aarch64-manylinux_2_31]
      --exact                                Perform an exact sync, removing extraneous packages
      --strict                               Validate the Python environment after completing the installation, to detect and with missing dependencies or other issues
      --dry-run                              Perform a dry run, i.e., don't actually install anything but resolve the dependencies and print the resulting plan
      --user                                 

Index options:
      --index <INDEX>                              The URLs to use when resolving dependencies, in addition to the default index [env: UV_INDEX=]
      --default-index <DEFAULT_INDEX>              The URL of the default package index (by default: <https://pypi.org/simple>) [env: UV_DEFAULT_INDEX=]
  -i, --index-url <INDEX_URL>                      (Deprecated: use `--default-index` instead) The URL of the Python package index (by default: <https://pypi.org/simple>) [env: UV_INDEX_URL=]
      --extra-index-url <EXTRA_INDEX_URL>          (Deprecated: use `--index` instead) Extra URLs of package indexes to use, in addition to `--index-url` [env: UV_EXTRA_INDEX_URL=]
  -f, --find-links <FIND_LINKS>                    Locations to search for candidate distributions, in addition to those found in the registry indexes [env: UV_FIND_LINKS=]
      --no-index                                   Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those provided via `--find-links`
      --index-strategy <INDEX_STRATEGY>            The strategy to use when resolving against multiple index URLs [env: UV_INDEX_STRATEGY=] [possible values: first-index, unsafe-first-match, unsafe-best-match]
      --keyring-provider <KEYRING_PROVIDER>        Attempt to use `keyring` for authentication for index URLs [env: UV_KEYRING_PROVIDER=] [possible values: disabled, subprocess]
      --allow-insecure-host <ALLOW_INSECURE_HOST>  Allow insecure connections to a host [env: UV_INSECURE_HOST=]

Resolver options:
  -U, --upgrade                            Allow package upgrades, ignoring pinned versions in any existing output file. Implies `--refresh`
  -P, --upgrade-package <UPGRADE_PACKAGE>  Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies `--refresh-package`
      --resolution <RESOLUTION>            The strategy to use when selecting between the different compatible versions for a given package requirement [env: UV_RESOLUTION=] [possible values: highest, lowest, lowest-direct]
      --prerelease <PRERELEASE>            The strategy to use when considering pre-release versions [env: UV_PRERELEASE=] [possible values: disallow, allow, if-necessary, explicit, if-necessary-or-explicit]
      --exclude-newer <EXCLUDE_NEWER>      Limit candidate packages to those that were uploaded prior to the given date [env: UV_EXCLUDE_NEWER=]
      --no-sources                         Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources

Installer options:
      --reinstall                              Reinstall all packages, regardless of whether they're already installed. Implies `--refresh`
      --reinstall-package <REINSTALL_PACKAGE>  Reinstall a specific package, regardless of whether it's already installed. Implies `--refresh-package`
      --link-mode <LINK_MODE>                  The method to use when installing packages from the global cache [env: UV_LINK_MODE=] [possible values: clone, copy, hardlink, symlink]
      --compile-bytecode                       Compile Python files to bytecode after installation [env: UV_COMPILE_BYTECODE=]

Build options:
  -C, --config-setting <CONFIG_SETTING>                          Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs
      --no-build-isolation                                       Disable isolation when building source distributions [env: UV_NO_BUILD_ISOLATION=]
      --no-build-isolation-package <NO_BUILD_ISOLATION_PACKAGE>  Disable isolation when building source distributions for a specific package

Cache options:
  -n, --no-cache                           Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation [env: UV_NO_CACHE=]
      --cache-dir <CACHE_DIR>              Path to the cache directory [env: UV_CACHE_DIR=]
      --refresh                            Refresh all cached data
      --refresh-package <REFRESH_PACKAGE>  Refresh cached data for a specific package

Python options:
  -p, --python <PYTHON>                        The Python interpreter into which packages should be installed. [env: UV_PYTHON=]
      --python-preference <PYTHON_PREFERENCE>  Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=] [possible values: only-managed, managed, system, only-system]
      --no-python-downloads                    Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]

Global options:
  -q, --quiet                      Do not print any output
  -v, --verbose...                 Use verbose output
      --color <COLOR_CHOICE>       Control colors in output [default: auto] [possible values: auto, always, never]
      --native-tls                 Whether to load TLS certificates from the platform's native certificate store [env: UV_NATIVE_TLS=]
      --offline                    Disable network access
      --no-progress                Hide all progress outputs
      --directory <DIRECTORY>      Change to the given directory prior to running the command
      --project <PROJECT>          Run the command within the given project directory
      --config-file <CONFIG_FILE>  The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
      --no-config                  Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) [env: UV_NO_CONFIG=]
  -h, --help                       Display the concise help for this command
  -V, --version                    Display the uv version

Use `uv help pip install` for more details.

```

</p>
</details> 

## Related Issues

* Closes #XXXX
