### PR TITLE
fix: Send first heartbeat when initializing job

### DIFF
--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -300,6 +300,7 @@ class Job(SystemModel):
     def start(self) -> None:
         """Mark the job has having started."""
         self.started_at = datetime.now(timezone.utc)
+        self._heartbeat()
         self.transit(State.RUNNING)
 
     def fail(self, error: t.Any | None = None) -> None:  # noqa: ANN401

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -146,6 +146,7 @@ class TestJob:
         assert not job.is_stale()
 
         # Jobs started more than 25 hours ago without a heartbeat are stale
+        job.last_heartbeat_at = None
         offset = timedelta(hours=HEARTBEATLESS_JOB_VALID_HOURS + 1)
         job.started_at = datetime.now(timezone.utc) - offset
         assert job.is_stale()
@@ -172,6 +173,7 @@ class TestJob:
 
         # Fails a stale job without a heartbeat
         job.start()
+        job.last_heartbeat_at = None
         offset = timedelta(hours=HEARTBEATLESS_JOB_VALID_HOURS + 1)
         job.started_at = datetime.now(timezone.utc) - offset
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

> I think we want to initialize `started_at` and `last_heartbeat_at` in the same transaction, cause your description makes it seem like we're failing in 286-288 here:
> 
> https://github.com/meltano/meltano/blob/7e05ed031c68e97434d1e2c98ada91f33bdd1e04/src/meltano/core/job/job.py#L282-L291 

 _Originally posted by @edgarrmondragon in [#9147](https://github.com/meltano/meltano/issues/9147#issuecomment-2744200772)_

## Related Issues

* Closes https://github.com/meltano/meltano/issues/9147
