### PR TITLE
test: Use `COVERAGE_CORE=sysmon` to speed up line average computation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -52,6 +52,7 @@ def _run_pytest(session: nox.Session) -> None:
                     root_path / f".coverage.{random_seed:010}.{session.name}",
                 ),
                 "NOX_CURRENT_SESSION": "tests",
+                "PYTHONWARNINGS": "ignore::coverage.exceptions.CoverageWarning",
             },
         )
         session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,7 @@ def _run_pytest(session: nox.Session) -> None:
     try:
         session.env.update(
             {
+                "COVERAGE_CORE": "sysmon",
                 "COVERAGE_RCFILE": str(root_path / "pyproject.toml"),
                 "COVERAGE_FILE": str(
                     root_path / f".coverage.{random_seed:010}.{session.name}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,15 +46,16 @@ def _run_pytest(session: nox.Session) -> None:
     try:
         session.env.update(
             {
-                "COVERAGE_CORE": "sysmon",
                 "COVERAGE_RCFILE": str(root_path / "pyproject.toml"),
                 "COVERAGE_FILE": str(
                     root_path / f".coverage.{random_seed:010}.{session.name}",
                 ),
                 "NOX_CURRENT_SESSION": "tests",
-                "PYTHONWARNINGS": "ignore::coverage.exceptions.CoverageWarning",
             },
         )
+        if session.python not in {"3.9", "3.10", "3.11"}:
+            session.env["COVERAGE_CORE"] = "sysmon"
+
         session.run(
             "pytest",
             "--cov=meltano",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ filterwarnings = [
   "ignore: Parsing dates involving a day of month without a year specified is:DeprecationWarning:dateparser.*",  # https://github.com/scrapinghub/dateparser/issues/1246
   "ignore::pytest.PytestUnraisableExceptionWarning",
   "ignore::pytest.PytestUnhandledThreadExceptionWarning",
-  "ignore:sys.monitoring isn't available:coverage.exceptions.CoverageWarning",
 ]
 log_cli = true
 log_cli_format = "%(message)s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ filterwarnings = [
   "ignore: Parsing dates involving a day of month without a year specified is:DeprecationWarning:dateparser.*",  # https://github.com/scrapinghub/dateparser/issues/1246
   "ignore::pytest.PytestUnraisableExceptionWarning",
   "ignore::pytest.PytestUnhandledThreadExceptionWarning",
+  "ignore:sys.monitoring isn't available:coverage.exceptions.CoverageWarning",
 ]
 log_cli = true
 log_cli_format = "%(message)s"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

> In Python 3.12 and above, you can try an experimental core based on the new [**`sys.monitoring`**](https://docs.python.org/3/library/sys.monitoring.html#module-sys.monitoring) module by defining a `COVERAGE_CORE=sysmon` environment variable. This should be faster, though plugins and dynamic contexts are not yet supported with it.[^1]

This manages to shave off 30-40 seconds from the test suite, and I think it'll be even more with CPython 3.14.

## Related Issues

* Closes #XXXX

[^1]: https://coverage.readthedocs.io/en/latest/cmd.html#execution-coverage-run