### PR TITLE
test: Fail tests when warnings are emitted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,11 @@ meltano = "meltano.cli:main"
 [tool.pytest.ini_options]
 addopts = "--cov=meltano --cov=tests --doctest-modules --durations=10 --order-scope=module -ra -n auto --dist=loadfile"
 asyncio_mode = "auto"
+filterwarnings = [
+  "error",
+  "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:time_machine.*",  # https://github.com/adamchainz/time-machine/issues/445
+  "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:botocore.auth.*", # https://github.com/boto/boto3/issues/3889
+]
 log_cli = 1
 log_cli_format = "%(message)s"
 log_cli_level = "CRITICAL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ filterwarnings = [
   "error",
   "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:time_machine.*",  # https://github.com/adamchainz/time-machine/issues/445
   "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:botocore.auth.*", # https://github.com/boto/boto3/issues/3889
+  "ignore::pytest.PytestUnraisableExceptionWarning",
 ]
 log_cli = 1
 log_cli_format = "%(message)s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ meltano = "meltano.cli:main"
 [tool.pytest.ini_options]
 addopts = "--cov=meltano --cov=tests --doctest-modules --durations=10 --order-scope=module -ra -n auto --dist=loadfile"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "class"
 filterwarnings = [
   "error",
   "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:time_machine.*",  # https://github.com/adamchainz/time-machine/issues/445

--- a/tests/meltano/core/test_project.py
+++ b/tests/meltano/core/test_project.py
@@ -96,9 +96,9 @@ class TestProject:
         assert Project.find() is project
 
     def test_find_threadsafe(self, project, concurrency) -> None:
-        workers = ThreadPool(concurrency["threads"])
-        projects = workers.map(Project.find, range(concurrency["cases"]))
-        assert all(x is project for x in projects)
+        with ThreadPool(concurrency["threads"]) as workers:
+            projects = workers.map(Project.find, range(concurrency["cases"]))
+            assert all(x is project for x in projects)
 
     @pytest.mark.concurrent
     def test_meltano_concurrency(self, project, concurrency) -> None:


### PR DESCRIPTION
- Ignore `datetime.datetime.utcnow()` deprecation warnings coming from third-party libraries

<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Related:

- https://github.com/meltano/meltano/issues/6973
- https://github.com/meltano/meltano/pull/8719

## Related Issues

* Closes #XXXX
