### PR TITLE
feat: `meltano remove` no longer requires specifying a plugin type, i.e. `meltano remove tap-github` works too

### DIFF
--- a/docs/docs/guide/plugin-management.md
+++ b/docs/docs/guide/plugin-management.md
@@ -529,13 +529,22 @@ RUN meltano install
 
 ## Removing a plugin from your project
 
-You can remove a [plugin](/concepts/project#plugins) from your Meltano [project](/concepts/project) by using [`meltano remove`](/reference/command-line-interface#remove). You have to specify a [type](/concepts/plugins#types) of plugin to remove, but you can remove multiple plugins of that type.
+You can remove a [plugin](/concepts/project#plugins) from your Meltano [project](/concepts/project) by using [`meltano remove`](/reference/command-line-interface#remove). The plugin type is automatically inferred from the plugin name, so you no longer need to specify the type explicitly.
 
 ```bash
+# New syntax (recommended) - plugin type is automatically inferred
+meltano remove <name>
+meltano remove <name> <name_two>
+
+# Deprecated syntax - will be removed in v4
 meltano remove <type> <name>
 meltano remove <type> <name> <name_two>
 
 # For example:
+meltano remove tap-gitlab
+meltano remove target-postgres target-csv
+
+# Deprecated syntax:
 meltano remove extractor tap-gitlab
 meltano remove loader target-postgres target-csv
 ```

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -1008,7 +1008,7 @@ The `lock` command does not run relative to a [Meltano Environment](https://docs
 
 ## `remove`
 
-`meltano remove` removes one or more [plugins](/concepts/plugins#project-plugins) of the same [type](/concepts/plugins#types) from your Meltano [project](/concepts/project).
+`meltano remove` removes one or more [plugins](/concepts/plugins#project-plugins) from your Meltano [project](/concepts/project).
 
 Specifically, [plugins](/concepts/plugins#project-plugins) will be removed from the:
 
@@ -1020,6 +1020,11 @@ Specifically, [plugins](/concepts/plugins#project-plugins) will be removed from 
 ### How to Use
 
 ```bash
+# New syntax (recommended) - plugin type is automatically inferred
+meltano remove <name>
+meltano remove <name> <name_two>
+
+# Deprecated syntax - will be removed in v4
 meltano remove <type> <name>
 meltano remove <type> <name> <name_two>
 ```
@@ -1031,10 +1036,12 @@ The `remove` command does not run relative to a [Meltano Environment](https://do
 ### Examples
 
 ```bash
-# meltano will attempt to remove an extractor called tap-gitlab
-meltano remove extractor tap-gitlab
+# New syntax - plugin type is automatically inferred
+meltano remove tap-gitlab
+meltano remove target-postgres target-csv
 
-# meltano will attempt to remove two loaders; target-postgres and target-csv
+# Deprecated syntax - will be removed in v4
+meltano remove extractor tap-gitlab
 meltano remove loader target-postgres target-csv
 ```
 

--- a/integration/example-library/meltano-objects/index.md
+++ b/integration/example-library/meltano-objects/index.md
@@ -35,5 +35,5 @@ meltano schedule add run_gitlab --job gitlab_to_jsonl --interval "@daily"
 ## Remove a plugin
 
 ```shell
-meltano remove extractor tap-gitlab
+meltano remove tap-gitlab
 ```

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -14,9 +14,11 @@ from meltano.cli.params import InstallPlugins, get_install_options, pass_project
 from meltano.cli.utils import (
     CliError,
     PartialInstrumentedCmd,
+    PluginTypeArg,
     add_plugin,
     add_required_plugins,
     check_dependencies_met,
+    infer_plugin_type,
 )
 from meltano.core.plugin import PluginRef, PluginType
 from meltano.core.plugin_install_service import PluginInstallReason
@@ -54,32 +56,6 @@ def _load_yaml_from_ref(
         raise click.BadParameter(str(e), ctx=ctx, param=param) from e
 
     return yaml.load(content) or {}
-
-
-class PluginTypeArg(click.Choice):
-    """A click parameter that converts a string to a PluginType."""
-
-    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
-        """Initialize the PluginTypeArg."""
-        super().__init__(PluginType.cli_arguments(), *args, **kwargs)
-
-    def convert(
-        self,
-        value: str,
-        param: click.Parameter | None,  # noqa: ARG002
-        ctx: click.Context | None,  # noqa: ARG002
-    ) -> PluginType:
-        """Convert the value to a PluginType."""
-        return PluginType.from_cli_argument(value)
-
-
-def _infer_plugin_type(plugin_name: str) -> PluginType:
-    if plugin_name.startswith("tap-"):
-        return PluginType.EXTRACTORS
-    if plugin_name.startswith("target-"):
-        return PluginType.LOADERS
-
-    return PluginType.UTILITIES
 
 
 @click.command(
@@ -194,9 +170,7 @@ async def add(
 
     plugin_refs: list[PluginRef] = [
         PluginRef(
-            plugin_type=_infer_plugin_type(name)
-            if plugin_type is None
-            else plugin_type,
+            plugin_type=infer_plugin_type(name) if plugin_type is None else plugin_type,
             name=name,
         )
         for name in plugin_names

--- a/src/meltano/cli/remove.py
+++ b/src/meltano/cli/remove.py
@@ -45,7 +45,7 @@ def remove(
             "and will be removed in Meltano v4. "
             "Please use the --plugin-type option instead.",
             DeprecationWarning,
-            stacklevel=0,
+            stacklevel=1,
         )
     else:
         plugin_names = plugin

--- a/src/meltano/cli/remove.py
+++ b/src/meltano/cli/remove.py
@@ -24,7 +24,6 @@ if t.TYPE_CHECKING:
 
 
 @click.command(cls=InstrumentedCmd, short_help="Remove plugins from your project.")
-# @click.argument("plugin_type", type=click.Choice(PluginType.cli_arguments()))
 @click.argument("plugin", nargs=-1, required=True)
 @click.option("--plugin-type", type=PluginTypeArg())
 @pass_project()

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -637,3 +637,30 @@ class AutoInstallBehavior(StrEnum):
     install = auto()
     no_install = auto()
     only_install = auto()
+
+
+class PluginTypeArg(click.Choice):
+    """A click parameter that converts a string to a PluginType."""
+
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Initialize the PluginTypeArg."""
+        super().__init__(PluginType.cli_arguments(), *args, **kwargs)
+
+    def convert(
+        self,
+        value: str,
+        param: click.Parameter | None,  # noqa: ARG002
+        ctx: click.Context | None,  # noqa: ARG002
+    ) -> PluginType:
+        """Convert the value to a PluginType."""
+        return PluginType.from_cli_argument(value)
+
+
+def infer_plugin_type(plugin_name: str) -> PluginType:
+    """Infer the plugin type from the plugin name."""
+    if plugin_name.startswith("tap-"):
+        return PluginType.EXTRACTORS
+    if plugin_name.startswith("target-"):
+        return PluginType.LOADERS
+
+    return PluginType.UTILITIES

--- a/tests/meltano/cli/test_remove.py
+++ b/tests/meltano/cli/test_remove.py
@@ -24,31 +24,78 @@ class TestCliRemove:
 
     def test_remove(self, project, tap: ProjectPlugin, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
-            result = cli_runner.invoke(cli, ["remove", tap.type.value, tap.name])
+            with pytest.warns(
+                DeprecationWarning,
+                match="plugin type as the first positional argument is deprecated",
+            ):
+                result = cli_runner.invoke(cli, ["remove", tap.type.value, tap.name])
+
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_once_with(project, [tap])
 
     def test_remove_multiple(self, project, tap, tap_gitlab, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
-            result = cli_runner.invoke(
-                cli,
-                ["remove", "extractors", tap.name, tap_gitlab.name],
-            )
+            with pytest.warns(
+                DeprecationWarning,
+                match="plugin type as the first positional argument is deprecated",
+            ):
+                result = cli_runner.invoke(
+                    cli,
+                    ["remove", "extractors", tap.name, tap_gitlab.name],
+                )
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_once_with(project, [tap, tap_gitlab])
 
     def test_remove_type_name(self, project, tap, target, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
-            result = cli_runner.invoke(cli, ["remove", "extractor", tap.name])
+            with pytest.warns(
+                DeprecationWarning,
+                match="plugin type as the first positional argument is deprecated",
+            ):
+                result = cli_runner.invoke(cli, ["remove", "extractor", tap.name])
+
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_with(project, [tap])
 
-            result = cli_runner.invoke(cli, ["remove", "loader", target.name])
+            with pytest.warns(
+                DeprecationWarning,
+                match="plugin type as the first positional argument is deprecated",
+            ):
+                result = cli_runner.invoke(cli, ["remove", "loader", target.name])
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_with(project, [target])
 
             assert remove_plugins_mock.call_count == 2
+
+    def test_remove_no_plugin_type(self, project, tap, tap_gitlab, cli_runner) -> None:
+        with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
+            result = cli_runner.invoke(cli, ["remove", tap.name, tap_gitlab.name])
+            assert_cli_runner(result)
+
+            remove_plugins_mock.assert_called_once_with(project, [tap, tap_gitlab])
+
+    def test_remove_with_explicit_plugin_type(
+        self,
+        project,
+        tap,
+        tap_gitlab,
+        cli_runner,
+    ) -> None:
+        with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "remove",
+                    "--plugin-type",
+                    "extractors",
+                    tap.name,
+                    tap_gitlab.name,
+                ],
+            )
+            assert_cli_runner(result)
+
+            remove_plugins_mock.assert_called_once_with(project, [tap, tap_gitlab])


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* https://github.com/meltano/meltano/pull/9317
* https://github.com/meltano/meltano/issues/7066

## Summary by Sourcery

Allow `meltano remove` to accept plugin names directly and infer their types, introduce a `--plugin-type` flag, deprecate the old positional type argument with a warning, and centralize plugin type inference logic.

New Features:
- Allow omitting the plugin type when running `meltano remove` by inferring types from names
- Add a `--plugin-type` option to the `remove` command
- Emit a deprecation warning when the plugin type is passed as the first positional argument

Enhancements:
- Extract and reuse `infer_plugin_type` and `PluginTypeArg` into the CLI utils module
- Refactor the `remove` command signature to accept only plugin names and derive types as needed
- Replace the private `_infer_plugin_type` in `add` with the shared `infer_plugin_type` function

Tests:
- Add tests for removing plugins without specifying a type
- Update existing remove tests to expect a `DeprecationWarning` for positional type arguments
- Add a test for the explicit `--plugin-type` usage

## Summary by Sourcery

Update the `meltano remove` command to infer plugin types automatically, introduce an explicit `--plugin-type` flag, emit deprecation warnings for the old positional type argument, centralize inference logic in shared utilities, update tests, and refresh documentation accordingly.

New Features:
- Allow omitting the plugin type for `meltano remove` by inferring it from plugin names
- Add a `--plugin-type` option to the `remove` command
- Deprecate the positional plugin type argument with a warning

Enhancements:
- Extract `infer_plugin_type` and `PluginTypeArg` into a shared CLI utils module
- Refactor the `add` and `remove` commands to use centralized plugin type inference

Documentation:
- Update CLI reference and guides to reflect the new inferred plugin type syntax and deprecate the old usage

Tests:
- Add tests for removing plugins without type or with the explicit `--plugin-type` flag
- Update existing tests to expect a `DeprecationWarning` for the old syntax