### PR TITLE
refactor: Use `ruamel.yaml.add_multi_representer` to add YAML representations of internal types

### DIFF
--- a/src/meltano/core/behavior/canonical.py
+++ b/src/meltano/core/behavior/canonical.py
@@ -7,7 +7,7 @@ import json
 import typing as t
 from functools import lru_cache
 
-import yaml
+import ruamel.yaml as yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 
 if t.TYPE_CHECKING:

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -7,7 +7,7 @@ import re
 import typing as t
 from collections import defaultdict
 
-import yaml
+import ruamel.yaml as yaml
 from structlog.stdlib import get_logger
 
 from meltano.core.behavior import NameEq


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor YAML serialization to leverage ruamel.yaml’s built-in multi‐representer registration for internal types.

Enhancements:
- Standardize on importing ruamel.yaml as the YAML engine across modules
- Register internal data types for YAML serialization using ruamel.yaml.add_multi_representer
- Remove manual/custom YAML representer logic and legacy yaml imports

## Summary by Sourcery

Refactor YAML serialization to leverage ruamel.yaml’s built-in multi-representer registration for internal types and clean up related imports and legacy code

Enhancements:
- Leverage ruamel.yaml.add_multi_representer for registering internal data types’ YAML serialization
- Standardize on importing ruamel.yaml as the YAML engine across modules
- Remove custom manual YAML representer logic and legacy yaml imports