### PR TITLE
feat: For the `python` project and plugin setting, rely on the `venv.backend` to discover the correct Python executable

### DIFF
--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -243,7 +243,7 @@ By default, plugins that use Python use the version of Python that was used to r
 When adding a new plugin, the Python version can be specified using the `--python` option:
 
 ```bash
-meltano add <type> <name> --python <Python executable name or path>
+meltano add <type> <name> --python <Python version or path>
 ```
 
 For example, to add `tap-github` using Python 3.12 (assuming `python3.12` is installed and on your `$PATH`):

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -69,6 +69,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
     name: str
     variant: str | None
     executable: str
+    python: str | None
 
     config_files: dict[str, str]
 
@@ -161,7 +162,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         self.set_presentation_attrs(extras)
         self.variant = variant
         self.pip_url = pip_url
-        self.python = python
+        self.python = str(python) if python else None
         self.executable = executable
         self.capabilities = capabilities
         self.settings_group_validation = settings_group_validation

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -107,7 +107,7 @@ class VirtualEnv:
         if self._system not in self._SUPPORTED_PLATFORMS:
             raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
         self.root = root.resolve()
-        self.python_path = sys.executable if not python else python
+        self.python_path = python if python else sys.executable
         self.plugin_fingerprint_path = self.root / ".meltano_plugin_fingerprint"
 
     @cached_property
@@ -404,8 +404,7 @@ class VenvService:
             sys.executable,
             "-m",
             "virtualenv",
-            "--python",
-            self.venv.python_path,
+            f"--python={self.venv.python_path}",
             str(self.venv.root),
             extract_stderr=extract_stderr,
         )
@@ -667,8 +666,7 @@ class UvVenvService(VenvService):
             self.uv,
             "pip",
             "install",
-            "--python",
-            str(self.exec_path("python")),
+            f"--python={self.exec_path('python')}",
             *pip_install_args,
             extract_stderr=extract_stderr,
             env=env,
@@ -688,8 +686,7 @@ class UvVenvService(VenvService):
             self.uv,
             "pip",
             "uninstall",
-            "--python",
-            str(self.exec_path("python")),
+            f"--python={self.exec_path('python')}",
             package,
         )
 
@@ -730,8 +727,7 @@ class UvVenvService(VenvService):
         return await exec_async(
             self.uv,
             "venv",
-            "--python",
-            self.venv.python_path,
+            f"--python={self.venv.python_path}",
             str(self.venv.root),
             extract_stderr=extract_stderr,
         )

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -107,7 +107,7 @@ class VirtualEnv:
         if self._system not in self._SUPPORTED_PLATFORMS:
             raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
         self.root = root.resolve()
-        self.python_path = python if python else sys.executable
+        self.python_path = python or sys.executable
         self.plugin_fingerprint_path = self.root / ".meltano_plugin_fingerprint"
 
     @cached_property

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -107,7 +107,7 @@ class VirtualEnv:
         if self._system not in self._SUPPORTED_PLATFORMS:
             raise MeltanoError(f"Platform {self._system!r} not supported.")  # noqa: EM102
         self.root = root.resolve()
-        self.python_path = sys.executable if not python else str(python)
+        self.python_path = sys.executable if not python else python
         self.plugin_fingerprint_path = self.root / ".meltano_plugin_fingerprint"
 
     @cached_property

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -806,9 +806,7 @@ class TestCliAdd:
         with (
             mock.patch("meltano.core.venv_service.exec_async") as exec_mock,
             mock.patch("meltano.core.venv_service.UvVenvService.install_pip_args"),
-            mock.patch(
-                "meltano.core.venv_service.VirtualEnv.write_fingerprint"
-            )
+            mock.patch("meltano.core.venv_service.VirtualEnv.write_fingerprint"),
         ):
             python = "python3.X"
             assert_cli_runner(

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -804,10 +804,11 @@ class TestCliAdd:
 
     def test_add_with_python_version(self, cli_runner: CliRunner) -> None:
         with (
+            mock.patch("meltano.core.venv_service.exec_async") as exec_mock,
+            mock.patch("meltano.core.venv_service.UvVenvService.install_pip_args"),
             mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.UvVenvService.install"),
+                "meltano.core.venv_service.VirtualEnv.write_fingerprint"
+            ) as write_fingerprint_mock,
         ):
             python = "python3.X"
             assert_cli_runner(
@@ -822,7 +823,8 @@ class TestCliAdd:
                     ),
                 ),
             )
-            venv_mock.assert_called_with(python)
+            assert exec_mock.call_args.args[3] == python
+            write_fingerprint_mock.assert_called_once()
 
     def test_add_with_force_flag(self, project: Project, cli_runner: CliRunner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -821,7 +821,7 @@ class TestCliAdd:
                     ),
                 ),
             )
