### PR TITLE
chore: Fix commitizen `version_provider` value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,7 @@ skip_covered = true
 
 [tool.commitizen]
 name = "cz_version_bump"
-version_provider = "pep610"
+version_provider = "pep621"
 prerelease_offset = 1
 tag_format = "v$major.$minor.$patch$prerelease"
 changelog_merge_prerelease = true


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Got my PEPs mixed up in https://github.com/meltano/meltano/pull/9144.

https://commitizen-tools.github.io/commitizen/config/#version-providers

## Related Issues

* #9144
