### PR TITLE
fix(cli): Avoid crashing with `KeyError` after a setting is unset

### DIFF
--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -483,6 +483,7 @@ def unset(ctx, setting_name, store) -> None:  # noqa: ANN001
     )
     session = ctx.obj["session"]
     tracker = ctx.obj["tracker"]
+    safe: bool = ctx.obj["safe"]
 
     path = list(setting_name)
     try:
@@ -498,7 +499,11 @@ def unset(ctx, setting_name, store) -> None:  # noqa: ANN001
         fg="green",
     )
 
-    current_value, current_metadata = settings.get_with_metadata(name, session=session)
+    current_value, current_metadata = settings.get_with_metadata(
+        name,
+        session=session,
+        redacted=safe,
+    )
     if (source := current_metadata["source"]) is not SettingValueStore.DEFAULT:
         click.secho(
             f"Current value is now: {current_value!r} "

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -104,16 +104,16 @@ def _use_meltano_env(func):  # noqa: ANN001, ANN202
     return _wrapper
 
 
-def get_label(metadata) -> str:  # noqa: ANN001
+def get_label(metadata, source) -> str:  # noqa: ANN001
     """Get the label for an environment variable's source.
 
     Args:
         metadata: the metadata for the variable
+        source: the source of the variable
 
     Returns:
         string describing the source of the variable's value
     """
-    source = metadata["source"]
     try:
         return f"from the {metadata['env_var']} variable in {source.label}"
     except KeyError:
@@ -309,7 +309,7 @@ def list_settings(ctx: click.Context, *, extras: bool) -> None:
         elif source is SettingValueStore.INHERITED:
             label = f"inherited from '{settings.plugin.parent.name}'"  # type: ignore[union-attr]
         else:
-            label = f"{get_label(config_metadata)}"
+            label = f"{get_label(config_metadata, source)}"
 
         redacted_with_value = safe and setting_def.is_redacted and value is not None
 
@@ -477,7 +477,10 @@ def unset(ctx, setting_name, store) -> None:  # noqa: ANN001
     """Unset the configurations' setting called `<name>`."""
     store = SettingValueStore(store)
 
-    settings = ctx.obj["settings"]
+    settings = t.cast(
+        "ProjectSettingsService | PluginSettingsService",
+        ctx.obj["settings"],
+    )
     session = ctx.obj["session"]
     tracker = ctx.obj["tracker"]
 
@@ -495,10 +498,11 @@ def unset(ctx, setting_name, store) -> None:  # noqa: ANN001
         fg="green",
     )
 
-    current_value, source = settings.get_with_source(name, session=session)
-    if source is not SettingValueStore.DEFAULT:
+    current_value, current_metadata = settings.get_with_metadata(name, session=session)
+    if (source := current_metadata["source"]) is not SettingValueStore.DEFAULT:
         click.secho(
-            f"Current value is now: {current_value!r} ({get_label(metadata)})",
+            f"Current value is now: {current_value!r} "
+            f"({get_label(current_metadata, source)})",
             fg="yellow",
         )
     tracker.track_command_event(CliEvent.completed)

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -363,7 +363,7 @@ class Project(Versioned):
             yield meltano_config
             try:
                 self.project_files.update(meltano_config.canonical())  # type: ignore[arg-type]
-            except Exception as err:
+            except Exception as err:  # pragma: no cover
                 logger.critical("Could not update meltano.yml: %s", err)
                 raise
 

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -316,3 +316,38 @@ class TestCliConfigSet:
             {},
         )
         assert tap_config["config"]["test"] == "dev-mock"
+
+
+class TestCliConfigUnset:
+    @pytest.mark.usefixtures("project")
+    def test_config_unset(self, cli_runner, tap) -> None:
+        secure_value = "thisisatest"
+        set_default_result = cli_runner.invoke(
+            cli,
+            ["config", tap.name, "set", "secure", secure_value],
+        )
+        assert_cli_runner(set_default_result)
+
+        meltano_yml_value = "thisisatest-meltano-yml"
+        set_meltano_yml_result = cli_runner.invoke(
+            cli,
+            [
+                "config",
+                tap.name,
+                "set",
+                "--store=meltano_yml",
+                "secure",
+                meltano_yml_value,
+            ],
+        )
+        assert_cli_runner(set_meltano_yml_result)
+
+        unset_result = cli_runner.invoke(
+            cli,
+            ["config", tap.name, "unset", "--store=meltano_yml", "secure"],
+        )
+        assert_cli_runner(unset_result)
+        assert (
+            f"Extractor '{tap.name}' setting 'secure' in `meltano.yml` was unset"
+        ) in unset_result.stdout
+        assert "Current value is now: '(redacted)'" in unset_result.stdout


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

The `metadata` dict returned by `SettingsService.unset` does not include a `source` key, so whenever a config was unset from a settings store and a value was still set in a different store, the command was crashing after un-setting the value and trying to display the remaining config value.

## Related Issues

* Closes #XXXX
