### PR TITLE
refactor: Use more standard `VIRTUAL_ENV` environment variable instead of the `--python` flag to install plugins into uv-managed venvs

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -677,7 +677,7 @@ class UvVenvService(VenvService):
             extract_stderr=extract_stderr,
             env={
                 **env,
-                "VIRTUAL_ENV": str(self.venv.root),
+                "VIRTUAL_ENV": self.venv.root.as_posix(),
             },
         )
 
@@ -697,7 +697,7 @@ class UvVenvService(VenvService):
             "uninstall",
             package,
             env={
-                "VIRTUAL_ENV": str(self.venv.root),
+                "VIRTUAL_ENV": self.venv.root.as_posix(),
             },
         )
 
@@ -755,7 +755,7 @@ class UvVenvService(VenvService):
             "--format=json",
             *args,
             env={
-                "VIRTUAL_ENV": str(self.venv.root),
+                "VIRTUAL_ENV": self.venv.root.as_posix(),
             },
         )
         stdout, _ = await proc.communicate()

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -668,15 +668,17 @@ class UvVenvService(VenvService):
         Returns:
             The process running `pip install` with the provided args.
         """
+        env = env or {}
         return await exec_async(
             self.uv,
             "pip",
             "install",
-            "--python",
-            str(self.exec_path("python")),
             *pip_install_args,
             extract_stderr=extract_stderr,
-            env=env,
+            env={
+                **env,
+                "VIRTUAL_ENV": str(self.venv.root),
+            },
         )
 
     @override
@@ -693,9 +695,10 @@ class UvVenvService(VenvService):
             self.uv,
             "pip",
             "uninstall",
-            "--python",
-            str(self.exec_path("python")),
             package,
+            env={
+                "VIRTUAL_ENV": str(self.venv.root),
+            },
         )
 
     @override
@@ -741,6 +744,7 @@ class UvVenvService(VenvService):
             extract_stderr=extract_stderr,
         )
 
+    @override
     async def list_installed(self, *args: str) -> list[dict[str, t.Any]]:
         """List the installed dependencies."""
         proc = await exec_async(
@@ -749,8 +753,10 @@ class UvVenvService(VenvService):
             "list",
             "--quiet",
             "--format=json",
-            f"--python={self.exec_path('python')}",
             *args,
+            env={
+                "VIRTUAL_ENV": str(self.venv.root),
+            },
         )
         stdout, _ = await proc.communicate()
         return json.loads(stdout)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor pip invocation in uv-managed virtual environments to leverage the standard VIRTUAL_ENV environment variable instead of passing the --python flag

Enhancements:
- Replace --python flag with setting VIRTUAL_ENV for pip install, uninstall, and list commands
- Default to an empty env dict when installing pip args if none is provided
- Add missing @override decorator to the list_installed method