### PR TITLE
test: Replace third-party `mock` library with `unittest.mock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ testing = [
   { include-group = "coverage" },
   "backoff>=2.1.2,<3",
   "colorama>=0.4.4,<0.5",
-  "mock>=5.0.2,<6",
   "moto>=5.0.21,<6",
   "pytest>=8.3.3,<9",
   "pytest-asyncio>=1",
@@ -323,7 +322,6 @@ line-length = 88
 [tool.ruff.lint]
 ignore = [
   "N818",   # Allow Exceptions to have suffix 'Exception' rather than 'Error'
-  "UP026",  # Replace `mock` import with `unittest.mock` - remove once Python 3.7 support is dropped
   "S310",   # Allow `urllib.open`
   "S603",   # Allow `subprocess.run(..., shell=False)`
   "COM812", # Handled by the Ruff formatter

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -9,8 +9,8 @@ import typing as t
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from pathlib import Path
+from unittest import mock
 
-import mock
 import pytest
 import structlog
 

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -6,8 +6,8 @@ import platform
 import shutil
 import typing as t
 from pathlib import Path
+from unittest import mock
 
-import mock
 import pytest
 import yaml
 

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -9,9 +9,9 @@ import typing as t
 import uuid
 from pathlib import Path
 from time import perf_counter_ns
+from unittest import mock
 
 import click
-import mock
 import pytest
 import yaml
 from structlog.stdlib import get_logger

--- a/tests/meltano/cli/test_compile.py
+++ b/tests/meltano/cli/test_compile.py
@@ -7,8 +7,8 @@ import shutil
 import typing as t
 from pathlib import Path
 from platform import system
+from unittest import mock
 
-import mock
 import pytest
 
 from meltano.cli import cli

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -4,10 +4,11 @@ import io
 import json
 import typing as t
 from signal import SIGTERM
+from unittest import mock
+from unittest.mock import AsyncMock
 
 import dotenv
 import pytest
-from mock import AsyncMock, mock
 
 from asserts import assert_cli_runner
 from meltano.cli import cli

--- a/tests/meltano/cli/test_elt.py
+++ b/tests/meltano/cli/test_elt.py
@@ -4,9 +4,10 @@ import asyncio
 import json
 import platform
 from dataclasses import dataclass
+from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
-from mock import AsyncMock, mock
 
 from asserts import assert_cli_runner
 from meltano.cli import cli

--- a/tests/meltano/cli/test_hub.py
+++ b/tests/meltano/cli/test_hub.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import typing as t
-
-import mock
+from unittest import mock
 
 from asserts import assert_cli_runner
 from meltano.cli import cli

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import os
 import shutil
+from unittest import mock
 
-import mock
 import pytest
 
 from asserts import assert_cli_runner

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 import platform
 import typing as t
+from unittest import mock
+from unittest.mock import AsyncMock, Mock, patch
 
-import mock
 import pytest
-from mock import AsyncMock, Mock, patch
 
 from meltano.cli import cli
 from meltano.core.plugin import PluginType

--- a/tests/meltano/cli/test_job_cmd.py
+++ b/tests/meltano/cli/test_job_cmd.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import typing as t
+from unittest import mock
 
-import mock
 import pytest
 
 from asserts import assert_cli_runner

--- a/tests/meltano/cli/test_remove.py
+++ b/tests/meltano/cli/test_remove.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import typing as t
+from unittest import mock
 
-import mock
 import pytest
 
 from asserts import assert_cli_runner

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -4,9 +4,10 @@ import asyncio
 import json
 import re
 import typing as t
+from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
-from mock import AsyncMock, mock
 
 from meltano.cli import cli
 from meltano.core.block.ioblock import IOBlock

--- a/tests/meltano/cli/test_schedule.py
+++ b/tests/meltano/cli/test_schedule.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import mock
+from unittest import mock
+
 import pytest
 
 from asserts import assert_cli_runner

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -4,8 +4,8 @@ import json
 import platform
 import re
 import typing as t
+from unittest import mock
 
-import mock
 import pytest
 
 from asserts import assert_cli_runner

--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -5,9 +5,9 @@ import platform
 import shutil
 import typing as t
 from importlib.metadata import PathDistribution
+from unittest import mock
 
 import boto3
-import mock
 import pytest
 from moto import mock_aws
 

--- a/tests/meltano/core/behavior/test_hookable.py
+++ b/tests/meltano/core/behavior/test_hookable.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from typing import NoReturn  # noqa: ICN003
+from unittest import mock
 
-import mock
 import pytest
 
 from meltano.core.behavior.hookable import HookObject, hook

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -7,10 +7,10 @@ import tempfile
 import typing as t
 import uuid
 from pathlib import Path
+from unittest import mock
+from unittest.mock import AsyncMock
 
-import mock
 import pytest
-from mock import AsyncMock
 
 from meltano.core.block.blockset import BlockSetValidationError
 from meltano.core.block.extract_load import (

--- a/tests/meltano/core/block/test_plugin_command.py
+++ b/tests/meltano/core/block/test_plugin_command.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
-from mock import AsyncMock
 
 from meltano.core.block.plugin_command import plugin_command_invoker
 

--- a/tests/meltano/core/block/test_singer.py
+++ b/tests/meltano/core/block/test_singer.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import asyncio
 import tempfile
 import typing as t
+from unittest import mock
+from unittest.mock import AsyncMock, Mock
 
-import mock
 import pytest
 import structlog
-from mock import AsyncMock, Mock
 from structlog.testing import capture_logs
 
 from meltano.core.block.singer import SingerBlock

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import typing as t
+from unittest import mock
 
 import click
-import mock
 import pytest
 from requests import HTTPError, Response
 from requests.adapters import BaseAdapter

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -6,9 +6,9 @@ import platform
 import sys
 import tempfile
 import typing as t
+from unittest import mock
 
 import anyio
-import mock
 import pytest
 import structlog
 from structlog.testing import LogCapture

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -7,10 +7,11 @@ import subprocess
 import sys
 import typing as t
 from contextlib import contextmanager, suppress
+from unittest import mock
+from unittest.mock import AsyncMock
 
 import anyio
 import pytest
-from mock import AsyncMock, mock
 
 from meltano.core.job import Job, Payload
 from meltano.core.plugin import PluginType

--- a/tests/meltano/core/plugin/test_airflow.py
+++ b/tests/meltano/core/plugin/test_airflow.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import io
 import typing as t
 from configparser import ConfigParser
+from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
-from mock import AsyncMock, mock
 
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_install_service import PluginInstallService

--- a/tests/meltano/core/plugin/test_superset.py
+++ b/tests/meltano/core/plugin/test_superset.py
@@ -4,9 +4,10 @@ import platform
 import sys
 import typing as t
 from importlib.util import module_from_spec, spec_from_file_location
+from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
-from mock import AsyncMock, mock
 
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_install_service import PluginInstallService

--- a/tests/meltano/core/runner/test_runner.py
+++ b/tests/meltano/core/runner/test_runner.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import typing as t
+from unittest import mock
+from unittest.mock import AsyncMock
 
-import mock
 import pytest
-from mock import AsyncMock
 
 from meltano.core.job import Job, Payload, State
 from meltano.core.logging.utils import capture_subprocess_output

--- a/tests/meltano/core/test_db_compat.py
+++ b/tests/meltano/core/test_db_compat.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from unittest.mock import Mock
 
 import pytest
-from mock import Mock
 
 from meltano.core.db import (
     MeltanoDatabaseCompatibilityError,

--- a/tests/meltano/core/test_db_connection.py
+++ b/tests/meltano/core/test_db_connection.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import typing as t
+from unittest.mock import Mock
 
 import pytest
 import yaml
-from mock import Mock
 from sqlalchemy.exc import OperationalError
 
 from meltano.core.db import NullConnectionStringError, connect, project_engine

--- a/tests/meltano/core/test_meltano_invoker.py
+++ b/tests/meltano/core/test_meltano_invoker.py
@@ -6,8 +6,8 @@ import subprocess
 import sys
 import typing as t
 from pathlib import Path
+from unittest import mock
 
-import mock
 import pytest
 
 import meltano

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -5,8 +5,8 @@ import json
 import os
 import shutil
 import typing as t
+from unittest import mock
 
-import mock
 import pytest
 import yaml
 from sqlalchemy.exc import OperationalError

--- a/tests/meltano/core/test_plugin_test_service.py
+++ b/tests/meltano/core/test_plugin_test_service.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import typing as t
 from signal import SIGTERM
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from mock import AsyncMock, Mock, patch
 
 from meltano.core.plugin.error import PluginNotSupportedError
 from meltano.core.plugin_test_service import (

--- a/tests/meltano/core/test_project_add_service.py
+++ b/tests/meltano/core/test_project_add_service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import typing as t
+from unittest import mock
 
-import mock
 import pytest
 
 from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import platform
 import typing as t
 from datetime import date, datetime, timezone
+from unittest import mock
 
-import mock
 import pytest
 
 from meltano.core.plugin import PluginType

--- a/tests/meltano/core/test_settings_store.py
+++ b/tests/meltano/core/test_settings_store.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from unittest import mock
 
-import mock
 import pytest
 
 from meltano.core.environment import Environment

--- a/tests/meltano/core/test_validation_service.py
+++ b/tests/meltano/core/test_validation_service.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import typing as t
+from unittest.mock import Mock
 
 import pytest
-from mock import Mock
 
 from meltano.core.plugin import PluginType
 from meltano.core.validation_service import ValidationOutcome, ValidationsRunner

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -7,8 +7,8 @@ import sys
 import typing as t
 from asyncio.subprocess import Process
 from pathlib import Path
+from unittest import mock
 
-import mock
 import pytest
 
 from meltano.core.error import AsyncSubprocessError, MeltanoError

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -8,8 +8,8 @@ from contextlib import contextmanager
 from http import server as server_lib
 from threading import Thread
 from time import sleep
+from unittest import mock
 
-import mock
 import pytest
 from snowplow_tracker import Emitter, SelfDescribing
 

--- a/uv.lock
+++ b/uv.lock
@@ -1373,7 +1373,6 @@ dev = [
     { name = "boto3-stubs", extra = ["essential"] },
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
-    { name = "mock" },
     { name = "moto" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1402,7 +1401,6 @@ testing = [
     { name = "backoff" },
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
-    { name = "mock" },
     { name = "moto" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1483,7 +1481,6 @@ dev = [
     { name = "boto3-stubs", extras = ["essential"], specifier = ">=1.35,<1.39" },
     { name = "colorama", specifier = ">=0.4.4,<0.5" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.12" },
-    { name = "mock", specifier = ">=5.0.2,<6" },
     { name = "moto", specifier = ">=5.0.21,<6" },
     { name = "mypy", specifier = ">=1.13.0,<2" },
     { name = "pytest", specifier = ">=8.3.3,<9" },
@@ -1509,7 +1506,6 @@ testing = [
     { name = "backoff", specifier = ">=2.1.2,<3" },
     { name = "colorama", specifier = ">=0.4.4,<0.5" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.12" },
-    { name = "mock", specifier = ">=5.0.2,<6" },
     { name = "moto", specifier = ">=5.0.21,<6" },
     { name = "pytest", specifier = ">=8.3.3,<9" },
     { name = "pytest-asyncio", specifier = ">=1" },
@@ -1532,15 +1528,6 @@ typing = [
     { name = "types-psutil", specifier = ">=7.0.0.20250218,<8" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240917,<7" },
     { name = "types-requests", specifier = ">=2.31.0,<3" },
-]
-
-[[package]]
-name = "mock"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/8c/14c2ae915e5f9dca5a22edd68b35be94400719ccfa068a03e0fb63d0f6f6/mock-5.2.0.tar.gz", hash = "sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0", size = 92796, upload-time = "2025-03-03T12:31:42.911Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1d468e0d58c3997b1dc219a9a9202e650d30c2fc85d481/mock-5.2.0-py3-none-any.whl", hash = "sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f", size = 31617, upload-time = "2025-03-03T12:31:41.518Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Replace all usages of the third-party `mock` library with the built-in `unittest.mock`, removing the external dependency and updating lint configuration accordingly.

Enhancements:
- Remove external `mock` dependency in favor of the standard library `unittest.mock`

Build:
- Remove `mock` from testing dependencies in pyproject.toml
- Drop Ruff lint ignore for rule UP026 now that `unittest.mock` is used

Tests:
- Update test files to replace `mock` imports with `unittest.mock`