### PR TITLE
refactor: Remove dependency on croniter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "click>=8.1,<9",
   "click-default-group>=1.2.4,<2",
   "click-didyoumean>=0.3.1,<0.4",
-  "croniter>=6.0.0,<7",
   "dateparser>=1.2.1",
   "fasteners>=0.19,<0.20",
   "flatten-dict>=0,<1",
@@ -143,7 +142,6 @@ testing = [
 typing = [
   "boto3-stubs[essential]>=1.35,<1.39",
   "mypy>=1.16.0,<2",
-  "types-croniter==5.0.1.20241205",
   "types-dateparser>=1.2.0.20250208",
   "types-jsonschema>=4.23.0.20240813,<5",
   "types-psutil>=7.0.0.20250218,<8",

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -7,7 +7,6 @@ import sys
 import typing as t
 
 import click
-from croniter import croniter
 
 from meltano.cli.params import pass_project
 from meltano.cli.utils import (
@@ -17,7 +16,12 @@ from meltano.cli.utils import (
 )
 from meltano.core.db import project_engine
 from meltano.core.job.stale_job_failer import fail_stale_jobs
-from meltano.core.schedule import CRON_INTERVALS, ELTSchedule, JobSchedule
+from meltano.core.schedule import (
+    CRON_INTERVALS,
+    ELTSchedule,
+    JobSchedule,
+    is_valid_cron,
+)
 from meltano.core.schedule_service import (
     BadCronError,
     ScheduleAlreadyExistsError,
@@ -114,7 +118,7 @@ class CronParam(click.ParamType):
 
     def convert(self, value: str, *_) -> str:
         """Validate and con interval."""
-        if value not in CRON_INTERVALS and not croniter.is_valid(value):
+        if value not in CRON_INTERVALS and not is_valid_cron(value):
             raise BadCronError(value)
 
         return value

--- a/src/meltano/core/schedule.py
+++ b/src/meltano/core/schedule.py
@@ -116,11 +116,10 @@ def _is_valid_field(field: str, field_index: int, /) -> bool:
 
     # Split by commas for multiple values
     min_val, max_val = FIELD_RANGES[field_index]
-    for part in field.split(","):
-        if not _is_valid_field_part(part, field_index, min_val, max_val):
-            return False
-
-    return True
+    return any(
+        _is_valid_field_part(part, field_index, min_val, max_val)
+        for part in field.split(",")
+    )
 
 
 def _is_valid_field_part(

--- a/src/meltano/core/schedule.py
+++ b/src/meltano/core/schedule.py
@@ -108,7 +108,7 @@ def _is_valid_field(field: str, field_index: int, /) -> bool:
 
     # Handle question mark (only valid for day and dow fields)
     if field == "?":
-        return field_index in (2, 4)  # day or dow
+        return field_index in {2, 4}  # day or dow
 
     # Handle "L" (last day of month, only valid for day field)
     if field == "l":

--- a/src/meltano/core/schedule.py
+++ b/src/meltano/core/schedule.py
@@ -23,7 +23,184 @@ CRON_INTERVALS: dict[str, str | None] = {
     "@weekly": "0 0 * * 0",
     "@monthly": "0 0 1 * *",
     "@yearly": "0 0 1 1 *",
+    "@annually": "0 0 1 1 *",
+    "@midnight": "0 0 * * *",
 }
+
+# Field ranges: min, max
+FIELD_RANGES = (
+    (0, 59),  # minute
+    (0, 23),  # hour
+    (1, 31),  # day
+    (1, 12),  # month
+    (0, 6),  # dow
+)
+
+# Month and day of week aliases
+MONTH_ALIASES = {
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "may": 5,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+
+DOW_ALIASES = {
+    "sun": 0,
+    "mon": 1,
+    "tue": 2,
+    "wed": 3,
+    "thu": 4,
+    "fri": 5,
+    "sat": 6,
+}
+
+# Predefined aliases
+CRON_ALIASES = {
+    "@yearly": "0 0 1 1 *",
+    "@annually": "0 0 1 1 *",
+    "@monthly": "0 0 1 * *",
+    "@weekly": "0 0 * * 0",
+    "@daily": "0 0 * * *",
+    "@midnight": "0 0 * * *",
+    "@hourly": "0 * * * *",
+}
+
+
+def is_valid_cron(expression: str) -> bool:
+    """Check if a cron expression is valid.
+
+    Args:
+        expression: The cron expression to validate
+
+    Returns:
+        True if the expression is valid, False otherwise
+    """
+    # Handle predefined aliases
+    expr = expression.strip().lower()
+    if _expr := CRON_INTERVALS.get(expr):
+        expr = _expr
+
+    # Split into fields
+    fields = expr.split()
+
+    # Valid cron expressions have 5
+    # TODO: Consider supporting seconds and year fields
+    if len(fields) != 5:
+        return False
+
+    # Validate each field
+    return all(_is_valid_field(field, i) for i, field in enumerate(fields))
+
+
+def _is_valid_field(field: str, field_index: int, /) -> bool:
+    """Validate a single cron field."""
+    # Handle wildcards
+    if field == "*":
+        return True
+
+    # Handle question mark (only valid for day and dow fields)
+    if field == "?":
+        return field_index in (2, 4)  # day or dow
+
+    # Handle "L" (last day of month, only valid for day field)
+    if field == "l":
+        return field_index == 2  # day field
+
+    # Split by commas for multiple values
+    min_val, max_val = FIELD_RANGES[field_index]
+    for part in field.split(","):
+        if not _is_valid_field_part(part, field_index, min_val, max_val):
+            return False
+
+    return True
+
+
+def _is_valid_field_part(
+    part: str,
+    field_index: int,
+    min_val: int,
+    max_val: int,
+    /,
+) -> bool:
+    """Validate a single part of a cron field."""
+    # Handle step values (e.g., "*/2", "1-5/2")
+    if "/" in part:
+        base, step = part.split("/", 1)
+        if not step.isdigit() or int(step) <= 0:
+            return False
+
+        # If base is empty after split, it means it was like "/2"
+        if not base:
+            return False
+
+        # Handle "*" as base (e.g., "*/5")
+        if base == "*":
+            return True
+
+        # Validate the base part
+        return _is_valid_field_part(base, field_index, min_val, max_val)
+
+    # Handle ranges (e.g., "1-5")
+    if "-" in part:
+        start, end = part.split("-", 1)
+        start_val = _parse_value(start, field_index)
+        end_val = _parse_value(end, field_index)
+
+        if start_val is None or end_val is None:
+            return False
+
+        # Allow wrap-around ranges like "fri-mon"
+        if start_val > end_val and field_index == 4:  # dow field
+            return True
+
+        # Handle day of week special case: 7 = Sunday (0)
+        if end_val == 7 and field_index == 4:
+            end_val = 0
+
+        return min_val <= start_val <= max_val and min_val <= end_val <= max_val
+
+    # Handle single values
+    value = _parse_value(part, field_index)
+    if value is None:
+        return False
+
+    # Special handling for day of week field to allow 7 as Sunday
+    if field_index == 4 and value == 7:
+        return True
+
+    return min_val <= value <= max_val
+
+
+def _parse_value(value: str, field_index: int, /) -> int | None:
+    """Parse a value, handling aliases and special cases."""
+    if not value:
+        return None
+
+    # Handle numeric values
+    if value.isdigit():
+        return int(value)
+
+    # Handle month aliases
+    if field_index == 3 and value in MONTH_ALIASES:
+        return MONTH_ALIASES[value]
+
+    # Handle day of week aliases
+    if field_index == 4 and value in DOW_ALIASES:
+        return DOW_ALIASES[value]
+
+    # Handle "L" for last day
+    if value == "l":
+        return 31 if field_index == 2 else None
+
+    return None
 
 
 class Schedule(NameEq, Canonical):

--- a/src/meltano/core/schedule_service.py
+++ b/src/meltano/core/schedule_service.py
@@ -6,14 +6,19 @@ import typing as t
 from datetime import date, datetime, timezone
 
 import structlog
-from croniter import croniter
 
 from meltano.core.error import MeltanoError
 from meltano.core.locked_definition_service import PluginNotFoundError
 from meltano.core.meltano_invoker import MeltanoInvoker
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.settings_service import PluginSettingsService
-from meltano.core.schedule import CRON_INTERVALS, ELTSchedule, JobSchedule, Schedule
+from meltano.core.schedule import (
+    CRON_INTERVALS,
+    ELTSchedule,
+    JobSchedule,
+    Schedule,
+    is_valid_cron,
+)
 from meltano.core.setting_definition import SettingMissingError
 from meltano.core.task_sets_service import TaskSetsService
 from meltano.core.utils import NotFound, coerce_datetime, find_named, iso8601_datetime
@@ -227,7 +232,7 @@ class ScheduleService:
         if (
             schedule.interval is not None
             and schedule.interval not in CRON_INTERVALS
-            and not croniter.is_valid(schedule.interval)
+            and not is_valid_cron(schedule.interval)
         ):
             raise BadCronError(schedule.interval)
 

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -10,7 +10,7 @@ import pytest
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
-from meltano.core.schedule import ELTSchedule, JobSchedule
+from meltano.core.schedule import ELTSchedule, JobSchedule, is_valid_cron
 from meltano.core.schedule_service import (
     BadCronError,
     Schedule,
@@ -74,6 +74,53 @@ class TestScheduleService:
     @pytest.fixture
     def subject(self, schedule_service):
         return schedule_service
+
+    @pytest.mark.parametrize(
+        "cron",
+        (
+            pytest.param("@yearly", id="yearly"),
+            pytest.param("@annually", id="annually"),
+            pytest.param("@monthly", id="monthly"),
+            pytest.param("@weekly", id="weekly"),
+            pytest.param("@daily", id="daily"),
+            pytest.param("@midnight", id="midnight"),
+            pytest.param("@hourly", id="hourly"),
+            pytest.param("0 0 1 1 0", id="New Year's Day at midnight"),
+            pytest.param("30 14 * * 1-5", id="2:30 PM weekdays"),
+            pytest.param("0 22 * * 7", id="10 PM every Sunday"),
+            pytest.param("0 0 * jan-jun *", id="every day in January through June"),
+            pytest.param("0 0 * dec mon", id="every Monday in December"),
+            pytest.param("0 0 ? * *", id="special character ? for day field"),
+            pytest.param("0 0 * * ?", id="special character ? for dow field"),
+            pytest.param("0 0 L * *", id="last day of month"),
+            pytest.param("0 0 3,13,23 * *", id="3rd, 13th, and 23rd day of month"),
+            pytest.param("0 0 20-L * *", id="20th through last day of month"),
+            pytest.param("0 0 * * 5-7", id="every Friday through Sunday"),
+            pytest.param("0 0 * * fri-tue", id="every Friday through Tuesday"),
+            pytest.param("0 0 */3 * *", id="every 3 hours"),
+            pytest.param("0 0 6-14/2 * *", id="every 2 hours from 6 AM to 2 PM"),
+        ),
+    )
+    def test_valid_cron(self, cron: str):
+        assert is_valid_cron(cron)
+
+    @pytest.mark.parametrize(
+        "cron",
+        (
+            pytest.param("0 0 /3 * *", id="empty base"),
+            pytest.param("0 0 */x * *", id="invalid step"),
+            pytest.param("0 0 * ? *", id="special character ? in other places"),
+            pytest.param("0 a * * *", id="invalid hour part"),
+            pytest.param("0 0 a-31 * *", id="invalid range parts"),
+            pytest.param("0 0 -31 * *", id="invalid range parts"),
+            pytest.param("* * * ene-dic *", id="unknown month aliases"),
+            pytest.param("0 0 * * dec dom", id="unknown day of week aliases"),
+            pytest.param("0 0 1 1 0 0", id="6-field format"),
+            pytest.param("0 0 1 1 0 0 2025", id="7-field format"),
+        ),
+    )
+    def test_invalid_cron(self, cron: str):
+        assert not is_valid_cron(cron)
 
     @pytest.mark.order(0)
     def test_add_schedules(

--- a/uv.lock
+++ b/uv.lock
@@ -664,19 +664,6 @@ toml = [
 ]
 
 [[package]]
-name = "croniter"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-    { name = "pytz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/2f/44d1ae153a0e27be56be43465e5cb39b9650c781e001e7864389deb25090/croniter-6.0.0.tar.gz", hash = "sha256:37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577", size = 64481, upload-time = "2024-12-17T17:17:47.32Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/4b/290b4c3efd6417a8b0c284896de19b1d5855e6dbdb97d2a35e68fa42de85/croniter-6.0.0-py2.py3-none-any.whl", hash = "sha256:2f878c3856f17896979b2a4379ba1f09c83e374931ea15cc835c5dd2eee9b368", size = 25468, upload-time = "2024-12-17T17:17:45.359Z" },
-]
-
-[[package]]
 name = "cryptography"
 version = "45.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1118,7 +1105,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1306,7 +1293,6 @@ dependencies = [
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "click-default-group" },
     { name = "click-didyoumean" },
-    { name = "croniter" },
     { name = "dateparser" },
     { name = "fasteners" },
     { name = "flatten-dict" },
@@ -1379,7 +1365,6 @@ dev = [
     { name = "requests-mock" },
     { name = "setproctitle" },
     { name = "time-machine" },
-    { name = "types-croniter" },
     { name = "types-dateparser" },
     { name = "types-jsonschema" },
     { name = "types-psutil" },
@@ -1411,7 +1396,6 @@ testing = [
 typing = [
     { name = "boto3-stubs", extra = ["essential"] },
     { name = "mypy" },
-    { name = "types-croniter" },
     { name = "types-dateparser" },
     { name = "types-jsonschema" },
     { name = "types-psutil" },
@@ -1435,7 +1419,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.1,<9" },
     { name = "click-default-group", specifier = ">=1.2.4,<2" },
     { name = "click-didyoumean", specifier = ">=0.3.1,<0.4" },
-    { name = "croniter", specifier = ">=6.0.0,<7" },
     { name = "dateparser", specifier = ">=1.2.1" },
     { name = "fasteners", specifier = ">=0.19,<0.20" },
     { name = "flatten-dict", specifier = ">=0,<1" },
@@ -1487,7 +1470,6 @@ dev = [
     { name = "requests-mock", specifier = ">=1.12.1,<2" },
     { name = "setproctitle", specifier = "~=1.3" },
     { name = "time-machine", specifier = ">=2.15.0,<3" },
-    { name = "types-croniter", specifier = "==5.0.1.20241205" },
     { name = "types-dateparser", specifier = ">=1.2.0.20250208" },
     { name = "types-jsonschema", specifier = ">=4.23.0.20240813,<5" },
     { name = "types-psutil", specifier = ">=7.0.0.20250218,<8" },
@@ -1516,7 +1498,6 @@ testing = [
 typing = [
     { name = "boto3-stubs", extras = ["essential"], specifier = ">=1.35,<1.39" },
     { name = "mypy", specifier = ">=1.16.0,<2" },
-    { name = "types-croniter", specifier = "==5.0.1.20241205" },
     { name = "types-dateparser", specifier = ">=1.2.0.20250208" },
     { name = "types-jsonschema", specifier = ">=4.23.0.20240813,<5" },
     { name = "types-psutil", specifier = ">=7.0.0.20250218,<8" },
@@ -3312,15 +3293,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/95/02564024f8668feab6733a2c491005b5281b048b3d0573510622cbcd9fd4/types_awscrt-0.27.4.tar.gz", hash = "sha256:c019ba91a097e8a31d6948f6176ede1312963f41cdcacf82482ac877cbbcf390", size = 16941, upload-time = "2025-06-29T22:58:04.756Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/40/cb4d04df4ac3520858f5b397a4ab89f34be2601000002a26edd8ddc0cac5/types_awscrt-0.27.4-py3-none-any.whl", hash = "sha256:a8c4b9d9ae66d616755c322aba75ab9bd793c6fef448917e6de2e8b8cdf66fb4", size = 39626, upload-time = "2025-06-29T22:58:03.157Z" },
-]
-
-[[package]]
-name = "types-croniter"
-version = "5.0.1.20241205"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/2f/f3298f148a7983df2a878d53c4a17ef1dd8654a155e11caa8decb7d79670/types_croniter-5.0.1.20241205.tar.gz", hash = "sha256:8a7cb10aa0b487c654a10c14d4e99098c92a5d68ee55c7a92a3df095831a6933", size = 10928, upload-time = "2024-12-05T02:58:03.648Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/ec/ff0222b912fdff040a1908ea226f64ff5a1a384a4062a8714eb8b80ea5d9/types_croniter-5.0.1.20241205-py3-none-any.whl", hash = "sha256:e36e992d6a4600ddf510991a20d3273b888ecea5d77a19078348e00775ba54d3", size = 9375, upload-time = "2024-12-05T02:58:02.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

The `croniter` dependency is only used to validate cron expressions, so this PR adds native validation for the common 5-field format.

## Related Issues

* Closes #9387

## Summary by Sourcery

Remove the croniter dependency by implementing a custom 5-field cron expression validator (including support for wildcards, ranges, steps, special characters, and month/day-of-week aliases), update CLI and schedule service to use the new validator, remove croniter from dependencies, and add comprehensive tests for valid and invalid expressions.

New Features:
- Add a native cron expression validator supporting wildcards, ranges, steps, special characters, and month/day-of-week aliases

Enhancements:
- Replace all croniter.is_valid calls in the CLI and schedule service with the new validator

Build:
- Remove croniter and types-croniter from project dependencies

Tests:
- Add parameterized tests covering a variety of valid and invalid cron expressions