### PR TITLE
Add ETL Data Cleaner with Pydantic Config and Validation

### DIFF
--- a/src/meltano/transformations/data_cleaner.py
+++ b/src/meltano/transformations/data_cleaner.py
@@ -1,8 +1,13 @@
-from typing import List, Dict, Any
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
 from pydantic import BaseModel
+
 
 class CleanConfig(BaseModel):
     required_fields: List[str] = []
+
 
 def clean_data(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     cleaned = []
@@ -14,6 +19,7 @@ def clean_data(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 new_record[new_key] = value
         cleaned.append(new_record)
     return cleaned
+
 
 def validate_data(records: List[Dict[str, Any]], config: CleanConfig) -> bool:
     for record in records:

--- a/src/meltano/transformations/data_cleaner.py
+++ b/src/meltano/transformations/data_cleaner.py
@@ -1,0 +1,23 @@
+from typing import List, Dict, Any
+from pydantic import BaseModel
+
+class CleanConfig(BaseModel):
+    required_fields: List[str] = []
+
+def clean_data(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    cleaned = []
+    for record in records:
+        new_record = {}
+        for key, value in record.items():
+            if value is not None:
+                new_key = key.lower()
+                new_record[new_key] = value
+        cleaned.append(new_record)
+    return cleaned
+
+def validate_data(records: List[Dict[str, Any]], config: CleanConfig) -> bool:
+    for record in records:
+        for field in config.required_fields:
+            if field.lower() not in record:
+                return False
+    return True

--- a/tests/test_data_cleaner.py
+++ b/tests/test_data_cleaner.py
@@ -1,0 +1,54 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+import unittest
+from meltano.transformations.data_cleaner import clean_data, validate_data, CleanConfig
+
+class TestDataCleaner(unittest.TestCase):
+    def test_clean_data(self):
+        records = [
+            {"Name": "Alice", "Age": 25, "City": None},
+            {"Name": "Bob", "Age": None, "City": "New York"}
+        ]
+        cleaned = clean_data(records)
+        expected = [
+            {"name": "Alice", "age": 25},
+            {"name": "Bob", "city": "New York"}
+        ]
+        self.assertEqual(cleaned, expected)
+
+    def test_clean_data_empty_input(self):
+        # Edge case: empty input
+        records = []
+        cleaned = clean_data(records)
+        expected = []
+        self.assertEqual(cleaned, expected)
+
+    def test_clean_data_all_none(self):
+        # Edge case: all None values
+        records = [
+            {"Name": None, "Age": None, "City": None}
+        ]
+        cleaned = clean_data(records)
+        expected = [{}]  # Empty dict
+        self.assertEqual(cleaned, expected)
+
+    def test_validate_data_success(self):
+        records = [
+            {"name": "Alice", "age": 25},
+            {"name": "Bob", "age": 30}
+        ]
+        config = CleanConfig(required_fields=["name", "age"])
+        self.assertTrue(validate_data(records, config))
+
+    def test_validate_data_failure(self):
+        records = [
+            {"name": "Alice"},
+            {"name": "Bob", "age": 30}
+        ]
+        config = CleanConfig(required_fields=["name", "age"])
+        self.assertFalse(validate_data(records, config))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_cleaner.py
+++ b/tests/test_data_cleaner.py
@@ -1,21 +1,23 @@
-import sys
+from __future__ import annotations
+
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
 import unittest
-from meltano.transformations.data_cleaner import clean_data, validate_data, CleanConfig
+
+from meltano.transformations.data_cleaner import CleanConfig, clean_data, validate_data
+
 
 class TestDataCleaner(unittest.TestCase):
     def test_clean_data(self):
         records = [
             {"Name": "Alice", "Age": 25, "City": None},
-            {"Name": "Bob", "Age": None, "City": "New York"}
+            {"Name": "Bob", "Age": None, "City": "New York"},
         ]
         cleaned = clean_data(records)
-        expected = [
-            {"name": "Alice", "age": 25},
-            {"name": "Bob", "city": "New York"}
-        ]
+        expected = [{"name": "Alice", "age": 25}, {"name": "Bob", "city": "New York"}]
         self.assertEqual(cleaned, expected)
 
     def test_clean_data_empty_input(self):
@@ -27,28 +29,21 @@ class TestDataCleaner(unittest.TestCase):
 
     def test_clean_data_all_none(self):
         # Edge case: all None values
-        records = [
-            {"Name": None, "Age": None, "City": None}
-        ]
+        records = [{"Name": None, "Age": None, "City": None}]
         cleaned = clean_data(records)
         expected = [{}]  # Empty dict
         self.assertEqual(cleaned, expected)
 
     def test_validate_data_success(self):
-        records = [
-            {"name": "Alice", "age": 25},
-            {"name": "Bob", "age": 30}
-        ]
+        records = [{"name": "Alice", "age": 25}, {"name": "Bob", "age": 30}]
         config = CleanConfig(required_fields=["name", "age"])
         self.assertTrue(validate_data(records, config))
 
     def test_validate_data_failure(self):
-        records = [
-            {"name": "Alice"},
-            {"name": "Bob", "age": 30}
-        ]
+        records = [{"name": "Alice"}, {"name": "Bob", "age": 30}]
         config = CleanConfig(required_fields=["name", "age"])
         self.assertFalse(validate_data(records, config))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

## Description

Implemented a modular ETL data cleaning function that removes null fields and standardizes field names to lowercase.  
Added a validation utility using a Pydantic CleanConfig model to ensure required fields are present before loading data into warehouses.  
Included comprehensive unit tests covering normal cases and edge cases.  
All unit tests passed successfully.


## Related Issues

N/A
