### PR TITLE
chore: Read Nox Python versions from PyPI classifiers

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,16 +27,18 @@ import nox
 # no duplicated dependencies between `pyproject.toml` and
 # `.pre-commit-config.yaml`.
 
+nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv"
+nox.options.sessions = [
+    "mypy",
+    "pre-commit",
+    "pytest",
+]
 
 root_path = Path(__file__).parent
-python_versions = (
-    "3.9",
-    "3.10",
-    "3.11",
-    "3.12",
-    "3.13",
-)
+pyproject = nox.project.load_toml()
+python_versions = nox.project.python_versions(pyproject)
+
 main_python_version = "3.13"
 
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Makes the classifiers in `pyproject.toml` the source of truth for the Python versions we support and test.

- https://nox.thea.codes/en/stable/config.html#nox.project.load_toml
- https://nox.thea.codes/en/stable/config.html#nox.project.python_versions

## Related Issues

* Closes #XXXX
