### PR TITLE
fix: Honor valid `properties` field name in `select` values

### DIFF
--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -263,6 +263,7 @@ def path_property(path: str) -> str:
     Examples:
       stream[0].properties.list_items.properties.account → list_items.account
       stream[0].properties.name                          → name
+      stream[0].properties.properties.properties.amount  → properties.amount
     """
     prop_regex = r"properties\.([^.]+)+"
     components = re.findall(prop_regex, path)
@@ -282,12 +283,9 @@ def property_breadcrumb(props: list[str]) -> list[str]:
     >>> property_breadcrumb(["payload", "content"])
     ['properties', 'payload', 'properties', 'content']
     """
-    if len(props) >= 2 and props[0] == "properties":
-        breadcrumb = props
-    else:
-        breadcrumb = []
-        for prop in props:
-            breadcrumb.extend(["properties", prop])
+    breadcrumb = []
+    for prop in props:
+        breadcrumb.extend(["properties", prop])
 
     return breadcrumb
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Related Issues

* Closes #9367

## Summary by Sourcery

Update tests to align with select breadcrumb change by removing redundant "properties" segments from expected rules and utilizing property_breadcrumb transformation.

Enhancements:
- Add imports for MetadataRule, SchemaRule, and property_breadcrumb in tests
- Improve type annotations for mock_metadata_executor and mock_schema_executor parameters

Tests:
- Refactor assert_rules helper to apply property_breadcrumb transform
- Adjust expected catalog rule breadcrumbs in select and schema tests to drop explicit "properties" segments

## Summary by Sourcery

Fix handling of valid `properties` field names in select rule breadcrumbs by simplifying property_breadcrumb implementation and updating tests accordingly

Bug Fixes:
- Simplify property_breadcrumb to always prepend "properties" to each breadcrumb segment, ensuring valid `properties` field names are honored in select rules

Documentation:
- Extend path_property docstring to illustrate deeper nested properties

Tests:
- Refactor assert_rules helper to apply property_breadcrumb transform and update expected breadcrumbs in select and schema tests
- Add imports for MetadataRule, SchemaRule, and property_breadcrumb and improve type annotations for mock executors in tests