### PR TITLE
fix: Avoid parsing valid ISO 8601 strings

### DIFF
--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -36,6 +36,18 @@ logger = structlog.stdlib.get_logger(__name__)
 
 TRUTHY = ("true", "1", "yes", "on")
 REGEX_EMAIL = r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
+REGEX_ISO8601 = (
+    r"^(\d{4})-"
+    r"(0[1-9]|1[0-2])-"
+    r"(0[1-9]|[12]\d|3[01])"
+    r"(?:[ T]"
+    r"([01]\d|2[0-3]):"
+    r"([0-5]\d):"
+    r"([0-5]\d)"
+    r"(?:\.(\d+))?"
+    r")?"
+    r"(Z|[+-](?:0\d|1[0-2]):(?:00|30))?$"
+)
 
 
 class NotFound(Exception):
@@ -893,6 +905,9 @@ def parse_date(date_string: str) -> str:
     Returns:
         The datetime object corresponding to the parsed date string.
     """
+    if re.match(REGEX_ISO8601, date_string):
+        return date_string
+
     if _parsed := dateparser.parse(
         date_string,
         settings={"RELATIVE_BASE": datetime.now(tz=timezone.utc)},


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Avoid parsing already valid ISO 8601 strings to prevent unexpected values being passed to plugins.

## Related Issues

* https://github.com/meltano/meltano/pull/9119
* Closes https://github.com/meltano/meltano/issues/9172
