### PR TITLE
chore: Update expected message from ignored `strptime` warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ filterwarnings = [
   "error",
   "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:time_machine.*",  # https://github.com/adamchainz/time-machine/issues/445
   "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:botocore.auth.*", # https://github.com/boto/boto3/issues/3889
-  "ignore: Parsing dates involving a day of month without a year specified is ambiguious:DeprecationWarning:dateparser.*",  # https://github.com/scrapinghub/dateparser/issues/1246
+  "ignore: Parsing dates involving a day of month without a year specified is:DeprecationWarning:dateparser.*",  # https://github.com/scrapinghub/dateparser/issues/1246
   "ignore::pytest.PytestUnraisableExceptionWarning",
   "ignore::pytest.PytestUnhandledThreadExceptionWarning",
 ]


### PR DESCRIPTION
The typo was fixed for CPython 3.14: https://github.com/python/cpython/commit/1f4a49ea53516e7ff177beedc09a1e4439b3be1f.

<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX
