### PR TITLE
chore: Enable type checking in `meltano.cli.install`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,7 +283,6 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 ignore_errors = true
 module = [
-  "meltano.cli.install",
   "meltano.cli.interactive.*",
   # Way too many modules at the root of meltano.core to tackle them all at once  # so listing them individually here.
   "meltano.core.models",

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -18,6 +18,7 @@ from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 from meltano.core.utils import run_async
 
 if t.TYPE_CHECKING:
+    from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
     from meltano.core.tracking import Tracker
 
@@ -119,7 +120,7 @@ async def install(
     tracker.track_command_event(CliEvent.completed)
 
 
-def _get_schedule_plugins(project: Project, schedule_name: str):  # noqa: ANN202
+def _get_schedule_plugins(project: Project, schedule_name: str) -> set[ProjectPlugin]:
     schedule_service = ScheduleService(project)
     schedule_obj = schedule_service.find_schedule(schedule_name)
     schedule_plugins = set()

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -307,7 +307,7 @@ def _validate_tasks(project: Project, task_set: TaskSets, ctx: click.Context) ->
             blocks=blocks,
         )
         try:
-            block_parser = BlockParser(logger, project, blocks)  # type: ignore[arg-type]
+            block_parser = BlockParser(logger, project, blocks)
             parsed_blocks = list(block_parser.find_blocks(0))
             tracker.add_contexts(PluginsTrackingContext.from_blocks(parsed_blocks))
         except Exception as err:

--- a/src/meltano/core/task_sets.py
+++ b/src/meltano/core/task_sets.py
@@ -59,6 +59,9 @@ def _flat_split(items: Iterable | str) -> Generator[str, None, None]:
 class TaskSets(NameEq, Canonical):
     """A named entity that holds one or more tasks that can be executed by Meltano."""
 
+    name: str
+    tasks: list[str] | list[list[str]]
+
     def __init__(self, name: str, tasks: list[str] | list[list[str]]):
         """Initialize a `TaskSets`.
 
@@ -122,7 +125,7 @@ class TaskSets(NameEq, Canonical):
         return self._as_args()
 
     @property
-    def flat_args_per_set(self) -> list[str] | list[list[str]]:
+    def flat_args_per_set(self) -> list[list[str]]:
         """Convert the job's tasks into perk task representations.
 
         Preserves top level list hierarchy.

--- a/src/meltano/core/task_sets.py
+++ b/src/meltano/core/task_sets.py
@@ -59,9 +59,6 @@ def _flat_split(items: Iterable | str) -> Generator[str, None, None]:
 class TaskSets(NameEq, Canonical):
     """A named entity that holds one or more tasks that can be executed by Meltano."""
 
-    name: str
-    tasks: list[str] | list[list[str]]
-
     def __init__(self, name: str, tasks: list[str] | list[list[str]]):
         """Initialize a `TaskSets`.
 
@@ -71,8 +68,8 @@ class TaskSets(NameEq, Canonical):
         """
         super().__init__()
 
-        self.name = name
-        self.tasks = tasks
+        self.name: str = name
+        self.tasks: list[str] | list[list[str]] = tasks
 
     @t.overload
     def _as_args(self) -> list[str]: ...


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enable static type checking in the `meltano.cli.install` module and related code by adding missing type annotations, refining function and attribute signatures, and removing the mypy ignore override for the module.

Enhancements:
- Add attribute type annotations for `name` and `tasks` in `TaskSets`.
- Restrict the return type of `flat_args_per_set` to `list[list[str]]`.
- Import `ProjectPlugin` for TYPE_CHECKING and annotate `_get_schedule_plugins` to return `set[ProjectPlugin]`.
- Remove the unnecessary `# type: ignore` on the `BlockParser` instantiation in the job CLI.

Build:
- Remove `meltano.cli.install` from the mypy ignore overrides in `pyproject.toml`.