### PR TITLE
docs: Use tabs to exemplify new and legacy syntax for `meltano add`

### DIFF
--- a/docs/docs/guide/complete_tutorial.md
+++ b/docs/docs/guide/complete_tutorial.md
@@ -5,6 +5,11 @@ layout: getting_started
 sidebar_position: 5
 ---
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
 Welcome! If you're ready to get started with Meltano and [run an EL[T] pipeline](#run-a-data-integration-el-pipeline)
 with a [data source](#add-an-extractor-to-pull-data-from-a-source) and [destination](#add-a-loader-to-send-data-to-a-destination) of your choosing, you've come to the right place!
 
@@ -174,25 +179,57 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
 
     - If an extractor is **supported out of the box**, add it to your project using [`meltano add`](/reference/command-line-interface#add):
 
-    ```bash
-    # Simplified syntax - plugin type is automatically detected
-    meltano add <plugin name>
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
 
-    # For example:
-    meltano add tap-gitlab  # Automatically detected as extractor
+```bash
+# Simplified syntax - plugin type is automatically detected
+meltano add <plugin name>
 
-    # If you have a preference for a non-default variant, select it using `--variant`:
-    meltano add tap-gitlab --variant=singer-io
+# For example:
+meltano add tap-gitlab  # Automatically detected as extractor
 
-    # Explicit plugin type for disambiguation:
-    meltano add --plugin-type extractor tap-gitlab
+# If you have a preference for a non-default variant, select it using `--variant`:
+meltano add tap-gitlab --variant=singer-io
 
-    # Deprecated positional syntax:
-    meltano add extractor tap-gitlab
+# Explicit plugin type for disambiguation:
+meltano add --plugin-type extractor tap-gitlab
 
-    # If you're using Docker, don't forget to mount the project directory:
-    docker run -v $(pwd):/project -w /project meltano/meltano add tap-gitlab
-    ```
+# If you're using Docker, don't forget to mount the project directory:
+docker run -v $(pwd):/project -w /project meltano/meltano add tap-gitlab
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
+meltano add extractor <plugin name>
+
+# For example:
+meltano add extractor tap-gitlab
+
+# If you have a preference for a non-default variant, select it using `--variant`:
+meltano add extractor tap-gitlab --variant=singer-io
+
+# If you're using Docker, don't forget to mount the project directory:
+docker run -v $(pwd):/project -w /project meltano/meltano add extractor tap-gitlab
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
 
     This will add the new plugin to your [`meltano.yml` project file](/concepts/project#plugins):
 
@@ -216,17 +253,51 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
 
             - If a Singer tap for your data source is **available**, add it to your project as a [custom plugin](/concepts/plugins#custom-plugins) using [`meltano add --custom`](/reference/command-line-interface#add):
 
-                  ```bash
-                  meltano add --custom extractor <tap name>
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
 
-                  # For example:
-                  meltano add --custom extractor tap-covid-19
+```bash
+meltano add --custom <tap name>
 
-                  # If you're using Docker, don't forget to mount the project directory,
-                  # and ensure that interactive mode is enabled so that Meltano can ask you
-                  # additional questions about the plugin and get your answers over STDIN:
-                  docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom extractor tap-covid-19
-                  ```
+# For example:
+meltano add --custom tap-covid-19
+
+# If you're using Docker, don't forget to mount the project directory,
+# and ensure that interactive mode is enabled so that Meltano can ask you
+# additional questions about the plugin and get your answers over STDIN:
+docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom tap-covid-19
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
+meltano add --custom extractor <tap name>
+
+# For example:
+meltano add --custom extractor tap-covid-19
+
+# If you're using Docker, don't forget to mount the project directory,
+# and ensure that interactive mode is enabled so that Meltano can ask you
+# additional questions about the plugin and get your answers over STDIN:
+docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom extractor tap-covid-19
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
 
                   Meltano will now ask you some additional questions to learn more about the plugin.
 
@@ -574,23 +645,53 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
 
             - If a loader is **supported out of the box**, add it to your project using [`meltano add`](/reference/command-line-interface#add):
 
-                  ```bash
-                  # Simplified syntax - plugin type is automatically detected
-                  meltano add <plugin name>
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
 
-                  # For this example, we'll use the default variant:
-                  meltano add target-postgres  # Automatically detected as loader
+```bash
+# Simplified syntax - plugin type is automatically detected
+meltano add <plugin name>
 
-                  # Or if you just want to use a non-default variant you can use this,
-                  # selected using `--variant`:
-                  meltano add target-postgres --variant=datamill-co
+# For this example, we'll use the default variant:
+meltano add target-postgres  # Automatically detected as loader
 
-                  # Explicit plugin type for disambiguation:
-                  meltano add --plugin-type loader target-postgres
+# Or if you just want to use a non-default variant you can use this,
+# selected using `--variant`:
+meltano add target-postgres --variant=datamill-co
 
-                  # Deprecated positional syntax:
-                  meltano add loader target-postgres
-                  ```
+# Explicit plugin type for disambiguation:
+meltano add --plugin-type loader target-postgres
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
+meltano add loader <plugin name>
+
+# For this example, we'll use the default variant:
+meltano add loader target-postgres
+
+# Or if you just want to use a non-default variant you can use this,
+# selected using `--variant`:
+meltano add loader target-postgres --variant=datamill-co
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
 
 :::info
 
@@ -616,17 +717,51 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
 
         - If a Singer target for your data destination is **available**, add it to your project as a [custom plugin](/concepts/plugins#custom-plugins) using [`meltano add --custom`](/reference/command-line-interface#add):
 
-              ```bash
-              meltano add --custom loader <target name>
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
 
-              # For example:
-              meltano add --custom loader target-bigquery
+```bash
+meltano add --custom <target name>
 
-              # If you're using Docker, don't forget to mount the project directory,
-              # and ensure that interactive mode is enabled so that Meltano can ask you
-              # additional questions about the plugin and get your answers over STDIN:
-              docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom loader target-bigquery
-              ```
+# For example:
+meltano add --custom target-bigquery
+
+# If you're using Docker, don't forget to mount the project directory,
+# and ensure that interactive mode is enabled so that Meltano can ask you
+# additional questions about the plugin and get your answers over STDIN:
+docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom target-bigquery
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
+meltano add --custom loader <target name>
+
+# For example:
+meltano add --custom loader target-bigquery
+
+# If you're using Docker, don't forget to mount the project directory,
+# and ensure that interactive mode is enabled so that Meltano can ask you
+# additional questions about the plugin and get your answers over STDIN:
+docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom loader target-bigquery
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
 
               Meltano will now ask you some additional questions to learn more about the plugin.
 
@@ -893,16 +1028,39 @@ schedules:
 
 1. Add the [Apache Airflow](https://airflow.apache.org/) utility to your project using [`meltano add`](/reference/command-line-interface#add), which will be responsible for managing the schedule and executing the appropriate `meltano run` commands:
 
-   ```bash
-   # Simplified syntax - plugin type is automatically detected
-   meltano add airflow  # Automatically detected as utility
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
 
-   # Explicit plugin type for disambiguation:
-   meltano add --plugin-type utility airflow
+```bash
+# Simplified syntax - plugin type is automatically detected
+meltano add airflow  # Automatically detected as utility
 
-   # Deprecated positional syntax:
-   meltano add utility airflow
-   ```
+# Explicit plugin type for disambiguation:
+meltano add --plugin-type utility airflow
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
+meltano add utility airflow
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
 
    This will add the new plugin to your [`meltano.yml` project file](/concepts/project#plugins):
 

--- a/docs/docs/guide/plugin-management.md
+++ b/docs/docs/guide/plugin-management.md
@@ -5,6 +5,11 @@ layout: doc
 sidebar_position: 2
 ---
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
 Meltano takes a modular approach to data engineering in general and EL(T) in particular,
 where your [project](/concepts/project) and pipelines are composed of [plugins](/concepts/plugins) of [different types](/concepts/plugins#types), most notably **extractors** ([Singer](https://singer.io) taps), **loaders** ([Singer](https://singer.io) targets), and **utilities** (like [dbt](https://www.getdbt.com) for transformations, [Airflow](https://airflow.apache.org/)/[Dagster](https://dagster.io/)/etc. for orchestration, and much more on [MeltanoHub](https://hub.meltano.com/utilities/)).
 
@@ -34,6 +39,18 @@ refer to the ["Plugin inheritance" section](#plugin-inheritance).
 [Discoverable plugins](/concepts/plugins#discoverable-plugins) can be added to your project by simply providing
 [`meltano add`](/reference/command-line-interface#add) with their name. Meltano will automatically detect the plugin type:
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
 ```bash
 # Simplified syntax - plugin type is automatically detected
 meltano add <name>
@@ -43,12 +60,8 @@ meltano add tap-gitlab        # Automatically detected as extractor
 meltano add target-postgres   # Automatically detected as loader
 meltano add dbt-snowflake     # Automatically detected as utility
 meltano add airflow           # Automatically detected as utility
-```
 
-You can explicitly specify the plugin type for disambiguation when needed:
-
-```bash
-# Explicit plugin type specification
+# Explicit plugin type specification for disambiguation when needed
 meltano add --plugin-type <type> <name>
 
 # For example:
@@ -58,15 +71,24 @@ meltano add --plugin-type utility dbt-snowflake
 meltano add --plugin-type utility airflow
 ```
 
-The original positional syntax is still supported but deprecated:
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
 
 ```bash
-# Deprecated syntax (will be removed in v4)
 meltano add <type> <name>
 
 # For example:
-meltano add extractor tap-gitlab  # Will show deprecation warning
+meltano add extractor tap-gitlab
 meltano add loader target-postgres
+meltano add utility dbt-snowflake
+meltano add utility airflow
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 This will add a [shadowing plugin definition](/concepts/project#shadowing-plugin-definitions) to your [`meltano.yml` project file](/concepts/project#plugins) under the `plugins` property, inside an array named after the plugin type:
@@ -116,6 +138,18 @@ has the same effect as adding it using [`meltano add`](/reference/command-line-i
 If multiple [variants](/concepts/plugins#variants) of a discoverable plugin are available,
 you can choose a specific (non-default) variant using the `--variant` option on [`meltano add`](/reference/command-line-interface#add):
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
 ```bash
 # With automatic type detection
 meltano add <name> --variant <variant>
@@ -125,9 +159,23 @@ meltano add target-postgres --variant=transferwise  # Type automatically detecte
 
 # With explicit type specification for disambiguation
 meltano add --plugin-type loader target-postgres --variant=transferwise
+```
 
-# Deprecated positional syntax
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
+meltano add loader <name> --variant <variant>
+
+# For example:
 meltano add loader target-postgres --variant=transferwise
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 As you might expect, this will be reflected in the `variant` and `pip_url` properties in your [`meltano.yml` project file](/concepts/project#plugins):
@@ -155,6 +203,18 @@ Alternatively, if you'd like to give the plugin a more descriptive name in your 
 you can use the `--inherit-from` (or `--as`) option on [`meltano add`](/reference/command-line-interface#add)
 to explicitly inherit from the discoverable plugin instead:
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
 ```bash
 # With automatic type detection
 meltano add <name> --inherit-from <discoverable-name>
@@ -166,7 +226,17 @@ meltano add --plugin-type <type> <name> --inherit-from <discoverable-name>
 # Or equivalently:
 meltano add --plugin-type <type> <discoverable-name> --as <name>
 
-# Deprecated positional syntax
+# For example:
+meltano add tap-postgres--billing --inherit-from tap-postgres
+meltano add tap-postgres --as tap-postgres--billing
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
 meltano add <type> <name> --inherit-from <discoverable-name>
 # Or equivalently:
 meltano add <type> <discoverable-name> --as <name>
@@ -174,6 +244,11 @@ meltano add <type> <discoverable-name> --as <name>
 # For example:
 meltano add extractor tap-postgres--billing --inherit-from tap-postgres
 meltano add extractor tap-postgres --as tap-postgres--billing
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 The corresponding [inheriting plugin definition](/concepts/project#inheriting-plugin-definitions) in your [`meltano.yml` project file](/concepts/project#plugins) will use `inherit_from`:
@@ -197,9 +272,36 @@ If you'd like to use multiple [variants](#variants) of the same discoverable plu
 Since plugins in your project need to have unique names, a discoverable plugin can only be shadowed once,
 but it can be inherited from multiple times, with each plugin free to choose its own variant:
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
+```bash
+meltano add target-snowflake --variant=transferwise --as target-snowflake--transferwise
+meltano add target-snowflake --variant=meltanolabs --as target-snowflake--meltanolabs
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
 ```bash
 meltano add loader target-snowflake --variant=transferwise --as target-snowflake--transferwise
-meltano add loader target-snowflake --variant=meltano --as target-snowflake--meltano
+meltano add loader target-snowflake --variant=meltanolabs --as target-snowflake--meltanolabs
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 Assuming a regular (shadowing) `target-snowflake` was added before using `meltano add loader target-snowflake`,
@@ -240,6 +342,36 @@ just like when shadowing with a `name` but no `variant`.
 like arbitrary Singer taps and targets,
 can be added to your project using the `--custom` option on [`meltano add`](/reference/command-line-interface#add):
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
+```bash
+meltano add --custom <name>
+
+# For example:
+meltano add --custom tap-covid-19
+meltano add --custom target-bigquery--custom
+
+# If you're using Docker, don't forget to mount the project directory,
+# and ensure that interactive mode is enabled so that Meltano can ask you
+# additional questions about the plugin and get your answers over STDIN:
+docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom tap-covid-19
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
 ```bash
 meltano add --custom <type> <name>
 
@@ -251,6 +383,11 @@ meltano add --custom loader target-bigquery--custom
 # and ensure that interactive mode is enabled so that Meltano can ask you
 # additional questions about the plugin and get your answers over STDIN:
 docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom extractor tap-covid-19
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 Since Meltano doesn't have the [base plugin description](/concepts/plugins#project-plugins) for the package in question yet,
@@ -379,6 +516,32 @@ To add a new plugin to your project that [inherits from an existing plugin](/con
 so that it can reuse the same package but override (parts of) its configuration,
 you can use the `--inherit-from` option on [`meltano add`](/reference/command-line-interface#add):
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
+```bash
+meltano add <name> --inherit-from <existing-name>
+
+# For example:
+meltano add tap-ga--client-foo --inherit-from tap-google-analytics
+meltano add tap-ga--client-bar --inherit-from tap-google-analytics
+meltano add tap-ga--client-foo--project-baz --inherit-from tap-ga--client-foo
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
 ```bash
 meltano add <type> <name> --inherit-from <existing-name>
 
@@ -386,6 +549,11 @@ meltano add <type> <name> --inherit-from <existing-name>
 meltano add extractor tap-ga--client-foo --inherit-from tap-google-analytics
 meltano add extractor tap-ga--client-bar --inherit-from tap-google-analytics
 meltano add extractor tap-ga--client-foo--project-baz --inherit-from tap-ga--client-foo
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 The corresponding [inheriting plugin definitions](/concepts/project#inheriting-plugin-definitions) in your [`meltano.yml` project file](/concepts/project#plugins) will use `inherit_from`:
@@ -542,22 +710,45 @@ RUN meltano install
 
 You can remove a [plugin](/concepts/project#plugins) from your Meltano [project](/concepts/project) by using [`meltano remove`](/reference/command-line-interface#remove). The plugin type is automatically inferred from the plugin name, so you no longer need to specify the type explicitly.
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
 ```bash
-# New syntax (recommended) - plugin type is automatically inferred
+# Plugin type is automatically inferred
 meltano remove <name>
 meltano remove <name> <name_two>
-
-# Deprecated syntax - will be removed in v4
-meltano remove <type> <name>
-meltano remove <type> <name> <name_two>
 
 # For example:
 meltano remove tap-gitlab
 meltano remove target-postgres target-csv
+```
 
-# Deprecated syntax:
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
+meltano remove <type> <name>
+meltano remove <type> <name> <name_two>
+
+# For example:
 meltano remove extractor tap-gitlab
 meltano remove loader target-postgres target-csv
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 Since the [`plugins` section](/concepts/project#plugins) of your [`meltano.yml` project file](/concepts/project) determines the plugins that make up your project, you can still manually remove a [plugin](/concepts/plugins#project-plugins) from your project by deleting its entry from this file. Traces of the plugin may remain in the other locations mentioned above.

--- a/docs/docs/tutorials/custom-extractor.md
+++ b/docs/docs/tutorials/custom-extractor.md
@@ -5,6 +5,11 @@ layout: doc
 sidebar_position: 2
 ---
 
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+```
+
 As much as we'd like to support all the data sources out there, we'll need your help to get there. If you find a data source that Meltano doesn't support right now, it might be time to get your hands dirty.
 
 ## What Are Custom Extractors?
@@ -208,8 +213,36 @@ Navigate to your project root directory on your shell and run the following comm
 
 ```bash
 meltano install
+```
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
+```bash
+meltano add target-jsonl
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
+```bash
 meltano add loader target-jsonl
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 This command installs your newly created tap, tap-jsonplaceholder, and a loader, target-jsonl, to the default Meltano project. It also creates an output directory where the extracted data will be loaded.
@@ -293,8 +326,34 @@ There are two ways you can do this:
 
 Run the command below to add the extractor as a custom extractor not hosted on MeltanoHub registry:
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
+```bash
+meltano add --custom tap-jsonplaceholder
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
 ```bash
 meltano add --custom extractor tap-jsonplaceholder
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 You will be prompted to input the namespace URL. Choose `tap-jsonplaceholder`.
@@ -326,8 +385,34 @@ Alternatively, you can create a [plugin definition](/concepts/project#custom-plu
 
 </details>
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
+```bash
+meltano add --from-ref tap-jsonplaceholder.yml tap-jsonplaceholder
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
 ```bash
 meltano add --from-ref tap-jsonplaceholder.yml extractor tap-jsonplaceholder
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 :::info
@@ -341,16 +426,68 @@ As you develop your custom extractor, it is possible that its settings will chan
 
 In this case, you will need to update the extractor in your project - by maintaining your plugin definiton YAML file in line with changes to the tap as you go, this is a simple process of running the previous command along with the `--update` flag:
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
+```bash
+meltano add --update --from-ref tap-jsonplaceholder.yml tap-jsonplaceholder
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
 ```bash
 meltano add --update --from-ref tap-jsonplaceholder.yml extractor tap-jsonplaceholder
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 ### Add a JSONL target
 
 Run the command below to add the JSONL loader that will contain the extracted data stream:
 
+```mdx-code-block
+<Tabs
+  groupId="meltano-version"
+  defaultValue="3.8"
+  values={[
+    { label: '3.8+', value: '3.8', },
+    { label: '3.7 and earlier', value: '3.7', },
+  ]}
+>
+<TabItem value="3.8">
+```
+
+```bash
+meltano add target-jsonl
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="3.7">
+```
+
 ```bash
 meltano add loader target-jsonl
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 ### Run an ELT Pipeline That Loads Data into a JSONL File

--- a/integration/example-library/meltano-objects/index.md
+++ b/integration/example-library/meltano-objects/index.md
@@ -9,8 +9,7 @@ To begin, download or copy the [meltano.yml](/integration/example-library/meltan
 ## Add a few plugins
 
 ```shell
-meltano add tap-gitlab
-meltano add target-jsonl
+meltano add tap-gitlab target-jsonl
 ```
 
 ## Add some environments


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Updated pages:

- https://deploy-preview-9385--meltano.netlify.app/guide/complete_tutorial/
- https://deploy-preview-9385--meltano.netlify.app/guide/plugin-management/
- https://deploy-preview-9385--meltano.netlify.app/tutorials/custom-extractor

## Related Issues

* meltano/meltano#7066

## Summary by Sourcery

Revise documentation to present both new and legacy 'meltano add' command syntaxes using tabbed code blocks, improving clarity for users on different Meltano versions.

Documentation:
- Update documentation to use tabbed code blocks for demonstrating new and legacy syntax for the 'meltano add' command across multiple guides and tutorials.
- Clarify and distinguish between syntax for Meltano versions 3.8+ and 3.7 and earlier in all relevant command examples.

## Summary by Sourcery

Documentation:
- Update documentation to use tabbed code blocks that distinguish between new and legacy 'meltano add' command syntax for Meltano versions 3.8+ and 3.7 and earlier across multiple guides and tutorials.