### PR TITLE
refactor: Refactor `CatalogRule` classes into dataclasses

### DIFF
--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # noqa: D100
 
+import dataclasses
 import fnmatch
 import re
 import sys
@@ -35,18 +36,12 @@ class CatalogDict(t.TypedDict):
     streams: list[dict[str, t.Any]]
 
 
-class CatalogRule:  # noqa: D101
-    def __init__(
-        self,
-        tap_stream_id: str | list[str],
-        breadcrumb: list[str] | None = None,
-        *,
-        negated: bool = False,
-    ):
-        """Create a catalog rule for a stream and property."""
-        self.tap_stream_id = tap_stream_id
-        self.breadcrumb = breadcrumb or []
-        self.negated = negated
+class _CatalogRuleProtocol(t.Protocol):
+    """A catalog rule for a stream and property."""
+
+    tap_stream_id: str | list[str]
+    breadcrumb: list[str]
+    negated: bool
 
     @classmethod
     def matching(
@@ -90,34 +85,34 @@ class CatalogRule:  # noqa: D101
         return result
 
 
-class MetadataRule(CatalogRule):  # noqa: D101
-    def __init__(
-        self,
-        tap_stream_id: str | list[str],
-        breadcrumb: list[str] | None,
-        key: str,
-        *,
-        value: bool,
-        negated: bool = False,
-    ):
-        """Create a metadata rule for a stream and property."""
-        super().__init__(tap_stream_id, breadcrumb, negated=negated)
-        self.key = key
-        self.value = value
+@dataclasses.dataclass
+class CatalogRule(_CatalogRuleProtocol):
+    """A catalog rule for a stream and property."""
+
+    tap_stream_id: str | list[str]
+    breadcrumb: list[str] = dataclasses.field(default_factory=list)
+    negated: bool = False
 
 
-class SchemaRule(CatalogRule):  # noqa: D101
-    def __init__(
-        self,
-        tap_stream_id: str | list[str],
-        breadcrumb: list[str] | None,
-        payload: dict,
-        *,
-        negated: bool = False,
-    ):
-        """Create a schema rule for a stream and property."""
-        super().__init__(tap_stream_id, breadcrumb, negated=negated)
-        self.payload = payload
+@dataclasses.dataclass
+class MetadataRule(_CatalogRuleProtocol):
+    """A metadata rule for a stream and property."""
+
+    tap_stream_id: str | list[str]
+    breadcrumb: list[str]
+    key: str
+    value: bool
+    negated: bool = False
+
+
+@dataclasses.dataclass
+class SchemaRule(_CatalogRuleProtocol):
+    """A schema rule for a stream and property."""
+
+    tap_stream_id: str | list[str]
+    breadcrumb: list[str]
+    payload: dict
+    negated: bool = False
 
 
 class SelectPattern(t.NamedTuple):

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -24,7 +24,7 @@ if t.TYPE_CHECKING:
 logger = structlog.stdlib.get_logger(__name__)
 
 Node = dict[str, t.Any]
-T = t.TypeVar("T", bound="CatalogRule")
+T = t.TypeVar("T", bound="_CatalogRuleProtocol")
 
 
 UNESCAPED_DOT = re.compile(r"(?<!\\)\.")


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Extracted from https://github.com/meltano/meltano/pull/8810 (https://github.com/meltano/meltano/pull/8810#discussion_r1779303245).

Dataclasses are considerably faster. Using Python 3.13:

```python
import timeit

code = """
rules = [
    MetadataRule(
        "my_stream",
        [],
        "selected",
        value=True,
    ),
    MetadataRule(
        "my_stream",
        ["properties", "prop", "properties", "*"],
        "selected",
        value=True,
    ),
    MetadataRule(
        "my_stream",
        ["properties", "prop"],
        "selected",
        value=True,
    ),
]
"""

setup = """
from meltano.core.plugin.singer.catalog import MetadataRule
"""

print(timeit.timeit(stmt=code, setup=setup, number=1000000))

# 0.6645766669989825 (normal class)
# 0.5106952080004703 (dataclass)
```

and they're also more succinct.

## Related Issues

* Closes #XXXX
