### PR TITLE
docs: Drop dbt version pin required by now fixed dbt-labs/dbt-postgres#96

### DIFF
--- a/docs/docs/getting-started/part3.mdx
+++ b/docs/docs/getting-started/part3.mdx
@@ -117,7 +117,7 @@ dbt initialized                dbt_ext_type=postgres dbt_profiles_dir=PosixPath(
 ```yaml
   utilities:
   - name: dbt-postgres
-    pip_url: dbt-core dbt-postgres<1.8 meltano-dbt-ext~=0.3.0
+    pip_url: dbt-core dbt-postgres meltano-dbt-ext~=0.3.0
 ```
 :::
 


### PR DESCRIPTION
## Description

As per https://github.com/meltano/meltano/issues/9190#issuecomment-2776975999 pinning dbt version to <1.8 is no longer necessary.

This PR removes the pin from the documentation.

## Related Issues

* Closes #9190
