### PR TITLE
chore: Bump Ruff to 0.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,9 +83,9 @@ repos:
           - "prettier@3.0.0"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.0
     hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]
     - id: ruff-format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -384,11 +384,7 @@ unfixable = [
 ]
 "src/meltano/migrations/versions/*" = [
   "D103",
-  "D415",
   "INP001",
-  "TC003",
-  "TID251",
-  "UP007",
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/src/meltano/cli/compile.py
+++ b/src/meltano/cli/compile.py
@@ -97,7 +97,10 @@ def compile_command(
         )
         project.refresh(environment=environment)
         manifest = Manifest(
-            project=project, path=path, check_schema=lint, redact_secrets=safe
+            project=project,
+            path=path,
+            check_schema=lint,
+            redact_secrets=safe,
         )
         try:
             with path.open("w") as manifest_file:

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -458,7 +458,8 @@ async def _run_job(
 
 @asynccontextmanager
 async def _redirect_output(
-    log: structlog.stdlib.BoundLogger, output_logger: OutputLogger
+    log: structlog.stdlib.BoundLogger,
+    output_logger: OutputLogger,
 ) -> t.AsyncGenerator[None, None]:
     meltano_stdout = output_logger.out(
         "meltano",
@@ -596,7 +597,7 @@ async def _run_extract_load(
             log.error("Loading failed", code=code, message=message)
         raise
 
-    log.info("Extract & load complete!")
+    log.info("Extract & load complete!")  # type: ignore[unreachable]
 
 
 async def _run_transform(

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -597,7 +597,7 @@ async def _run_extract_load(
             log.error("Loading failed", code=code, message=message)
         raise
 
-    log.info("Extract & load complete!")  # type: ignore[unreachable]
+    log.info("Extract & load complete!")
 
 
 async def _run_transform(

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -96,7 +96,7 @@ async def test(
     *,
     all_tests: bool,
     install_plugins: InstallPlugins,
-    plugin_tests: tuple[str, ...] = (),
+    plugin_tests: tuple[str, ...],
 ) -> None:
     """Run validations using plugins' tests.
 

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -103,8 +103,10 @@ class ELBContext:
         Returns:
             The run directory for the current job.
         """
-        if self.job:  # noqa: RET503
+        if self.job:
             return self.project.job_dir(self.job.job_name, str(self.job.run_id))
+
+        return None
 
 
 class ELBContextBuilder:
@@ -419,9 +421,10 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
         Returns:
             The index of the block furthest from the start that has exited and required input.
         """  # noqa: E501
-        for idx, block in reversed(list(enumerate(self.blocks))):  # noqa: RET503
+        for idx, block in reversed(list(enumerate(self.blocks))):
             if block.requires_input and block.proxy_stderr.done():
                 return idx
+        return None
 
     def upstream_complete(self, index: int) -> bool | None:
         """Return whether blocks upstream from a given block index are already done.
@@ -432,12 +435,14 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
         Returns:
             True if all upstream blocks are done, False otherwise.
         """
-        for idx, block in enumerate(self.blocks):  # noqa: RET503
+        for idx, block in enumerate(self.blocks):
             if idx >= index:
                 return True
             if block.process_future.done():
                 continue
             return False
+
+        return None
 
     async def upstream_stop(self, index) -> None:  # noqa: ANN001
         """Stop all blocks upstream of a given index.

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -415,7 +415,8 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
                 raise BlockSetHasNoStateError
         return self._state_service
 
-    def index_last_input_done(self) -> int | None:
+    # TODO: This doesn't seem to be used anywhere. Remove?
+    def index_last_input_done(self) -> int | None:  # pragma: no cover
         """Return index of the block furthest from the start that has exited and required input.
 
         Returns:
@@ -425,7 +426,7 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
             (
                 idx
                 for idx, block in reversed(list(enumerate(self.blocks)))
-                if block.requires_input and block.proxy_stderr.done()
+                if block.consumer and block.proxy_stderr().done()
             ),
             None,
         )

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -430,7 +430,7 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
             None,
         )
 
-    def upstream_complete(self, index: int) -> bool | None:
+    def upstream_complete(self, index: int) -> bool:
         """Return whether blocks upstream from a given block index are already done.
 
         Args:
@@ -439,14 +439,7 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
         Returns:
             True if all upstream blocks are done, False otherwise.
         """
-        for idx, block in enumerate(self.blocks):
-            if idx >= index:
-                return True
-            if block.process_future.done():
-                continue
-            return False
-
-        return None
+        return all(block.process_future.done() for block in self.blocks[:index])
 
     async def upstream_stop(self, index) -> None:  # noqa: ANN001
         """Stop all blocks upstream of a given index.

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -421,10 +421,14 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
         Returns:
             The index of the block furthest from the start that has exited and required input.
         """  # noqa: E501
-        for idx, block in reversed(list(enumerate(self.blocks))):
-            if block.requires_input and block.proxy_stderr.done():
-                return idx
-        return None
+        return next(
+            (
+                idx
+                for idx, block in reversed(list(enumerate(self.blocks)))
+                if block.requires_input and block.proxy_stderr.done()
+            ),
+            None,
+        )
 
     def upstream_complete(self, index: int) -> bool | None:
         """Return whether blocks upstream from a given block index are already done.

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -96,18 +96,6 @@ class ELBContext:
 
         self.base_output_logger = base_output_logger
 
-    @property
-    def elt_run_dir(self) -> Path | None:
-        """Obtain the run directory for the current job.
-
-        Returns:
-            The run directory for the current job.
-        """
-        if self.job:
-            return self.project.job_dir(self.job.job_name, str(self.job.run_id))
-
-        return None
-
 
 class ELBContextBuilder:
     """Build up ELBContexts for ExtractLoadBlocks."""

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -116,17 +116,13 @@ class Job(SystemModel):
     id: Mapped[IntPK]
     job_name: Mapped[str]
     run_id: Mapped[GUIDType]
-    _state: Mapped[t.Optional[str]] = mapped_column(name="state")  # noqa: UP007
+    _state: Mapped[t.Optional[str]] = mapped_column(name="state")  # noqa: UP045
     started_at: Mapped[datetime] = mapped_column(DateTimeUTC)
-    last_heartbeat_at: Mapped[t.Optional[datetime]] = mapped_column(  # noqa: UP007
-        DateTimeUTC,
-    )
-    ended_at: Mapped[t.Optional[datetime]] = mapped_column(DateTimeUTC)  # noqa: UP007
+    last_heartbeat_at: Mapped[t.Optional[datetime]] = mapped_column(DateTimeUTC)  # noqa: UP045
+    ended_at: Mapped[t.Optional[datetime]] = mapped_column(DateTimeUTC)  # noqa: UP045
     payload: Mapped[dict] = mapped_column(MutableDict.as_mutable(JSONEncodedDict))
     payload_flags: Mapped[Payload] = mapped_column(IntFlag, default=0)
-    trigger: Mapped[t.Optional[str]] = mapped_column(  # noqa: UP007
-        default=current_trigger,
-    )
+    trigger: Mapped[t.Optional[str]] = mapped_column(default=current_trigger)  # noqa: UP045
 
     def __init__(self, **kwargs: t.Any) -> None:
         """Construct a Job.

--- a/src/meltano/core/job_state.py
+++ b/src/meltano/core/job_state.py
@@ -27,12 +27,10 @@ class JobState(SystemModel):
     __tablename__ = "state"
     state_id: Mapped[str] = mapped_column(unique=True, primary_key=True)
 
-    updated_at: Mapped[t.Optional[datetime]] = mapped_column(  # noqa: UP007
-        onupdate=datetime.now,
-    )
+    updated_at: Mapped[t.Optional[datetime]] = mapped_column(onupdate=datetime.now)  # noqa: UP045
 
-    partial_state: Mapped[t.Optional[StateType]]  # noqa: UP007
-    completed_state: Mapped[t.Optional[StateType]]  # noqa: UP007
+    partial_state: Mapped[t.Optional[StateType]]  # noqa: UP045
+    completed_state: Mapped[t.Optional[StateType]]  # noqa: UP045
 
     def __eq__(self, other: object) -> bool:
         """Check equality with another JobState.

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -124,7 +124,7 @@ def default_config(
         formatter_config = {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.processors.KeyValueRenderer(
-                key_order=["timestamp", "level", "event", "logger"]
+                key_order=["timestamp", "level", "event", "logger"],
             ),
             "foreign_pre_chain": LEVELED_TIMESTAMPED_PRE_CHAIN,
         }

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -254,7 +254,7 @@ class Manifest:
             for k, v in env.items()
         }
 
-    def env_aware_merge_mappings(
+    def env_aware_merge_mappings(  # noqa: RET503
         self,
         data: MutableMapping[str, t.Any],
         key: str,
@@ -274,7 +274,7 @@ class Manifest:
         """
         if key != "env":
             return NotImplemented
-        data[key] = self.sanitize_env_vars(  # noqa: RET503
+        data[key] = self.sanitize_env_vars(
             {
                 **expand_env_vars(
                     data[key],

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -266,6 +266,7 @@ class Variant(NameEq, Canonical):
     def __init__(
         self,
         name: str | None = None,
+        *,
         original: bool | None = None,
         deprecated: bool | None = None,
         docs: str | None = None,

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -495,5 +495,5 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
             `PluginType.MAPPERS`).
         """
         return self.type is PluginType.MAPPERS and bool(
-            self.extra_config.get("_mapping")
+            self.extra_config.get("_mapping"),
         )

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -64,7 +64,7 @@ class SingerPlugin(BasePlugin):  # noqa: D101
         return {
             "SINGER_SDK_LOG_CONFIG": str(plugin_invoker.files["singer_sdk_logging"]),
             "LOGGING_CONF_FILE": str(
-                plugin_invoker.files["pipelinewise_singer_logging"]
+                plugin_invoker.files["pipelinewise_singer_logging"],
             ),
         }
 

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -207,6 +207,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
     def find_plugin(
         self,
         plugin_name: str,
+        *,
         plugin_type: PluginType | None = None,
         invokable: bool | None = None,
         configurable: bool | None = None,
@@ -519,8 +520,8 @@ class ProjectPluginsService:  # (too many methods, attributes)
             try:
                 return (
                     self.find_plugin(
+                        plugin.inherit_from,
                         plugin_type=plugin.type,
-                        plugin_name=plugin.inherit_from,
                     ),
                     DefinitionSource.INHERITED,
                 )

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -204,7 +204,7 @@ class SingerRunner(Runner):  # noqa: D101
         if target_code:
             raise RunnerError("Loader failed", {PluginType.LOADERS: target_code})  # noqa: EM101
 
-    def dry_run(self, tap: PluginInvoker, target: PluginInvoker) -> t.NoReturn:  # noqa: D102
+    def dry_run(self, tap: PluginInvoker, target: PluginInvoker) -> None:  # noqa: D102
         logger.info("Dry run:")
         logger.info(f"\textractor: {tap.plugin.name} at '{tap.exec_path()}'")  # noqa: G004
         logger.info(f"\tloader: {target.plugin.name} at '{target.exec_path()}'")  # noqa: G004
@@ -215,7 +215,7 @@ class SingerRunner(Runner):  # noqa: D101
         loader_log=None,  # noqa: ANN001
         extractor_out=None,  # noqa: ANN001
         loader_out=None,  # noqa: ANN001
-    ) -> t.NoReturn:
+    ) -> None:
         tap = self.context.extractor_invoker()
         target = self.context.loader_invoker()
 

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -204,29 +204,30 @@ class SingerRunner(Runner):  # noqa: D101
         if target_code:
             raise RunnerError("Loader failed", {PluginType.LOADERS: target_code})  # noqa: EM101
 
-    def dry_run(self, tap: PluginInvoker, target: PluginInvoker) -> None:  # noqa: D102
+    def dry_run(self, tap: PluginInvoker, target: PluginInvoker) -> t.NoReturn:  # noqa: D102
         logger.info("Dry run:")
         logger.info(f"\textractor: {tap.plugin.name} at '{tap.exec_path()}'")  # noqa: G004
         logger.info(f"\tloader: {target.plugin.name} at '{target.exec_path()}'")  # noqa: G004
 
-    async def run(  # noqa: ANN201, D102
+    async def run(  # noqa: D102
         self,
         extractor_log=None,  # noqa: ANN001
         loader_log=None,  # noqa: ANN001
         extractor_out=None,  # noqa: ANN001
         loader_out=None,  # noqa: ANN001
-    ):
+    ) -> t.NoReturn:
         tap = self.context.extractor_invoker()
         target = self.context.loader_invoker()
 
         if self.context.dry_run:
-            return self.dry_run(tap, target)
+            self.dry_run(tap, target)
+            return
 
         async with (
             tap.prepared(self.context.session),
             target.prepared(self.context.session),
         ):
-            await self.invoke(  # noqa: RET503
+            await self.invoke(
                 tap,
                 target,
                 extractor_log=extractor_log,

--- a/src/meltano/core/select_service.py
+++ b/src/meltano/core/select_service.py
@@ -28,7 +28,7 @@ class SelectService:  # noqa: D101
         self.project = project
         self._extractor = self.project.plugins.find_plugin(
             extractor,
-            PluginType.EXTRACTORS,
+            plugin_type=PluginType.EXTRACTORS,
         )
 
     @property

--- a/src/meltano/core/setting.py
+++ b/src/meltano/core/setting.py
@@ -14,14 +14,14 @@ class Setting(SystemModel):  # noqa: D101
     __tablename__ = "plugin_settings"
 
     # represent the mapping to the ENV
-    label: Mapped[t.Optional[str]]  # noqa: UP007
-    description: Mapped[t.Optional[str]] = mapped_column(types.Text)  # noqa: UP007
+    label: Mapped[t.Optional[str]]  # noqa: UP045
+    description: Mapped[t.Optional[str]] = mapped_column(types.Text)  # noqa: UP045
 
     # represent a materialized path to support
     # a nested configuration.
     name: Mapped[StrPK]
-    namespace: Mapped[t.Optional[StrPK]]  # noqa: UP007
-    value: Mapped[t.Optional[str]] = mapped_column(types.PickleType)  # noqa: UP007
+    namespace: Mapped[t.Optional[StrPK]]  # noqa: RUF100, UP007, UP045
+    value: Mapped[t.Optional[str]] = mapped_column(types.PickleType)  # noqa: UP045
     enabled: Mapped[bool] = mapped_column(default=False)
 
     def __repr__(self) -> str:  # noqa: D105

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -205,6 +205,7 @@ class SettingsService(metaclass=ABCMeta):
 
     def config_with_metadata(
         self,
+        *,
         prefix: str | None = None,
         extras: bool | None = None,
         source: SettingValueStore = SettingValueStore.AUTO,
@@ -609,7 +610,7 @@ class SettingsService(metaclass=ABCMeta):
         self.log(f"Reset settings with metadata: {metadata}")
         return metadata
 
-    def definitions(self, extras: bool | None = None) -> Iterable[SettingDefinition]:
+    def definitions(self, *, extras: bool | None = None) -> Iterable[SettingDefinition]:
         """Return setting definitions along with extras.
 
         Args:

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -239,8 +239,8 @@ class Tracker:  # - too many (public) methods
             # Project ID has changed
             self.track_telemetry_state_change_event(
                 "project_id",
-                stored_telemetry_settings.project_id,
-                self.project_id,
+                from_value=stored_telemetry_settings.project_id,
+                to_value=self.project_id,
             )
 
         if (
@@ -251,8 +251,8 @@ class Tracker:  # - too many (public) methods
             # Telemetry state has changed
             self.track_telemetry_state_change_event(
                 "send_anonymous_usage_stats",
-                stored_telemetry_settings.send_anonymous_usage_stats,
-                self.send_anonymous_usage_stats,
+                from_value=stored_telemetry_settings.send_anonymous_usage_stats,
+                to_value=self.send_anonymous_usage_stats,
             )
 
     @cached_property
@@ -348,6 +348,7 @@ class Tracker:  # - too many (public) methods
     def track_telemetry_state_change_event(
         self,
         setting_name: str,
+        *,
         from_value: uuid.UUID | str | bool | None,
         to_value: uuid.UUID | str | bool | None,
     ) -> None:

--- a/src/meltano/migrations/versions/23ea52e6d784_add_resource_type_to_embed_token.py
+++ b/src/meltano/migrations/versions/23ea52e6d784_add_resource_type_to_embed_token.py
@@ -31,7 +31,8 @@ def upgrade() -> None:
     max_string_length = max_string_length_for_dialect(dialect_name)
 
     op.add_column(
-        "embed_tokens", sa.Column("resource_type", sa.String(max_string_length))
+        "embed_tokens",
+        sa.Column("resource_type", sa.String(max_string_length)),
     )
 
     metadata = sa.MetaData()

--- a/src/meltano/migrations/versions/6828cc5b1a4f_create_dedicated_state_table.py
+++ b/src/meltano/migrations/versions/6828cc5b1a4f_create_dedicated_state_table.py
@@ -51,7 +51,9 @@ class JobState(SystemModel):
     state_id = Column(types.String, unique=True, primary_key=True, nullable=False)
 
     updated_at = Column(
-        types.TIMESTAMP, server_default=func.now(), onupdate=func.current_timestamp()
+        types.TIMESTAMP,
+        server_default=func.now(),
+        onupdate=func.current_timestamp(),
     )
 
     partial_state = Column(MutableDict.as_mutable(JSONEncodedDict))
@@ -86,7 +88,9 @@ class JobState(SystemModel):
         # completed job. If there are no completed jobs, get the full history of
         # incomplete jobs and use the most recent state emitted per stream
         incomplete_state_jobs = finder.with_payload(
-            session, flags=Payload.INCOMPLETE_STATE, since=incomplete_since
+            session,
+            flags=Payload.INCOMPLETE_STATE,
+            since=incomplete_since,
         )
         for incomplete_state_job in incomplete_state_jobs:
             if "singer_state" in incomplete_state_job.payload:
@@ -138,7 +142,7 @@ class JobFinder:
         return session.query(Job).filter(
             (Job.job_name == self.state_id)
             & (Job.state == State.SUCCESS)
-            & Job.ended_at.isnot(None)
+            & Job.ended_at.isnot(None),
         )
 
     def running(self, session):  # noqa: ANN001, ANN201
@@ -151,7 +155,7 @@ class JobFinder:
             All runnings states for state_id.
         """
         return session.query(Job).filter(
-            (Job.job_name == self.state_id) & (Job.state == State.RUNNING)
+            (Job.job_name == self.state_id) & (Job.state == State.RUNNING),
         )
 
     def latest_success(self, session):  # noqa: ANN001, ANN201
@@ -194,7 +198,7 @@ class JobFinder:
                 (Job.job_name == self.state_id)
                 & (Job.payload_flags != 0)
                 & (Job.payload_flags.op("&")(flags) == flags)
-                & Job.ended_at.isnot(None)
+                & Job.ended_at.isnot(None),
             )
             .order_by(Job.ended_at.asc())
         )
@@ -247,7 +251,7 @@ class JobFinder:
                     Job.last_heartbeat_at.is_(None)
                     & (Job.started_at < last_valid_started_at)
                 )
-            )
+            ),
         )
 
     def stale(self, session):  # noqa: ANN001, ANN201

--- a/src/meltano/migrations/versions/990c0665f3ce_ensure_user_login_count_default_value.py
+++ b/src/meltano/migrations/versions/990c0665f3ce_ensure_user_login_count_default_value.py
@@ -25,7 +25,7 @@ def upgrade() -> None:
     connection = op.get_bind()
 
     connection.execute(
-        user.update().where(user.c.login_count is None).values({"login_count": 0})
+        user.update().where(user.c.login_count is None).values({"login_count": 0}),
     )
 
 

--- a/src/meltano/migrations/versions/b4c05e463b53_.py
+++ b/src/meltano/migrations/versions/b4c05e463b53_.py
@@ -50,7 +50,8 @@ def upgrade() -> None:
         sa.Column("started_at", datetime_type),
         sa.Column("ended_at", datetime_type),
         sa.Column(
-            "payload", MutableDict.as_mutable(JSONEncodedDict(max_string_length))
+            "payload",
+            MutableDict.as_mutable(JSONEncodedDict(max_string_length)),
         ),
         sa.Column("payload_flags", IntFlag, default=0),
     )

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -79,7 +79,10 @@ class TestCliAdd:
                 assert res.exit_code == 0, res.stdout
                 assert f"Added {plugin_type.descriptor} '{plugin_name}'" in res.stdout
 
-                plugin = project.plugins.find_plugin(plugin_name, plugin_type)
+                plugin = project.plugins.find_plugin(
+                    plugin_name,
+                    plugin_type=plugin_type,
+                )
                 assert plugin
                 assert plugin.variant == default_variant
 
@@ -130,17 +133,17 @@ class TestCliAdd:
 
             tap_gitlab = project.plugins.find_plugin(
                 "tap-gitlab",
-                PluginType.EXTRACTORS,
+                plugin_type=PluginType.EXTRACTORS,
             )
             assert tap_gitlab
             tap_adwords = project.plugins.find_plugin(
                 "tap-adwords",
-                PluginType.EXTRACTORS,
+                plugin_type=PluginType.EXTRACTORS,
             )
             assert tap_adwords
             tap_facebook = project.plugins.find_plugin(
                 "tap-facebook",
-                PluginType.EXTRACTORS,
+                plugin_type=PluginType.EXTRACTORS,
             )
             assert tap_facebook
 
@@ -213,7 +216,10 @@ class TestCliAdd:
         assert_cli_runner(result)
 
         # Plugin has been added to meltano.yml
-        plugin = project.plugins.find_plugin("airflow", PluginType.FILES)
+        plugin = project.plugins.find_plugin(
+            "airflow",
+            plugin_type=PluginType.FILES,
+        )
         assert plugin
 
         # Automatic updating is enabled
@@ -239,7 +245,10 @@ class TestCliAdd:
 
         # Plugin has not been added to meltano.yml
         with pytest.raises(PluginNotFoundError):
-            project.plugins.find_plugin("docker-compose", PluginType.FILES)
+            project.plugins.find_plugin(
+                "docker-compose",
+                plugin_type=PluginType.FILES,
+            )
 
         # File has been created
         assert "Created docker-compose.yml" in output
@@ -278,7 +287,10 @@ class TestCliAdd:
 
         # ensure the plugin is not present
         with pytest.raises(PluginNotFoundError):
-            project.plugins.find_plugin("tap-unknown", PluginType.EXTRACTORS)
+            project.plugins.find_plugin(
+                "tap-unknown",
+                plugin_type=PluginType.EXTRACTORS,
+            )
 
     @pytest.mark.xfail(reason="Uninstall not implemented yet.")
     def test_add_fails(self, project: Project, cli_runner) -> None:
@@ -291,7 +303,10 @@ class TestCliAdd:
 
         # ensure the plugin is not present
         with pytest.raises(PluginNotFoundError):
-            project.plugins.find_plugin("tap-mock", PluginType.EXTRACTORS)
+            project.plugins.find_plugin(
+                "tap-mock",
+                plugin_type=PluginType.EXTRACTORS,
+            )
 
     def test_add_variant(self, project: Project, cli_runner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
@@ -309,8 +324,8 @@ class TestCliAdd:
             assert_cli_runner(res)
 
             plugin = project.plugins.find_plugin(
+                "mapper-mock",
                 plugin_type=PluginType.MAPPERS,
-                plugin_name="mapper-mock",
             )
             assert plugin.variant == "alternative"
 
@@ -539,7 +554,7 @@ class TestCliAdd:
                         os.linesep,  # default executable
                         os.linesep,  # default capabilities
                         os.linesep,  # default settings
-                    ]
+                    ],
                 ),
             )
             assert_cli_runner(res)
@@ -607,7 +622,10 @@ class TestCliAdd:
                 assert res.exit_code == 0, res.stdout
                 assert f"Added {plugin_type.descriptor} '{plugin_name}'" in res.stdout
 
-                plugin = project.plugins.find_plugin(plugin_name, plugin_type)
+                plugin = project.plugins.find_plugin(
+                    plugin_name,
+                    plugin_type=plugin_type,
+                )
                 assert plugin
                 assert plugin.variant == default_variant
 
@@ -687,7 +705,10 @@ class TestCliAdd:
 
         assert f"Added {plugin_type.singular} '{plugin_name}'" in res.output
 
-        plugin = project.plugins.find_plugin(plugin_name, plugin_type)
+        plugin = project.plugins.find_plugin(
+            plugin_name,
+            plugin_type=plugin_type,
+        )
         assert plugin.name == plugin_name
         assert plugin.variant == "test"
 
@@ -811,7 +832,7 @@ class TestCliAdd:
             )
             tap_gitlab = project.plugins.find_plugin(
                 "tap-gitlab",
-                PluginType.EXTRACTORS,
+                plugin_type=PluginType.EXTRACTORS,
             )
 
         assert_cli_runner(res)

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -150,10 +150,12 @@ class EventMatcher:
         Returns:
             True if the event was found, False otherwise.
         """
-        for line in self.seen_events:  # noqa: RET503
+        for line in self.seen_events:
             matches = line["event"] == event
             if matches:
                 return True
+
+        return False
 
     def find_by_event(self, event: str) -> list[dict] | None:
         """Return the first matching event, that matches the given event.

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -73,17 +73,6 @@ def elb_context(project, session, test_job, output_logger) -> ELBContext:
     return ctx
 
 
