### PR TITLE
refactor: Split job and ELT schedules into separate classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,9 +235,14 @@ source = [
 
 [tool.coverage.report]
 exclude_also = [
+  # Ignore TYPE_CHECKING blocks
   '''if (t\.)?TYPE_CHECKING:''',
+  # Ignore assert_never type checks
   '''(t\.)?assert_never''',
+  # Ignore ellipsis in abstract methods
   "\\.\\.\\.",
+  # Comments to turn coverage on and off
+  'no cover: start(?s:.)*?no cover: stop',
 ]
 precision = 2
 show_missing = true

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -12,6 +12,7 @@ from meltano.cli.utils import CliError, PartialInstrumentedCmd
 from meltano.core.block.block_parser import BlockParser
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_install_service import install_plugins
+from meltano.core.schedule import ELTSchedule, JobSchedule
 from meltano.core.schedule_service import ScheduleService
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 from meltano.core.utils import run_async
@@ -122,17 +123,21 @@ def _get_schedule_plugins(project: Project, schedule_name: str):  # noqa: ANN202
     schedule_service = ScheduleService(project)
     schedule_obj = schedule_service.find_schedule(schedule_name)
     schedule_plugins = set()
-    if schedule_obj.elt_schedule:
+    if isinstance(schedule_obj, ELTSchedule):
         for plugin_name in (schedule_obj.extractor, schedule_obj.loader):
             schedule_plugins.add(project.plugins.find_plugin(plugin_name))
-    else:
+    elif isinstance(schedule_obj, JobSchedule):
         task_sets = schedule_service.task_sets_service.get(schedule_obj.job)
         for blocks in task_sets.flat_args_per_set:
             parser = BlockParser(logger, project, blocks)
             for plugin in parser.plugins:
                 schedule_plugins.add(
-                    project.plugins.find_plugin(plugin.info.get("name"))
+                    project.plugins.find_plugin(plugin.info["name"])
                     if plugin.type == PluginType.MAPPERS
                     else plugin,
                 )
+    else:  # pragma: no cover
+        msg = f"Invalid schedule type: {type(schedule_obj)}"
+        raise ValueError(msg)
+
     return schedule_plugins

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -17,7 +17,7 @@ from meltano.cli.utils import (
 )
 from meltano.core.db import project_engine
 from meltano.core.job.stale_job_failer import fail_stale_jobs
-from meltano.core.schedule import CRON_INTERVALS
+from meltano.core.schedule import CRON_INTERVALS, ELTSchedule, JobSchedule
 from meltano.core.schedule_service import (
     BadCronError,
     ScheduleAlreadyExistsError,
@@ -44,7 +44,7 @@ if t.TYPE_CHECKING:
 )
 @click.pass_context
 @pass_project(migrate=True)
-def schedule(project, ctx) -> None:  # noqa: ANN001
+def schedule(project: Project, ctx: click.Context) -> None:
     """Manage pipeline schedules.
 
     \b
@@ -89,7 +89,7 @@ def _add_elt(
         session.close()
 
 
-def _add_job(ctx, name: str, job: str, interval: str) -> None:  # noqa: ANN001
+def _add_job(ctx: click.Context, name: str, job: str, interval: str) -> None:
     """Add a new scheduled job."""
     project: Project = ctx.obj["project"]
     schedule_service: ScheduleService = ctx.obj["schedule_service"]
@@ -112,7 +112,7 @@ class CronParam(click.ParamType):
 
     name = "cron"
 
-    def convert(self, value, *_):  # noqa: ANN001, ANN201
+    def convert(self, value: str, *_) -> str:
         """Validate and con interval."""
         if value not in CRON_INTERVALS and not croniter.is_valid(value):
             raise BadCronError(value)
@@ -187,7 +187,7 @@ def add(
     _add_job(ctx, name, job, interval)
 
 
-def _format_job_list_output(entry: Schedule, job: TaskSets) -> dict:
+def _format_job_list_output(entry: JobSchedule, job: TaskSets) -> dict:
     return {
         "name": entry.name,
         "interval": entry.interval,
@@ -200,7 +200,7 @@ def _format_job_list_output(entry: Schedule, job: TaskSets) -> dict:
     }
 
 
-def _format_elt_list_output(entry: Schedule, session: Session) -> dict:
+def _format_elt_list_output(entry: ELTSchedule, session: Session) -> dict:
     start_date = coerce_datetime(entry.start_date)
     start_date_str = start_date.date().isoformat() if start_date else None
 
@@ -256,35 +256,43 @@ def list_schedules(ctx: click.Context, list_format: str) -> None:
             }
 
             for txt_schedule in schedule_service.schedules():
-                if txt_schedule.job:
+                if isinstance(txt_schedule, JobSchedule):
                     click.echo(
                         f"[{txt_schedule.interval}] job {txt_schedule.name}: "
                         f"{txt_schedule.job} → "
                         f"{task_sets_service.get(txt_schedule.job).tasks}",
                     )
-                else:
-                    markers = transform_elt_markers[txt_schedule.transform]  # type: ignore[index]
+                elif isinstance(txt_schedule, ELTSchedule):
+                    markers = transform_elt_markers[txt_schedule.transform]
                     click.echo(
                         f"[{txt_schedule.interval}] elt {txt_schedule.name}: "
                         f"{txt_schedule.extractor} {markers[0]} "
                         f"{txt_schedule.loader} {markers[1]} transforms",
                     )
+                else:  # pragma: no cover
+                    msg = f"Invalid schedule type: {type(txt_schedule)}"
+                    raise ValueError(msg)
 
         elif list_format == "json":
             job_schedules = []
             elt_schedules = []
             for json_schedule in schedule_service.schedules():
-                if json_schedule.job:
+                # if json_schedule.job:
+                if isinstance(json_schedule, JobSchedule):
                     job_schedules.append(
                         _format_job_list_output(
                             json_schedule,
                             task_sets_service.get(json_schedule.job),
                         ),
                     )
-                else:
+                elif isinstance(json_schedule, ELTSchedule):
                     elt_schedules.append(
                         _format_elt_list_output(json_schedule, session),
                     )
+                else:  # pragma: no cover
+                    msg = f"Invalid schedule type: {type(json_schedule)}"
+                    raise ValueError(msg)
+
             click.echo(
                 json.dumps(
                     {"schedules": {"job": job_schedules, "elt": elt_schedules}},
@@ -318,7 +326,7 @@ def run(ctx: click.Context, name: str, elt_options: tuple[str]) -> None:
 )
 @click.argument("name", required=True)
 @click.pass_context
-def remove(ctx, name) -> None:  # noqa: ANN001
+def remove(ctx: click.Context, name: str) -> None:
     """Remove a schedule.
 
     Usage:
@@ -328,7 +336,7 @@ def remove(ctx, name) -> None:  # noqa: ANN001
 
 
 def _update_job_schedule(
-    candidate: Schedule,
+    candidate: JobSchedule,
     job: str | None,
     interval: str | None = None,
 ) -> Schedule:
@@ -345,11 +353,6 @@ def _update_job_schedule(
     Returns:
         The updated schedule.
     """
-    if not candidate.job:
-        raise click.ClickException(
-            f"Cannot update schedule {candidate.name} with job only flags as "  # noqa: EM102
-            "its a elt schedule",
-        )
     if job:
         candidate.job = job
     if interval:
@@ -358,7 +361,7 @@ def _update_job_schedule(
 
 
 def _update_elt_schedule(
-    candidate: Schedule,
+    candidate: ELTSchedule,
     extractor: str | None,
     loader: str | None,
     transform: str | None,
@@ -379,12 +382,6 @@ def _update_elt_schedule(
     Returns:
         The updated schedule.
     """
-    if candidate.job:
-        raise click.ClickException(
-            f"Cannot update schedule {candidate.name} with elt only flags as "  # noqa: EM102
-            "its a scheduled job",
-        )
-
     if extractor:
         candidate.extractor = extractor
     if loader:
@@ -437,13 +434,13 @@ def set_cmd(
     schedule_service: ScheduleService = ctx.obj["schedule_service"]
     candidate = schedule_service.find_schedule(name)
 
-    if candidate.job:
+    if isinstance(candidate, JobSchedule):
         if extractor or loader or transform:
             raise click.ClickException(
                 "Cannot mix --job with --extractor/--loader/--transform",  # noqa: EM101
             )
         updated = _update_job_schedule(candidate, job, interval)
-    else:
+    elif isinstance(candidate, ELTSchedule):
         if job:
             raise click.ClickException(
                 "Cannot mix --job with --extractor/--loader/--transform",  # noqa: EM101
@@ -455,6 +452,9 @@ def set_cmd(
             transform,
             interval,
         )
+    else:  # pragma: no cover
+        msg = f"Invalid schedule type: {type(candidate)}"
+        raise ValueError(msg)
 
     schedule_service.update_schedule(updated)
     click.echo(f"Updated schedule '{name}'")

--- a/src/meltano/core/meltano_file.py
+++ b/src/meltano/core/meltano_file.py
@@ -9,7 +9,7 @@ from meltano.core.behavior.canonical import Canonical
 from meltano.core.environment import Environment
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
-from meltano.core.schedule import Schedule
+from meltano.core.schedule import ELTSchedule, JobSchedule, Schedule
 from meltano.core.task_sets import TaskSets
 
 if t.TYPE_CHECKING:
@@ -100,7 +100,13 @@ class MeltanoFile(Canonical):
         Returns:
             List of new Schedule instances.
         """
-        return [Schedule.parse(obj) for obj in schedules]
+        result: list[Schedule] = []
+        for schedule in schedules:
+            if schedule.get("job"):
+                result.append(JobSchedule(**schedule))
+            else:
+                result.append(ELTSchedule(**schedule))
+        return result
 
     @staticmethod
     def load_environments(environments: Iterable[dict]) -> list[Environment]:

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -23,6 +23,14 @@ if t.TYPE_CHECKING:
 logger = structlog.stdlib.get_logger(__name__)
 
 
+class PluginInfo(t.TypedDict):
+    """Plugin info dictionary."""
+
+    name: str
+    namespace: str | None
+    variant: str | None
+
+
 class CyclicInheritanceError(Exception):
     """Exception raised when project plugin inherits from itself cyclicly."""
 
@@ -245,7 +253,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         return self.is_attr_set(self.VARIANT_ATTR)
 
     @property
-    def info(self) -> dict[str, str | None]:
+    def info(self) -> PluginInfo:
         """Plugin info dict.
 
         Returns:

--- a/tests/meltano/cli/test_schedule.py
+++ b/tests/meltano/cli/test_schedule.py
@@ -183,10 +183,10 @@ class TestCliSchedule:
 
     def test_schedule_set(
         self,
-        cli_runner,
-        elt_schedule,
-        job_schedule,
-        schedule_service,
+        cli_runner: MeltanoCliRunner,
+        elt_schedule: ELTSchedule,
+        job_schedule: JobSchedule,
+        schedule_service: ScheduleService,
     ) -> None:
         with mock.patch(
             "meltano.cli.schedule.ScheduleService",
@@ -259,6 +259,7 @@ class TestCliSchedule:
                 ],
             )
             assert res.exit_code == 1
+            assert "Cannot mix --job" in res.output
             assert isinstance(
                 schedule_service.find_schedule(job_schedule.name),
                 JobSchedule,
@@ -269,6 +270,7 @@ class TestCliSchedule:
                 ["schedule", "set", elt_schedule.name, "--job", "mock-job-renamed"],
             )
             assert res.exit_code == 1
+            assert "Cannot mix --job" in res.output
             assert isinstance(
                 schedule_service.find_schedule(elt_schedule.name),
                 ELTSchedule,

--- a/tests/meltano/cli/test_schedule.py
+++ b/tests/meltano/cli/test_schedule.py
@@ -259,7 +259,7 @@ class TestCliSchedule:
                 ],
             )
             assert res.exit_code == 1
-            assert "Cannot mix --job" in res.output
+            assert "Cannot mix --job" in res.stderr
             assert isinstance(
                 schedule_service.find_schedule(job_schedule.name),
                 JobSchedule,
@@ -270,7 +270,7 @@ class TestCliSchedule:
                 ["schedule", "set", elt_schedule.name, "--job", "mock-job-renamed"],
             )
             assert res.exit_code == 1
-            assert "Cannot mix --job" in res.output
+            assert "Cannot mix --job" in res.stderr
             assert isinstance(
                 schedule_service.find_schedule(elt_schedule.name),
                 ELTSchedule,

--- a/tests/meltano/cli/test_schedule.py
+++ b/tests/meltano/cli/test_schedule.py
@@ -297,8 +297,8 @@ class TestCliSchedule:
         ):
             res = cli_runner.invoke(cli, ["schedule", "list"])
             assert res.exit_code == 0
-            assert elt_schedule.name in res.stdout
-            assert job_schedule.name in res.stdout
+            assert f"elt {elt_schedule.name}" in res.stdout
+            assert f"job {job_schedule.name}" in res.stdout
 
             res = cli_runner.invoke(cli, ["schedule", "list", "--format", "json"])
             assert res.exit_code == 0

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -10,6 +10,7 @@ import pytest
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
+from meltano.core.schedule import ELTSchedule, JobSchedule
 from meltano.core.schedule_service import (
     BadCronError,
     Schedule,
@@ -36,7 +37,7 @@ def create_elt_schedule():
         }
 
         attrs.update(kwargs)
-        return Schedule(name=name, **attrs)
+        return ELTSchedule(name=name, **attrs)
 
     return make
 
@@ -47,12 +48,11 @@ def create_job_schedule():
         attrs = {
             "job": "job-mock",
             "interval": "@daily",
-            "start_date": None,
             "env": {},
         }
 
         attrs.update(kwargs)
-        return Schedule(name=name, **attrs)
+        return JobSchedule(name=name, **attrs)
 
     return make
 
@@ -319,16 +319,19 @@ class TestScheduleService:
     @pytest.mark.usefixtures("create_elt_schedule")
     def test_find_namespace_schedule_custom_extractor(
         self,
-        subject,
+        subject: ScheduleService,
         custom_tap,
     ) -> None:
-        schedule = Schedule(
+        schedule = ELTSchedule(
             name="tap-custom",
             extractor="tap-custom",
+            loader="target-mock",
+            transform="skip",
             interval="@daily",
         )
         subject.add_schedule(schedule)
         found_schedule = subject.find_namespace_schedule(custom_tap.namespace)
+        assert isinstance(found_schedule, ELTSchedule)
         assert found_schedule.extractor == custom_tap.name
 
     def test_find_namespace_schedule_not_found(self, subject) -> None:


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

To follow the principle of "Making illegal states unrepresentable".

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enforce distinct schedule types by splitting the Schedule class into ELTSchedule and JobSchedule subclasses and updating all related creation, parsing, CLI commands, and service logic to dispatch on the new types.

Enhancements:
- Introduce ELTSchedule and JobSchedule subclasses to make illegal states unrepresentable.
- Refactor ScheduleService, meltano_file loader, and run invocation to instantiate and handle schedule subclasses based on their type.
- Update CLI formatting, list, set, and install commands to dispatch on ELTSchedule vs JobSchedule instead of checking job attributes.
- Replace NotImplementedError guards and mixed-state logic with explicit instance checks for scheduling behavior.

Tests:
- Adjust tests to assert on ELTSchedule and JobSchedule instance types after operations.

Chores:
- Define PluginInfo TypedDict and refine the plugin.info return type.
- Update TaskSets.flat_args_per_set return signature to a list of lists.

## Summary by Sourcery

Split the unified Schedule class into dedicated ELTSchedule and JobSchedule subclasses and update all related components to use explicit type-based dispatching for schedule operations.

Enhancements:
- Introduce ELTSchedule and JobSchedule subclasses to enforce distinct schedule types.
- Refactor ScheduleService, meltano_file loader, CLI commands, and run invocation logic to dispatch based on schedule type.
- Replace NotImplementedError guards and mixed-state attribute checks with explicit instance checks for scheduling behavior.

Tests:
- Update tests to assert on ELTSchedule and JobSchedule instances and verify CLI list output in text and JSON formats.

Chores:
- Add PluginInfo TypedDict and refine the plugin.info return type.
- Extend coverage configuration to ignore TYPE_CHECKING blocks, assert_never checks, ellipsis in abstract methods, and no cover markers in pyproject.toml.