### PR TITLE
revert: Revert unusable `utc` log formatter parameter

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -27,3 +27,6 @@ dcdd9f09c105baf2f10d3214a730aa3f6c535726
 
 # chore: Enable type checking in `meltano.core.behavior.addon`
 30d70e5462bea855243714614ec2151961cae5e4
+
+# feat(core): Support emitting logs with timestamps in local time
+4560c05ada3d3e462ceeeae728455c4943e0a5c5

--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -33,8 +33,6 @@ A few key points to note:
    - `meltano.core.logging.json_log_formatter` - A formatter that renders lines in JSON format.
    - `meltano.core.logging.key_value` - A formatter that renders lines in key=value format.
    - `meltano.core.logging.plain_formatter` - A formatter that renders lines in a plain text format.
-
-   All formatters support a `utc` parameter (defaults to `True`) that controls whether timestamps are rendered in UTC or local time.
 2. Different loggers can use different handlers and log at different log levels.
 3. We support all the [standard python logging handlers](https://docs.python.org/3/library/logging.handlers.html#) (e.g. rotating files, syslog, etc).
 4. If a logging config file is found, it will take precedence over the `--log-format` and `--log-level` CLI options.
@@ -60,7 +58,6 @@ formatters:
     colors: true # also enables traceback formatting with `rich`
     show_locals: true # enables local variable logging in tracebacks (can be very verbose and leak sensitive data)
     max_frames: 5 # maximum number of frames to show in tracebacks (default: 2)
-    utc: false # use local time instead of UTC for timestamps
   key_value: # log format for traditional key=value style logs
     (): meltano.core.logging.key_value_formatter
     sort_keys: false

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -138,7 +138,9 @@ def _process_formatter(
     """
     return structlog.stdlib.ProcessorFormatter(
         processors=processors,
-        foreign_pre_chain=LEVELED_TIMESTAMPED_PRE_CHAIN,  # FYI: this needs to be kept consistent between all `ProcessorFormatter` instances
+        # FYI: this needs to be kept consistent between all `ProcessorFormatter`
+        # instances
+        foreign_pre_chain=LEVELED_TIMESTAMPED_PRE_CHAIN,
         **kwargs,
     )
 

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -120,7 +120,6 @@ def rich_exception_formatter_factory(
 
 def _process_formatter(
     *processors: Processor,
-    utc: bool = True,
     **kwargs: t.Any,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Use _process_formatter to configure a structlog.stdlib.ProcessFormatter.
@@ -131,7 +130,6 @@ def _process_formatter(
     Args:
         *processors: One or more structlog message processors such as
             `structlog.dev.ConsoleRenderer`.
-        utc: Whether to use UTC time for timestamps.
         **kwargs: Additional keyword arguments to pass to the logging.Formatter
             constructor.
 
@@ -140,10 +138,7 @@ def _process_formatter(
     """
     return structlog.stdlib.ProcessorFormatter(
         processors=processors,
-        foreign_pre_chain=(
-            structlog.stdlib.add_log_level,
-            structlog.processors.TimeStamper(fmt="iso", utc=utc),
-        ),
+        foreign_pre_chain=LEVELED_TIMESTAMPED_PRE_CHAIN,
         **kwargs,
     )
 
@@ -153,7 +148,6 @@ def console_log_formatter(
     colors: bool = False,
     callsite_parameters: bool = False,
     show_locals: bool = False,
-    utc: bool = True,
     max_frames: int = 2,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter for console rendering that supports colorization.
@@ -162,7 +156,6 @@ def console_log_formatter(
         colors: Add color to output.
         callsite_parameters: Whether to include callsite parameters in the output.
         show_locals: Whether to show local variables in the traceback.
-        utc: Whether to use UTC time for timestamps.
         max_frames: Maximum number of frames to show in a traceback, 0 for no maximum.
 
     Returns:
@@ -190,7 +183,6 @@ def console_log_formatter(
             colors=colors,
             exception_formatter=exception_formatter,
         ),
-        utc=utc,
     )
 
 
@@ -200,7 +192,6 @@ def key_value_formatter(
     key_order: Sequence[str] | None = None,
     drop_missing: bool = False,
     callsite_parameters: bool = False,
-    utc: bool = True,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter that renders lines in key=value format.
 
@@ -212,7 +203,6 @@ def key_value_formatter(
         drop_missing: When True, extra keys in *key_order* will be dropped
             rather than rendered as None.
         callsite_parameters: Whether to include callsite parameters in the output.
-        utc: Whether to use UTC time for timestamps.
 
     Returns:
         A configured key=value formatter.
@@ -225,7 +215,6 @@ def key_value_formatter(
             key_order=key_order,
             drop_missing=drop_missing,
         ),
-        utc=utc,
     )
 
 
@@ -234,7 +223,6 @@ def json_formatter(
     callsite_parameters: bool = False,
     dict_tracebacks: bool = True,
     show_locals: bool = False,
-    utc: bool = True,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter that renders lines in JSON format.
 
@@ -242,7 +230,6 @@ def json_formatter(
         callsite_parameters: Whether to include callsite parameters in the JSON output.
         dict_tracebacks: Whether to include tracebacks in the JSON output.
         show_locals: Whether to include local variables in the traceback.
-        utc: Whether to use UTC time for timestamps.
 
     Returns:
         A configured JSON formatter.
@@ -255,7 +242,6 @@ def json_formatter(
         ),
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         structlog.processors.JSONRenderer(),
-        utc=utc,
     )
 
 
@@ -283,7 +269,6 @@ def plain_formatter(
     datefmt: str | None = None,
     style: str = "%",
     validate: bool = True,
-    utc: bool = True,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter that renders lines in a simple format.
 
@@ -292,7 +277,7 @@ def plain_formatter(
         datefmt: The date format string.
         style: The format style.
         validate: Whether to validate the format string.
-        utc: Whether to use UTC time for timestamps.
+        features: Logging features to enable.
 
     Returns:
         A configured simple formatter.
@@ -306,7 +291,6 @@ def plain_formatter(
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
         _event_renderer,
-        utc=utc,
         fmt=fmt,
         datefmt=datefmt,
         style=style,

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -138,7 +138,7 @@ def _process_formatter(
     """
     return structlog.stdlib.ProcessorFormatter(
         processors=processors,
-        foreign_pre_chain=LEVELED_TIMESTAMPED_PRE_CHAIN,
+        foreign_pre_chain=LEVELED_TIMESTAMPED_PRE_CHAIN,  # FYI: this needs to be kept consistent between all `ProcessorFormatter` instances
         **kwargs,
     )
 

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -196,19 +196,6 @@ class TestLogFormatters:
 
         assert "exception" not in message_dict
 
-    def test_json_formatter_utc(self, record_with_exception) -> None:
-        formatter = formatters.json_formatter(utc=True)
-        output = formatter.format(record_with_exception)
-        message_dict = json.loads(output)
-        assert "timestamp" in message_dict
-        assert message_dict["timestamp"].endswith("Z")
-
-        formatter = formatters.json_formatter(utc=False)
-        output = formatter.format(record_with_exception)
-        message_dict = json.loads(output)
-        assert "timestamp" in message_dict
-        assert not message_dict["timestamp"].endswith("Z")
-
     def test_json_formatter_locals(self, record_with_exception) -> None:
         formatter = formatters.json_formatter(show_locals=True)
         output = formatter.format(record_with_exception)


### PR DESCRIPTION
Reverts PR

- https://github.com/meltano/meltano/pull/9328

The parameter works for the formatter in isolation, but it is
fundamentally unusable when the rest of in the internal logging infra is
applied.

So, I'm removing this since it won't result in the expected results anyway and will only cause confusion.

This reverts commit 4560c05ada3d3e462ceeeae728455c4943e0a5c5.

<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Revert the unusable `utc` parameter from all logging formatters and remove its associated tests and documentation

Enhancements:
- Remove `utc` argument from `_process_formatter`, `console_log_formatter`, `key_value_formatter`, `json_formatter`, and `plain_formatter`
- Replace manual timestamping chain with the shared `LEVELED_TIMESTAMPED_PRE_CHAIN` in process formatter

Documentation:
- Remove `utc` parameter references from logging guide documentation

Tests:
- Delete unit tests covering `utc` behavior in JSON formatter