### PR TITLE
feat(cli): New `--state-strategy` CLI option to control the behavior of state updates in `run` and `el`/`elt` commands

### DIFF
--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -605,7 +605,7 @@ meltano el <extractor> <loader> [--state-id TEXT]
 
 - A `--merge-state` flag can be passed to merge state with that of previous runs. **DEPRECATED**: Use `--state-strategy=merge` instead.
 
-- A `--state-strategy` option can be passed to control how state is merged with that of previous runs. Valid values are `merge` and `overwrite`.
+- A `--state-strategy` option can be passed to control how state is merged with that of previous runs. Valid values are `auto`, `merge`, and `overwrite`. The default is `auto`.
 
 - One or more `--select <entity>` options can be passed to only extract records for matching [selected entities](#select).
   Similarly, `--exclude <entity>` can be used to extract records for all selected entities _except_ for those specified.
@@ -1081,6 +1081,7 @@ meltano run --refresh-catalog tap-salesforce target-postgres
 - `--force` will force a job run even if a conflicting job with the same generated ID is in progress.
 - `--state-id-suffix` define a custom suffix to generate a state ID with for each EL pair.
 - `--merge-state` will merge state with that of previous runs. See the [example in the Meltano repository](https://github.com/meltano/meltano/blob/main/integration/example-library/meltano-run-merge-states/index.md).
+- `--state-strategy` will control how state is merged with that of previous runs. Valid values are `auto`, `merge`, and `overwrite`. The default is `auto`.
 - `--run-id` will use the provided UUID for the current run. This is useful when your workflow is managed by an external system and you want to track the run in Meltano.
 - `--refresh-catalog` will force a refresh of the catalog, ignoring any existing cached catalog from previous runs.
 - The `--install/--no-install/--only-install` switch controls auto-install behavior. See the [Auto-install behavior](#auto-install-behavior) section for more information.

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -606,7 +606,11 @@ meltano el <extractor> <loader> [--state-id TEXT]
 - One or more `--select <entity>` options can be passed to only extract records for matching [selected entities](#select).
   Similarly, `--exclude <entity>` can be used to extract records for all selected entities _except_ for those specified.
 
-- A `--merge-state` flag can be passed to merge state with that of previous runs.
+- A `--merge-state` flag can be passed to merge state with that of previous runs. DEPRECATED: Use `--state-strategy=merge` instead.
+
+- A `--state-strategy` option can be passed to control how state is merged with that of previous runs. Valid values are `merge` and `overwrite`.
+  This is equivalent to setting the [`state_strategy` extractor extra](/concepts/plugins#state-strategy-extra).
+  The default is `overwrite`.
 
   Notes:
 

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -603,14 +603,12 @@ meltano el <extractor> <loader> [--state-id TEXT]
 - A `--state` option can be passed to manually provide a [state file](https://hub.meltano.com/singer/spec#state-files) for the extractor, as an alternative to letting state be [looked up based on the State ID](/guide/integration#incremental-replication-state).
   This is equivalent to setting the [`state` extractor extra](/concepts/plugins#state-extra).
 
-- One or more `--select <entity>` options can be passed to only extract records for matching [selected entities](#select).
-  Similarly, `--exclude <entity>` can be used to extract records for all selected entities _except_ for those specified.
-
-- A `--merge-state` flag can be passed to merge state with that of previous runs. DEPRECATED: Use `--state-strategy=merge` instead.
+- A `--merge-state` flag can be passed to merge state with that of previous runs. **DEPRECATED**: Use `--state-strategy=merge` instead.
 
 - A `--state-strategy` option can be passed to control how state is merged with that of previous runs. Valid values are `merge` and `overwrite`.
-  This is equivalent to setting the [`state_strategy` extractor extra](/concepts/plugins#state-strategy-extra).
-  The default is `overwrite`.
+
+- One or more `--select <entity>` options can be passed to only extract records for matching [selected entities](#select).
+  Similarly, `--exclude <entity>` can be used to extract records for all selected entities _except_ for those specified.
 
   Notes:
 

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -603,9 +603,9 @@ meltano el <extractor> <loader> [--state-id TEXT]
 - A `--state` option can be passed to manually provide a [state file](https://hub.meltano.com/singer/spec#state-files) for the extractor, as an alternative to letting state be [looked up based on the State ID](/guide/integration#incremental-replication-state).
   This is equivalent to setting the [`state` extractor extra](/concepts/plugins#state-extra).
 
-- A `--merge-state` flag can be passed to merge state with that of previous runs. **DEPRECATED**: Use `--state-strategy=merge` instead.
-
 - A `--state-strategy` option can be passed to control how state is merged with that of previous runs. Valid values are `auto`, `merge`, and `overwrite`. The default is `auto`.
+
+- A `--merge-state` flag can be passed to merge state with that of previous runs. **DEPRECATED**: Use `--state-strategy=merge` instead.
 
 - One or more `--select <entity>` options can be passed to only extract records for matching [selected entities](#select).
   Similarly, `--exclude <entity>` can be used to extract records for all selected entities _except_ for those specified.
@@ -1080,8 +1080,8 @@ meltano run --refresh-catalog tap-salesforce target-postgres
 - `--full-refresh` will force a full refresh and ignore the prior state. The new state after completion will still be updated with the execution results, unless `--no-state-update` is also specified. The `MELTANO_RUN_FULL_REFRESH` environment variable can be used to set this behavior.
 - `--force` will force a job run even if a conflicting job with the same generated ID is in progress.
 - `--state-id-suffix` define a custom suffix to generate a state ID with for each EL pair.
-- `--merge-state` will merge state with that of previous runs. See the [example in the Meltano repository](https://github.com/meltano/meltano/blob/main/integration/example-library/meltano-run-merge-states/index.md).
-- `--state-strategy` will control how state is merged with that of previous runs. Valid values are `auto`, `merge`, and `overwrite`. The default is `auto`.
+- `--state-strategy` will control how state is merged with that of previous runs. Valid values are `auto`, `merge`, and `overwrite`. The default is `auto`. See the [example in the Meltano repository](https://github.com/meltano/meltano/blob/main/integration/example-library/meltano-run-merge-states/index.md).
+- `--merge-state` will merge state with that of previous runs. **Deprecated**: use `--state-strategy` instead.
 - `--run-id` will use the provided UUID for the current run. This is useful when your workflow is managed by an external system and you want to track the run in Meltano.
 - `--refresh-catalog` will force a refresh of the catalog, ignoring any existing cached catalog from previous runs.
 - The `--install/--no-install/--only-install` switch controls auto-install behavior. See the [Auto-install behavior](#auto-install-behavior) section for more information.
@@ -1105,7 +1105,7 @@ meltano --environment=dev run --force tap-gitlab target-postgres tap-salesforce 
 meltano --environment=dev --state-id-suffix pipeline-alias run tap-gitlab hide-secrets target-postgres
 
 # run a pipeline, merging state with that of previous runs.
-meltano --environment=dev run --merge-state tap-gitlab target-postgres
+meltano --environment=dev run --state-strategy=merge tap-gitlab target-postgres
 ```
 
 ### Using `run` with Environments

--- a/integration/example-library/meltano-run-merge-states/index.md
+++ b/integration/example-library/meltano-run-merge-states/index.md
@@ -59,7 +59,7 @@ meltano run tap-with-state target-jsonl --state-id-suffix=merge
 Run a 'full refresh' pipeline of a single stream, but merge the current pipelines state with the latest stored state.
 
 ```shell
-TAP_WITH_STATE_TS='2023-01-01T01:00:00+00:00' \
+TAP_WITH_STATE_TS='2024-01-01T00:00:00+00:00' \
 TAP_WITH_STATE__SELECT_FILTER='["stream_1"]' \
 meltano run tap-with-state target-jsonl --full-refresh --state-id-suffix=merge --state-strategy=merge
 ```
@@ -75,7 +75,7 @@ meltano --environment=dev state get dev:tap-with-state-to-target-jsonl:merge
   "singer_state": {
     "bookmarks": {
       "stream_1": {
-        "created_at": "2023-01-01T01:00:00+00:00"
+        "created_at": "2024-01-01T00:00:00+00:00"
       },
       "stream_2": {
         "created_at": "2023-01-01T00:00:00+00:00"

--- a/integration/example-library/meltano-run-merge-states/index.md
+++ b/integration/example-library/meltano-run-merge-states/index.md
@@ -24,7 +24,7 @@ Run a 'full refresh' pipeline of a single stream.
 ```shell
 TAP_WITH_STATE_TS='2023-01-01T01:00:00+00:00' \
 TAP_WITH_STATE__SELECT_FILTER='["stream_1"]' \
-meltano run tap-with-state target-jsonl --full-refresh --state-id-suffix=no-merge
+meltano run tap-with-state target-jsonl --full-refresh --state-id-suffix=no-merge --state-strategy=overwrite
 ```
 
 Note that the state will only contain the bookmark for `stream_1`.
@@ -61,7 +61,7 @@ Run a 'full refresh' pipeline of a single stream, but merge the current pipeline
 ```shell
 TAP_WITH_STATE_TS='2023-01-01T01:00:00+00:00' \
 TAP_WITH_STATE__SELECT_FILTER='["stream_1"]' \
-meltano run tap-with-state target-jsonl --full-refresh --state-id-suffix=merge --merge-state
+meltano run tap-with-state target-jsonl --full-refresh --state-id-suffix=merge --state-strategy=merge
 ```
 
 Note that the state will now contain both the new bookmark for `stream_1` and the old bookmarks for the other streams.

--- a/integration/meltano-run-merge-states/validate.sh
+++ b/integration/meltano-run-merge-states/validate.sh
@@ -7,4 +7,4 @@ source "$(git rev-parse --show-toplevel)/integration/commons.sh"
 cd "${TEST_DOCS_DIR}"
 
 meltano state get dev:tap-with-state-to-target-jsonl:no-merge | grep '{"singer_state": {"bookmarks": {"stream_1": {"created_at": "2023-01-01T01:00:00+00:00"}}}}'
-meltano state get dev:tap-with-state-to-target-jsonl:merge | grep '{"singer_state": {"bookmarks": {"stream_1": {"created_at": "2023-01-01T01:00:00+00:00"}, "stream_2": {"created_at": "2023-01-01T00:00:00+00:00"}, "stream_3": {"created_at": "2023-01-01T00:00:00+00:00"}}}}'
+meltano state get dev:tap-with-state-to-target-jsonl:merge | grep '{"singer_state": {"bookmarks": {"stream_1": {"created_at": "2024-01-01T00:00:00+00:00"}, "stream_2": {"created_at": "2023-01-01T00:00:00+00:00"}, "stream_3": {"created_at": "2023-01-01T00:00:00+00:00"}}}}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ testing = [
   "pytest-order~=1.3",
   "pytest-randomly~=3.16",
   "pytest-structlog~=1.1",
-  "pytest-subtests>=0.14.2",
   "pytest-xdist~=3.6",
   "requests-mock>=1.12.1,<2",
   "setproctitle~=1.3",  # Used by pytest-xdist to aid with handling resource intensive processes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ testing = [
   "pytest-order~=1.3",
   "pytest-randomly~=3.16",
   "pytest-structlog~=1.1",
+  "pytest-subtests>=0.14.2",
   "pytest-xdist~=3.6",
   "requests-mock>=1.12.1,<2",
   "setproctitle~=1.3",  # Used by pytest-xdist to aid with handling resource intensive processes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,9 +132,10 @@ testing = [
   "pytest-order~=1.3",
   "pytest-randomly~=3.16",
   "pytest-structlog~=1.1",
+  "pytest-subtests>=0.14.2",
   "pytest-xdist~=3.6",
   "requests-mock>=1.12.1,<2",
-  "setproctitle~=1.3",  # Used by pytest-xdist to aid with handling resource intensive processes.
+  "setproctitle~=1.3", # Used by pytest-xdist to aid with handling resource intensive processes.
   "time-machine>=2.15.0,<3",
 ]
 typing = [

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -121,7 +121,7 @@ class ELOptions:
         # use click 8.2+ exclusively
         type=click.Choice([strategy.value for strategy in StateStrategy]),
         help="Strategy to use for state updates.",
-        default=None,  # TODO: Default to MERGE after a deprecation period
+        default=StateStrategy.AUTO.value,
     )
     run_id = click.option(
         "--run-id",
@@ -173,7 +173,7 @@ async def el(  # WPS408
     state_id: str | None,
     force: bool,
     merge_state: bool,
-    state_strategy: str | None,
+    state_strategy: str,
     run_id: uuid.UUID | None,
     install_plugins: InstallPlugins,
 ) -> None:
@@ -255,7 +255,7 @@ async def elt(  # WPS408
     state_id: str | None,
     force: bool,
     merge_state: bool,
-    state_strategy: str | None,
+    state_strategy: str,
     install_plugins: InstallPlugins,
     run_id: uuid.UUID | None,
 ) -> None:
@@ -311,7 +311,7 @@ async def _run_el_command(
     state_id: str | None,
     force: bool,
     merge_state: bool,
-    state_strategy: str | None,
+    state_strategy: str,
     install_plugins: InstallPlugins,
     run_id: uuid.UUID | None,
 ) -> None:

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -401,13 +401,12 @@ def _elt_context_builder(
     dry_run: bool = False,
     full_refresh: bool = False,
     refresh_catalog: bool = False,
-    select_filter: list[str] | None = None,
+    select_filter: list[str],
     catalog: str | None = None,
     state: str | None = None,
     state_strategy: StateStrategy,
     run_id: uuid.UUID | None = None,
 ) -> ELTContextBuilder:
-    select_filter = select_filter or []
     transform_name = None
     if transform != "skip":
         transform_name = _find_transform_for_extractor(project, extractor)

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -15,6 +15,7 @@ from meltano.cli.params import (
     pass_project,
 )
 from meltano.cli.utils import CliEnvironmentBehavior, CliError, PartialInstrumentedCmd
+from meltano.core._state import StateStrategy
 from meltano.core.block.block_parser import BlockParser, validate_block_sets
 from meltano.core.block.blockset import BlockSet
 from meltano.core.block.plugin_command import PluginCommandBlock
@@ -148,6 +149,8 @@ async def run(
 
     tracker: Tracker = ctx.obj["tracker"]
 
+    state_strategy = StateStrategy.MERGE if merge_state else StateStrategy.OVERWRITE
+
     try:
         parser = BlockParser(
             logger,
@@ -158,7 +161,7 @@ async def run(
             no_state_update=no_state_update,
             force=force,
             state_id_suffix=state_id_suffix,
-            merge_state=merge_state,
+            state_strategy=state_strategy,
             run_id=run_id,
         )
         parsed_blocks = list(parser.find_blocks(0))

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -92,7 +92,7 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
     # TODO: use click.Choice(StateStrategy) once we drop support for Python 3.9 and use
     # click 8.2+ exclusively
     type=click.Choice([strategy.value for strategy in StateStrategy]),
-    default=None,  # TODO: Default to MERGE after a deprecation period
+    default=StateStrategy.AUTO.value,
     help="Strategy to use for state updates.",
 )
 @click.option(
@@ -121,7 +121,7 @@ async def run(
     force: bool,
     state_id_suffix: str,
     merge_state: bool,
-    state_strategy: str | None,
+    state_strategy: str,
     run_id: uuid.UUID | None,
     blocks: list[str],
     install_plugins: InstallPlugins,

--- a/src/meltano/core/_protocols/el_context.py
+++ b/src/meltano/core/_protocols/el_context.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import typing as t
+
+from meltano.core._state import StateStrategy
+
+
+class ELContextProtocol(t.Protocol):
+    """Protocol for EL context classes."""
+
+    full_refresh: bool | None
+    select_filter: list[str]
+    state_strategy: StateStrategy
+
+    def should_merge_states(self) -> bool:
+        """Check whether the EL state is incomplete and should be merged."""
+        return (
+            self.full_refresh is True and len(self.select_filter) > 0
+        ) or self.state_strategy is StateStrategy.MERGE

--- a/src/meltano/core/_protocols/el_context.py
+++ b/src/meltano/core/_protocols/el_context.py
@@ -8,8 +8,12 @@ from meltano.core._state import StateStrategy
 class ELContextProtocol(t.Protocol):
     """Protocol for EL context classes."""
 
+    full_refresh: bool | None
     state_strategy: StateStrategy
 
     def should_merge_states(self) -> bool:
         """Check whether the EL state is incomplete and should be merged."""
-        return self.state_strategy == StateStrategy.MERGE
+        return (
+            self.full_refresh is True  # Full refresh implies merging states
+            and self.state_strategy == StateStrategy.AUTO
+        ) or self.state_strategy == StateStrategy.MERGE

--- a/src/meltano/core/_protocols/el_context.py
+++ b/src/meltano/core/_protocols/el_context.py
@@ -16,4 +16,4 @@ class ELContextProtocol(t.Protocol):
         """Check whether the EL state is incomplete and should be merged."""
         return (
             self.full_refresh is True and len(self.select_filter) > 0
-        ) or self.state_strategy is StateStrategy.MERGE
+        ) or self.state_strategy == StateStrategy.MERGE

--- a/src/meltano/core/_protocols/el_context.py
+++ b/src/meltano/core/_protocols/el_context.py
@@ -8,12 +8,8 @@ from meltano.core._state import StateStrategy
 class ELContextProtocol(t.Protocol):
     """Protocol for EL context classes."""
 
-    full_refresh: bool | None
-    select_filter: list[str]
     state_strategy: StateStrategy
 
     def should_merge_states(self) -> bool:
         """Check whether the EL state is incomplete and should be merged."""
-        return (
-            self.full_refresh is True and len(self.select_filter) > 0
-        ) or self.state_strategy == StateStrategy.MERGE
+        return self.state_strategy == StateStrategy.MERGE

--- a/src/meltano/core/_state.py
+++ b/src/meltano/core/_state.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import enum
 import sys
 
+import structlog
+
 if sys.version_info < (3, 11):
     from backports.strenum import StrEnum
 else:
     from enum import StrEnum
+
+logger = structlog.stdlib.get_logger()
 
 
 class StateStrategy(StrEnum):
@@ -14,3 +18,32 @@ class StateStrategy(StrEnum):
 
     MERGE = enum.auto()
     OVERWRITE = enum.auto()
+
+    @classmethod
+    def from_cli_args(
+        cls,
+        *,
+        merge_state: bool,
+        state_strategy: str | None,
+    ) -> StateStrategy:
+        import click
+
+        if merge_state and state_strategy is not None:
+            msg = "Cannot use both --merge-state and --state-strategy"
+            raise click.UsageError(msg)
+
+        if merge_state:
+            logger.warning(
+                "The --merge-state option is deprecated and will be removed in a "
+                "future version. Use --state-strategy=merge instead.",
+            )
+            return StateStrategy.MERGE
+
+        if state_strategy is None:
+            logger.warning(
+                "No --state-strategy provided, defaulting to 'overwrite'. This will be "
+                "changed to 'merge' in a future version.",
+            )
+            return StateStrategy.OVERWRITE
+
+        return StateStrategy(state_strategy)

--- a/src/meltano/core/_state.py
+++ b/src/meltano/core/_state.py
@@ -26,9 +26,9 @@ class StateStrategy(StrEnum):
         merge_state: bool,
         state_strategy: str | None,
     ) -> StateStrategy:
-        import click
-
         if merge_state and state_strategy is not None:
+            import click
+
             msg = "Cannot use both --merge-state and --state-strategy"
             raise click.UsageError(msg)
 

--- a/src/meltano/core/_state.py
+++ b/src/meltano/core/_state.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import enum
+import sys
+
+if sys.version_info < (3, 11):
+    from backports.strenum import StrEnum
+else:
+    from enum import StrEnum
+
+
+class StateStrategy(StrEnum):
+    """Strategy to use for state management."""
+
+    MERGE = enum.auto()
+    OVERWRITE = enum.auto()

--- a/src/meltano/core/_state.py
+++ b/src/meltano/core/_state.py
@@ -16,6 +16,7 @@ logger = structlog.stdlib.get_logger()
 class StateStrategy(StrEnum):
     """Strategy to use for state management."""
 
+    AUTO = enum.auto()
     MERGE = enum.auto()
     OVERWRITE = enum.auto()
 
@@ -24,9 +25,9 @@ class StateStrategy(StrEnum):
         cls,
         *,
         merge_state: bool,
-        state_strategy: str | None,
+        state_strategy: str,
     ) -> StateStrategy:
-        if merge_state and state_strategy is not None:
+        if merge_state and state_strategy != StateStrategy.AUTO.value:
             import click
 
             msg = "Cannot use both --merge-state and --state-strategy"
@@ -38,12 +39,5 @@ class StateStrategy(StrEnum):
                 "future version. Use --state-strategy=merge instead.",
             )
             return StateStrategy.MERGE
-
-        if state_strategy is None:
-            logger.warning(
-                "No --state-strategy provided, defaulting to 'overwrite'. This will be "
-                "changed to 'merge' in a future version.",
-            )
-            return StateStrategy.OVERWRITE
 
         return StateStrategy(state_strategy)

--- a/src/meltano/core/block/block_parser.py
+++ b/src/meltano/core/block/block_parser.py
@@ -80,7 +80,7 @@ class BlockParser:  # noqa: D101
         no_state_update: bool | None = False,
         force: bool | None = False,
         state_id_suffix: str | None = None,
-        state_strategy: StateStrategy = StateStrategy.MERGE,
+        state_strategy: StateStrategy = StateStrategy.AUTO,
         run_id: uuid.UUID | None = None,
     ):
         """Parse a meltano run command invocation into a list of blocks.

--- a/src/meltano/core/block/block_parser.py
+++ b/src/meltano/core/block/block_parser.py
@@ -9,6 +9,7 @@ import typing as t
 
 import click
 
+from meltano.core._state import StateStrategy
 from meltano.core.block.blockset import BlockSet, BlockSetValidationError
 from meltano.core.block.extract_load import ELBContextBuilder, ExtractLoadBlocks
 from meltano.core.block.plugin_command import PluginCommandBlock, plugin_command_invoker
@@ -79,7 +80,7 @@ class BlockParser:  # noqa: D101
         no_state_update: bool | None = False,
         force: bool | None = False,
         state_id_suffix: str | None = None,
-        merge_state: bool | None = False,
+        state_strategy: StateStrategy = StateStrategy.OVERWRITE,
         run_id: uuid.UUID | None = None,
     ):
         """Parse a meltano run command invocation into a list of blocks.
@@ -95,7 +96,7 @@ class BlockParser:  # noqa: D101
             force: Whether to force a run if a job is already running (applies
                 to all found sets).
             state_id_suffix: State ID suffix to use.
-            merge_state: Whether to merge state at end of run.
+            state_strategy: Strategy to use for state evolution.
             run_id: Custom run ID to use.
 
         Raises:
@@ -112,7 +113,7 @@ class BlockParser:  # noqa: D101
         self._plugins: list[ProjectPlugin] = []
         self._commands: dict[int, str] = {}
         self._mappings_ref: dict[int, str] = {}
-        self._merge_state = merge_state
+        self._state_strategy = state_strategy
         self._run_id = run_id
 
         task_sets_service: TaskSetsService = TaskSetsService(project)
@@ -254,7 +255,7 @@ class BlockParser:  # noqa: D101
             .with_refresh_catalog(refresh_catalog=self._refresh_catalog)
             .with_no_state_update(no_state_update=self._no_state_update)
             .with_state_id_suffix(self._state_id_suffix)
-            .with_merge_state(merge_state=self._merge_state)
+            .with_state_strategy(state_strategy=self._state_strategy)
             .with_run_id(self._run_id)
         )
 

--- a/src/meltano/core/block/block_parser.py
+++ b/src/meltano/core/block/block_parser.py
@@ -80,7 +80,7 @@ class BlockParser:  # noqa: D101
         no_state_update: bool | None = False,
         force: bool | None = False,
         state_id_suffix: str | None = None,
-        state_strategy: StateStrategy = StateStrategy.OVERWRITE,
+        state_strategy: StateStrategy = StateStrategy.MERGE,
         run_id: uuid.UUID | None = None,
     ):
         """Parse a meltano run command invocation into a list of blocks.

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager, closing
 
 import structlog
 
+from meltano.core._protocols.el_context import ELContextProtocol
 from meltano.core._state import StateStrategy
 from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.db import project_engine
@@ -45,7 +46,7 @@ class BlockSetHasNoStateError(Exception):
     """Block has no state."""
 
 
-class ELBContext:
+class ELBContext(ELContextProtocol):
     """ELBContext holds the context for ELB BlockSets."""
 
     def __init__(
@@ -96,12 +97,6 @@ class ELBContext:
         self.catalog = None
 
         self.base_output_logger = base_output_logger
-
-    def incomplete_state(self) -> bool:
-        """Check whether the state is incomplete and should be merged."""
-        return (
-            self.full_refresh is True and len(self.select_filter) > 0
-        ) or self.state_strategy is StateStrategy.MERGE
 
 
 class ELBContextBuilder:

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -61,7 +61,7 @@ class ELBContext(ELContextProtocol):
         update_state: bool | None = True,
         state_id_suffix: str | None = None,
         base_output_logger: OutputLogger | None = None,
-        state_strategy: StateStrategy = StateStrategy.MERGE,
+        state_strategy: StateStrategy = StateStrategy.AUTO,
         run_id: uuid.UUID | None = None,
     ):
         """Use an ELBContext to pass information on to ExtractLoadBlocks.
@@ -123,7 +123,7 @@ class ELBContextBuilder:
         self._state_id_suffix = None
         self._env = {}
         self._blocks = []
-        self._state_strategy = StateStrategy.MERGE
+        self._state_strategy = StateStrategy.AUTO
         self._run_id: uuid.UUID | None = None
 
         self._base_output_logger = None

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -61,7 +61,7 @@ class ELBContext(ELContextProtocol):
         update_state: bool | None = True,
         state_id_suffix: str | None = None,
         base_output_logger: OutputLogger | None = None,
-        state_strategy: StateStrategy = StateStrategy.OVERWRITE,
+        state_strategy: StateStrategy = StateStrategy.MERGE,
         run_id: uuid.UUID | None = None,
     ):
         """Use an ELBContext to pass information on to ExtractLoadBlocks.
@@ -123,7 +123,7 @@ class ELBContextBuilder:
         self._state_id_suffix = None
         self._env = {}
         self._blocks = []
-        self._state_strategy = StateStrategy.OVERWRITE
+        self._state_strategy = StateStrategy.MERGE
         self._run_id: uuid.UUID | None = None
 
         self._base_output_logger = None

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -97,6 +97,12 @@ class ELBContext:
 
         self.base_output_logger = base_output_logger
 
+    def incomplete_state(self) -> bool:
+        """Check whether the state is incomplete and should be merged."""
+        return (
+            self.full_refresh is True and len(self.select_filter) > 0
+        ) or self.state_strategy is StateStrategy.MERGE
+
 
 class ELBContextBuilder:
     """Build up ELBContexts for ExtractLoadBlocks."""

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -106,7 +106,7 @@ class ELTContext(ELContextProtocol):
         catalog: str | None = None,
         state: str | None = None,
         base_output_logger: OutputLogger | None = None,
-        state_strategy: StateStrategy = StateStrategy.MERGE,
+        state_strategy: StateStrategy = StateStrategy.AUTO,
         run_id: uuid.UUID | None = None,
     ):
         """Initialise ELT Context instance.
@@ -246,7 +246,7 @@ class ELTContextBuilder:
         self._catalog: str | None = None
         self._state: str | None = None
         self._base_output_logger: OutputLogger | None = None
-        self._state_strategy: StateStrategy = StateStrategy.MERGE
+        self._state_strategy: StateStrategy = StateStrategy.AUTO
 
     def with_session(self, session: Session) -> ELTContextBuilder:
         """Include session when building context.

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -162,6 +162,12 @@ class ELTContext:
 
         return None
 
+    def incomplete_state(self) -> bool:
+        """Check whether the state is incomplete and should be merged."""
+        return (
+            self.full_refresh is True and len(self.select_filter) > 0
+        ) or self.state_strategy is StateStrategy.MERGE
+
     def invoker_for(self, plugin_type: PluginType) -> PluginInvoker:
         """Get invoker for given plugin type.
 

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -106,7 +106,7 @@ class ELTContext(ELContextProtocol):
         catalog: str | None = None,
         state: str | None = None,
         base_output_logger: OutputLogger | None = None,
-        state_strategy: StateStrategy = StateStrategy.OVERWRITE,
+        state_strategy: StateStrategy = StateStrategy.MERGE,
         run_id: uuid.UUID | None = None,
     ):
         """Initialise ELT Context instance.
@@ -246,7 +246,7 @@ class ELTContextBuilder:
         self._catalog: str | None = None
         self._state: str | None = None
         self._base_output_logger: OutputLogger | None = None
-        self._state_strategy: StateStrategy = StateStrategy.OVERWRITE
+        self._state_strategy: StateStrategy = StateStrategy.MERGE
 
     def with_session(self, session: Session) -> ELTContextBuilder:
         """Include session when building context.

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typing as t
 
+from meltano.core._protocols.el_context import ELContextProtocol
 from meltano.core._state import StateStrategy
 from meltano.core.plugin import PluginRef, PluginType
 from meltano.core.plugin.error import PluginNotFoundError
@@ -84,7 +85,7 @@ class PluginContext(t.NamedTuple):
         return {**self.plugin.info_env, **self.config_env()}
 
 
-class ELTContext:
+class ELTContext(ELContextProtocol):
     """ELT Context."""
 
     def __init__(
@@ -161,12 +162,6 @@ class ELTContext:
             return self.project.job_dir(self.job.job_name, str(self.job.run_id))
 
         return None
-
-    def incomplete_state(self) -> bool:
-        """Check whether the state is incomplete and should be merged."""
-        return (
-            self.full_refresh is True and len(self.select_filter) > 0
-        ) or self.state_strategy is StateStrategy.MERGE
 
     def invoker_for(self, plugin_type: PluginType) -> PluginInvoker:
         """Get invoker for given plugin type.

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typing as t
 
+from meltano.core._state import StateStrategy
 from meltano.core.plugin import PluginRef, PluginType
 from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.settings_service import PluginSettingsService
@@ -104,7 +105,7 @@ class ELTContext:
         catalog: str | None = None,
         state: str | None = None,
         base_output_logger: OutputLogger | None = None,
-        merge_state: bool | None = False,
+        state_strategy: StateStrategy = StateStrategy.OVERWRITE,
         run_id: uuid.UUID | None = None,
     ):
         """Initialise ELT Context instance.
@@ -125,7 +126,7 @@ class ELTContext:
             catalog: Catalog to pass to extractor.
             state: State to pass to extractor.
             base_output_logger: OutputLogger to use.
-            merge_state: Flag. Merges State at the end of run
+            state_strategy: State strategy to use.
             run_id: Run ID.
         """
         self.project = project
@@ -146,7 +147,7 @@ class ELTContext:
         self.state = state
 
         self.base_output_logger = base_output_logger
-        self.merge_state = merge_state
+        self.state_strategy = state_strategy
         self.run_id = run_id
 
     @property
@@ -244,7 +245,7 @@ class ELTContextBuilder:
         self._catalog: str | None = None
         self._state: str | None = None
         self._base_output_logger: OutputLogger | None = None
-        self._merge_state: bool = False
+        self._state_strategy: StateStrategy = StateStrategy.OVERWRITE
 
     def with_session(self, session: Session) -> ELTContextBuilder:
         """Include session when building context.
@@ -372,16 +373,16 @@ class ELTContextBuilder:
         self._refresh_catalog = refresh_catalog
         return self
 
-    def with_merge_state(self, *, merge_state: bool):  # noqa: ANN201
+    def with_state_strategy(self, *, state_strategy: StateStrategy):  # noqa: ANN201
         """Set whether the state is to be merged or overwritten.
 
         Args:
-            merge_state: Merges the state at the end of run.
+            state_strategy: State strategy to use.
 
         Returns:
             Updated ELTContextBuilder instance.
         """
-        self._merge_state = merge_state
+        self._state_strategy = state_strategy
         return self
 
     def with_select_filter(self, select_filter: list[str]) -> ELTContextBuilder:
@@ -551,5 +552,5 @@ class ELTContextBuilder:
             catalog=self._catalog,
             state=self._state,
             base_output_logger=self._base_output_logger,
-            merge_state=self._merge_state,
+            state_strategy=self._state_strategy,
         )

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 
 from structlog.stdlib import get_logger
 
-from meltano.core._state import StateStrategy
 from meltano.core.behavior.hookable import hook
 from meltano.core.job import Job, Payload
 from meltano.core.setting_definition import SettingDefinition
@@ -178,10 +177,11 @@ class SingerTarget(SingerPlugin):
         if not elt_context or not elt_context.job or not elt_context.session:
             return
 
-        incomplete_state = (
-            elt_context.full_refresh and elt_context.select_filter
-        ) or elt_context.state_strategy is StateStrategy.MERGE
-        payload_flag = Payload.INCOMPLETE_STATE if incomplete_state else Payload.STATE
+        payload_flag = (
+            Payload.INCOMPLETE_STATE
+            if elt_context.incomplete_state()
+            else Payload.STATE
+        )
 
         plugin_invoker.add_output_handler(
             plugin_invoker.StdioSource.STDOUT,

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -179,7 +179,7 @@ class SingerTarget(SingerPlugin):
 
         payload_flag = (
             Payload.INCOMPLETE_STATE
-            if elt_context.incomplete_state()
+            if elt_context.should_merge_states()
             else Payload.STATE
         )
 

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 from structlog.stdlib import get_logger
 
+from meltano.core._state import StateStrategy
 from meltano.core.behavior.hookable import hook
 from meltano.core.job import Job, Payload
 from meltano.core.setting_definition import SettingDefinition
@@ -179,7 +180,7 @@ class SingerTarget(SingerPlugin):
 
         incomplete_state = (
             elt_context.full_refresh and elt_context.select_filter
-        ) or elt_context.merge_state
+        ) or elt_context.state_strategy is StateStrategy.MERGE
         payload_flag = Payload.INCOMPLETE_STATE if incomplete_state else Payload.STATE
 
         plugin_invoker.add_output_handler(

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -312,7 +312,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
                 return MeltanoState.from_file(state_id, reader)
         except Exception as e:
             if self.is_file_not_found_error(e):
-                logger.info("No state found for {%s.", state_id)
+                logger.info("No state found for %s.", state_id)
                 return None
             raise e
 

--- a/tests/meltano/core/plugin/singer/test_target.py
+++ b/tests/meltano/core/plugin/singer/test_target.py
@@ -7,7 +7,7 @@ import pytest
 
 from meltano.core.job import Job, Payload
 from meltano.core.plugin import PluginType
-from meltano.core.plugin.singer.target import BookmarkWriter
+from meltano.core.plugin.singer.target import BookmarkWriter, SingerTarget
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
 from meltano.core.state_service import StateService
 
@@ -84,7 +84,7 @@ class TestSingerTarget:
     @pytest.mark.asyncio
     async def test_setup_bookmark_writer(
         self,
-        subject,
+        subject: SingerTarget,
         session,
         plugin_invoker_factory,
         elt_context_builder,

--- a/tests/meltano/core/plugin/singer/test_target.py
+++ b/tests/meltano/core/plugin/singer/test_target.py
@@ -7,13 +7,15 @@ import pytest
 
 from meltano.core.job import Job, Payload
 from meltano.core.plugin import PluginType
-from meltano.core.plugin.singer.target import BookmarkWriter, SingerTarget
+from meltano.core.plugin.singer.target import BookmarkWriter
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
 from meltano.core.state_service import StateService
 
 if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from meltano.core.elt_context import ELTContextBuilder
+    from meltano.core.plugin.singer.target import SingerTarget
     from meltano.core.project_add_service import ProjectAddService
 
 
@@ -87,7 +89,7 @@ class TestSingerTarget:
         subject: SingerTarget,
         session,
         plugin_invoker_factory,
-        elt_context_builder,
+        elt_context_builder: ELTContextBuilder,
     ) -> None:
         job = Job(job_name="pytest_test_runner")
 

--- a/tests/meltano/core/protocols/test_el_context.py
+++ b/tests/meltano/core/protocols/test_el_context.py
@@ -1,6 +1,9 @@
+# ruff: noqa: FBT001, FBT003
+
 from __future__ import annotations
 
 import typing as t
+from dataclasses import dataclass
 
 from meltano.core._protocols.el_context import ELContextProtocol
 from meltano.core._state import StateStrategy
@@ -9,51 +12,31 @@ if t.TYPE_CHECKING:
     from pytest_subtests import SubTests
 
 
+@dataclass
 class MyContext(ELContextProtocol):
-    def __init__(
-        self,
-        *,
-        full_refresh: bool | None,
-        state_strategy: StateStrategy,
-    ):
-        self.full_refresh = full_refresh
-        self.state_strategy = state_strategy
+    full_refresh: bool | None
+    state_strategy: StateStrategy
 
 
 class TestELContextProtocol:
     def test_should_merge_states(self, subtests: SubTests):
+        def _(full_refresh: bool, state_strategy: StateStrategy):
+            return MyContext(full_refresh, state_strategy)
+
         with subtests.test("Full refresh & auto → merge"):
-            assert MyContext(
-                full_refresh=True,
-                state_strategy=StateStrategy.AUTO,
-            ).should_merge_states()
+            assert _(True, StateStrategy.AUTO).should_merge_states()
 
         with subtests.test("Full refresh & merge → merge"):
-            assert MyContext(
-                full_refresh=True,
-                state_strategy=StateStrategy.MERGE,
-            ).should_merge_states()
+            assert _(True, StateStrategy.MERGE).should_merge_states()
 
         with subtests.test("Full refresh & overwrite → overwrite"):
-            assert not MyContext(
-                full_refresh=True,
-                state_strategy=StateStrategy.OVERWRITE,
-            ).should_merge_states()
+            assert not _(True, StateStrategy.OVERWRITE).should_merge_states()
 
         with subtests.test("Incremental & auto → overwrite"):
-            assert not MyContext(
-                full_refresh=False,
-                state_strategy=StateStrategy.AUTO,
-            ).should_merge_states()
+            assert not _(False, StateStrategy.AUTO).should_merge_states()
 
         with subtests.test("Incremental & merge → merge"):
-            assert MyContext(
-                full_refresh=False,
-                state_strategy=StateStrategy.MERGE,
-            ).should_merge_states()
+            assert _(False, StateStrategy.MERGE).should_merge_states()
 
         with subtests.test("Incremental & overwrite → overwrite"):
-            assert not MyContext(
-                full_refresh=False,
-                state_strategy=StateStrategy.OVERWRITE,
-            ).should_merge_states()
+            assert not _(False, StateStrategy.OVERWRITE).should_merge_states()

--- a/tests/meltano/core/protocols/test_el_context.py
+++ b/tests/meltano/core/protocols/test_el_context.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import typing as t
+
+from meltano.core._protocols.el_context import ELContextProtocol
+from meltano.core._state import StateStrategy
+
+if t.TYPE_CHECKING:
+    from pytest_subtests import SubTests
+
+
+class MyContext(ELContextProtocol):
+    def __init__(
+        self,
+        *,
+        full_refresh: bool | None,
+        select_filter: list[str],
+        state_strategy: StateStrategy,
+    ):
+        self.full_refresh = full_refresh
+        self.select_filter = select_filter
+        self.state_strategy = state_strategy
+
+
+class TestELContextProtocol:
+    def test_incomplete_state(self, subtests: SubTests):
+        with subtests.test("Full refresh + stream selection = merge"):
+            assert MyContext(
+                full_refresh=True,
+                select_filter=["a", "b"],
+                state_strategy=StateStrategy.MERGE,
+            ).should_merge_states()
+
+            assert MyContext(
+                full_refresh=True,
+                select_filter=["a", "b"],
+                state_strategy=StateStrategy.OVERWRITE,
+            ).should_merge_states()
+
+        with subtests.test("No stream selection + merge strategy = merge"):
+            assert MyContext(
+                full_refresh=True,
+                select_filter=[],
+                state_strategy=StateStrategy.MERGE,
+            ).should_merge_states()
+
+        with subtests.test("No stream selection + overwrite strategy = overwrite"):
+            assert not MyContext(
+                full_refresh=True,
+                select_filter=[],
+                state_strategy=StateStrategy.OVERWRITE,
+            ).should_merge_states()
+
+        with subtests.test("Incremental + merge strategy = merge"):
+            assert MyContext(
+                full_refresh=False,
+                select_filter=["a", "b"],
+                state_strategy=StateStrategy.MERGE,
+            ).should_merge_states()
+
+        with subtests.test("Incremental + overwrite strategy = overwrite"):
+            assert not MyContext(
+                full_refresh=False,
+                select_filter=["a", "b"],
+                state_strategy=StateStrategy.OVERWRITE,
+            ).should_merge_states()

--- a/tests/meltano/core/protocols/test_el_context.py
+++ b/tests/meltano/core/protocols/test_el_context.py
@@ -1,66 +1,21 @@
 from __future__ import annotations
 
-import typing as t
-
 from meltano.core._protocols.el_context import ELContextProtocol
 from meltano.core._state import StateStrategy
-
-if t.TYPE_CHECKING:
-    from pytest_subtests import SubTests
 
 
 class MyContext(ELContextProtocol):
     def __init__(
         self,
         *,
-        full_refresh: bool | None,
-        select_filter: list[str],
         state_strategy: StateStrategy,
     ):
-        self.full_refresh = full_refresh
-        self.select_filter = select_filter
         self.state_strategy = state_strategy
 
 
 class TestELContextProtocol:
-    def test_incomplete_state(self, subtests: SubTests):
-        with subtests.test("Full refresh + stream selection = merge"):
-            assert MyContext(
-                full_refresh=True,
-                select_filter=["a", "b"],
-                state_strategy=StateStrategy.MERGE,
-            ).should_merge_states()
-
-            assert MyContext(
-                full_refresh=True,
-                select_filter=["a", "b"],
-                state_strategy=StateStrategy.OVERWRITE,
-            ).should_merge_states()
-
-        with subtests.test("No stream selection + merge strategy = merge"):
-            assert MyContext(
-                full_refresh=True,
-                select_filter=[],
-                state_strategy=StateStrategy.MERGE,
-            ).should_merge_states()
-
-        with subtests.test("No stream selection + overwrite strategy = overwrite"):
-            assert not MyContext(
-                full_refresh=True,
-                select_filter=[],
-                state_strategy=StateStrategy.OVERWRITE,
-            ).should_merge_states()
-
-        with subtests.test("Incremental + merge strategy = merge"):
-            assert MyContext(
-                full_refresh=False,
-                select_filter=["a", "b"],
-                state_strategy=StateStrategy.MERGE,
-            ).should_merge_states()
-
-        with subtests.test("Incremental + overwrite strategy = overwrite"):
-            assert not MyContext(
-                full_refresh=False,
-                select_filter=["a", "b"],
-                state_strategy=StateStrategy.OVERWRITE,
-            ).should_merge_states()
+    def test_should_merge_states(self):
+        assert MyContext(state_strategy=StateStrategy.MERGE).should_merge_states()
+        assert not MyContext(
+            state_strategy=StateStrategy.OVERWRITE
+        ).should_merge_states()

--- a/tests/meltano/core/protocols/test_el_context.py
+++ b/tests/meltano/core/protocols/test_el_context.py
@@ -1,21 +1,59 @@
 from __future__ import annotations
 
+import typing as t
+
 from meltano.core._protocols.el_context import ELContextProtocol
 from meltano.core._state import StateStrategy
+
+if t.TYPE_CHECKING:
+    from pytest_subtests import SubTests
 
 
 class MyContext(ELContextProtocol):
     def __init__(
         self,
         *,
+        full_refresh: bool | None,
         state_strategy: StateStrategy,
     ):
+        self.full_refresh = full_refresh
         self.state_strategy = state_strategy
 
 
 class TestELContextProtocol:
-    def test_should_merge_states(self):
-        assert MyContext(state_strategy=StateStrategy.MERGE).should_merge_states()
-        assert not MyContext(
-            state_strategy=StateStrategy.OVERWRITE
-        ).should_merge_states()
+    def test_should_merge_states(self, subtests: SubTests):
+        with subtests.test("Full refresh & auto → merge"):
+            assert MyContext(
+                full_refresh=True,
+                state_strategy=StateStrategy.AUTO,
+            ).should_merge_states()
+
+        with subtests.test("Full refresh & merge → merge"):
+            assert MyContext(
+                full_refresh=True,
+                state_strategy=StateStrategy.MERGE,
+            ).should_merge_states()
+
+        with subtests.test("Full refresh & overwrite → overwrite"):
+            assert not MyContext(
+                full_refresh=True,
+                state_strategy=StateStrategy.OVERWRITE,
+            ).should_merge_states()
+
+        with subtests.test("Incremental & auto → overwrite"):
+            assert not MyContext(
+                full_refresh=False,
+                state_strategy=StateStrategy.AUTO,
+            ).should_merge_states()
+
+        with subtests.test("Incremental & merge → merge"):
+            assert MyContext(
+                full_refresh=False,
+                state_strategy=StateStrategy.MERGE,
+            ).should_merge_states()
+
+        with subtests.test("Incremental & overwrite → overwrite"):
+            assert not MyContext(
+                full_refresh=False,
+                state_strategy=StateStrategy.OVERWRITE,
+            ).should_merge_states()

--- a/tests/meltano/core/runner/test_runner.py
+++ b/tests/meltano/core/runner/test_runner.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from meltano.core._state import StateStrategy
 from meltano.core.job import Job, Payload, State
 from meltano.core.logging.utils import capture_subprocess_output
 from meltano.core.plugin_invoker import PluginInvoker
@@ -161,60 +162,65 @@ class TestSingerRunner:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("full_refresh", "merge_state", "select_filter", "payload_flag"),
+        (
+            "full_refresh",
+            "state_strategy",
+            "select_filter",
+            "payload_flag",
+        ),
         (
             pytest.param(
                 False,
-                False,
+                StateStrategy.OVERWRITE,
                 [],
                 Payload.STATE,
-                id="incremental-no-merge-no-select--complete-state",
+                id="incremental-overwrite-no-select--complete-state",
             ),
             pytest.param(
                 True,
-                False,
+                StateStrategy.OVERWRITE,
                 [],
                 Payload.STATE,
-                id="full-refresh-no-merge-no-select--complete-state",
+                id="full-refresh-overwrite-no-select--complete-state",
             ),
             pytest.param(
                 False,
-                False,
+                StateStrategy.OVERWRITE,
                 ["entity"],
                 Payload.STATE,
-                id="incremental-no-merge-select--complete-state",
+                id="incremental-overwrite-select--complete-state",
             ),
             pytest.param(
                 True,
-                False,
+                StateStrategy.OVERWRITE,
                 ["entity"],
                 Payload.INCOMPLETE_STATE,
-                id="full-refresh-no-merge-select--incomplete-state",
+                id="full-refresh-overwrite-select--incomplete-state",
             ),
             pytest.param(
                 False,
-                True,
+                StateStrategy.MERGE,
                 [],
                 Payload.INCOMPLETE_STATE,
                 id="incremental-merge-no-select--incomplete-state",
             ),
             pytest.param(
                 True,
-                True,
+                StateStrategy.MERGE,
                 [],
                 Payload.INCOMPLETE_STATE,
                 id="full-refresh-merge-no-select--incomplete-state",
             ),
             pytest.param(
                 False,
-                True,
+                StateStrategy.MERGE,
                 ["entity"],
                 Payload.INCOMPLETE_STATE,
                 id="incremental-merge-select--incomplete-state",
             ),
             pytest.param(
                 True,
-                True,
+                StateStrategy.MERGE,
                 ["entity"],
                 Payload.INCOMPLETE_STATE,
                 id="full-refresh-merge-select--incomplete-state",
@@ -223,7 +229,7 @@ class TestSingerRunner:
     )
     async def test_bookmark(
         self,
-        subject,
+        subject: SingerRunner,
         session,
         target,
         target_config_dir,
@@ -233,7 +239,7 @@ class TestSingerRunner:
         select_filter,
         payload_flag,
         elt_context,
-        merge_state,
+        state_strategy,
     ) -> None:
         lines = (b'{"line": 1}\n', b'{"line": 2}\n', b'{"line": 3}\n')
 
@@ -245,7 +251,7 @@ class TestSingerRunner:
 
         subject.context.full_refresh = full_refresh
         subject.context.select_filter = select_filter
-        subject.context.merge_state = merge_state
+        subject.context.state_strategy = state_strategy
 
         target_invoker = plugin_invoker_factory(
             target,

--- a/tests/meltano/core/runner/test_runner.py
+++ b/tests/meltano/core/runner/test_runner.py
@@ -163,19 +163,46 @@ class TestSingerRunner:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         (
+            "full_refresh",
             "state_strategy",
             "payload_flag",
         ),
         (
             pytest.param(
-                StateStrategy.MERGE,
+                True,
+                StateStrategy.AUTO,
                 Payload.INCOMPLETE_STATE,
-                id="merge--incomplete-state",
+                id="full-refresh-auto--incomplete-state",
             ),
             pytest.param(
+                False,
+                StateStrategy.AUTO,
+                Payload.STATE,
+                id="incremental-auto--complete-state",
+            ),
+            pytest.param(
+                True,
                 StateStrategy.OVERWRITE,
                 Payload.STATE,
-                id="overwrite--complete-state",
+                id="full-refresh-overwrite--complete-state",
+            ),
+            pytest.param(
+                False,
+                StateStrategy.OVERWRITE,
+                Payload.STATE,
+                id="incremental-overwrite--complete-state",
+            ),
+            pytest.param(
+                True,
+                StateStrategy.MERGE,
+                Payload.INCOMPLETE_STATE,
+                id="full-refresh-merge--incomplete-state",
+            ),
+            pytest.param(
+                False,
+                StateStrategy.MERGE,
+                Payload.INCOMPLETE_STATE,
+                id="incremental-merge--incomplete-state",
             ),
         ),
     )
@@ -187,6 +214,7 @@ class TestSingerRunner:
         target_config_dir,
         target_process,
         plugin_invoker_factory,
+        full_refresh,
         payload_flag,
         elt_context,
         state_strategy,
@@ -199,6 +227,7 @@ class TestSingerRunner:
         target_process.stdout.at_eof.side_effect = (False, False, False, True)
         target_process.stdout.readline = AsyncMock(side_effect=lines)
 
+        subject.context.full_refresh = full_refresh
         subject.context.state_strategy = state_strategy
 
         target_invoker = plugin_invoker_factory(

--- a/tests/meltano/core/runner/test_runner.py
+++ b/tests/meltano/core/runner/test_runner.py
@@ -163,67 +163,19 @@ class TestSingerRunner:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         (
-            "full_refresh",
             "state_strategy",
-            "select_filter",
             "payload_flag",
         ),
         (
             pytest.param(
-                False,
+                StateStrategy.MERGE,
+                Payload.INCOMPLETE_STATE,
+                id="merge--incomplete-state",
+            ),
+            pytest.param(
                 StateStrategy.OVERWRITE,
-                [],
                 Payload.STATE,
-                id="incremental-overwrite-no-select--complete-state",
-            ),
-            pytest.param(
-                True,
-                StateStrategy.OVERWRITE,
-                [],
-                Payload.STATE,
-                id="full-refresh-overwrite-no-select--complete-state",
-            ),
-            pytest.param(
-                False,
-                StateStrategy.OVERWRITE,
-                ["entity"],
-                Payload.STATE,
-                id="incremental-overwrite-select--complete-state",
-            ),
-            pytest.param(
-                True,
-                StateStrategy.OVERWRITE,
-                ["entity"],
-                Payload.INCOMPLETE_STATE,
-                id="full-refresh-overwrite-select--incomplete-state",
-            ),
-            pytest.param(
-                False,
-                StateStrategy.MERGE,
-                [],
-                Payload.INCOMPLETE_STATE,
-                id="incremental-merge-no-select--incomplete-state",
-            ),
-            pytest.param(
-                True,
-                StateStrategy.MERGE,
-                [],
-                Payload.INCOMPLETE_STATE,
-                id="full-refresh-merge-no-select--incomplete-state",
-            ),
-            pytest.param(
-                False,
-                StateStrategy.MERGE,
-                ["entity"],
-                Payload.INCOMPLETE_STATE,
-                id="incremental-merge-select--incomplete-state",
-            ),
-            pytest.param(
-                True,
-                StateStrategy.MERGE,
-                ["entity"],
-                Payload.INCOMPLETE_STATE,
-                id="full-refresh-merge-select--incomplete-state",
+                id="overwrite--complete-state",
             ),
         ),
     )
@@ -235,8 +187,6 @@ class TestSingerRunner:
         target_config_dir,
         target_process,
         plugin_invoker_factory,
-        full_refresh,
-        select_filter,
         payload_flag,
         elt_context,
         state_strategy,
@@ -249,8 +199,6 @@ class TestSingerRunner:
         target_process.stdout.at_eof.side_effect = (False, False, False, True)
         target_process.stdout.readline = AsyncMock(side_effect=lines)
 
-        subject.context.full_refresh = full_refresh
-        subject.context.select_filter = select_filter
         subject.context.state_strategy = state_strategy
 
         target_invoker = plugin_invoker_factory(

--- a/tests/meltano/core/test_state_strategy.py
+++ b/tests/meltano/core/test_state_strategy.py
@@ -12,7 +12,7 @@ class TestStateStrategy:
         assert (
             StateStrategy.from_cli_args(
                 merge_state=True,
-                state_strategy=None,
+                state_strategy=StateStrategy.AUTO.value,
             )
             is StateStrategy.MERGE
         )
@@ -20,9 +20,9 @@ class TestStateStrategy:
         assert (
             StateStrategy.from_cli_args(
                 merge_state=False,
-                state_strategy=None,
+                state_strategy=StateStrategy.AUTO.value,
             )
-            is StateStrategy.OVERWRITE
+            is StateStrategy.AUTO
         )
 
         assert (

--- a/tests/meltano/core/test_state_strategy.py
+++ b/tests/meltano/core/test_state_strategy.py
@@ -7,6 +7,7 @@ from meltano.core._state import StateStrategy
 
 
 class TestStateStrategy:
+    # TODO: Remove this test once we remove the `--merge-state` CLI flag
     def test_state_strategy_from_cli_args(self):
         assert (
             StateStrategy.from_cli_args(

--- a/tests/meltano/core/test_state_strategy.py
+++ b/tests/meltano/core/test_state_strategy.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import click
+import pytest
+
+from meltano.core._state import StateStrategy
+
+
+class TestStateStrategy:
+    def test_state_strategy_from_cli_args(self):
+        assert (
+            StateStrategy.from_cli_args(
+                merge_state=True,
+                state_strategy=None,
+            )
+            is StateStrategy.MERGE
+        )
+
+        assert (
+            StateStrategy.from_cli_args(
+                merge_state=False,
+                state_strategy=None,
+            )
+            is StateStrategy.OVERWRITE
+        )
+
+        assert (
+            StateStrategy.from_cli_args(
+                merge_state=False,
+                state_strategy=StateStrategy.MERGE,
+            )
+            is StateStrategy.MERGE
+        )
+
+        assert (
+            StateStrategy.from_cli_args(
+                merge_state=False,
+                state_strategy=StateStrategy.OVERWRITE,
+            )
+            is StateStrategy.OVERWRITE
+        )
+
+        with pytest.raises(click.UsageError):
+            StateStrategy.from_cli_args(
+                merge_state=True,
+                state_strategy=StateStrategy.MERGE,
+            )
+
+        with pytest.raises(click.UsageError):
+            StateStrategy.from_cli_args(
+                merge_state=True,
+                state_strategy=StateStrategy.OVERWRITE,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1380,7 +1380,6 @@ dev = [
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
-    { name = "pytest-subtests" },
     { name = "pytest-xdist" },
     { name = "requests-mock" },
     { name = "setproctitle" },
@@ -1408,7 +1407,6 @@ testing = [
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
-    { name = "pytest-subtests" },
     { name = "pytest-xdist" },
     { name = "requests-mock" },
     { name = "setproctitle" },
@@ -1488,7 +1486,6 @@ dev = [
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = "~=3.16" },
     { name = "pytest-structlog", specifier = "~=1.1" },
-    { name = "pytest-subtests", specifier = ">=0.14.2" },
     { name = "pytest-xdist", specifier = "~=3.6" },
     { name = "requests-mock", specifier = ">=1.12.1,<2" },
     { name = "setproctitle", specifier = "~=1.3" },
@@ -1513,7 +1510,6 @@ testing = [
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = "~=3.16" },
     { name = "pytest-structlog", specifier = "~=1.1" },
-    { name = "pytest-subtests", specifier = ">=0.14.2" },
     { name = "pytest-xdist", specifier = "~=3.6" },
     { name = "requests-mock", specifier = ">=1.12.1,<2" },
     { name = "setproctitle", specifier = "~=1.3" },
@@ -2400,19 +2396,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/7c/3fb89ed643578c60f5d7192614f7feaf0dbc4a1cb4c786885b12672fed1f/pytest_structlog-1.1.tar.gz", hash = "sha256:440123b0a7f93482383995b3fb796ed8c1b9a37edf405683a34774993ef09543", size = 12642, upload-time = "2024-07-25T02:55:32.001Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/13/6d0e43e1f322f7b965a0e094754b66b76a137a86ab9bb1f2c1498efdc4e3/pytest_structlog-1.1-py3-none-any.whl", hash = "sha256:928475948f886bc027f1550dccb892fb46bfb8bb1ddb0c44ab4fa3c5b3f3079a", size = 8520, upload-time = "2024-07-25T02:55:30.481Z" },
-]
-
-[[package]]
-name = "pytest-subtests"
-version = "0.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/59/30/6ec8dfc678ddfd1c294212bbd7088c52d3f7fbf3f05e6d8a440c13b9741a/pytest_subtests-0.14.2.tar.gz", hash = "sha256:7154a8665fd528ee70a76d00216a44d139dc3c9c83521a0f779f7b0ad4f800de", size = 18083, upload-time = "2025-06-13T10:50:01.636Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/d4/9bf12e59fb882b0cf4f993871e1adbee094802224c429b00861acee1a169/pytest_subtests-0.14.2-py3-none-any.whl", hash = "sha256:8da0787c994ab372a13a0ad7d390533ad2e4385cac167b3ac501258c885d0b66", size = 9115, upload-time = "2025-06-13T10:50:00.543Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1380,6 +1380,7 @@ dev = [
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
+    { name = "pytest-subtests" },
     { name = "pytest-xdist" },
     { name = "requests-mock" },
     { name = "setproctitle" },
@@ -1407,6 +1408,7 @@ testing = [
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
+    { name = "pytest-subtests" },
     { name = "pytest-xdist" },
     { name = "requests-mock" },
     { name = "setproctitle" },
@@ -1486,6 +1488,7 @@ dev = [
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = "~=3.16" },
     { name = "pytest-structlog", specifier = "~=1.1" },
+    { name = "pytest-subtests", specifier = ">=0.14.2" },
     { name = "pytest-xdist", specifier = "~=3.6" },
     { name = "requests-mock", specifier = ">=1.12.1,<2" },
     { name = "setproctitle", specifier = "~=1.3" },
@@ -1510,6 +1513,7 @@ testing = [
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = "~=3.16" },
     { name = "pytest-structlog", specifier = "~=1.1" },
+    { name = "pytest-subtests", specifier = ">=0.14.2" },
     { name = "pytest-xdist", specifier = "~=3.6" },
     { name = "requests-mock", specifier = ">=1.12.1,<2" },
     { name = "setproctitle", specifier = "~=1.3" },
@@ -2396,6 +2400,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/7c/3fb89ed643578c60f5d7192614f7feaf0dbc4a1cb4c786885b12672fed1f/pytest_structlog-1.1.tar.gz", hash = "sha256:440123b0a7f93482383995b3fb796ed8c1b9a37edf405683a34774993ef09543", size = 12642, upload-time = "2024-07-25T02:55:32.001Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/13/6d0e43e1f322f7b965a0e094754b66b76a137a86ab9bb1f2c1498efdc4e3/pytest_structlog-1.1-py3-none-any.whl", hash = "sha256:928475948f886bc027f1550dccb892fb46bfb8bb1ddb0c44ab4fa3c5b3f3079a", size = 8520, upload-time = "2024-07-25T02:55:30.481Z" },
+]
+
+[[package]]
+name = "pytest-subtests"
+version = "0.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/30/6ec8dfc678ddfd1c294212bbd7088c52d3f7fbf3f05e6d8a440c13b9741a/pytest_subtests-0.14.2.tar.gz", hash = "sha256:7154a8665fd528ee70a76d00216a44d139dc3c9c83521a0f779f7b0ad4f800de", size = 18083, upload-time = "2025-06-13T10:50:01.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d4/9bf12e59fb882b0cf4f993871e1adbee094802224c429b00861acee1a169/pytest_subtests-0.14.2-py3-none-any.whl", hash = "sha256:8da0787c994ab372a13a0ad7d390533ad2e4385cac167b3ac501258c885d0b66", size = 9115, upload-time = "2025-06-13T10:50:00.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #9238

## Summary by Sourcery

Introduce a unified `StateStrategy` enum and new `--state-strategy` option to replace the legacy `--merge-state` flag, refactor contexts and parsing logic to use the new strategy, update documentation and tests accordingly.

New Features:
- Add `--state-strategy` CLI option (auto|merge|overwrite) for `run`, `el`, and `elt` commands

Bug Fixes:
- Fix log message formatting in filesystem state store

Enhancements:
- Deprecate and hide the `--merge-state` flag in favor of `--state-strategy`
- Introduce `StateStrategy` enum and `from_cli_args` logic to unify state merging behavior
- Refactor EL(B)Context, ELTContext, context builders, and BlockParser to use `state_strategy` instead of `merge_state`

Documentation:
- Update CLI reference and examples to document `--state-strategy` and deprecate `--merge-state`

Tests:
- Add tests for `StateStrategy.from_cli_args` and `ELContextProtocol.should_merge_states`
- Update existing runner and target tests to use `state_strategy` parameter

Chores:
- Add `pytest-subtests` to development dependencies