### PR TITLE
ci: Speed up Docker builds using uv

### DIFF
--- a/docker/meltano/Dockerfile
+++ b/docker/meltano/Dockerfile
@@ -9,18 +9,27 @@ ENV PIP_NO_CACHE_DIR=1
 
 RUN mkdir "${WORKDIR}" && \
     apt-get update && \
-    apt-get install -y build-essential freetds-bin freetds-dev git libkrb5-dev libssl-dev tdsodbc unixodbc unixodbc-dev && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      freetds-bin \
+      freetds-dev \
+      git \
+      libkrb5-dev \
+      libssl-dev \
+      tdsodbc \
+      unixodbc \
+      unixodbc-dev && \
+    pip install --no-cache-dir uv && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 WORKDIR "${WORKDIR}"
 
 # Create a virtual environment, and activate it
-RUN python -m venv /venv
+RUN uv venv /venv
 ENV PATH="/venv/bin:${PATH}"
 
 # Installing the application from a pre-built wheel in the dist directory
 RUN --mount=type=bind,source=dist,target=/tmp/meltano-dist \
-    pip install --upgrade pip wheel && \
-    pip install "meltano[azure,gcs,mssql,postgres,psycopg2,s3] @ file://$(ls /tmp/meltano-dist/meltano-*.whl)"
+    uv pip install "meltano[azure,gcs,mssql,postgres,psycopg2,s3] @ file://$(ls /tmp/meltano-dist/meltano-*.whl)"
 
 ENTRYPOINT ["meltano"]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* https://github.com/meltano/meltano/issues/7661

## Summary by Sourcery

Optimize the Meltano Dockerfile to speed up builds and reduce image size

Enhancements:
- Install apt packages using --no-install-recommends and clean caches to slim the image
- Add uv CLI and replace python -m venv and pip commands with uv venv and uv pip for faster environment setup