### PR TITLE
refactor: Replace `atomicwrites` with stdlib functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
   "aiodocker>=0.24.0,<0.25",
   "alembic>=1.14.0,<2",
   "anyio>=4.4.0,<5",
-  "atomicwrites>=1.2.1,<2",
   "backports-strenum>=1.3.1,<2 ; python_version < '3.11'",
   "check-jsonschema~=0.33.0",
   "click>=8.1,<9",
@@ -280,7 +279,6 @@ ignore_errors = true
 module = [
   "meltano.cli.interactive.*",
   # Way too many modules at the root of meltano.core to tackle them all at once  # so listing them individually here.
-  "meltano.core.project_files",
   "meltano.core.project_settings_service",
   "meltano.core.task_sets_service",
   "meltano.core.transform_add_service",

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import tempfile
 import typing as t
 from copy import copy
 
 import structlog
-from atomicwrites import atomic_write
 from ruamel.yaml import CommentedMap, CommentedSeq, YAMLError
 
 from meltano.core import yaml
@@ -14,7 +16,6 @@ from meltano.core.utils import deep_merge
 
 if t.TYPE_CHECKING:
     from collections.abc import Mapping
-    from os import PathLike
     from pathlib import Path
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -51,7 +52,7 @@ class ProjectFiles:
         """
         self.root = root.resolve()
         self._meltano_file_path = meltano_file_path.resolve()
-        self._plugin_file_map = {}
+        self._plugin_file_map: dict[tuple[str, ...], str] = {}
         self._raw_contents_map: dict[str, CommentedMap] = {}
         self._cached_loaded: CommentedMap | None = None
 
@@ -165,7 +166,7 @@ class ProjectFiles:
         # Deduplicate entries
         return list(dict.fromkeys(include_paths))
 
-    def _add_to_index(self, key: tuple, include_path: Path) -> None:
+    def _add_to_index(self, key: tuple[str, ...], include_path: Path) -> None:
         """Add a new key:path to the `_plugin_file_map`.
 
         Args:
@@ -365,6 +366,17 @@ class ProjectFiles:
             schedules = file_dict.get("schedules", CommentedSeq())
             original_schedules.copy_attributes(schedules)
 
-    def _write_file(self, file_path: PathLike, contents: Mapping) -> None:
-        with atomic_write(file_path, overwrite=True) as fl:
-            yaml.dump(contents, fl)
+    def _write_file(self, file_path: str | os.PathLike[str], contents: Mapping) -> None:
+        fd, tmp_name = tempfile.mkstemp(suffix=".tmp.yml")
+        try:
+            with os.fdopen(fd, "w") as tmp_file:
+                yaml.dump(contents, tmp_file)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+            # Atomically replace the target file
+            os.replace(tmp_name, file_path)  # noqa: PTH105
+        except Exception:  # pragma: no cover
+            # Clean up temp file if write or replace fails
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)  # noqa: PTH108
+            raise

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -367,7 +367,8 @@ class ProjectFiles:
             original_schedules.copy_attributes(schedules)
 
     def _write_file(self, file_path: str | os.PathLike[str], contents: Mapping) -> None:
-        fd, tmp_name = tempfile.mkstemp(suffix=".tmp.yml")
+        dirname = os.path.dirname(file_path)  # noqa: PTH120
+        fd, tmp_name = tempfile.mkstemp(dir=dirname, suffix=".tmp.yml")
         try:
             with os.fdopen(fd, "w") as tmp_file:
                 yaml.dump(contents, tmp_file)

--- a/uv.lock
+++ b/uv.lock
@@ -184,12 +184,6 @@ wheels = [
 ]
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11", size = 14227, upload-time = "2022-07-08T18:31:40.459Z" }
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1297,7 +1291,6 @@ dependencies = [
     { name = "aiodocker" },
     { name = "alembic" },
     { name = "anyio" },
-    { name = "atomicwrites" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
     { name = "check-jsonschema" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1423,7 +1416,6 @@ requires-dist = [
     { name = "aiodocker", specifier = ">=0.24.0,<0.25" },
     { name = "alembic", specifier = ">=1.14.0,<2" },
     { name = "anyio", specifier = ">=4.4.0,<5" },
-    { name = "atomicwrites", specifier = ">=1.2.1,<2" },
     { name = "azure-common", marker = "extra == 'azure'", specifier = ">=1.1.28,<2" },
     { name = "azure-core", marker = "extra == 'azure'", specifier = ">=1.32.0,<2" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.19.0,<2" },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Replace `atomicwrites`-based file writes with stdlib-based atomic write logic, drop the `atomicwrites` dependency, and enhance type annotations in project_files.py.

Enhancements:
- Implement atomic file writes with `tempfile.mkstemp`, `os.replace`, and `os.fsync` instead of relying on `atomicwrites`.
- Add explicit type annotations for `_plugin_file_map` and the `_add_to_index` method key parameter in `project_files.py`.
- Clean up unused imports and adjust method signatures to use standard library types.

Build:
- Remove `atomicwrites` from project dependencies in `pyproject.toml`.

CI:
- Include `meltano.core.project_files` in coverage by removing it from the ignore list.