-class TestELBContext:
-    def test_elt_run_dir_is_returned(
-        self,
-        project,
-        test_job,
-        elb_context: ELBContext,
-    ) -> None:
-        expected_path = project.job_dir(test_job.job_name, str(test_job.run_id))
-        assert elb_context.elt_run_dir == Path(expected_path)
-
-
 class TestELBContextBuilder:
     @pytest.fixture
     def target_postgres(self, project_add_service):

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -23,7 +23,8 @@ if t.TYPE_CHECKING:
 
 ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 ExcInfo: TypeAlias = t.Union[
-    tuple[type[BaseException], BaseException, TracebackType], tuple[None, None, None]
+    tuple[type[BaseException], BaseException, TracebackType],
+    tuple[None, None, None],
 ]
 
 

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -999,7 +999,7 @@ class TestSingerTap:
                 return_value=False,
             ),
             mock.patch(
-                "meltano.core.plugin.singer.tap._stream_redirect"
+                "meltano.core.plugin.singer.tap._stream_redirect",
             ) as stream_mock,
         ):
             await subject.run_discovery(invoker, catalog_path)

--- a/tests/meltano/core/plugin/test_airflow.py
+++ b/tests/meltano/core/plugin/test_airflow.py
@@ -59,7 +59,7 @@ class TestAirflow:
                 writer.seek(0)
 
                 handle_mock.communicate = AsyncMock(
-                    return_value=(writer.read().encode(), None)
+                    return_value=(writer.read().encode(), None),
                 )
             # check version
             elif "version" in popen_args:

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -252,7 +252,7 @@ class TestLocalFilesystemStateStoreManager:
                         {
                             "partial": expected_state,
                             "completed": expected_state,
-                        }
+                        },
                     ),
                 ) == MeltanoState.from_file(state_id, state_file)
 
