### PR TITLE
feat: Catalog is now refreshed when `--full-refresh` is used

### DIFF
--- a/src/meltano/core/_protocols/el_context.py
+++ b/src/meltano/core/_protocols/el_context.py
@@ -10,6 +10,7 @@ class ELContextProtocol(t.Protocol):
 
     full_refresh: bool | None
     state_strategy: StateStrategy
+    refresh_catalog: bool | None
 
     def should_merge_states(self) -> bool:
         """Check whether the EL state is incomplete and should be merged."""
@@ -17,3 +18,7 @@ class ELContextProtocol(t.Protocol):
             self.full_refresh is True  # Full refresh implies merging states
             and self.state_strategy == StateStrategy.AUTO
         ) or self.state_strategy == StateStrategy.MERGE
+
+    def should_refresh_catalog(self) -> bool:
+        """Check whether the catalog should be refreshed or used from cache."""
+        return self.refresh_catalog is True or self.full_refresh is True

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -397,7 +397,7 @@ class SingerTap(SingerPlugin):
             return catalog_path
 
         use_cached_catalog = (
-            not (elt_context and elt_context.refresh_catalog)
+            not (elt_context and elt_context.should_refresh_catalog())
             and plugin_invoker.plugin_config_extras["_use_cached_catalog"]
         )
 

--- a/tests/meltano/core/protocols/test_el_context.py
+++ b/tests/meltano/core/protocols/test_el_context.py
@@ -51,9 +51,13 @@ class TestELContextProtocol:
 
         with subtests.test("Refresh catalog & incremental → refresh catalog"):
             assert _(False, True).should_refresh_catalog()
+            assert _(None, True).should_refresh_catalog()
 
         with subtests.test("No refresh catalog & full refresh → refresh catalog"):
             assert _(True, False).should_refresh_catalog()
+            assert _(True, None).should_refresh_catalog()
 
         with subtests.test("No refresh catalog & incremental → use cached catalog"):
             assert not _(False, False).should_refresh_catalog()
+            assert not _(False, None).should_refresh_catalog()
+            assert not _(None, None).should_refresh_catalog()

--- a/tests/meltano/core/protocols/test_el_context.py
+++ b/tests/meltano/core/protocols/test_el_context.py
@@ -14,8 +14,9 @@ if t.TYPE_CHECKING:
 
 @dataclass
 class MyContext(ELContextProtocol):
-    full_refresh: bool | None
-    state_strategy: StateStrategy
+    full_refresh: bool | None = None
+    state_strategy: StateStrategy = StateStrategy.AUTO
+    refresh_catalog: bool | None = None
 
 
 class TestELContextProtocol:
@@ -40,3 +41,19 @@ class TestELContextProtocol:
 
         with subtests.test("Incremental & overwrite → overwrite"):
             assert not _(False, StateStrategy.OVERWRITE).should_merge_states()
+
+    def test_should_refresh_catalog(self, subtests: SubTests):
+        def _(full_refresh: bool, refresh_catalog: bool):
+            return MyContext(full_refresh, refresh_catalog=refresh_catalog)
+
+        with subtests.test("Refresh catalog & full refresh → refresh catalog"):
+            assert _(True, True).should_refresh_catalog()
+
+        with subtests.test("Refresh catalog & incremental → refresh catalog"):
+            assert _(False, True).should_refresh_catalog()
+
+        with subtests.test("No refresh catalog & full refresh → refresh catalog"):
+            assert _(True, False).should_refresh_catalog()
+
+        with subtests.test("No refresh catalog & incremental → use cached catalog"):
+            assert not _(False, False).should_refresh_catalog()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes https://github.com/meltano/meltano/issues/7899

## Summary by Sourcery

Enable catalog refresh on full-refresh or explicit request by introducing a refresh_catalog flag and should_refresh_catalog logic, updating the Singer tap to honor it, and adding corresponding tests

New Features:
- Add a refresh_catalog attribute to the ELContextProtocol with a default value
- Implement a should_refresh_catalog method to determine when to reload the catalog

Enhancements:
- Update the Singer tap to use should_refresh_catalog for catalog caching logic

Tests:
- Add unit tests covering should_refresh_catalog behavior across full_refresh and refresh_catalog combinations