### PR TITLE
feat: `meltano install` no longer requires specifying a plugin type, i.e. `meltano install tap-github target-postgres` works too

### DIFF
--- a/docs/docs/guide/analysis.md
+++ b/docs/docs/guide/analysis.md
@@ -47,7 +47,7 @@ utilities:
 3. Re-install the plugin:
 
 ```bash
-meltano install utility superset
+meltano install superset
 ```
 
 ### Secret Key

--- a/docs/docs/guide/plugin-management.md
+++ b/docs/docs/guide/plugin-management.md
@@ -368,7 +368,7 @@ The `pip_url`, `executable`, `capabilities`, and `settings` properties
 constitute the plugin's [base plugin description](/concepts/plugins#project-plugins):
 everything Meltano needs to know in order to be able to use the package as a plugin.
 
-:::caution
+:::tip
 
   <p>Once you've got the plugin working in your project, please consider <a href="/contribute/plugins#discoverable-plugins">adding it to Meltano Hub</a> to make it discoverable and supported out of the box for new users!</p>
 :::
@@ -436,9 +436,14 @@ to install (or update) all plugins specified in your [`meltano.yml` project file
 
 To install a specific plugin in your project, use [`meltano install <name>`](/reference/command-line-interface#install), e.g. `meltano install tap-gitlab target-postgres`. Meltano will automatically detect the plugin type. Subsequent calls to `meltano install` will upgrade a plugin to its latest version, if any. To completely uninstall and reinstall a plugin, use `--clean`.
 
-:::info
+:::warning[Deprecated Syntax]
 
-You can still use the legacy syntax `meltano install extractor tap-gitlab` or `meltano install - tap-gitlab`, but these forms are deprecated and will be removed in Meltano v4.
+The following syntax forms are deprecated and will be removed in Meltano v4:
+
+| Deprecated Syntax | Use Instead |
+| --- | --- |
+| `meltano install <plugin_type> <plugin_name>` | `meltano install --plugin-type <plugin_type> <plugin_name>` |
+| `meltano install - <plugin_name>` | `meltano install <plugin_name>` |
 
 :::
 

--- a/docs/docs/guide/plugin-management.md
+++ b/docs/docs/guide/plugin-management.md
@@ -434,7 +434,13 @@ by default, you'll need to explicitly run [`meltano install`](/reference/command
 before any other `meltano` commands whenever you clone or pull an existing Meltano project from version control,
 to install (or update) all plugins specified in your [`meltano.yml` project file](/concepts/project#meltano-yml-project-file).
 
-To install a specific plugin in your project, use [`meltano install [<type>|-] <name>`](/reference/command-line-interface#install), e.g. `meltano install extractor tap-gitlab` or `meltano install - tap-gitlab`. Subsequent calls to `meltano install` will upgrade a plugin to its latest version, if any. To completely uninstall and reinstall a plugin, use `--clean`.
+To install a specific plugin in your project, use [`meltano install <name>`](/reference/command-line-interface#install), e.g. `meltano install tap-gitlab target-postgres`. Meltano will automatically detect the plugin type. Subsequent calls to `meltano install` will upgrade a plugin to its latest version, if any. To completely uninstall and reinstall a plugin, use `--clean`.
+
+:::info
+
+You can still use the legacy syntax `meltano install extractor tap-gitlab` or `meltano install - tap-gitlab`, but these forms are deprecated and will be removed in Meltano v4.
+
+:::
 
 ## Pinning a plugin to a specific version
 
@@ -601,10 +607,10 @@ If you've forked a plugin's repository and made changes to it, you can update yo
 1. Reinstall the plugin from the new `pip_url` using [`meltano install`](/reference/command-line-interface#install):
 
    ```bash
-   meltano install [<type>|-] <name>
+   meltano install [--plugin-type=<type>] <name>
 
    # For example:
-   meltano install extractor tap-gitlab
+   meltano install tap-gitlab
    ```
 
 If your fork supports additional settings, you can set them as [custom settings](/guide/configuration#custom-settings).
@@ -643,10 +649,10 @@ you can [add the new variant as a separate plugin](#multiple-variants) or switch
 1. Reinstall the plugin from the new `pip_url` using [`meltano install`](/reference/command-line-interface#install):
 
    ```bash
-   meltano install [<type>|-] <name>
+   meltano install [--plugin-type=<type>] <name>
 
    # For example:
-   meltano install loader target-postgres
+   meltano install target-postgres
    ```
 
 1. View the current configuration using [`meltano config <name> list`](/reference/command-line-interface#config) to see if it is still valid:

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -853,10 +853,23 @@ The `init` command does not run relative to a [Meltano Environment](https://docs
 
 Installs dependencies of your project based on the **meltano.yml** file.
 
+You can install plugins by simply providing their names without specifying their type. Meltano will automatically detect the plugin type:
+
+```bash
+meltano install tap-github target-postgres
+```
+
 Optionally, provide a plugin type argument to only (re)install plugins of a certain type.
 Additionally, plugin names can be provided to only (re)install those specific plugins.
 
-To install a plugin without knowing its type, or to install multiple plugins of varying types, use the special `-` (any) character as the plugin type argument, followed by plugin name(s). `meltano install -` with no additional positional arguments has the same effect as `meltano install` (i.e. install all plugins).
+:::warning Deprecated Syntax
+
+The following syntax forms are deprecated and will be removed in Meltano v4:
+
+- `meltano install <plugin_type> <plugin_name>` - Use `meltano install <plugin_name>` or `--plugin-type` instead
+- `meltano install - <plugin_name>` - Use `meltano install <plugin_name>` instead
+
+:::
 
 To only install plugins for a particular schedule specify the `--schedule` argument.
 This can be useful in CI test workflows or for deployments that need to install plugins before every run.
@@ -876,15 +889,24 @@ Meltano stores package installation logs in `.meltano/logs/pip/{plugin_type}/{pl
 ### How to Use
 
 ```bash
+# Install all plugins
 meltano install
-meltano install -
 
-meltano install extractors
-meltano install extractor tap-gitlab
-meltano install extractors tap-gitlab tap-adwords
-meltano install - tap-gitlab target-postgres
+# Install specific plugins (recommended - automatically detects type)
+meltano install tap-github target-postgres
+meltano install tap-gitlab
+meltano install - tap-gitlab target-postgres  # Deprecated syntax
+
+# Install plugins by type
+meltano install --plugin-type=extractor tap-gitlab
+meltano install extractors  # Deprecated syntax
+meltano install --plugin-type=extractor tap-gitlab tap-adwords
+meltano install extractors tap-gitlab tap-adwords  # Deprecated syntax
+
+# Install plugins for a specific schedule
 meltano install --schedule=<schedule_name>
 
+# Install with additional options
 meltano install --parallelism=16
 meltano install --clean
 

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -862,12 +862,14 @@ meltano install tap-github target-postgres
 Optionally, provide a plugin type argument to only (re)install plugins of a certain type.
 Additionally, plugin names can be provided to only (re)install those specific plugins.
 
-:::warning Deprecated Syntax
+:::warning[Deprecated Syntax]
 
 The following syntax forms are deprecated and will be removed in Meltano v4:
 
-- `meltano install <plugin_type> <plugin_name>` - Use `meltano install <plugin_name>` or `--plugin-type` instead
-- `meltano install - <plugin_name>` - Use `meltano install <plugin_name>` instead
+| Deprecated Syntax | Use Instead |
+| --- | --- |
+| `meltano install <plugin_type> <plugin_name>` | `meltano install --plugin-type <plugin_type> <plugin_name>` |
+| `meltano install - <plugin_name>` | `meltano install <plugin_name>` |
 
 :::
 

--- a/integration/meltano-env-precedence/validate.sh
+++ b/integration/meltano-env-precedence/validate.sh
@@ -9,7 +9,7 @@ set +o pipefail
 
 export STACKED=1
 
-meltano install utility example
+meltano install example
 
 # FIXME: https://github.com/meltano/meltano/issues/7023
 [ "$(meltano invoke --print-var STACKED example:echo-stacked)" = $'STACKED=4\nStacked env var value is: 4' ]

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -483,7 +483,7 @@ class TestCliInstall:
         assert result.exit_code == 2
         assert (
             "Use only --plugin-type to install plugins of a specific type"
-            in result.output
+            in result.stderr
         )
 
         result = cli_runner.invoke(
@@ -493,7 +493,7 @@ class TestCliInstall:
         assert result.exit_code == 2
         assert (
             "Use only --plugin-type to install plugins of a specific type"
-            in result.output
+            in result.stderr
         )
 
 

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import typing as t
 from unittest import mock
 
 import pytest
@@ -10,6 +11,9 @@ from asserts import assert_cli_runner
 from meltano.cli import cli
 from meltano.core.plugin import PluginType
 from meltano.core.project_add_service import PluginAlreadyAddedException
+
+if t.TYPE_CHECKING:
+    from fixtures.cli import MeltanoCliRunner
 
 
 class TestCliInstall:
@@ -39,7 +43,12 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
-            result = cli_runner.invoke(cli, ["install", "-"])
+            with pytest.warns(
+                DeprecationWarning,
+                match="Using `-` to install plugins of any type is deprecated",
+            ):
+                result = cli_runner.invoke(cli, ["install", "-"])
+
             assert_cli_runner(result)
 
             install_plugin_mock.assert_called_once_with(
@@ -63,7 +72,25 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
             install_plugin_mock_e.return_value = True
 
-            result = cli_runner.invoke(cli, ["install", "extractors"])
+            with pytest.warns(
+                DeprecationWarning,
+                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
+            ):
+                result = cli_runner.invoke(cli, ["install", "extractors"])
+            assert_cli_runner(result)
+
+            install_plugin_mock_e.assert_called_once_with(
+                project,
+                [tap, tap_gitlab],
+                parallelism=None,
+                clean=False,
+                force=False,
+            )
+
+        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
+            install_plugin_mock_e.return_value = True
+
+            result = cli_runner.invoke(cli, ["install", "--plugin-type=extractors"])
             assert_cli_runner(result)
 
             install_plugin_mock_e.assert_called_once_with(
@@ -77,7 +104,11 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_l:
             install_plugin_mock_l.return_value = True
 
-            result = cli_runner.invoke(cli, ["install", "loaders"])
+            with pytest.warns(
+                DeprecationWarning,
+                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
+            ):
+                result = cli_runner.invoke(cli, ["install", "loaders"])
             assert_cli_runner(result)
 
             install_plugin_mock_l.assert_called_once_with(
@@ -91,7 +122,11 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_m:
             install_plugin_mock_m.return_value = True
 
-            result = cli_runner.invoke(cli, ["install", "mappers"])
+            with pytest.warns(
+                DeprecationWarning,
+                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
+            ):
+                result = cli_runner.invoke(cli, ["install", "mappers"])
             assert_cli_runner(result)
 
             assert install_plugin_mock_m.call_count == 1
@@ -117,7 +152,28 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
             install_plugin_mock_e.return_value = True
 
-            result = cli_runner.invoke(cli, ["install", "extractor", tap.name])
+            with pytest.warns(
+                DeprecationWarning,
+                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
+            ):
+                result = cli_runner.invoke(cli, ["install", "extractor", tap.name])
+            assert_cli_runner(result)
+
+            install_plugin_mock_e.assert_called_once_with(
+                project,
+                [tap],
+                parallelism=None,
+                clean=False,
+                force=False,
+            )
+
+        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
+            install_plugin_mock_e.return_value = True
+
+            result = cli_runner.invoke(
+                cli,
+                ["install", "--plugin-type=extractors", tap.name],
+            )
             assert_cli_runner(result)
 
             install_plugin_mock_e.assert_called_once_with(
@@ -131,7 +187,11 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_l:
             install_plugin_mock_l.return_value = True
 
-            result = cli_runner.invoke(cli, ["install", "loader", target.name])
+            with pytest.warns(
+                DeprecationWarning,
+                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
+            ):
+                result = cli_runner.invoke(cli, ["install", "loader", target.name])
             assert_cli_runner(result)
 
             install_plugin_mock_l.assert_called_once_with(
@@ -145,7 +205,11 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_m:
             install_plugin_mock_m.return_value = True
 
-            result = cli_runner.invoke(cli, ["install", "mapper", mapper.name])
+            with pytest.warns(
+                DeprecationWarning,
+                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
+            ):
+                result = cli_runner.invoke(cli, ["install", "mapper", mapper.name])
             assert_cli_runner(result)
 
             assert install_plugin_mock_m.call_count == 1
@@ -164,9 +228,30 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
+            with pytest.warns(
+                DeprecationWarning,
+                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
+            ):
+                result = cli_runner.invoke(
+                    cli,
+                    ["install", "extractors", tap.name, tap_gitlab.name],
+                )
+            assert_cli_runner(result)
+
+            install_plugin_mock.assert_called_once_with(
+                project,
+                [tap, tap_gitlab],
+                parallelism=None,
+                clean=False,
+                force=False,
+            )
+
+        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
+            install_plugin_mock.return_value = True
+
             result = cli_runner.invoke(
                 cli,
-                ["install", "extractors", tap.name, tap_gitlab.name],
+                ["install", "--plugin-type=extractors", tap.name, tap_gitlab.name],
             )
             assert_cli_runner(result)
 
@@ -190,9 +275,29 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
+            with pytest.warns(
+                DeprecationWarning,
+                match="Using `-` to install plugins of any type is deprecated",
+            ):
+                result = cli_runner.invoke(
+                    cli,
+                    ["install", "-", tap.name, target.name, dbt.name],
+                )
+            assert_cli_runner(result)
+
+            install_plugin_mock.assert_called_once_with(
+                project,
+                [tap, target, dbt],
+                parallelism=None,
+                clean=False,
+                force=False,
+            )
+
+        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
+            install_plugin_mock.return_value = True
             result = cli_runner.invoke(
                 cli,
-                ["install", "-", tap.name, target.name, dbt.name],
+                ["install", tap.name, target.name, dbt.name],
             )
             assert_cli_runner(result)
 
@@ -365,6 +470,31 @@ class TestCliInstall:
             assert install_plugin_mock.mock_calls[0].kwargs["parallelism"] is None
             assert install_plugin_mock.mock_calls[0].kwargs["clean"] is False
             assert install_plugin_mock.mock_calls[0].kwargs["force"] is False
+
+    def test_install_conflicting_plugin_type_and_positional_argument(
+        self,
+        tap,
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        result = cli_runner.invoke(
+            cli,
+            ["install", "--plugin-type=extractors", "extractors", tap.name],
+        )
+        assert result.exit_code == 2
+        assert (
+            "Use only --plugin-type to install plugins of a specific type"
+            in result.output
+        )
+
+        result = cli_runner.invoke(
+            cli,
+            ["install", "extractors", "--plugin-type=extractors", "-", tap.name],
+        )
+        assert result.exit_code == 2
+        assert (
+            "Use only --plugin-type to install plugins of a specific type"
+            in result.output
+        )
 
 
 # un_engine_uri forces us to create a new project, we must do this before the


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

`meltano install tap-github target-postgres` is now supported.

## Related Issues

* https://github.com/meltano/meltano/issues/7066
* https://github.com/meltano/meltano/pull/9317
* https://github.com/meltano/meltano/pull/9350

## Summary by Sourcery

Implement automatic plugin type detection for the `install` command, remove the requirement to specify plugin type or use the `-` any-type marker, deprecate the old positional syntax with warnings and errors, and update tests and documentation accordingly.

New Features:
- Allow `meltano install <plugin_name>...` to install plugins without specifying their type
- Support installing multiple plugins of varying types without using the special `-` marker

Enhancements:
- Deprecate the positional plugin type syntax and the `-` any-type marker with deprecation warnings and enforce exclusive use of `--plugin-type`
- Consolidate CLI arguments into a single `plugin` positional parameter alongside a `--plugin-type` option
- Raise usage errors when mixing deprecated positional syntax with the new `--plugin-type` option

Documentation:
- Revise `meltano install` documentation to highlight automatic type detection, deprecate legacy syntax, and update usage examples

Tests:
- Add and update tests to verify deprecation warnings, new argument parsing behavior, and conflicting syntax errors

## Summary by Sourcery

Allow `meltano install` to accept plugin names directly (auto-detecting their types) and deprecate the old positional-type syntax, updating the CLI, documentation, and tests to support and warn about the new behavior.

New Features:
- Enable installing plugins by name only without specifying their type, e.g. `meltano install tap-github target-postgres`

Enhancements:
- Add deprecation warnings for the old positional-type syntax and the special `-` argument
- Introduce a `--plugin-type` option in place of the deprecated first-positional plugin type argument
- Enforce an error when `--plugin-type` is used alongside the deprecated positional-type argument

Documentation:
- Update CLI reference to describe automatic plugin-type detection and new `--plugin-type` option
- Add a warning section listing deprecated `meltano install` syntax in reference and guide documentation
- Revise examples across docs and integration scripts to use the new install syntax

Tests:
- Adapt install CLI tests to assert deprecation warnings for old syntax and to validate the new argument handling
- Add tests for conflicting `--plugin-type` and positional-type usage resulting in a usage error