### PR TITLE
packaging: Remove urllib3<2 constraint for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,6 @@ dependencies = [
   "structlog>=25.1.0,<26",
   "typing-extensions>=4.12.2,<5",
   "tzlocal~=5.3",
-  # Compatibility issues with boto: https://github.com/boto/botocore/pull/3034
-  "urllib3<2 ; python_version < '3.10'",
   "uv>=0.1.24,<0.8",
   "virtualenv>=20.26.6,<21",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1335,7 +1335,6 @@ dependencies = [
     { name = "structlog" },
     { name = "typing-extensions" },
     { name = "tzlocal" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "uv" },
     { name = "virtualenv" },
 ]
@@ -1466,7 +1465,6 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.1.0,<26" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5" },
     { name = "tzlocal", specifier = "~=5.3" },
-    { name = "urllib3", marker = "python_full_version < '3.10'", specifier = "<2" },
     { name = "uv", specifier = ">=0.1.24,<0.8" },
     { name = "virtualenv", specifier = ">=20.26.6,<21" },
 ]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Remove the conditional urllib3<2 version constraint for Python<3.10 in the project’s dependencies and update the lockfile accordingly.

Build:
- Remove the urllib3<2 ; python_version<'3.10' constraint from pyproject.toml
- Regenerate uv.lock to reflect the updated dependencies