### PR TITLE
fix: Avoid writing empty state after an invalid STATE message

### DIFF
--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -73,7 +73,7 @@ class BookmarkWriter:
                 "Received state is invalid, incremental state has not been updated",
             )
 
-            # If no state is defined, do not save it. Saving an empty or undefined state could overwrite a valid existing state 
+            # If no state is defined, do not save it. Saving an empty or undefined state could overwrite a valid existing state
             # in cases where the incoming state message is incorrect.
             if new_state:
                 job = self.job

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -73,30 +73,31 @@ class BookmarkWriter:
                 "Received state is invalid, incremental state has not been updated",
             )
 
-            # If no state is defined, do not save it. Saving an empty or undefined state could overwrite a valid existing state 
-            # in cases where the incoming state message is incorrect.
-            if new_state:
-                job = self.job
-                job.payload[SINGER_STATE_KEY] = new_state
-                job.payload_flags |= self.payload_flag
-                try:
-                    job.save(self.session)
-                    self.state_service.add_state(
-                        job,
-                        json.dumps(job.payload),
-                        job.payload_flags,
-                    )
-                except Exception:  # pragma: no cover
-                    logger.debug("Failed to persist state", exc_info=True)
-                    logger.warning(
-                        "Unable to persist state, or received state is invalid, "
-                        "incremental state has not been updated",
-                    )
-                else:
-                    logger.info(
-                        f"Incremental state has been updated at {datetime.now(tz=timezone.utc)}.",  # noqa: E501, G004
-                    )
-                    logger.debug(f"Incremental state: {new_state}")  # noqa: G004
+        # If no state is defined, do not save it. Saving an empty or undefined state
+        # could overwrite a valid existing state
+        # in cases where the incoming state message is incorrect.
+        if new_state:
+            job = self.job
+            job.payload[SINGER_STATE_KEY] = new_state
+            job.payload_flags |= self.payload_flag
+            try:
+                job.save(self.session)
+                self.state_service.add_state(
+                    job,
+                    json.dumps(job.payload),
+                    job.payload_flags,
+                )
+            except Exception:  # pragma: no cover
+                logger.debug("Failed to persist state", exc_info=True)
+                logger.warning(
+                    "Unable to persist state, or received state is invalid, "
+                    "incremental state has not been updated",
+                )
+            else:
+                logger.info(
+                    f"Incremental state has been updated at {datetime.now(tz=timezone.utc)}.",  # noqa: E501, G004
+                )
+                logger.debug(f"Incremental state: {new_state}")  # noqa: G004
 
 
 class SingerTarget(SingerPlugin):

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -72,32 +72,29 @@ class BookmarkWriter:
             logger.warning(
                 "Received state is invalid, incremental state has not been updated",
             )
+            return
 
-        # If no state is defined, do not save it. Saving an empty or undefined state
-        # could overwrite a valid existing state
-        # in cases where the incoming state message is incorrect.
-        if new_state:
-            job = self.job
-            job.payload[SINGER_STATE_KEY] = new_state
-            job.payload_flags |= self.payload_flag
-            try:
-                job.save(self.session)
-                self.state_service.add_state(
-                    job,
-                    json.dumps(job.payload),
-                    job.payload_flags,
-                )
-            except Exception:  # pragma: no cover
-                logger.debug("Failed to persist state", exc_info=True)
-                logger.warning(
-                    "Unable to persist state, or received state is invalid, "
-                    "incremental state has not been updated",
-                )
-            else:
-                logger.info(
-                    f"Incremental state has been updated at {datetime.now(tz=timezone.utc)}.",  # noqa: E501, G004
-                )
-                logger.debug(f"Incremental state: {new_state}")  # noqa: G004
+        job = self.job
+        job.payload[SINGER_STATE_KEY] = new_state
+        job.payload_flags |= self.payload_flag
+        try:
+            job.save(self.session)
+            self.state_service.add_state(
+                job,
+                json.dumps(job.payload),
+                job.payload_flags,
+            )
+        except Exception:  # pragma: no cover
+            logger.debug("Failed to persist state", exc_info=True)
+            logger.warning(
+                "Unable to persist state, or received state is invalid, "
+                "incremental state has not been updated",
+            )
+        else:
+            logger.info(
+                f"Incremental state has been updated at {datetime.now(tz=timezone.utc)}.",  # noqa: E501, G004
+            )
+            logger.debug(f"Incremental state: {new_state}")  # noqa: G004
 
 
 class SingerTarget(SingerPlugin):

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -73,27 +73,30 @@ class BookmarkWriter:
                 "Received state is invalid, incremental state has not been updated",
             )
 
