### PR TITLE
docs: Fixed typo `mapper` -> `mappers` in `meltano.yml` inline data mapping example

### DIFF
--- a/docs/docs/guide/mappers.md
+++ b/docs/docs/guide/mappers.md
@@ -142,7 +142,7 @@ id,first_name,last_name,email,ip_address
 ```
 
 ```yaml
-plugins
+plugins:
   mappers:
   - name: meltano-map-transformer
     variant: meltano

--- a/docs/docs/guide/mappers.md
+++ b/docs/docs/guide/mappers.md
@@ -87,7 +87,7 @@ A few example configurations using inline stream maps are:
 
 This example shows the SDK based meltanolabs variant of tap-github configured to lowercase all repo names in the issues stream.
 
-```yaml
+```yaml title="meltano.yml"
   - name: tap-github
     variant: meltanolabs
     pip_url: meltanolabs-tap-github
@@ -141,7 +141,7 @@ id,first_name,last_name,email,ip_address
 1,Ethe,Book,ebook0@twitter.com,67.61.243.220
 ```
 
-```yaml
+```yaml title="meltano.yml"
 plugins:
   mappers:
   - name: meltano-map-transformer

--- a/docs/docs/guide/mappers.md
+++ b/docs/docs/guide/mappers.md
@@ -143,7 +143,7 @@ id,first_name,last_name,email,ip_address
 
 ```yaml
 plugins
-  mapper:
+  mappers:
   - name: meltano-map-transformer
     variant: meltano
     pip_url: meltano-map-transform


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update the mappers guide examples to include file titles on YAML code blocks and correct the plugin mapping key from `mapper` to `mappers`.

Documentation:
- Add `title="meltano.yml"` annotations to YAML code fences in the mappers guide.
- Fix typo in the inline example by changing the `mapper` key to `mappers` under `plugins`.