### PR TITLE
refactor: use dict instead of `OrderedDict`

### DIFF
--- a/src/meltano/core/behavior/hookable.py
+++ b/src/meltano/core/behavior/hookable.py
@@ -7,7 +7,6 @@ called before or after given trigger.
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from contextlib import asynccontextmanager
 
 import structlog
@@ -55,7 +54,7 @@ class Hookable(type):
         return new_type
 
     def __prepare__(cls, bases, **kwds):  # noqa: ANN001, ANN003, ANN204, D105
-        return OrderedDict()
+        return {}
 
 
 class HookObject(metaclass=Hookable):

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -5,7 +5,6 @@ import fnmatch
 import re
 import sys
 import typing as t
-from collections import OrderedDict
 from enum import Enum, auto
 from functools import singledispatch
 
@@ -562,7 +561,7 @@ class SchemaExecutor(CatalogExecutor):  # noqa: D101
 class ListExecutor(CatalogExecutor):  # noqa: D101
     def __init__(self) -> None:  # noqa: D107
         # properties per stream
-        self.properties: dict[str, set[str]] = OrderedDict()
+        self.properties: dict[str, set[str]] = {}
 
         super().__init__()
 
@@ -598,7 +597,7 @@ class SelectedNode(t.NamedTuple):
 class ListSelectedExecutor(CatalogExecutor):  # noqa: D101
     def __init__(self) -> None:  # noqa: D107
         self.streams: set[SelectedNode] = set()
-        self.properties: dict[str, set[SelectedNode]] = OrderedDict()
+        self.properties: dict[str, set[SelectedNode]] = {}
         super().__init__()
 
     @property

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import typing as t
-from collections import OrderedDict
 from copy import copy
 
 import structlog
@@ -164,7 +163,7 @@ class ProjectFiles:
                 include_paths.remove(self._meltano_file_path)
 
         # Deduplicate entries
-        return list(OrderedDict.fromkeys(include_paths))
+        return list(dict.fromkeys(include_paths))
 
     def _add_to_index(self, key: tuple, include_path: Path) -> None:
         """Add a new key:path to the `_plugin_file_map`.

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import collections
 import functools
 import hashlib
 import math
@@ -242,7 +241,7 @@ def nest(
     return cursor[tail]
 
 
-def nest_object(flat_object):  # noqa: ANN001, ANN201, D103
+def nest_object(flat_object: dict[str, t.Any]):  # noqa: ANN201, D103
     obj = {}
     for key, value in flat_object.items():
         nest(obj, key, value)
@@ -611,7 +610,7 @@ def uniques_in(original: Sequence[T]) -> list[T]:
     Returns:
         A list of unique values from the provided sequence in the order they appeared.
     """
-    return list(collections.OrderedDict.fromkeys(original))
+    return list(dict.fromkeys(original))
 
 
 # https://gist.github.com/cbwar/d2dfbc19b140bd599daccbe0fe925597#gistcomment-2845059

--- a/tests/meltano/core/test_select_service.py
+++ b/tests/meltano/core/test_select_service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import typing as t
-from collections import OrderedDict
 
 import pytest
 
@@ -60,46 +59,40 @@ async def test_select_service_list_all(
             selection=SelectionType.SELECTED,
         ),
     }
-    assert list_all.properties == OrderedDict(
-        {
-            "users": {
-                SelectedNode(
-                    key="id",
-                    selection=SelectionType.AUTOMATIC,
-                ),
-            },
+    assert list_all.properties == {
+        "users": {
+            SelectedNode(
+                key="id",
+                selection=SelectionType.AUTOMATIC,
+            ),
         },
-    )
+    }
 
     # Update the catalog to include a new property
     catalog["streams"][0]["schema"]["properties"]["name"] = {"type": "string"}
 
     # Without refreshing the catalog, the new property should not be included
     list_all = await service.list_all(session, refresh=False)
-    assert list_all.properties == OrderedDict(
-        {
-            "users": {
-                SelectedNode(
-                    key="id",
-                    selection=SelectionType.AUTOMATIC,
-                ),
-            },
+    assert list_all.properties == {
+        "users": {
+            SelectedNode(
+                key="id",
+                selection=SelectionType.AUTOMATIC,
+            ),
         },
-    )
+    }
 
     # Refreshing the catalog should include the new property
     list_all = await service.list_all(session, refresh=True)
-    assert list_all.properties == OrderedDict(
-        {
-            "users": {
-                SelectedNode(
-                    key="id",
-                    selection=SelectionType.AUTOMATIC,
-                ),
-                SelectedNode(
-                    key="name",
-                    selection=SelectionType.AUTOMATIC,
-                ),
-            },
+    assert list_all.properties == {
+        "users": {
+            SelectedNode(
+                key="id",
+                selection=SelectionType.AUTOMATIC,
+            ),
+            SelectedNode(
+                key="name",
+                selection=SelectionType.AUTOMATIC,
+            ),
         },
-    )
+    }

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections import OrderedDict
-
 import pytest
 
 from meltano.core.utils import (
@@ -43,14 +41,14 @@ def test_nest() -> None:
     assert subject == {"a": {"b": "not_a_dict", "list": [], "value": {"value": 1}}}
 
     # make sure existing values aren't cleared when `value=None` and `force=True`
-    _ = nest(subject, "a.b", OrderedDict({"d": "d_value"}), force=True)
+    _ = nest(subject, "a.b", {"d": "d_value"}, force=True)
     assert subject == {
-        "a": {"b": OrderedDict({"d": "d_value"}), "list": [], "value": {"value": 1}},
+        "a": {"b": {"d": "d_value"}, "list": [], "value": {"value": 1}},
     }
     similar_b = nest(subject, "a.b", force=True)
-    assert similar_b == OrderedDict({"d": "d_value"})
+    assert similar_b == {"d": "d_value"}
     assert subject == {
-        "a": {"b": OrderedDict({"d": "d_value"}), "list": [], "value": {"value": 1}},
+        "a": {"b": {"d": "d_value"}, "list": [], "value": {"value": 1}},
     }
 
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Starting [with Python 3.7](https://docs.python.org/3.7/whatsnew/3.7.html), "insertion-order preservation nature of [dict](https://docs.python.org/3.7/library/stdtypes.html#typesmapping) objects [has been declared](https://mail.python.org/pipermail/python-dev/2017-December/151283.html) to be an official part of the Python language spec".

## Related Issues

* Closes #XXXX
