### PR TITLE
fix: Avoid prepending a slash to state file path in Cloud state backends

### DIFF
--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -68,7 +68,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
             lambda comp1, comp2: f"{comp1}{comp2}"
             if (comp1.endswith(self.delimiter) or comp2.startswith(self.delimiter))
             else f"{comp1}{self.delimiter}{comp2}",
-            components,
+            filter(None, components),
         )
 
     @staticmethod

--- a/src/meltano/core/state_store/google.py
+++ b/src/meltano/core/state_store/google.py
@@ -6,11 +6,15 @@ import typing as t
 from contextlib import contextmanager
 from functools import cached_property
 
+import structlog.stdlib
+
 from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.state_store.filesystem import CloudStateStoreManager
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator
+
+logger = structlog.stdlib.get_logger(__name__)
 
 GOOGLE_INSTALLED = True
 
@@ -130,7 +134,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
             blob.delete()
         except Exception as e:
             if self.is_file_not_found_error(e):
-                ...
+                logger.debug("File not found: %s", file_path, exc_info=e)
             else:
                 raise e
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

We were generating an invalid Blob name with a leading slash and then swalloing the exception during deletion, so the user had no idea what was wrong.

The exception looked like this:

```
NotFound('DELETE https://storage.googleapis.com/storage/v1/b/meltano-state/o/%2Fdev%3Atap-fedidb-to-target-jsonl%2Fstate.json?prettyPrint=false: No such object: meltano-state//dev:tap-fedidb-to-target-jsonl/state.json')
```

**Notice the double slash after the bucket name.**

The changes here:

1. Ensure we ignore empty strings when joining path/blob/object names so we don't end up with states with leading or trailing slashes
1. Log the `NotFound` exception at the debug level.

## Related Issues

* Closes #9017
