### PR TITLE
test: Fix flaky `meltano compile` test that checks for some events in the logs

### DIFF
--- a/tests/meltano/cli/test_compile.py
+++ b/tests/meltano/cli/test_compile.py
@@ -128,7 +128,7 @@ class TestCompile:
             # check is good enough:
             assert len(log.events) == 2
             return
-        assert log.events == [
+        assert log.events[-2:] == [
             {
                 "event": (
                     f"Failed to validate project files against Meltano "


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Fix flaky `meltano compile` test by changing its log events assertion to only verify the last two events instead of the entire list.

Bug Fixes:
- Fix flaky `meltano compile` test by matching only the last two log events.

Tests:
- Relax log events assertion in `test_compile.py` to avoid failures due to additional events.