### PR TITLE
test: Further test env var expansion in inherited plugins

### DIFF
--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -520,10 +520,10 @@ class SettingsService(metaclass=ABCMeta):
             return None, metadata
 
         if setting_def and cast_value:
-            cast_value = setting_def.cast_value(value)
-            if cast_value != value:
+            new_value = setting_def.cast_value(value)
+            if new_value != value:
                 metadata["uncast_value"] = value
-                value = cast_value
+                value = new_value
 
         metadata.update(
             store.manager(self, **kwargs).set(

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -478,7 +478,7 @@ class SettingsService(metaclass=ABCMeta):
         store: SettingValueStore = SettingValueStore.AUTO,
         *,
         redacted_value: str = REDACTED_VALUE,
-        cast: bool = True,
+        cast_value: bool = True,
         **kwargs: t.Any,
     ) -> tuple[t.Any, dict[str, t.Any]]:
         """Set the value and metadata for a setting.
@@ -488,7 +488,7 @@ class SettingsService(metaclass=ABCMeta):
             value: the value to set the setting to
             store: the store to set the value in
             redacted_value: the value to use when redacting the setting
-            cast: Whether to cast the setting value to its expected type
+            cast_value: Whether to cast the setting value to its expected type
             **kwargs: additional keyword args to pass during
                 `SettingsStoreManager` instantiation
 
@@ -519,7 +519,7 @@ class SettingsService(metaclass=ABCMeta):
             metadata["redacted"] = True
             return None, metadata
 
-        if setting_def and cast:
+        if setting_def and cast_value:
             cast_value = setting_def.cast_value(value)
             if cast_value != value:
                 metadata["uncast_value"] = value

--- a/tests/meltano/core/test_plugin_install_service.py
+++ b/tests/meltano/core/test_plugin_install_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import os
+import platform
 import re
+import sys
 import typing as t
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -152,6 +154,13 @@ class TestPluginInstallService:
             "target-csv",
         ]
 
+    @pytest.mark.xfail(
+        platform.system() == "Windows" and sys.version_info >= (3, 13),
+        reason=(
+            "The test fails on Windows and Python 3.13+ because of missing wheels. "
+            "See https://github.com/closeio/ciso8601/issues/155."
+        ),
+    )
     @pytest.mark.slow
     async def test_install_all(self, subject) -> None:
         all_plugins = await subject.install_all_plugins()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* #9300

## Summary by Sourcery

Improve handling of environment variable expansion in inherited plugin settings and clarify casting semantics by renaming internal parameters.

Enhancements:
- Rename `cast` parameter to `cast_value` in `set_with_metadata` for clearer semantics

Tests:
- Extend plugin settings tests to verify environment variable expansion and metadata accuracy for inherited settings

## Summary by Sourcery

Clarify casting semantics by renaming the `cast` parameter to `cast_value` in `set_with_metadata` and strengthen inherited plugin settings by adding tests that verify environment variable expansion and metadata accuracy.

Enhancements:
- Rename `cast` parameter to `cast_value` in `set_with_metadata` for clearer casting semantics

Tests:
- Extend inherited plugin settings tests to cover environment variable expansion and metadata accuracy