### PR TITLE
ci: Open the version bump against the branch from which it was dispatched

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -86,5 +86,5 @@ jobs:
         body: |
           Bump changelog for release v${{ steps.cz-bump.outputs.version }}
         branch: release/v${{ steps.cz-bump.outputs.version }}
-        base: main
         labels: release
+        assignees: "${{ github.actor }}"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update version bump workflow to open PRs against their source branch and assign them to the initiator

CI:
- Remove hard-coded 'main' as the base branch for version bump PRs
- Add 'assignees' field to assign the version bump PR to the triggering user