-            assert exec_mock.call_args.args[3] == python
+            assert exec_mock.call_args.args[-2] == f"--python={python}"
 
     def test_add_with_force_flag(self, project: Project, cli_runner: CliRunner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -808,7 +808,7 @@ class TestCliAdd:
             mock.patch("meltano.core.venv_service.UvVenvService.install_pip_args"),
             mock.patch(
                 "meltano.core.venv_service.VirtualEnv.write_fingerprint"
-            ) as write_fingerprint_mock,
+            )
         ):
             python = "python3.X"
             assert_cli_runner(
@@ -824,7 +824,6 @@ class TestCliAdd:
                 ),
             )
             assert exec_mock.call_args.args[3] == python
-            write_fingerprint_mock.assert_called_once()
 
     def test_add_with_force_flag(self, project: Project, cli_runner: CliRunner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import platform
-import sys
 import typing as t
 from asyncio.subprocess import Process
 from pathlib import Path
@@ -235,22 +234,6 @@ class TestVirtualEnv:
             ),
         ):
             VirtualEnv(project.venvs_dir("pytest", "pytest"))
-
-    def test_different_python_versions(self, project: Project) -> None:
-        root = project.venvs_dir("pytest", "pytest")
-
-        assert (
-            VirtualEnv(root, python=None).python_path
-            == VirtualEnv(root).python_path
-            == VirtualEnv(root, python=sys.executable).python_path
-            == sys.executable
-        )
-
-        path_str = "/usr/bin/test-python-executable"
-        venv = VirtualEnv(root, python=path_str)
-        assert venv.python_path == path_str
-
-        assert VirtualEnv(root, python="3.11").python_path == "3.11"
 
 
 class TestUvVenvService(TestVenvService):

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -12,7 +12,6 @@ import pytest
 from meltano.core.error import AsyncSubprocessError, MeltanoError
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
-from meltano.core.plugin_install_service import install_pip_plugin
 from meltano.core.venv_service import UvVenvService, VenvService, VirtualEnv
 
 if t.TYPE_CHECKING:
@@ -21,15 +20,6 @@ if t.TYPE_CHECKING:
 
 class TestVenvService:
     cls = VenvService
-
-    def _check_venv_created_with_python(
-        self,
-        project: Project,
-        python: str | None,
-    ) -> None:
-        with mock.patch("meltano.core.venv_service._resolve_python_path") as venv_mock:
-            self.cls(project=project)
-            venv_mock.assert_called_once_with(python)
 
     def assert_pip_log_file(self, service: VenvService) -> None:
         assert service.pip_log_path.exists()
@@ -179,68 +169,47 @@ class TestVenvService:
         assert subject.requires_clean_install(["example==0.1.0"])
         assert subject.requires_clean_install(["example", "another-package"])
 
-    def test_top_level_python_setting(self, project: Project) -> None:
-        project.settings.set("python", "test-python-executable-project-level")
-        self._check_venv_created_with_python(
-            project,
-            "test-python-executable-project-level",
-        )
-        project.settings.unset("python")
-        self._check_venv_created_with_python(project, None)
-
-    async def test_plugin_python_setting(self, project: Project) -> None:
+    async def test_python_setting(self, project: Project) -> None:
         plugin = ProjectPlugin(
             PluginType.EXTRACTORS,
             name="tap-mock",
             python="test-python-executable-plugin-level",
         )
+        subject = self.cls.from_plugin(project, plugin)
 
-        with (
-            mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.VenvService.install"),
-        ):
-            await install_pip_plugin(project=project, plugin=plugin)
-            venv_mock.assert_called_once_with("test-python-executable-plugin-level")
+        with mock.patch("meltano.core.venv_service.exec_async") as exec_mock:
+            await subject.create_venv()
+            exec_mock.assert_called_once()
+            assert exec_mock.call_args.args[4] == "test-python-executable-plugin-level"
 
         # Setting the project-level `python` setting should have no effect at first
         # because the plugin-level setting takes precedence.
         project.settings.set("python", "test-python-executable-project-level")
+        subject = self.cls.from_plugin(project, plugin)
 
-        with (
-            mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.VenvService.install"),
-        ):
-            await install_pip_plugin(project=project, plugin=plugin)
-            venv_mock.assert_called_once_with("test-python-executable-plugin-level")
+        with mock.patch("meltano.core.venv_service.exec_async") as exec_mock:
+            await subject.create_venv()
+            exec_mock.assert_called_once()
+            assert exec_mock.call_args.args[4] == "test-python-executable-plugin-level"
 
         # The project-level setting should have an effect after the plugin-level
         # setting is unset
         plugin = ProjectPlugin(PluginType.EXTRACTORS, name="tap-mock")
