### PR TITLE
feat: The `process` key containing the process ID for a Meltano invocation is now added to logs when `callsite_parameters: true` is used

### DIFF
--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -62,7 +62,7 @@ formatters:
     sort_keys: false
   json: # log format for json formatted logs
     (): meltano.core.logging.json_formatter
-    callsite_parameters: true # adds `pathname`, `lineno`, and `func_name` to each log entry
+    callsite_parameters: true # adds `pathname`, `lineno`, `func_name` and `process` to each log entry
     dict_tracebacks: false # removes the `exception` object that is added to each log entry
     show_locals: true # enables local variable logging in tracebacks
 

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -68,6 +68,7 @@ def _processors_from_kwargs(
                 structlog.processors.CallsiteParameter.PATHNAME,
                 structlog.processors.CallsiteParameter.LINENO,
                 structlog.processors.CallsiteParameter.FUNC_NAME,
+                structlog.processors.CallsiteParameter.PROCESS,
             ),
         )
 

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import sys
 import typing as t
@@ -97,6 +98,7 @@ class TestLogFormatters:
         assert "pathname='/path/to/my_module.py'" in output
         assert "lineno=1" in output
         assert "func_name='my_func'" in output
+        assert f"process={os.getpid()}" in output
 
     def test_json_formatter_callsite_parameters(self, record):
         formatter = formatters.json_formatter(callsite_parameters=True)
@@ -105,6 +107,7 @@ class TestLogFormatters:
         assert message_dict["pathname"] == "/path/to/my_module.py"
         assert message_dict["lineno"] == 1
         assert message_dict["func_name"] == "my_func"
+        assert message_dict["process"] == os.getpid()
 
     def test_json_formatter_exception(self, record_with_exception) -> None:
         formatter = formatters.json_formatter()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Follows from #8494.

## Related Issues

* https://github.com/meltano/meltano/issues/8494
* https://github.com/meltano/meltano/issues/9005
