### PR TITLE
fix: Create Singer logging config regardless of any arguments passed to `meltano invoke <plugin> ...`

### DIFF
--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -93,7 +93,7 @@ class SingerPlugin(BasePlugin):  # noqa: D101
     async def setup_logging_hook(
         self,
         plugin_invoker: PluginInvoker,
-        exec_args: tuple[str, ...] = (),
+        exec_args: tuple[str, ...] = (),  # noqa: ARG002
     ) -> None:
         """Set up logging before invoking tap.
 
@@ -104,9 +104,6 @@ class SingerPlugin(BasePlugin):  # noqa: D101
         Returns:
             None
         """
-        if exec_args:
-            return
-
         singer_sdk_logging = plugin_invoker.files["singer_sdk_logging"]
         pipelinewise_logging = plugin_invoker.files["pipelinewise_singer_logging"]
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Noticed this thanks to this Hub workflow:

```console
$ meltano invoke tap-peopleware --help | tee help-output.txt
2025-06-26T16:51:57.692118Z [info     ] Environment 'dev' is active   
Traceback (most recent call last):
  File "/home/runner/work/hub/hub/project/.meltano/extractors/tap-peopleware/venv/bin/tap-peopleware", line 8, in <module>
    sys.exit(TapPeopleware.cli())
  File "/home/runner/work/hub/hub/project/.meltano/extractors/tap-peopleware/venv/lib/python3.10/site-packages/singer_sdk/cli/__init__.py", line 35, in __get__
    return self.method(owner)
  File "/home/runner/work/hub/hub/project/.meltano/extractors/tap-peopleware/venv/lib/python3.10/site-packages/singer_sdk/plugin_base.py", line 690, in cli
    _setup_console_logging(log_level=_plugin_log_level(plugin_name=cls.name))
  File "/home/runner/work/hub/hub/project/.meltano/extractors/tap-peopleware/venv/lib/python3.10/site-packages/singer_sdk/_logging.py", line 47, in _setup_console_logging
    logging.config.dictConfig(_load_yaml_logging_config(log_config_path))
  File "/home/runner/work/hub/hub/project/.meltano/extractors/tap-peopleware/venv/lib/python3.10/site-packages/singer_sdk/_logging.py", line 24, in _load_yaml_logging_config
    with path.open() as f:
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/pathlib.py", line 1119, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/hub/hub/project/.meltano/run/tap-peopleware/tap.singer_sdk_logging.json'
```

https://github.com/meltano/hub/actions/runs/15902542043/job/44867108635

## Related Issues

* Fixes a bug introducted in https://github.com/meltano/meltano/pull/9077/

## Summary by Sourcery

Bug Fixes:
- Remove the `exec_args` guard so that Singer logging config is created even when arguments are provided to the invoke command.