### PR TITLE
refactor: Avoid checking catalog cache key if user passed a custom catalog

### DIFF
--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -369,8 +369,8 @@ class SingerTap(SingerPlugin):
         with suppress(PluginLacksCapabilityError):
             await self.discover_catalog(plugin_invoker)
 
-    async def _discover_catalog(self, plugin_invoker: PluginInvoker) -> Path:
-        """Perform catalog discovery.
+    async def _get_catalog(self, plugin_invoker: PluginInvoker) -> Path:
+        """Get the user-provided or discovered catalog file.
 
         Args:
             plugin_invoker: The invocation handler of the plugin instance.
@@ -427,7 +427,7 @@ class SingerTap(SingerPlugin):
         Returns:
             None
         """
-        catalog_path = await self._discover_catalog(plugin_invoker)
+        catalog_path = await self._get_catalog(plugin_invoker)
 
         # test for the result to be a valid catalog
         try:

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -393,8 +393,8 @@ class SingerTap(SingerPlugin):
             custom_catalog_path = plugin_invoker.project.root / custom_catalog_filename
             try:
                 shutil.copy(custom_catalog_path, catalog_path)
-            except FileNotFoundError as err:
-                msg = f"Could not find catalog file {custom_catalog_path}"
+            except OSError as err:
+                msg = f"Failed to copy catalog file: {err.strerror}"
                 raise PluginExecutionError(msg) from err
 
             logger.info("Using custom catalog in %s", custom_catalog_path)

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -400,13 +400,12 @@ class SingerTap(SingerPlugin):
             logger.info("Using custom catalog in %s", custom_catalog_path)
             return
 
-        use_catalog_cache = True
-        if (
-            elt_context and elt_context.refresh_catalog
-        ) or not plugin_invoker.plugin_config_extras["_use_cached_catalog"]:
-            use_catalog_cache = False
+        use_cached_catalog = (
+            not (elt_context and elt_context.refresh_catalog)
+            and plugin_invoker.plugin_config_extras["_use_cached_catalog"]
+        )
 
-        if catalog_path.exists() and use_catalog_cache:
+        if catalog_path.exists() and use_cached_catalog:
             with suppress(FileNotFoundError):
                 cached_key = catalog_cache_key_path.read_text()
                 new_cache_key = self.catalog_cache_key(plugin_invoker)

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -27,6 +27,8 @@ from meltano.core.state_service import InvalidJobStateError, StateService
 if t.TYPE_CHECKING:
     from collections.abc import Callable
 
+    from sqlalchemy.orm import Session
+
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.plugin_invoker import PluginInvoker
     from meltano.core.project import Project
@@ -329,7 +331,7 @@ class TestSingerTap:
             ):
                 with pytest.raises(
                     PluginExecutionError,
-                    match="Catalog discovery failed",
+                    match="Invalid catalog",
                 ) as exc_info:
                     await subject.discover_catalog(invoker)
 
@@ -343,33 +345,21 @@ class TestSingerTap:
         self,
         project: Project,
         session,
-        plugin_invoker_factory,
+        plugin_invoker_factory: Callable[[ProjectPlugin], PluginInvoker],
         subject: SingerTap,
         monkeypatch,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
 
         custom_catalog_filename = "custom_catalog.json"
+        custom_catalog_path = project.root.joinpath(custom_catalog_filename)
+        custom_catalog_path.write_text('{"custom": true}')
 
         monkeypatch.setitem(
             invoker.settings_service.config_override,
             "_catalog",
             custom_catalog_filename,
         )
-
-        async with invoker.prepared(session):
-            with pytest.raises(
-                PluginExecutionError,
-                match="Failed to copy catalog file",
-            ) as exc_info:
-                await subject.discover_catalog(invoker)
-
-            cause = exc_info.value.__cause__
-            assert isinstance(cause, OSError)
-            assert cause.strerror == "No such file or directory"
-
-        custom_catalog_path = project.root.joinpath(custom_catalog_filename)
-        custom_catalog_path.write_text('{"custom": true}')
 
         # These files should be ignored if a custom catalog is provided
         invoker.files["catalog"].write_text('{"previous": true}')
@@ -391,6 +381,71 @@ class TestSingerTap:
         assert invoker.files["catalog"].read_text() == '{"custom": true}'
         assert not mocked_run_discovery.called
         assert not mocked_catalog_cache_key.called
+
+    @pytest.mark.asyncio
+    async def test_discover_catalog_custom_missing(
+        self,
+        project: Project,
+        session: Session,
+        plugin_invoker_factory: Callable[[ProjectPlugin], PluginInvoker],
+        subject: SingerTap,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test using a custom catalog file that doesn't exist."""
+        invoker = plugin_invoker_factory(subject)
+
+        custom_catalog_filename = "custom_catalog.json"
+        custom_catalog_path = project.root.joinpath(custom_catalog_filename)
+        custom_catalog_path.unlink(missing_ok=True)
+
+        monkeypatch.setitem(
+            invoker.settings_service.config_override,
+            "_catalog",
+            custom_catalog_filename,
+        )
+
+        async with invoker.prepared(session):
+            with pytest.raises(
+                PluginExecutionError,
+                match="Failed to copy catalog file",
+            ) as exc_info:
+                await subject.discover_catalog(invoker)
+
+            cause = exc_info.value.__cause__
+            assert isinstance(cause, OSError)
+            assert cause.strerror == "No such file or directory"
+
+    @pytest.mark.asyncio
+    async def test_discover_catalog_custom_invalid(
+        self,
+        project: Project,
+        session: Session,
+        plugin_invoker_factory: Callable[[ProjectPlugin], PluginInvoker],
+        subject: SingerTap,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test using a custom catalog file that is invalid JSON."""
+        invoker = plugin_invoker_factory(subject)
+
+        custom_catalog_filename = "custom_catalog.json"
+        custom_catalog_path = project.root.joinpath(custom_catalog_filename)
+        custom_catalog_path.write_text("Not JSON")
+
+        monkeypatch.setitem(
+            invoker.settings_service.config_override,
+            "_catalog",
+            custom_catalog_filename,
+        )
+
+        async with invoker.prepared(session):
+            with pytest.raises(
+                PluginExecutionError,
+                match="Invalid catalog",
+            ) as exc_info:
+                await subject.discover_catalog(invoker)
+
+            cause = exc_info.value.__cause__
+            assert isinstance(cause, json.JSONDecodeError)
 
     @pytest.mark.asyncio
     async def test_apply_select(


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Links

- https://meltano.slack.com/archives/C069CQNHDNF/p1748436899403689

## Summary by Sourcery

Refactor SingerTap catalog discovery to support and prioritize user-provided catalogs, streamline cache handling, and enhance error messaging, with accompanying tests for custom catalog scenarios.

Bug Fixes:
- Improve error handling for missing or invalid custom catalog files

Enhancements:
- Introduce a new _get_catalog helper to centralize custom and cached catalog retrieval
- Refactor discover_catalog to use _get_catalog and simplify cache key logic
- Skip cache checks entirely when a custom catalog is supplied

Tests:
- Add tests for using a custom catalog, missing custom file, and invalid JSON scenarios