### PR TITLE
ci: Test with free Linux arm64 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,17 +38,17 @@ jobs:
     strategy:
       matrix:
         include:
-        - { python-version: '3.9',  os: ubuntu-latest, backend-db: sqlite, id: 'py39-ubuntu-sqlite'  }
-        - { python-version: '3.10', os: ubuntu-latest, backend-db: sqlite, id: 'py310-ubuntu-sqlite' }
-        - { python-version: '3.11', os: ubuntu-latest, backend-db: sqlite, id: 'py311-ubuntu-sqlite' }
-        - { python-version: '3.12', os: ubuntu-latest, backend-db: sqlite, id: 'py312-ubuntu-sqlite' }
-        - { python-version: '3.13', os: ubuntu-latest, backend-db: sqlite, id: 'py313-ubuntu-sqlite' }
-        - { python-version: '3.14', os: ubuntu-latest, backend-db: sqlite, id: 'py314-ubuntu-sqlite' }
-        - { python-version: '3.9',  os: ubuntu-latest, backend-db: postgresql, id: 'py39-ubuntu-psycopg2'  }
-        - { python-version: '3.10', os: ubuntu-latest, backend-db: postgresql, id: 'py310-ubuntu-psycopg2' }
-        - { python-version: '3.11', os: ubuntu-latest, backend-db: postgresql, id: 'py311-ubuntu-psycopg2' }
-        - { python-version: '3.12', os: ubuntu-latest, backend-db: postgresql, id: 'py312-ubuntu-psycopg2' }
-        - { python-version: '3.13', os: ubuntu-latest, backend-db: postgresql, id: 'py313-ubuntu-psycopg2' }
+        - { python-version: '3.9',  os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py39-ubuntu-sqlite'  }
+        - { python-version: '3.10', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py310-ubuntu-sqlite' }
+        - { python-version: '3.11', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py311-ubuntu-sqlite' }
+        - { python-version: '3.12', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py312-ubuntu-sqlite' }
+        - { python-version: '3.13', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py313-ubuntu-sqlite' }
+        - { python-version: '3.14', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py314-ubuntu-sqlite' }
+        - { python-version: '3.9',  os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py39-ubuntu-psycopg2'  }
+        - { python-version: '3.10', os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py310-ubuntu-psycopg2' }
+        - { python-version: '3.11', os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py311-ubuntu-psycopg2' }
+        - { python-version: '3.12', os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py312-ubuntu-psycopg2' }
+        - { python-version: '3.13', os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py313-ubuntu-psycopg2' }
         - { python-version: '3.9',  os: ubuntu-latest, backend-db: mssql, id: 'py39-ubuntu-mssql'  }
         - { python-version: '3.10', os: ubuntu-latest, backend-db: mssql, id: 'py310-ubuntu-mssql' }
         - { python-version: '3.11', os: ubuntu-latest, backend-db: mssql, id: 'py311-ubuntu-mssql' }
@@ -60,12 +60,12 @@ jobs:
         - { python-version: '3.11', os: windows-2025,  backend-db: sqlite, id: 'py311-windows-sqlite' }
         - { python-version: '3.12', os: windows-2025,  backend-db: sqlite, id: 'py312-windows-sqlite' }
         - { python-version: '3.13', os: windows-2025,  backend-db: sqlite, id: 'py313-windows-sqlite' }
-        - { python-version: '3.9',  os: ubuntu-latest, backend-db: postgresql_psycopg3, id: 'py39-ubuntu-psycopg3'  }
-        - { python-version: '3.10', os: ubuntu-latest, backend-db: postgresql_psycopg3, id: 'py310-ubuntu-psycopg3' }
-        - { python-version: '3.11', os: ubuntu-latest, backend-db: postgresql_psycopg3, id: 'py311-ubuntu-psycopg3' }
-        - { python-version: '3.12', os: ubuntu-latest, backend-db: postgresql_psycopg3, id: 'py312-ubuntu-psycopg3' }
-        - { python-version: '3.13', os: ubuntu-latest, backend-db: postgresql_psycopg3, id: 'py313-ubuntu-psycopg3' }
-        - { python-version: '3.13', os: ubuntu-latest, backend-db: sqlite, markers: 'concurrent', id: 'concurrent-ubuntu'  }
+        - { python-version: '3.9',  os: ubuntu-24.04-arm, backend-db: postgresql_psycopg3, id: 'py39-ubuntu-psycopg3'  }
+        - { python-version: '3.10', os: ubuntu-24.04-arm, backend-db: postgresql_psycopg3, id: 'py310-ubuntu-psycopg3' }
+        - { python-version: '3.11', os: ubuntu-24.04-arm, backend-db: postgresql_psycopg3, id: 'py311-ubuntu-psycopg3' }
+        - { python-version: '3.12', os: ubuntu-24.04-arm, backend-db: postgresql_psycopg3, id: 'py312-ubuntu-psycopg3' }
+        - { python-version: '3.13', os: ubuntu-24.04-arm, backend-db: postgresql_psycopg3, id: 'py313-ubuntu-psycopg3' }
+        - { python-version: '3.13', os: ubuntu-24.04-arm, backend-db: sqlite, markers: 'concurrent', id: 'concurrent-ubuntu'  }
         - { python-version: '3.13', os: windows-2025,  backend-db: sqlite, markers: 'concurrent', id: 'concurrent-windows' }
       fail-fast: false
 
@@ -116,7 +116,6 @@ jobs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: x64
         check-latest: true
         allow-prereleases: true
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This shaves a few minutes from the test suite, in big part probably because it actually gives pytest-xdist 4 cores.

- https://github.com/orgs/community/discussions/148648
- https://github.com/orgs/community/discussions/155713

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Switch the GitHub Actions test matrix to use Ubuntu arm64 runners for various Python versions and database backends, and drop the forced x64 architecture to leverage native arm64 hosts and reduce test runtime.

CI:
- Add ubuntu-24.04-arm runner entries for Python 3.9–3.14 with sqlite, postgresql, postgresql_psycopg3, and concurrent test jobs
- Remove the explicit x64 architecture setting in setup-python to enable arm64 execution

## Summary by Sourcery

Switch CI test matrix to ARM64 Linux runners to leverage native ARM hosts and reduce test runtime

CI:
- Use ubuntu-24.04-arm runners for Python 3.9–3.14 jobs with SQLite, PostgreSQL, PostgreSQL_psycopg3, and concurrent tests
- Remove explicit x64 architecture in setup-python to enable ARM64 execution