-        job = self.job
-        job.payload[SINGER_STATE_KEY] = new_state
-        job.payload_flags |= self.payload_flag
-        try:
-            job.save(self.session)
-            self.state_service.add_state(
-                job,
-                json.dumps(job.payload),
-                job.payload_flags,
-            )
-        except Exception:  # pragma: no cover
-            logger.debug("Failed to persist state", exc_info=True)
-            logger.warning(
-                "Unable to persist state, or received state is invalid, "
-                "incremental state has not been updated",
-            )
-        else:
-            logger.info(
-                f"Incremental state has been updated at {datetime.now(tz=timezone.utc)}.",  # noqa: E501, G004
-            )
-            logger.debug(f"Incremental state: {new_state}")  # noqa: G004
+            # If no state is defined, do not save it. Saving an empty or undefined state could overwrite a valid existing state 
+            # in cases where the incoming state message is incorrect.
+            if new_state:
+                job = self.job
+                job.payload[SINGER_STATE_KEY] = new_state
+                job.payload_flags |= self.payload_flag
+                try:
+                    job.save(self.session)
+                    self.state_service.add_state(
+                        job,
+                        json.dumps(job.payload),
+                        job.payload_flags,
+                    )
+                except Exception:  # pragma: no cover
+                    logger.debug("Failed to persist state", exc_info=True)
+                    logger.warning(
+                        "Unable to persist state, or received state is invalid, "
+                        "incremental state has not been updated",
+                    )
+                else:
+                    logger.info(
+                        f"Incremental state has been updated at {datetime.now(tz=timezone.utc)}.",  # noqa: E501, G004
+                    )
+                    logger.debug(f"Incremental state: {new_state}")  # noqa: G004
 
 
 class SingerTarget(SingerPlugin):

--- a/tests/meltano/core/plugin/singer/test_target.py
+++ b/tests/meltano/core/plugin/singer/test_target.py
@@ -1,15 +1,60 @@
 from __future__ import annotations
 
+import json
 import typing as t
 
 import pytest
 
 from meltano.core.job import Job, Payload
 from meltano.core.plugin import PluginType
+from meltano.core.plugin.singer.target import BookmarkWriter
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
+from meltano.core.state_service import StateService
 
 if t.TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from meltano.core.project_add_service import ProjectAddService
+
+
+class TestBookmarkWriter:
+    @pytest.mark.parametrize(
+        ("state_line", "expected_state"),
+        (
+            pytest.param(
+                "test",
+                {"singer_state": {"foo": "bar"}},
+                id="invalid_state",
+            ),
+            pytest.param(
+                '{"qux": "quux"}',
+                {"singer_state": {"qux": "quux"}},
+                id="valid_state",
+            ),
+        ),
+    )
+    @pytest.mark.asyncio
+    async def test_writeline(
+        self,
+        session: Session,
+        state_line: str,
+        expected_state: dict,
+    ) -> None:
+        existing_state = {"singer_state": {"foo": "bar"}}
+        state_service = StateService(session=session)
+
+        job = Job(job_name="pytest_test_runner", payload=existing_state)
+        job.save(session)
+        state_service.add_state(job, json.dumps(existing_state))
+
+        writer = BookmarkWriter(
+            job,
+            session,
+            state_service=state_service,
+        )
+        writer.writeline(state_line)
+
+        assert state_service.get_state(job.job_name) == expected_state
 
 
 class TestSingerTarget:


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

This pull request includes a change to the `writeline` method in `src/meltano/core/plugin/singer/target.py`. The change ensures that only valid states are saved, preventing potential overwrites of existing valid states when the incoming state message is incorrect (which makes new state empty).

Here is an example of this failure in logs (extraction failed after it and state was empty):
```
2025-04-21T16:14:46.146989Z [warning  ] Received state is invalid, incremental state has not been updated
2025-04-21T16:14:46.215886Z [info     ] Incremental state has been updated at 2025-04-21 16:14:46.215847+00:00.

+ meltano state get STATE_ID
{"singer_state": {}}
```


<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX
