### PR TITLE
feat(core): Support emitting logs with timestamps in local time

### DIFF
--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -33,6 +33,8 @@ A few key points to note:
    - `meltano.core.logging.json_log_formatter` - A formatter that renders lines in JSON format.
    - `meltano.core.logging.key_value` - A formatter that renders lines in key=value format.
    - `meltano.core.logging.plain_formatter` - A formatter that renders lines in a plain text format.
+
+   All formatters support a `utc` parameter (defaults to `True`) that controls whether timestamps are rendered in UTC or local time.
 2. Different loggers can use different handlers and log at different log levels.
 3. We support all the [standard python logging handlers](https://docs.python.org/3/library/logging.handlers.html#) (e.g. rotating files, syslog, etc).
 4. If a logging config file is found, it will take precedence over the `--log-format` and `--log-level` CLI options.
@@ -57,6 +59,7 @@ formatters:
     (): meltano.core.logging.console_log_formatter
     colors: true # also enables traceback formatting with `rich`
     show_locals: true # enables local variable logging in tracebacks (can be very verbose and leak sensitive data)
+    utc: false # use local time instead of UTC for timestamps
   key_value: # log format for traditional key=value style logs
     (): meltano.core.logging.key_value_formatter
     sort_keys: false

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -117,6 +117,7 @@ def rich_exception_formatter_factory(
 
 def _process_formatter(
     *processors: Processor,
+    utc: bool = True,
     **kwargs: t.Any,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Use _process_formatter to configure a structlog.stdlib.ProcessFormatter.
@@ -127,6 +128,7 @@ def _process_formatter(
     Args:
         *processors: One or more structlog message processors such as
             `structlog.dev.ConsoleRenderer`.
+        utc: Whether to use UTC time for timestamps.
         **kwargs: Additional keyword arguments to pass to the logging.Formatter
             constructor.
 
@@ -135,7 +137,10 @@ def _process_formatter(
     """
     return structlog.stdlib.ProcessorFormatter(
         processors=processors,
-        foreign_pre_chain=LEVELED_TIMESTAMPED_PRE_CHAIN,
+        foreign_pre_chain=(
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=utc),
+        ),
         **kwargs,
     )
 
@@ -145,6 +150,7 @@ def console_log_formatter(
     colors: bool = False,
     callsite_parameters: bool = False,
     show_locals: bool = False,
+    utc: bool = True,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter for console rendering that supports colorization.
 
@@ -152,6 +158,7 @@ def console_log_formatter(
         colors: Add color to output.
         callsite_parameters: Whether to include callsite parameters in the output.
         show_locals: Whether to show local variables in the traceback.
+        utc: Whether to use UTC time for timestamps.
 
     Returns:
         A configured console log formatter.
@@ -176,6 +183,7 @@ def console_log_formatter(
             colors=colors,
             exception_formatter=exception_formatter,
         ),
+        utc=utc,
     )
 
 
@@ -185,6 +193,7 @@ def key_value_formatter(
     key_order: Sequence[str] | None = None,
     drop_missing: bool = False,
     callsite_parameters: bool = False,
+    utc: bool = True,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter that renders lines in key=value format.
 
@@ -196,6 +205,7 @@ def key_value_formatter(
         drop_missing: When True, extra keys in *key_order* will be dropped
             rather than rendered as None.
         callsite_parameters: Whether to include callsite parameters in the output.
+        utc: Whether to use UTC time for timestamps.
 
     Returns:
         A configured key=value formatter.
@@ -208,6 +218,7 @@ def key_value_formatter(
             key_order=key_order,
             drop_missing=drop_missing,
         ),
+        utc=utc,
     )
 
 
@@ -216,6 +227,7 @@ def json_formatter(
     callsite_parameters: bool = False,
     dict_tracebacks: bool = True,
     show_locals: bool = False,
+    utc: bool = True,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter that renders lines in JSON format.
 
@@ -223,6 +235,7 @@ def json_formatter(
         callsite_parameters: Whether to include callsite parameters in the JSON output.
         dict_tracebacks: Whether to include tracebacks in the JSON output.
         show_locals: Whether to include local variables in the traceback.
+        utc: Whether to use UTC time for timestamps.
 
     Returns:
         A configured JSON formatter.
@@ -235,6 +248,7 @@ def json_formatter(
         ),
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         structlog.processors.JSONRenderer(),
+        utc=utc,
     )
 
 
@@ -262,6 +276,7 @@ def plain_formatter(
     datefmt: str | None = None,
     style: str = "%",
     validate: bool = True,
+    utc: bool = True,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter that renders lines in a simple format.
 
@@ -270,7 +285,7 @@ def plain_formatter(
         datefmt: The date format string.
         style: The format style.
         validate: Whether to validate the format string.
-        features: Logging features to enable.
+        utc: Whether to use UTC time for timestamps.
 
     Returns:
         A configured simple formatter.
@@ -284,6 +299,7 @@ def plain_formatter(
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
         _event_renderer,
+        utc=utc,
         fmt=fmt,
         datefmt=datefmt,
         style=style,

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -136,6 +136,19 @@ class TestLogFormatters:
 
         assert "exception" not in message_dict
 
+    def test_json_formatter_utc(self, record_with_exception) -> None:
+        formatter = formatters.json_formatter(utc=True)
+        output = formatter.format(record_with_exception)
+        message_dict = json.loads(output)
+        assert "timestamp" in message_dict
+        assert message_dict["timestamp"].endswith("Z")
+
+        formatter = formatters.json_formatter(utc=False)
+        output = formatter.format(record_with_exception)
+        message_dict = json.loads(output)
+        assert "timestamp" in message_dict
+        assert not message_dict["timestamp"].endswith("Z")
+
     def test_json_formatter_locals(self, record_with_exception) -> None:
         formatter = formatters.json_formatter(show_locals=True)
         output = formatter.format(record_with_exception)


### PR DESCRIPTION
Closes https://github.com/meltano/meltano/issues/9327.

## Summary
• Add `utc` parameter to all logging formatters to control timestamp format
• When `utc=False`, timestamps are rendered in local time instead of UTC
• Update documentation to reflect the new parameter
• Add tests to verify UTC/local time behavior

## Test plan
- [x] Run existing test suite to ensure no regressions
- [x] Add new test to verify UTC vs local time timestamp behavior
- [x] Update documentation with usage examples

## Summary by Sourcery

Support toggling timestamp output between UTC and local time across all logging formatters by introducing a new `utc` parameter.

New Features:
- Add `utc` parameter to console, key-value, JSON, and plain-text log formatters to control timestamp timezone

Documentation:
- Update the logging guide to document the `utc` parameter and show its usage in configuration examples

Tests:
- Add tests to verify log timestamps end with 'Z' when `utc=True` and use local time when `utc=False`