### PR TITLE
refactor: Replace deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`

### DIFF
--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import shutil
@@ -60,7 +61,7 @@ async def _stream_redirect(
     while stream and not stream.at_eof():
         data = await stream.readline()
         for file_like_obj in file_like_objs:
-            if asyncio.iscoroutinefunction(file_like_obj.write):
+            if inspect.iscoroutinefunction(file_like_obj.write):
                 await file_like_obj.write(data.decode(encoding) if write_str else data)
             else:
                 file_like_obj.write(data.decode(encoding) if write_str else data)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

https://docs.python.org/3.14/whatsnew/3.14.html#deprecated.

## Related Issues

NA.

## Summary by Sourcery

Enhancements:
- Replace deprecated asyncio.iscoroutinefunction with inspect.iscoroutinefunction in stream redirection logic

## Summary by Sourcery

Enhancements:
- Replace deprecated asyncio.iscoroutinefunction with inspect.iscoroutinefunction in stream redirection logic