### PR TITLE
refactor: Standardize how the positional plugin type parameter and the `--plugin-type` option are handled in `meltano add`, `meltano install` and `meltano remove`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ filterwarnings = [
   "ignore:datetime.datetime.utcnow.* is deprecated:DeprecationWarning:botocore.auth.*", # https://github.com/boto/boto3/issues/3889
   "ignore: Parsing dates involving a day of month without a year specified is:DeprecationWarning:dateparser.*",  # https://github.com/scrapinghub/dateparser/issues/1246
   "ignore::pytest.PytestUnraisableExceptionWarning",
+  "ignore::ResourceWarning",
   "ignore:Passing the plugin type as the first positional argument is deprecated and will be removed in Meltano v4:DeprecationWarning",  # https://github.com/meltano/meltano/issues/7066
 ]
 log_cli = true

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import typing as t
-import warnings
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -19,6 +18,7 @@ from meltano.cli.utils import (
     add_required_plugins,
     check_dependencies_met,
     infer_plugin_type,
+    validate_plugin_type_args,
 )
 from meltano.core.plugin import PluginRef, PluginType
 from meltano.core.plugin_install_service import PluginInstallReason
@@ -141,18 +141,7 @@ async def add(
     """  # noqa: D301
     tracker: Tracker = ctx.obj["tracker"]
 
-    if plugin_type is None and plugin[0] in PluginType.cli_arguments():
-        plugin_type = PluginType.from_cli_argument(plugin[0])
-        plugin_names = plugin[1:]
-        warnings.warn(
-            "Passing the plugin type as the first positional argument is deprecated "
-            "and will be removed in Meltano v4. "
-            "Please use the --plugin-type option instead.",
-            DeprecationWarning,
-            stacklevel=0,
-        )
-    else:
-        plugin_names = plugin
+    plugin_names, plugin_type = validate_plugin_type_args(plugin, plugin_type, ctx)
 
     if as_name:
         # `add <type> <inherit-from> --as <name>``

--- a/src/meltano/cli/remove.py
+++ b/src/meltano/cli/remove.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import typing as t
-import warnings
 
 import click
 
 from meltano.cli.params import pass_project
-from meltano.cli.utils import InstrumentedCmd, PluginTypeArg, infer_plugin_type
-from meltano.core.plugin import PluginType
+from meltano.cli.utils import (
+    InstrumentedCmd,
+    PluginTypeArg,
+    infer_plugin_type,
+    validate_plugin_type_args,
+)
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_location_remove import (
     DbRemoveManager,
@@ -20,15 +23,18 @@ from meltano.core.plugin_remove_service import PluginRemoveService
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from meltano.core.plugin import PluginType
     from meltano.core.project import Project
 
 
 @click.command(cls=InstrumentedCmd, short_help="Remove plugins from your project.")
 @click.argument("plugin", nargs=-1, required=True)
 @click.option("--plugin-type", type=PluginTypeArg())
+@click.pass_context
 @pass_project()
 def remove(
     project: Project,
+    ctx: click.Context,
     plugin: tuple[str, ...],
     plugin_type: PluginType | None,
 ) -> None:
@@ -37,18 +43,7 @@ def remove(
     \b
     Read more at https://docs.meltano.com/reference/command-line-interface#remove
     """  # noqa: D301
-    if plugin_type is None and plugin[0] in PluginType.cli_arguments():
-        plugin_type = PluginType.from_cli_argument(plugin[0])
-        plugin_names = plugin[1:]
-        warnings.warn(
-            "Passing the plugin type as the first positional argument is deprecated "
-            "and will be removed in Meltano v4. "
-            "Please use the --plugin-type option instead.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-    else:
-        plugin_names = plugin
+    plugin_names, plugin_type = validate_plugin_type_args(plugin, plugin_type, ctx)
 
     plugins = [
         ProjectPlugin(

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -962,6 +962,7 @@ class TestCliAdd:
                 force=False,
             )
 
+    @pytest.mark.usefixtures("reset_project_context")
     def test_add_conflicting_plugin_type_and_positional_argument(
         self,
         tap,

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import platform
@@ -337,7 +338,8 @@ class TestCliAdd:
         cli_runner,
     ) -> None:
         # Make sure tap-mock is not in the project as a project plugin
-        project.plugins.remove_from_file(tap)
+        with contextlib.suppress(PluginNotFoundError):
+            project.plugins.remove_from_file(tap)
 
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -961,3 +961,22 @@ class TestCliAdd:
                 reason=PluginInstallReason.ADD,
                 force=False,
             )
+
+    def test_add_conflicting_plugin_type_and_positional_argument(
+        self,
+        tap,
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        result = cli_runner.invoke(
+            cli,
+            ["add", "--plugin-type=extractors", "extractors", tap.name],
+        )
+        assert result.exit_code == 2
+        assert "Use only --plugin-type to specify plugin type" in result.stderr
+
+        result = cli_runner.invoke(
+            cli,
+            ["add", "extractors", "--plugin-type=extractors", tap.name],
+        )
+        assert result.exit_code == 2
+        assert "Use only --plugin-type to specify plugin type" in result.stderr

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -45,7 +45,7 @@ class TestCliInstall:
 
             with pytest.warns(
                 DeprecationWarning,
-                match="Using `-` to install plugins of any type is deprecated",
+                match='Using "-" to specify plugins of any type is deprecated',
             ):
                 result = cli_runner.invoke(cli, ["install", "-"])
 
@@ -277,7 +277,7 @@ class TestCliInstall:
 
             with pytest.warns(
                 DeprecationWarning,
-                match="Using `-` to install plugins of any type is deprecated",
+                match='Using "-" to specify plugins of any type is deprecated',
             ):
                 result = cli_runner.invoke(
                     cli,
@@ -481,20 +481,14 @@ class TestCliInstall:
             ["install", "--plugin-type=extractors", "extractors", tap.name],
         )
         assert result.exit_code == 2
-        assert (
-            "Use only --plugin-type to install plugins of a specific type"
-            in result.stderr
-        )
+        assert "Use only --plugin-type to specify plugin type" in result.stderr
 
         result = cli_runner.invoke(
             cli,
             ["install", "extractors", "--plugin-type=extractors", "-", tap.name],
         )
         assert result.exit_code == 2
-        assert (
-            "Use only --plugin-type to install plugins of a specific type"
-            in result.stderr
-        )
+        assert "Use only --plugin-type to specify plugin type" in result.stderr
 
 
 # un_engine_uri forces us to create a new project, we must do this before the

--- a/tests/meltano/cli/test_remove.py
+++ b/tests/meltano/cli/test_remove.py
@@ -99,3 +99,22 @@ class TestCliRemove:
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_once_with(project, [tap, tap_gitlab])
+
+    def test_remove_conflicting_plugin_type_and_positional_argument(
+        self,
+        tap,
+        cli_runner,
+    ) -> None:
+        result = cli_runner.invoke(
+            cli,
+            ["remove", "--plugin-type=extractors", "extractors", tap.name],
+        )
+        assert result.exit_code == 2
+        assert "Use only --plugin-type to specify plugin type" in result.stderr
+
+        result = cli_runner.invoke(
+            cli,
+            ["remove", "extractors", "--plugin-type=extractors", tap.name],
+        )
+        assert result.exit_code == 2
+        assert "Use only --plugin-type to specify plugin type" in result.stderr


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Related Issues

* https://github.com/meltano/meltano/pull/7066
* https://github.com/meltano/meltano/pull/9317
* https://github.com/meltano/meltano/pull/9350
* https://github.com/meltano/meltano/pull/9351

## Summary by Sourcery

Standardize handling of plugin type specification in add/install/remove commands by extracting validation logic into a shared helper and deprecating positional type arguments

Enhancements:
- Extract plugin type and positional argument validation into validate_plugin_type_args utility
- Refactor meltano add, install, and remove commands to use the new validation helper and unify deprecation warnings

Build:
- Ignore ResourceWarning in project-wide pytest filterwarnings

Tests:
- Add tests to assert error raised when both positional plugin type and --plugin-type flag are provided
- Suppress PluginNotFoundError in test_add to avoid unstable cleanup