@@ -506,7 +506,7 @@ class TestS3StateStoreManager:
                     MeltanoState(
                         state_id=state_id,
                         completed_state={},
-                    )
+                    ),
                 )
 
             exc = exc_info.value
@@ -529,7 +529,7 @@ class TestS3StateStoreManager:
                     MeltanoState(
                         state_id="state-id",
                         completed_state={},
-                    )
+                    ),
                 )
 
             assert exc_info.value.response["Error"]["Code"] == "NoSuchBucket"

--- a/tests/meltano/core/tracking/test_environment_context.py
+++ b/tests/meltano/core/tracking/test_environment_context.py
@@ -16,7 +16,7 @@ def test_notable_flag_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert EnvironmentContext().data["notable_flag_env_vars"] == {}
 
-    def check(env_var_values: tuple[str, ...], expected: bool | None) -> None:
+    def check(env_var_values: tuple[str, ...], *, expected: bool | None) -> None:
         for notable_flag_env_var in EnvironmentContext.notable_flag_env_vars:
             monkeypatch.setenv(
                 notable_flag_env_var,

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -341,8 +341,8 @@ class TestTracker:
 
         tracker.track_telemetry_state_change_event(
             "project_id",
-            uuid.uuid4(),
-            uuid.uuid4(),
+            from_value=uuid.uuid4(),
+            to_value=uuid.uuid4(),
         )
         assert passed
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Bump Ruff to v0.12.0 and reformat the codebase to comply with updated lint rules, including style cleanups, removal of unused code, and adjustments to tests and SQLAlchemy mappings.

Enhancements:
- Remove the unused `elt_run_dir` property and its tests from the ExtractLoad block
- Refactor `index_last_input_done` and `upstream_complete` with generator expressions and comprehensions

Build:
- Update pre-commit config to use ruff@0.12.0

CI:
- Change Ruff hook ID to `ruff-check` in .pre-commit-config.yaml

Tests:
- Adjust tests for trailing commas, keyword-only parameters, explicit return values, and updated function signatures to satisfy new lint rules

Chores:
- Add and normalize trailing commas, enforce keyword-only arguments, update or remove deprecated `# noqa` codes, and tweak mapped_column definitions throughout the codebase