### PR TITLE
chore: Enable Ruff `LOG` rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,6 +348,7 @@ select = [
   "ICN",   # flake8-import-conventions
   "INP",   # flake8-no-pep420
   "ISC",   # flake8-implicit-str-concat
+  "LOG",   # flake8-logging
   "N",     # pep8-naming
   "PERF",  # Perflint
   "PGH",   # pygrep-hooks
@@ -379,8 +380,9 @@ unfixable = [
 "tests/**" = [
   "ANN",
   "D1",
-  "S101", # Allow 'assert' in tests
-  "INP",  # Don't require __init__.py files in tests directories
+  "S101",    # Allow 'assert' in tests
+  "INP",     # Don't require __init__.py files in tests directories
+  "LOG015",  # Allow `logging.<level>` in tests
 ]
 "src/meltano/migrations/versions/*" = [
   "D103",
@@ -412,15 +414,6 @@ convention = "google"
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "logging.getLogger".msg = "Use `structlog.stdlib.get_logger` instead"
-"logging.critical".msg = "Create a logger with `structlog.stdlib.get_logger`"
-"logging.fatal".msg = "Create a logger with `structlog.stdlib.get_logger`"
-"logging.error".msg = "Create a logger with `structlog.stdlib.get_logger`"
-"logging.exception".msg = "Create a logger with `structlog.stdlib.get_logger`"
-"logging.warning".msg = "Create a logger with `structlog.stdlib.get_logger`"
-"logging.warn".msg = "Create a logger with `structlog.stdlib.get_logger`"
-"logging.info".msg = "Create a logger with `structlog.stdlib.get_logger`"
-"logging.debug".msg = "Create a logger with `structlog.stdlib.get_logger`"
-"logging.log".msg = "Create a logger with `structlog.stdlib.get_logger`"
 "meltano.cli.cli.command".msg = "Use `click.command` and `meltano.cli.cli.add_command` instead"
 "meltano.cli.cli.group".msg = "Use `click.group` and `meltano.cli.cli.add_command` instead"
 

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -58,7 +58,7 @@ class CliError(Exception):
         if self.printed:
             return
 
-        logger.debug(str(self), exc_info=True)
+        logger.error(str(self), exc_info=self)
         click.secho(str(self), fg="red", err=True)
 
         self.printed = True

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -2084,7 +2084,7 @@ def job_logging_service(project):
 @contextmanager
 def project_directory(project_init_service):
     project = project_init_service.init()
-    logging.debug(f"Created new project at {project.root}")  # noqa: G004, TID251
+    logging.debug(f"Created new project at {project.root}")  # noqa: G004
 
     # empty out the `plugins`
     with project.meltano_update() as meltano:
@@ -2099,7 +2099,7 @@ def project_directory(project_init_service):
         yield project
     finally:
         Project.deactivate()
-        logging.debug(f"Cleaned project at {project.root}")  # noqa: G004, TID251
+        logging.debug(f"Cleaned project at {project.root}")  # noqa: G004
 
 
 @pytest.fixture(scope="class")

--- a/tests/fixtures/db/__init__.py
+++ b/tests/fixtures/db/__init__.py
@@ -44,7 +44,7 @@ def vacuum_db(engine_sessionmaker):
     try:
         yield
     finally:
-        logging.debug("Cleaning system database...")  # noqa: TID251
+        logging.debug("Cleaning system database...")
         engine, _ = engine_sessionmaker
         close_all_sessions()
         metadata = MetaData()

--- a/tests/fixtures/db/mssql.py
+++ b/tests/fixtures/db/mssql.py
@@ -91,4 +91,4 @@ def pg_stats(request, session):
     from meltano.core.job import Job
 
     jobs = session.query(Job).all()
-    logging.info("%s created %d Job.", request.node.name, len(jobs))  # noqa: TID251
+    logging.info("%s created %d Job.", request.node.name, len(jobs))

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -33,7 +33,7 @@ def tmp_project(
 ) -> Generator[Project, None, None]:
     project_init_service = ProjectInitService(name)
     blank_project = project_init_service.init()
-    logging.debug(f"Created new project at {blank_project.root}")  # noqa: G004, TID251
+    logging.debug(f"Created new project at {blank_project.root}")  # noqa: G004
     blank_project.meltanofile.unlink()
     compatible_copy_tree(source, blank_project.root)
     Project._default = None
@@ -44,4 +44,4 @@ def tmp_project(
             yield project
         finally:
             Project.deactivate()
-            logging.debug(f"Cleaned project at {project.root}")  # noqa: G004, TID251
+            logging.debug(f"Cleaned project at {project.root}")  # noqa: G004

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -217,9 +217,9 @@ class TestOutputLogger:
             ),
             logging_out.redirect_logging(),
         ):
-            logging.info("info")  # noqa: TID251
-            logging.warning("warning")  # noqa: TID251
-            logging.error("error")  # noqa: TID251
+            logging.info("info")
+            logging.warning("warning")
+            logging.error("error")
 
         async with await anyio.open_file(subject.file) as logf:
             log_file_contents = [json.loads(line) for line in await logf.readlines()]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enable Ruff flake8-logging rules, adjust lint configuration, remove manual logging suppressions, and correct CLI error logging severity.

Bug Fixes:
- Log CLI errors at the error level with proper exc_info context instead of debug.

Enhancements:
- Enable Ruff’s LOG rule in the lint configuration and whitelist LOG015 in test directories.
- Remove explicit flake8-tidy-imports bans for logging.<level> calls to defer to Ruff.

Build:
- Add "LOG" to Ruff’s selected rule sets in pyproject.toml.

Tests:
- Remove redundant noqa suppressions for logging calls across tests and fixtures.