+        subject = self.cls.from_plugin(project, plugin)
 
-        with (
-            mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.VenvService.install"),
-        ):
-            await install_pip_plugin(project=project, plugin=plugin)
-            venv_mock.assert_called_once_with("test-python-executable-project-level")
+        with mock.patch("meltano.core.venv_service.exec_async") as exec_mock:
+            await subject.create_venv()
+            exec_mock.assert_called_once()
+            assert exec_mock.call_args.args[4] == "test-python-executable-project-level"
 
         project.settings.unset("python")
+        subject = self.cls.from_plugin(project, plugin)
 
         # After both the project-level and plugin-level are unset, it should be None
-        with (
-            mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.VenvService.install"),
-        ):
-            await install_pip_plugin(project=project, plugin=plugin)
-            venv_mock.assert_called_once_with(None)
+        with mock.patch("meltano.core.venv_service.exec_async") as exec_mock:
+            await subject.create_venv()
+            exec_mock.assert_called_once()
+            assert Path(exec_mock.call_args.args[4]).is_absolute()
 
 
 class TestVirtualEnv:
@@ -277,56 +246,11 @@ class TestVirtualEnv:
             == sys.executable
         )
 
-        with (
-            mock.patch(
-                "shutil.which",
-                return_value="/usr/bin/test-python-executable",
-            ),
-            mock.patch("os.access", return_value=True),
-        ):
-            assert (
-                VirtualEnv(root, python="test-python-executable").python_path
-                == "/usr/bin/test-python-executable"
-            )
+        path_str = "/usr/bin/test-python-executable"
+        venv = VirtualEnv(root, python=path_str)
+        assert venv.python_path == path_str
 
-        with (
-            mock.patch("os.path.exists", return_value=True),
-            mock.patch(
-                "os.access",
-                return_value=True,
-            ),
-        ):
-            path_str = "/usr/bin/test-python-executable"
-            venv = VirtualEnv(root, python=path_str)
-            assert venv.python_path == path_str
-
-            venv = VirtualEnv(root, python=Path(path_str))
-            assert venv.python_path == str(Path(path_str).resolve())
-
-        with (
-            mock.patch(
-                "shutil.which",
-                return_value="/usr/bin/test-python-executable",
-            ),
-            mock.patch("os.access", return_value=False),
-            pytest.raises(
-                MeltanoError,
-                match="'/usr/bin/test-python-executable' is not executable",
-            ),
-        ):
-            VirtualEnv(root, python="test-python-executable")
-
-        with pytest.raises(
-            MeltanoError,
-            match="Python executable 'test-python-executable' was not found",
-        ):
-            VirtualEnv(root, python="test-python-executable")
-
-        with pytest.raises(
-            MeltanoError,
-            match="not the number 3.11",
-        ):
-            VirtualEnv(root, python=3.11)
+        assert VirtualEnv(root, python="3.11").python_path == "3.11"
 
 
 class TestUvVenvService(TestVenvService):
@@ -368,47 +292,44 @@ class TestUvVenvService(TestVenvService):
         ):
             await subject.install(["cowsay"])
 
-    async def test_plugin_python_setting(self, project: Project) -> None:
+    async def test_python_setting(self, project: Project) -> None:
         plugin = ProjectPlugin(
             PluginType.EXTRACTORS,
             name="tap-mock",
             python="test-python-executable-plugin-level",
         )
-        with (
-            mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.UvVenvService.install"),
-        ):
-            await install_pip_plugin(project=project, plugin=plugin)
-            venv_mock.assert_called_once_with("test-python-executable-plugin-level")
+        subject = self.cls.from_plugin(project, plugin)
 
+        with mock.patch("meltano.core.venv_service.exec_async") as exec_mock:
+            await subject.create_venv()
+            exec_mock.assert_called_once()
+            assert exec_mock.call_args.args[3] == "test-python-executable-plugin-level"
+
+        # Setting the project-level `python` setting should have no effect at first
+        # because the plugin-level setting takes precedence.
         project.settings.set("python", "test-python-executable-project-level")
-        with (
-            mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.UvVenvService.install"),
-        ):
-            await install_pip_plugin(project=project, plugin=plugin)
-            venv_mock.assert_called_once_with("test-python-executable-plugin-level")
+        subject = self.cls.from_plugin(project, plugin)
 
+        with mock.patch("meltano.core.venv_service.exec_async") as exec_mock:
+            await subject.create_venv()
+            exec_mock.assert_called_once()
+            assert exec_mock.call_args.args[3] == "test-python-executable-plugin-level"
+
+        # The project-level setting should have an effect after the plugin-level
+        # setting is unset
         plugin = ProjectPlugin(PluginType.EXTRACTORS, name="tap-mock")
