### PR TITLE
docs: The "most straightforward" way to install Meltano now is uv

### DIFF
--- a/docs/docs/guide/production.md
+++ b/docs/docs/guide/production.md
@@ -73,7 +73,7 @@ your project-specific Docker image will already contain all of your project file
 
 Just like on your local machine, the most straightforward way to install Meltano
 onto a production environment is to
-[use `pip` to install the `meltano` package from PyPI](/getting-started/installation#local-installation).
+[use `uv` to install the `meltano` package from PyPI](/getting-started/installation).
 
 If you add `meltano` (or `meltano==<version>`) to your project's `requirements.txt`
 file, you can choose to automatically run `pip install -r requirements.txt` on your

--- a/docs/docs/guide/production.md
+++ b/docs/docs/guide/production.md
@@ -76,7 +76,7 @@ onto a production environment is to
 [use `uv` to install the `meltano` package from PyPI](/getting-started/installation).
 
 If you add `meltano` (or `meltano==<version>`) to your project's `requirements.txt`
-file, you can choose to automatically run `pip install -r requirements.txt` on your
+file, you can choose to automatically run `uv pip install -r requirements.txt` on your
 production environment whenever your Meltano project is updated to ensure you're always
 on the latest (or requested) version.
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* https://github.com/meltano/meltano/discussions/9369

## Summary by Sourcery

Update the production deployment docs to recommend using `uv` for Meltano installation and correct the installation link

Documentation:
- Change installation command in production guide from `pip` to `uv`
- Remove local-installation anchor from the installation link in the production docs

## Summary by Sourcery

Update the production guide to recommend using the `uv` command wrapper for installing Meltano instead of `pip`.

Documentation:
- Replace `pip install meltano` with `uv install meltano` in production installation instructions
- Prefix requirement installs with `uv pip install -r requirements.txt` in the production guide