### PR TITLE
docs: Use a different repo in part 1 of Getting Started guide

### DIFF
--- a/docs/docs/getting-started/part1.mdx
+++ b/docs/docs/getting-started/part1.mdx
@@ -196,7 +196,7 @@ The GitHub tap requires [configuration](/guide/configuration) before it can star
 meltano config tap-github set --interactive
 ```
 
-2. Follow the prompts to step through all available settings, the ones you'll need to fill out are repositories (formatted like `["sbalnojan/meltano-lightdash"]`), start_date, and your auth_token.
+2. Follow the prompts to step through all available settings, the ones you'll need to fill out are repositories (formatted like `["sbalnojan/meltano-lightdash"]`), start_date, and your auth_token. For the `start_date` you must enter a date on or before `2022-09-14` to retrieve the meltano-lightdash repo's [only commit](https://github.com/sbalnojan/meltano-lightdash/commit/409bdd601e0531833665f538bccecd0f69e101c0).
 
 <br />
 
@@ -238,7 +238,7 @@ This will add the configuration to your [`meltano.yml` project file](/concepts/p
     extractors:
       - name: tap-github
         config:
-          start_date: '2024-01-01'
+          start_date: '2020-01-01'
           repositories:
           - sbalnojan/meltano-lightdash
 ```

--- a/docs/docs/getting-started/part1.mdx
+++ b/docs/docs/getting-started/part1.mdx
@@ -196,7 +196,7 @@ The GitHub tap requires [configuration](/guide/configuration) before it can star
 meltano config tap-github set --interactive
 ```
 
-2. Follow the prompts to step through all available settings, the ones you'll need to fill out are repositories (formatted like `["sbalnojan/meltano-lightdash"]`), start_date, and your auth_token. For the `start_date` you must enter a date on or before `2022-09-14` to retrieve the meltano-lightdash repo's [only commit](https://github.com/sbalnojan/meltano-lightdash/commit/409bdd601e0531833665f538bccecd0f69e101c0).
+2. Follow the prompts to step through all available settings, the ones you'll need to fill out are repositories (formatted like `["meltano/meltano"]`), start_date, and your auth_token.
 
 <br />
 
@@ -238,9 +238,9 @@ This will add the configuration to your [`meltano.yml` project file](/concepts/p
     extractors:
       - name: tap-github
         config:
-          start_date: '2020-01-01'
+          start_date: '2024-01-01'
           repositories:
-          - sbalnojan/meltano-lightdash
+          - meltano/meltano
 ```
 
 It will also add your secret auth token to the file `.env`:


### PR DESCRIPTION
## Description

start_date shown in part1.mdx for meltano.yml will not load any data rows for the repo shown — setting start date much earlier and adding explanation to avoid confusion.
