### PR TITLE
fix: Do not try to cast expandable inherited settings

### DIFF
--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -35,6 +35,7 @@ from meltano.core.utils import run_async
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
     from meltano.core.project_settings_service import ProjectSettingsService
+    from meltano.core.setting_definition import SettingDefinition
     from meltano.core.settings_service import SettingsService
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -271,7 +272,7 @@ def list_settings(ctx: click.Context, *, extras: bool) -> None:
     for name, config_metadata in full_config.items():
         value = config_metadata["value"]
         source = config_metadata["source"]
-        setting_def = config_metadata["setting"]
+        setting_def: SettingDefinition = config_metadata["setting"]
 
         if extras:
             if not setting_def.is_extra:

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -14,9 +14,6 @@ if t.TYPE_CHECKING:
     from meltano.core.setting_definition import EnvVar, SettingDefinition
 
 
-_T = t.TypeVar("_T", bound="PluginSettingsService")
-
-
 class PluginSettingsService(SettingsService):
     """Settings manager for Meltano plugins."""
 
@@ -212,7 +209,7 @@ class PluginSettingsService(SettingsService):
         self.project.plugins.update_environment_plugin(self.environment_plugin_config)
 
     @cached_property
-    def inherited_settings_service(self: _T) -> _T | None:
+    def inherited_settings_service(self) -> PluginSettingsService | None:
         """Return settings service to inherit configuration from.
 
         Returns:


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #9299 

## Summary by Sourcery

Disable casting for expandable inherited settings and expose control over value casting.

Bug Fixes:
- Prevent casting of expandable inherited settings to avoid invalid type conversions.

Enhancements:
- Add a `cast` parameter to `set_with_metadata` to control value casting.
- Restrict automatic casting in `get_with_metadata` to non-expandable settings only.
- Remove unused type variable and refine type hints in plugin settings service and CLI.

Tests:
- Add `test_get_expandable_inherited` to verify that expandable inherited settings are not cast.

## Summary by Sourcery

Prevent automatic casting of expandable inherited settings and expose explicit control over value casting in settings APIs, while refining related type hints.

Bug Fixes:
- Prevent casting of expandable inherited settings to avoid invalid type conversions.

Enhancements:
- Add a `cast` parameter to `set_with_metadata` to allow callers to disable casting.
- Restrict automatic value casting in `get_with_metadata` to non-expandable settings only.

Tests:
- Add `test_get_expandable_inherited` to verify that expandable inherited settings bypass casting.