### PR TITLE
fix: Stringify YAML values from top-level `env` key of `meltano.yml`

### DIFF
--- a/src/meltano/core/meltano_file.py
+++ b/src/meltano/core/meltano_file.py
@@ -25,7 +25,7 @@ class MeltanoFile(Canonical):
     schedules: list[Schedule]
     environments: list[Environment]
     jobs: list[TaskSets]
-    env: dict[str, t.Any]
+    env: dict[str, str | None]
 
     def __init__(
         self,
@@ -34,7 +34,7 @@ class MeltanoFile(Canonical):
         schedules: list[dict] | None = None,
         environments: list[dict] | None = None,
         jobs: list[dict] | None = None,
-        env: dict[str, str] | None = None,
+        env: dict | None = None,
         **extras: t.Any,
     ):
         """Construct a new MeltanoFile object from meltano.yml file.
@@ -56,7 +56,7 @@ class MeltanoFile(Canonical):
             schedules=self.load_schedules(schedules or []),
             environments=self.load_environments(environments or []),
             jobs=self.load_job_tasks(jobs or []),
-            env=env or {},
+            env=self.load_env(env or {}),
         )
 
     def load_plugins(self, plugins: dict[str, dict]) -> Canonical:
@@ -125,6 +125,21 @@ class MeltanoFile(Canonical):
             A list of `Job` objects.
         """
         return [TaskSets.parse(obj) for obj in jobs]
+
+    @staticmethod
+    def load_env(env: dict) -> dict[str, str | None]:
+        """Parse `EnvVars` objects from python objects.
+
+        Args:
+            env: Dictionary of environment variables.
+
+        Returns:
+            A new `EnvVars` object.
+        """
+        return {
+            str(key): str(value) if value is not None else None
+            for key, value in env.items()
+        }
 
     @staticmethod
     def get_plugins_for_mappings(mapper_config: dict) -> list[ProjectPlugin]:

--- a/tests/meltano/core/test_meltano_file.py
+++ b/tests/meltano/core/test_meltano_file.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime
+
 import pytest
 
 from meltano.core.meltano_file import MeltanoFile
@@ -62,3 +64,18 @@ class TestMeltanoFile:
             == test_config["mappings"][1]["name"]
         )
         assert plugins[1].config == test_config["mappings"][1]["config"]
+
+    def test_load_env(self) -> None:
+        meltano_file = MeltanoFile(
+            version=1,
+            env={
+                "FOO": 1,
+                "BAR": datetime.datetime(2025, 5, 20, tzinfo=datetime.timezone.utc),
+            },
+            plugins={},
+            schedules=[],
+            environments=[],
+            jobs=[],
+        )
+        assert meltano_file.env["FOO"] == "1"
+        assert meltano_file.env["BAR"] == "2025-05-20 00:00:00+00:00"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

If a user passes a value in `env` that ruamel.yaml would parse as anything other than a string, it breaks the subprocess call because it expects a mapping of `str` to `str` (or also `bytes` to `bytes` on UNIX).

## Related Issues

* https://github.com/meltano/meltano/pull/9158
