### PR TITLE
fix: Omit warning log messages coming from `urllib3` certificate errors

### DIFF
--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -181,6 +181,9 @@ def default_config(
             "urllib3": {
                 "level": logging.INFO,
             },
+            "urllib3.connection": {
+                "level": logging.ERROR,
+            },
             "asyncio": {
                 "level": logging.INFO,
             },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

These errors and warnings usually come from the Snowplow tracker request, which is non-critical for Meltano to work, so we can safely hide them by default.

Users can still enable them with [a custom logging configuration](https://docs.meltano.com/guide/logging/).

Source for the logs:

https://github.com/urllib3/urllib3/blob/3e8f2db735dcaced6a3b777aa1966f40c018af7c/src/urllib3/connection.py#L985-L990

## Related Issues

* Closes #XXXX
