### PR TITLE
fix: support both .yaml and .yml extensions for logging config files

### DIFF
--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -15,7 +15,7 @@ meltano --log-format=json run my-job
 
 Logging in meltano can also be controlled in more detail via a standard yaml formatted [python logging dict config file](https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema).
 
-By default, meltano will look for this in a `logging.yaml` file in the project root. However, you can override this by
+By default, meltano will look for this in a `logging.yaml` file in the project root. Both `.yaml` and `.yml` file extensions are supported. However, you can override this by
 setting the [environment variable](/guide/configuration#configuring-settings) `MELTANO_CLI_LOG_CONFIG` or by using the
 `meltano` CLI option `--log-config`. e.g. `meltano --log-config=my-prod-logging.yaml ...`.
 

--- a/docs/docs/reference/settings.mdx
+++ b/docs/docs/reference/settings.mdx
@@ -598,7 +598,7 @@ meltano --log-format=json ...
 - `meltano` CLI option: `--log-config`
 - Default: `logging.yaml`
 
-The path of a valid yaml formatted [python logging dict config file](https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema) to use to configure logging _if present_.
+The path of a valid yaml formatted [python logging dict config file](https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema) to use to configure logging _if present_. Supports both `.yaml` and `.yml` file extensions.
 
 #### How to use
 
@@ -607,6 +607,8 @@ The path of a valid yaml formatted [python logging dict config file](https://doc
 
 ```bash
 meltano config meltano set cli log_config /path/to/logging.yaml
+# or
+meltano config meltano set cli log_config /path/to/logging.yml
 ```
 
   </TabItem>
@@ -614,6 +616,8 @@ meltano config meltano set cli log_config /path/to/logging.yaml
 
 ```bash
 export MELTANO_CLI_LOG_CONFIG=/path/to/logging.yaml
+# or
+export MELTANO_CLI_LOG_CONFIG=/path/to/logging.yml
 ```
 
   </TabItem>
@@ -621,6 +625,8 @@ export MELTANO_CLI_LOG_CONFIG=/path/to/logging.yaml
 
 ```bash
 meltano --log-config=/path/to/logging.yaml ...
+# or
+meltano --log-config=/path/to/logging.yml ...
 ```
 
   </TabItem>

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -241,8 +241,8 @@ def setup_logging(
         log_path = Path(log_config)
         config = read_config(log_path)
 
-        if config is None and log_path.suffix in {".yaml", ".yml"}:
-            fallback_ext = ".yml" if log_path.suffix == ".yaml" else ".yaml"
+        if config is None and log_path.suffix.lower() in {".yaml", ".yml"}:
+            fallback_ext = ".yml" if log_path.suffix.lower() == ".yaml" else ".yaml"
             fallback_path = log_path.with_suffix(fallback_ext)
             config = read_config(fallback_path)
             if config:

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -158,7 +158,7 @@ def test_setup_logging_yml_extension_fallback(
 
             # Verify the fallback message was logged
             expected_message = (
-                f"Using logging config from {expected_fallback.name} "
+                f"Using logging configuration from {expected_fallback.name} "
                 f"(fallback from {config_file})"
             )
             mock_logger.info.assert_called_with(expected_message)

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-import typing
+import typing as t
 import zoneinfo
 
 import pytest
@@ -16,7 +16,7 @@ from meltano.core.logging.utils import (
     setup_logging,
 )
 
-if typing.TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from pathlib import Path
 
 

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -173,3 +173,8 @@ def test_setup_logging_yml_extension_fallback(
     yml_path.unlink()
     yaml_path.write_text(yaml.dump(log_config_dict))
     test_fallback("logging.yml", yaml_path)
+
+    # Test case-insensitive extension (.YAML -> .yml)
+    yaml_path.unlink()
+    yml_path.write_text(yaml.dump(log_config_dict))
+    test_fallback("logging.YAML", yml_path)

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-import zoneinfo
 import typing
+import zoneinfo
 
 import pytest
 import time_machine
@@ -122,7 +122,6 @@ def test_setup_logging_yml_extension_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that setup_logging supports both .yaml and .yml extensions via fallback."""
-    from pathlib import Path
     from unittest.mock import Mock, patch
 
     import yaml
@@ -163,7 +162,6 @@ def test_setup_logging_yml_extension_fallback(
                 f"(fallback from {config_file})"
             )
             mock_logger.info.assert_called_with(expected_message)
-
 
     # Test .yaml -> .yml fallback
     yml_path.write_text(yaml.dump(log_config_dict))

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -136,53 +136,40 @@ def test_setup_logging_yml_extension_fallback(
     yml_path = tmp_path / "logging.yml"
     original_cwd = Path.cwd()
 
-    # Test .yaml -> .yml fallback
-    yml_path.write_text(yaml.dump(log_config_dict))
-    monkeypatch.chdir(tmp_path)
-
     logged_messages = []
 
     def capture_log_call(*args, **kwargs):
         logged_messages.append(str(args[0]) if args else str(kwargs))
 
-    try:
-        with patch("meltano.core.logging.utils.logger.info", capture_log_call):
-            setup_logging(log_config="logging.yaml")
-            root_logger = logging.getLogger()  # noqa: TID251
-            assert len(root_logger.handlers) > 0
-            handler = root_logger.handlers[0]
-            assert hasattr(handler, "formatter")
+    def test_fallback(config_file: str, expected_fallback: Path):
+        """Test logging config fallback from one extension to another."""
+        monkeypatch.chdir(tmp_path)
 
-            expected_message = (
-                "Using logging config from logging.yml (fallback from logging.yaml)"
-            )
-            assert any(expected_message in msg for msg in logged_messages), (
-                f"Expected fallback message '{expected_message}' not found in logs: "
-                + "\n".join(logged_messages)
-            )
-    finally:
-        monkeypatch.chdir(original_cwd)
+        try:
+            with patch("meltano.core.logging.utils.logger.info", capture_log_call):
+                setup_logging(log_config=config_file)
+                root_logger = logging.getLogger()  # noqa: TID251
+                assert len(root_logger.handlers) > 0
+                handler = root_logger.handlers[0]
+                assert hasattr(handler, "formatter")
+
+                expected_message = (
+                    f"Using logging config from {expected_fallback.name} "
+                    f"(fallback from {config_file})"
+                )
+                assert any(expected_message in msg for msg in logged_messages), (
+                    f"Expected fallback message '{expected_message}' not found in "
+                    f"logs: {logged_messages}"
+                )
+        finally:
+            monkeypatch.chdir(original_cwd)
+            logged_messages.clear()
+
+    # Test .yaml -> .yml fallback
+    yml_path.write_text(yaml.dump(log_config_dict))
+    test_fallback("logging.yaml", yml_path)
 
     # Test .yml -> .yaml fallback
-    logged_messages.clear()
     yml_path.unlink()
     yaml_path.write_text(yaml.dump(log_config_dict))
-    monkeypatch.chdir(tmp_path)
-
-    try:
-        with patch("meltano.core.logging.utils.logger.info", capture_log_call):
-            setup_logging(log_config="logging.yml")
-            root_logger = logging.getLogger()  # noqa: TID251
-            assert len(root_logger.handlers) > 0
-            handler = root_logger.handlers[0]
-            assert hasattr(handler, "formatter")
-
-            expected_message = (
-                "Using logging config from logging.yaml (fallback from logging.yml)"
-            )
-            assert any(expected_message in msg for msg in logged_messages), (
-                f"Expected fallback message '{expected_message}' not found in logs: "
-                + "\n".join(logged_messages)
-            )
-    finally:
-        monkeypatch.chdir(original_cwd)
+    test_fallback("logging.yml", yaml_path)


### PR DESCRIPTION
I thought I'd try another `good first issue` but I'm not at all familiar with the codebase yet so I'm sure I'll need some feedback and direction here. Thank you for taking a look! 🙏🏾

## Summary
Adds fallback support for logging configuration files to work with both `.yaml` and `.yml` extensions. When Meltano cannot find the specified logging config file, it now tries the alternate extension automatically.

Closes #7013

## Changes
- Modified `setup_logging()` in `src/meltano/core/logging/utils.py` to add bidirectional fallback logic
- Added fallback message logging to inform users when alternate filename is used
- Updated documentation to mention support for both extensions
- Added comprehensive test coverage for both fallback scenarios

## Implementation Details
- Uses `pathlib.Path` for robust file extension handling
- Only attempts fallback for YAML files (`.yaml`/`.yml` extensions)
- Logs fallback usage after logging system is configured
- Maintains backward compatibility (default remains `logging.yaml`)

## Test Plan

### Automated Tests
- Added `test_setup_logging_yml_extension_fallback()` covering both fallback directions
- All existing tests pass with no regressions

### Manual Testing

**Test with modified Meltano:**
```bash
# Install modified version
cd /path/to/meltano
python3 -m venv test_env && source test_env/bin/activate
pip install -e . && meltano init test_fallback && cd test_fallback

# Create logging.yaml with custom format
cat > logging.yaml << 'EOF'
version: 1
formatters:
  custom:
    format: 'YAML: %(levelname)s - %(message)s'
handlers:
  console:
    class: logging.StreamHandler
    formatter: custom
root:
  level: INFO
  handlers: [console]
EOF

# Test .yml → .yaml fallback (specify .yml but only .yaml exists)
MELTANO_CLI_LOG_CONFIG=logging.yml meltano --log-level=info config
```

**Expected output:**
```
YAML: INFO - {'event': 'Using logging config from logging.yaml (fallback from logging.yml)', 'level': 'info', 'timestamp': '2025-07-17T02:52:40.089712Z'}
Usage: meltano config [OPTIONS] PLUGIN_NAME COMMAND [ARGS]...
...
```

**Test .yaml → .yml fallback:**
```bash
# Rename file to test opposite direction
mv logging.yaml logging.yml

# Test fallback from .yaml to .yml (specify .yaml but only .yml exists)
MELTANO_CLI_LOG_CONFIG=logging.yaml meltano --log-level=info config
```

**Expected output:**
```
YAML: INFO - {'event': 'Using logging config from logging.yml (fallback from logging.yaml)', 'level': 'info', 'timestamp': '2025-07-17T02:52:00.316004Z'}
Usage: meltano config [OPTIONS] PLUGIN_NAME COMMAND [ARGS]...
...
```

**Key observations:**
- ✅ Fallback message appears showing exact source and target files
- ✅ Custom format `YAML: INFO -` is used (proving config loaded successfully)
- ✅ Both directions work: `.yml` ↔ `.yaml`

**Verify fix necessity with fresh installation:**
```bash
# Test with unmodified Meltano
python -m venv fresh_env && source fresh_env/bin/activate
pip install meltano && meltano init test_fresh && cd test_fresh

# Create only logging.yml (with custom format)
cat > logging.yml << 'EOF'
version: 1
formatters:
  custom:
    format: 'FRESH: %(levelname)s - %(message)s'
handlers:
  console:
    class: logging.StreamHandler
    formatter: custom
root:
  level: INFO
  handlers: [console]
EOF

# Try to use .yaml (should fail silently in unmodified version)
MELTANO_CLI_LOG_CONFIG=logging.yaml meltano --help
# Expected: Standard format (no "FRESH:" prefix), confirming fallback doesn't exist
```

This enables users to use either `.yaml` or `.yml` extensions interchangeably for their logging configuration files.

## Summary by Sourcery

Add bidirectional extension fallback for logging configuration files so that specifying either .yaml or .yml will automatically load the alternate if the specified file is not found.

New Features:
- Add automatic fallback between .yaml and .yml extensions when loading logging configuration files

Enhancements:
- Log an informational message when a fallback configuration file is used

Documentation:
- Update documentation to mention support for both .yaml and .yml extensions in logging config

Tests:
- Add tests covering both .yaml→.yml and .yml→.yaml fallback scenarios in setup_logging