### PR TITLE
test: Replace use of `backoff` with native `urllib3` retries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   "structlog>=25.1.0,<26",
   "typing-extensions>=4.12.2,<5",
   "tzlocal~=5.3",
+  "urllib3>=1.26.20",
   "uv>=0.1.24,<0.8",
   "virtualenv>=20.26.6,<21",
 ]
@@ -124,7 +125,6 @@ pre-commit = [
 ]
 testing = [
   { include-group = "coverage" },
-  "backoff>=2.1.2,<3",
   "colorama>=0.4.4,<0.5",
   "moto>=5.0.21,<6",
   "pytest>=8.3.3,<9",
@@ -179,7 +179,6 @@ filterwarnings = [
   "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:botocore.auth.*", # https://github.com/boto/boto3/issues/3889
   "ignore: Parsing dates involving a day of month without a year specified is:DeprecationWarning:dateparser.*",  # https://github.com/scrapinghub/dateparser/issues/1246
   "ignore::pytest.PytestUnraisableExceptionWarning",
-  "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning",  # https://github.com/litl/backoff/pull/220
   "ignore:Passing the plugin type as the first positional argument is deprecated and will be removed in Meltano v4:DeprecationWarning",  # https://github.com/meltano/meltano/issues/7066
 ]
 log_cli = true

--- a/tests/fixtures/docker/snowplow.py
+++ b/tests/fixtures/docker/snowplow.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
-import json
-import os
-import subprocess
+import logging
 import typing as t
-from urllib.request import urlopen
 
-import backoff
 import pytest
+import urllib3
+from urllib3.util.retry import Retry
 
 from meltano.core.project_settings_service import ProjectSettingsService
+
+if t.TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from pytest_docker.plugin import Services
+
+logger = logging.getLogger(__name__)  # noqa: TID251
 
 
 class SnowplowMicro:
@@ -27,10 +32,19 @@ class SnowplowMicro:
         self.url = f"{collector_endpoint}/micro"
         self.all()  # Wait until a connection is established
 
-    @backoff.on_exception(backoff.expo, ConnectionError, max_tries=5)
     def get(self, endpoint: str) -> t.Any:
-        with urlopen(f"{self.url}/{endpoint}") as response:
-            return json.load(response)
+        retries = Retry(total=5, backoff_factor=0.5)
+        with urllib3.PoolManager(retries=retries) as http:
+            return http.request("GET", f"{self.url}/{endpoint}").json()
+
+    def ping(self) -> bool:
+        """Ping the Snowplow Micro service."""
+        try:
+            self.get("all")
+        except Exception:  # pragma: no cover
+            return False
+
+        return True
 
     def all(self) -> dict[str, int]:
         """Get a dict counting the # of good/bad events, and the total # of events."""
@@ -50,7 +64,9 @@ class SnowplowMicro:
 
 
 @pytest.fixture(scope="session")
-def snowplow_session(request) -> SnowplowMicro | None:
+def snowplow_session(
+    request: pytest.FixtureRequest,
+) -> Generator[SnowplowMicro | None, None, None]:
     """Start a Snowplow Micro Docker container, then yield a `SnowplowMicro` instance.
 
     The environment variable `$MELTANO_SNOWPLOW_COLLECTOR_ENDPOINTS` is set to
@@ -65,13 +81,20 @@ def snowplow_session(request) -> SnowplowMicro | None:
     try:
         # Getting the `docker_services` fixture essentially causes
         # `docker-compose up` to be run
-        request.getfixturevalue("docker_services")
-        args = ("docker", "port", f"pytest{os.getpid()}-snowplow-1")
-        proc = subprocess.run(args, capture_output=True, text=True)
-        address_and_port = proc.stdout.strip().split(" -> ")[1]
-        collector_endpoint = f"http://{address_and_port}"
+        services: Services = request.getfixturevalue("docker_services")
+        docker_ip: str = request.getfixturevalue("docker_ip")
+        port = services.port_for("snowplow", 9090)
+        collector_endpoint = f"http://{docker_ip}:{port}"
+
+        client = SnowplowMicro(collector_endpoint)
+        services.wait_until_responsive(
+            timeout=30,
+            pause=0.1,
+            check=client.ping,
+        )
         yield SnowplowMicro(collector_endpoint)
     except Exception:  # pragma: no cover
+        logger.exception("Failed to start Snowplow Micro")
         yield None
 
 
@@ -79,7 +102,7 @@ def snowplow_session(request) -> SnowplowMicro | None:
 def snowplow_optional(
     snowplow_session: SnowplowMicro | None,
     monkeypatch,
-) -> SnowplowMicro | None:
+) -> Generator[SnowplowMicro | None, None, None]:
     """Provide a clean `SnowplowMicro` instance.
 
     This fixture resets the `SnowplowMicro` instance, and enables the
@@ -90,22 +113,23 @@ def snowplow_optional(
     """
     if snowplow_session is None:  # pragma: no cover
         yield None
-    else:
-        if isinstance(ProjectSettingsService.config_override, dict):
-            monkeypatch.delitem(
-                ProjectSettingsService.config_override,
-                "send_anonymous_usage_stats",
-                raising=False,
-            )
-        monkeypatch.setenv("MELTANO_SEND_ANONYMOUS_USAGE_STATS", "True")
-        monkeypatch.setenv(
-            "MELTANO_SNOWPLOW_COLLECTOR_ENDPOINTS",
-            f'["{snowplow_session.collector_endpoint}"]',
+        return
+
+    if isinstance(ProjectSettingsService.config_override, dict):  # pragma: no branch
+        monkeypatch.delitem(
+            ProjectSettingsService.config_override,
+            "send_anonymous_usage_stats",
+            raising=False,
         )
-        try:
-            yield snowplow_session
-        finally:
-            snowplow_session.reset()
+    monkeypatch.setenv("MELTANO_SEND_ANONYMOUS_USAGE_STATS", "True")
+    monkeypatch.setenv(
+        "MELTANO_SNOWPLOW_COLLECTOR_ENDPOINTS",
+        f'["{snowplow_session.collector_endpoint}"]',
+    )
+    try:
+        yield snowplow_session
+    finally:
+        snowplow_session.reset()
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -253,15 +253,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
-
-[[package]]
 name = "backports-strenum"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1334,6 +1325,8 @@ dependencies = [
     { name = "structlog" },
     { name = "typing-extensions" },
     { name = "tzlocal" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "uv" },
     { name = "virtualenv" },
 ]
@@ -1366,7 +1359,6 @@ coverage = [
     { name = "coverage", extra = ["toml"] },
 ]
 dev = [
-    { name = "backoff" },
     { name = "boto3-stubs", extra = ["essential"] },
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
@@ -1397,7 +1389,6 @@ pre-commit = [
     { name = "pre-commit" },
 ]
 testing = [
-    { name = "backoff" },
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
     { name = "moto" },
@@ -1468,6 +1459,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.1.0,<26" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5" },
     { name = "tzlocal", specifier = "~=5.3" },
+    { name = "urllib3", specifier = ">=1.26.20" },
     { name = "uv", specifier = ">=0.1.24,<0.8" },
     { name = "virtualenv", specifier = ">=20.26.6,<21" },
 ]
@@ -1476,7 +1468,6 @@ provides-extras = ["azure", "gcs", "mssql", "postgres", "psycopg2", "s3"]
 [package.metadata.requires-dev]
 coverage = [{ name = "coverage", extras = ["toml"], specifier = ">=7.8" }]
 dev = [
-    { name = "backoff", specifier = ">=2.1.2,<3" },
     { name = "boto3-stubs", extras = ["essential"], specifier = ">=1.35,<1.39" },
     { name = "colorama", specifier = ">=0.4.4,<0.5" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.8" },
@@ -1504,7 +1495,6 @@ dev = [
 ]
 pre-commit = [{ name = "pre-commit", specifier = ">=4.0.1,<5" }]
 testing = [
-    { name = "backoff", specifier = ">=2.1.2,<3" },
     { name = "colorama", specifier = ">=0.4.4,<0.5" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.8" },
     { name = "moto", specifier = ">=5.0.21,<6" },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor Snowplow test fixtures to replace backoff with urllib3 retries, streamline Docker fixture setup, and update dependencies accordingly.

Enhancements:
- Replace backoff-based retry logic in SnowplowMicro.get with native urllib3 Retry for connection handling
- Introduce a ping method and use pytest-docker’s wait_until_responsive to ensure service readiness
- Refactor snowplow_session fixture to use pytest-docker’s Services API instead of subprocess for port lookup
- Simplify snowplow_optional fixture signature and control flow while preserving environment setup
- Add logging for fixture startup failures and improve typing annotations

Build:
- Add urllib3 dependency
- Remove backoff from test dependencies