### PR TITLE
docs: Improve reference description of `settings[*].aliases` and `settings[*].env`

### DIFF
--- a/docs/docs/reference/plugin-definition-syntax.md
+++ b/docs/docs/reference/plugin-definition-syntax.md
@@ -416,13 +416,19 @@ settings:
 
 Optional. An array of aliases for the setting.
 
+An alias is an alternative setting name that can be used in 'meltano.yml' and 'meltano config set'. For example,
+
 ```yaml
-settings:
-- name: setting_name
-  aliases:
-  - setting_name_alias
-  - setting_name_alias_2
+plugins:
+- name: target-rdbms
+  settings:
+  - name: dbname
+    aliases:
+    - database
+    - database_name
 ```
+
+means that, along with the `TARGET_RDBMS_DBNAME` environment variable, the `target-rdbms` plugin also supports the `TARGET_RDBMS_DATABASE` and `TARGET_RDBMS_DATABASE_NAME` environment variables for the same setting. It also means that the `dbname` setting can be used in `meltano.yml` and `meltano config set` using the `database` and `database_name` aliases.
 
 ### `settings[*].description`
 
@@ -447,7 +453,17 @@ settings:
 
 ### `settings[*].env`
 
-Use to delegate to an environment variable for overriding this setting's value.
+Meltano takes the value of the setting and injects it into the plugin's runtime environment as this environment variable, in addition to the default environment variable (of the form `<PLUGIN_NAME>_<SETTING_NAME>`, etc.).
+
+For example, the following setting definition:
+
+```yaml
+settings:
+- name: setting_name
+  env: SOME_API_KEY
+```
+
+will result in the plugin being able to access the value of the setting via the `SOME_API_KEY` environment variable.
 
 ### `settings[*].hidden`
 Optional. Use to hide a setting.


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

- https://deploy-preview-9352--meltano.netlify.app/reference/plugin-definition-syntax#settingsaliases
- https://deploy-preview-9352--meltano.netlify.app/reference/plugin-definition-syntax#settingsenv

## Related Issues

* Closes #8600

## Summary by Sourcery

Enhance plugin definition reference by clarifying how `settings[*].aliases` and `settings[*].env` operate and including concrete YAML examples.

Documentation:
- Clarify that `settings[*].aliases` provides alternate names usable in `meltano.yml`, `meltano config set`, and as corresponding environment variables
- Explain that `settings[*].env` injects the setting value into the plugin runtime environment under a custom variable name alongside the default variable, with an illustrative example