-        with (
-            mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.UvVenvService.install"),
-        ):
-            await install_pip_plugin(project=project, plugin=plugin)
-            venv_mock.assert_called_once_with("test-python-executable-project-level")
+        subject = self.cls.from_plugin(project, plugin)
+
+        with mock.patch("meltano.core.venv_service.exec_async") as exec_mock:
+            await subject.create_venv()
+            exec_mock.assert_called_once()
+            assert exec_mock.call_args.args[3] == "test-python-executable-project-level"
 
         project.settings.unset("python")
-        with (
-            mock.patch(
-                "meltano.core.venv_service._resolve_python_path",
-            ) as venv_mock,
-            mock.patch("meltano.core.venv_service.UvVenvService.install"),
-        ):
-            await install_pip_plugin(project=project, plugin=plugin)
-            venv_mock.assert_called_once_with(None)
+        subject = self.cls.from_plugin(project, plugin)
+
+        # After both the project-level and plugin-level are unset, it should be None
+        with mock.patch("meltano.core.venv_service.exec_async") as exec_mock:
+            await subject.create_venv()
+            exec_mock.assert_called_once()
+            assert Path(exec_mock.call_args.args[3]).is_absolute()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This allows uv to download and install Python versions if they're not found locally.

Example:

```console
# Starting on a fresh Meltano on Python 3.13 in Docker
$ uv python list | grep -v "available"
cpython-3.13.5-linux-aarch64-gnu                   /usr/local/bin/python3.13
cpython-3.13.5-linux-aarch64-gnu                   /usr/local/bin/python3 -> python3.13
cpython-3.13.5-linux-aarch64-gnu                   /usr/local/bin/python -> python3

$ meltano init --no-usage-stats project
$ cd project
$ meltano add --python 3.9 target-jsonl

# Notice that uv downloaded Python 3.9!
$ uv python list | grep -v "available"
cpython-3.13.5-linux-aarch64-gnu                   /usr/local/bin/python3.13
cpython-3.13.5-linux-aarch64-gnu                   /usr/local/bin/python3 -> python3.13
cpython-3.13.5-linux-aarch64-gnu                   /usr/local/bin/python -> python3
cpython-3.9.23-linux-aarch64-gnu                   /root/.local/share/uv/python/cpython-3.9.23-linux-aarch64-gnu/bin/python3.9

# Switching then to virtualenv fails to find the uv-managed Python, but I'll report this to them
$ MELTANO_VENV_BACKEND=virtualenv meltano install --clean
CliError: Failed to install plugin(s)
```

## Related Issues

* https://github.com/pypa/virtualenv/issues/2901

## Summary by Sourcery

Delegate Python executable resolution to the virtual environment backend by removing internal resolution logic, simplifying `VirtualEnv` initialization, and updating services to pass raw Python version or path; introduce plugin-level Python setting and a factory method for service instantiation, and update tests and documentation to reflect these changes.

New Features:
- Add `python` attribute to ProjectPlugin to store specified Python version or path
- Introduce `VenvService.from_plugin` class method to create service instances with plugin-level settings

Enhancements:
- Remove internal `_resolve_python_path` logic and delegate Python executable discovery to the virtual environment backend
- Simplify `VirtualEnv` initialization to assign `python_path` directly from the provided string or default to `sys.executable`
- Pass raw Python version/path to `exec_async` when creating virtual environments in `VenvService` and `UvVenvService`
- Use a default stderr extractor in `create_venv` methods

Documentation:
- Clarify CLI docs to describe the `--python` option as accepting a Python version or path

Tests:
- Refactor tests to patch `exec_async` and verify the Python argument passed to the venv backend
- Remove obsolete tests around `_resolve_python_path` and legacy virtual environment creation

## Summary by Sourcery

Allow specifying plugin- and project-level Python versions or paths and delegate executable discovery to the venv backend by removing internal resolution logic, simplifying VirtualEnv initialization, standardizing `--python=` flags in service calls, and updating tests and documentation.

New Features:
- Add a `python` attribute to ProjectPlugin to store user-specified Python version or path
- Introduce a `VenvService.from_plugin` factory method to initialize services with plugin-level Python settings

Enhancements:
- Remove the internal `_resolve_python_path` logic and rely on the virtual environment backend for executable discovery
- Simplify VirtualEnv to set `python_path` directly from the provided value or default to `sys.executable`
- Standardize venv and pip commands to use `--python=<path>` flags instead of separate arguments

Documentation:
- Clarify the CLI `--python` option as accepting a Python version or path

Tests:
- Refactor tests to patch `exec_async` and assert `--python=` flags, removing obsolete resolution tests