### PR TITLE
fix: Use `config generate` command to generate `airflow.cfg` configuration file

### DIFF
--- a/src/meltano/core/plugin/airflow.py
+++ b/src/meltano/core/plugin/airflow.py
@@ -120,7 +120,8 @@ class Airflow(BasePlugin):
         """
         # generate the default `airflow.cfg`
         handle = await invoker.invoke_async(
-            "config", "generate",
+            "config",
+            "generate",
             require_preparation=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/src/meltano/core/plugin/airflow.py
+++ b/src/meltano/core/plugin/airflow.py
@@ -120,20 +120,20 @@ class Airflow(BasePlugin):
         """
         # generate the default `airflow.cfg`
         handle = await invoker.invoke_async(
-            "--help",
+            "config", "generate",
             require_preparation=False,
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        exit_code = await handle.wait()
-
-        if exit_code:
+        stdout, stderr = await handle.communicate()
+        if handle.returncode:
             raise AsyncSubprocessError(
-                "Command `airflow --help` failed",  # noqa: EM101
+                "Command `airflow config generate` failed",  # noqa: EM101
                 process=handle,
             )
-
-        # Read and update airflow.cfg
+        config_file_path = invoker.files["config"]
+        with config_file_path.open("wb") as config_file:
+            config_file.write(stdout)
         self.update_config_file(invoker)
 
         # we've changed the configuration here, so we need to call

--- a/tests/meltano/core/plugin/test_airflow.py
+++ b/tests/meltano/core/plugin/test_airflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import typing as t
 from configparser import ConfigParser
 
@@ -38,26 +39,32 @@ class TestAirflow:
         handle_mock.name = subject.name
         handle_mock.wait = AsyncMock(return_value=0)
         handle_mock.returncode = 0
-        handle_mock.communicate = AsyncMock(return_value=(b"2.0.1", None))
         handle_mock.stdout.at_eof.side_effect = (False, True)
 
         original_exec = asyncio.create_subprocess_exec
 
         def popen_mock(cmd, *popen_args, **kwargs):
-            # first time, it creates the `airflow.cfg`
-            if "--help" in popen_args:
+            # generate Airflow config
+            if popen_args[:2] == ("config", "generate"):
                 assert "env" in kwargs
                 assert kwargs["env"]["AIRFLOW_HOME"] == str(run_dir)
 
                 airflow_cfg = ConfigParser()
                 airflow_cfg["core"] = {"dummy": "dummy"}
                 airflow_cfg["webserver"] = {"dummy": "dummy"}
-                with run_dir.joinpath("airflow.cfg").open("w") as cfg:
-                    airflow_cfg.write(cfg)
-            # second time, check version
+
+                writer = io.StringIO()
+                airflow_cfg.write(writer)
+                writer.seek(0)
+
+                handle_mock.communicate = AsyncMock(
+                    return_value=(writer.read().encode(), None)
+                )
+            # check version
             elif "version" in popen_args:
+                handle_mock.communicate = AsyncMock(return_value=(b"2.0.1", None))
                 return handle_mock
-            # third time, it creates the `airflow.db`
+            # create `airflow.db`
             elif {"db", "init"}.issubset(popen_args):
                 assert kwargs["env"]["AIRFLOW_HOME"] == str(run_dir)
 
@@ -84,7 +91,7 @@ class TestAirflow:
                     for _, popen_args, kwargs in popen.mock_calls
                     if popen_args and isinstance(popen_args, tuple)
                 ]
-                assert commands[0][1] == "--help"
+                assert commands[0][1:3] == ("config", "generate")
                 assert commands[1][1] == "version"
                 assert commands[2][1] == "db"
                 assert commands[2][2] == "init"


### PR DESCRIPTION
**Description**
This PR addresses an issue with generating the airflow.cfg configuration file. Specifically, it updates the command used to generate the configuration from airflow --help to airflow config generate, ensuring that the correct command is executed to generate the configuration.

**Changes include:**

- Replacing the --help argument with config generate to correctly invoke the configuration generation.

- Redirecting the output from subprocess.PIPE instead of subprocess.DEVNULL to capture the configuration content.

- Saving the generated configuration to the appropriate file path (config_file_path).

- Updating the configuration file after it has been generated.

**Related Issues**
Closes https://github.com/meltano/meltano/issues/9177