### PR TITLE
feat: Limit the traceback in console logs format to two frames

### DIFF
--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -29,7 +29,7 @@ A logging.yaml contains a few key sections that you should be aware of.
 A few key points to note:
 
 1. Different handlers can use different formats. Meltano ships with [3 formatters](https://github.com/meltano/meltano/blob/main/src/meltano/core/logging/formatters.py):
-   - `meltano.core.logging.console_log_formatter` - A formatter that renders lines for the console, with optional colorization. When colorization is enabled, tracebacks are formatted with the `rich` python library.
+   - `meltano.core.logging.console_log_formatter` - A formatter that renders lines for the console, with optional colorization. When colorization is enabled, tracebacks are formatted with the `rich` python library. Supports `colors` (bool), `show_locals` (bool), `max_frames` (int, default: 2), and `utc` (bool) parameters.
    - `meltano.core.logging.json_log_formatter` - A formatter that renders lines in JSON format.
    - `meltano.core.logging.key_value` - A formatter that renders lines in key=value format.
    - `meltano.core.logging.plain_formatter` - A formatter that renders lines in a plain text format.
@@ -59,6 +59,7 @@ formatters:
     (): meltano.core.logging.console_log_formatter
     colors: true # also enables traceback formatting with `rich`
     show_locals: true # enables local variable logging in tracebacks (can be very verbose and leak sensitive data)
+    max_frames: 5 # maximum number of frames to show in tracebacks (default: 2)
     utc: false # use local time instead of UTC for timestamps
   key_value: # log format for traditional key=value style logs
     (): meltano.core.logging.key_value_formatter

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -84,6 +84,7 @@ def rich_exception_formatter_factory(
     *,
     no_color: bool | None = None,
     show_locals: bool = False,
+    max_frames: int = 100,
 ) -> Callable[[t.TextIO, structlog.types.ExcInfo], None]:
     """Create an exception formatter for logging using the rich package.
 
@@ -95,6 +96,7 @@ def rich_exception_formatter_factory(
         color_system: The color system supported by your terminal.
         no_color: Enabled no color mode, or None to auto detect. Defaults to None.
         show_locals: Whether to show local variables in the traceback.
+        max_frames: Maximum number of frames to show in a traceback, 0 for no maximum.
 
     Returns:
         Exception formatter function.
@@ -109,6 +111,7 @@ def rich_exception_formatter_factory(
             Traceback.from_exception(
                 *exc_info,
                 show_locals=show_locals,
+                max_frames=max_frames,
             ),
         )
 
@@ -151,6 +154,7 @@ def console_log_formatter(
     callsite_parameters: bool = False,
     show_locals: bool = False,
     utc: bool = True,
+    max_frames: int = 2,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter for console rendering that supports colorization.
 
@@ -159,6 +163,7 @@ def console_log_formatter(
         callsite_parameters: Whether to include callsite parameters in the output.
         show_locals: Whether to show local variables in the traceback.
         utc: Whether to use UTC time for timestamps.
+        max_frames: Maximum number of frames to show in a traceback, 0 for no maximum.
 
     Returns:
         A configured console log formatter.
@@ -169,11 +174,13 @@ def console_log_formatter(
         exception_formatter = rich_exception_formatter_factory(
             color_system="truecolor",
             show_locals=show_locals,
+            max_frames=max_frames,
         )
     else:
         exception_formatter = rich_exception_formatter_factory(
             no_color=True,
             show_locals=show_locals,
+            max_frames=max_frames,
         )
 
     return _process_formatter(

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -149,6 +149,12 @@ class TestLogFormatters:
         assert "frames hidden" not in output_unlimited
         assert output_unlimited.count("in level_") == 5
 
+        # Test that max_frames=0 shows all frames (unlimited)
+        formatter_zero = formatters.console_log_formatter(max_frames=0)
+        output_zero = formatter_zero.format(record_with_deep_exception)
+        assert "frames hidden" not in output_zero
+        assert output_zero.count("in level_") == 5
+
     def test_key_value_formatter(self, record):
         formatter = formatters.key_value_formatter()
         output = formatter.format(record)

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -38,6 +38,36 @@ def exc_info() -> ExcInfo:
         return sys.exc_info()
 
 
+@pytest.fixture
+def deep_exc_info() -> ExcInfo:
+    """Create a deeper call stack for testing max_frames."""
+
+    def level_5():
+        local_var_5 = "level_5_value"  # noqa: F841
+        raise ValueError("Deep stack error")  # noqa: EM101
+
+    def level_4():
+        local_var_4 = "level_4_value"  # noqa: F841
+        level_5()
+
+    def level_3():
+        local_var_3 = "level_3_value"  # noqa: F841
+        level_4()
+
+    def level_2():
+        local_var_2 = "level_2_value"  # noqa: F841
+        level_3()
+
+    def level_1():
+        local_var_1 = "level_1_value"  # noqa: F841
+        level_2()
+
+    try:
+        level_1()
+    except ValueError:
+        return sys.exc_info()
+
+
 class TestLogFormatters:
     """Test the log formatters."""
 
@@ -74,6 +104,18 @@ class TestLogFormatters:
             exc_info=exc_info,
         )
 
+    @pytest.fixture
+    def record_with_deep_exception(self, deep_exc_info: ExcInfo):
+        return logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="test",
+            lineno=1,
+            msg="deep stack test",
+            args=None,
+            exc_info=deep_exc_info,
+        )
+
     def test_console_log_formatter_colors(self, record, monkeypatch) -> None:
         monkeypatch.delenv("NO_COLOR", raising=False)
         formatter = formatters.console_log_formatter(colors=True)
@@ -94,6 +136,18 @@ class TestLogFormatters:
         output = formatter.format(record_with_exception)
         assert "locals" in output
         assert "my_var = 'my_value'" in output
+
+    def test_console_log_formatter_max_frames(self, record_with_deep_exception) -> None:
+        # Test that max_frames limits the number of frames shown
+        formatter_limited = formatters.console_log_formatter(max_frames=2)
+        output_limited = formatter_limited.format(record_with_deep_exception)
+        assert "frames hidden" in output_limited
+
+        # Test that high max_frames shows all frames
+        formatter_unlimited = formatters.console_log_formatter(max_frames=100)
+        output_unlimited = formatter_unlimited.format(record_with_deep_exception)
+        assert "frames hidden" not in output_unlimited
+        assert output_unlimited.count("in level_") == 5
 
     def test_key_value_formatter(self, record):
         formatter = formatters.key_value_formatter()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Tracebacks are very hard to read at the moment, mostly because they are extremely long in most cases. This should ensure that the only most important context is displayed. The full traceback can be recovered by enabling debug level logs, or by using a custom logging configuration file.

## Related Issues

NA

## Summary by Sourcery

Introduce a configurable `max_frames` parameter to cap traceback depth in console logs and default it to two frames for non-debug levels, while preserving full tracebacks in debug mode.

New Features:
- Add `max_frames` argument to `rich_exception_formatter_factory` and `console_log_formatter` to control the number of displayed traceback frames.
- Automatically set `max_frames` to 2 for normal log levels and to unlimited in debug within the default logging configuration.

Enhancements:
- Normalize and unify log level casing and level handling in `default_config` and `setup_logging`.

Documentation:
- Update logging guide to document the new `max_frames` option and its default value for console formatting.

Tests:
- Introduce `deep_exc_info` fixture and corresponding test to assert both limited and unlimited frame display behaviors.