### PR TITLE
refactor: Make generic error message more log-friendly

### DIFF
--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -77,7 +77,7 @@ setup_logging()
 logger = structlog.stdlib.get_logger(__name__)
 
 troubleshooting_message = """\
-Need help fixing this problem? Visit http://melta.no/ for troubleshooting steps, or to
+Need help fixing this problem? Visit http://melta.no/ for troubleshooting steps, or to \
 join our friendly Slack community.
 """
 

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -46,7 +46,7 @@ logger = structlog.stdlib.get_logger(__name__)
 class CliError(Exception):
     """CLI Error."""
 
-    def __init__(self, *args, exit_code: int = 1, **kwargs) -> None:  # noqa: ANN002, ANN003
+    def __init__(self, *args: t.Any, exit_code: int = 1, **kwargs: t.Any) -> None:
         """Instantiate custom CLI Error exception."""
         super().__init__(*args, **kwargs)
 
@@ -58,8 +58,7 @@ class CliError(Exception):
         if self.printed:
             return
 
-        logger.error(str(self), exc_info=self)
-        click.secho(str(self), fg="red", err=True)
+        logger.error(str(self), exc_info=self.__cause__)
 
         self.printed = True
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refine CLI error handling by logging the root cause exception for better diagnostics and streamline error output formatting.

Enhancements:
- Add type annotations to `CliError` constructor parameters for clarity.
- Log the underlying exception cause (`__cause__`) instead of the `CliError` itself in `CliError.print`.
- Remove redundant `click.secho` call to centralize error output via logger.
- Adjust the troubleshooting message string formatting for cleaner CLI display.