### PR TITLE
feat: `meltano add` now updates existing plugins by default

### DIFF
--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -107,8 +107,9 @@ def _load_yaml_from_ref(
     ),
 )
 @click.option(
-    "--update",
+    "--update/--no-update",
     is_flag=True,
+    default=True,
     help="Update an existing plugin.",
 )
 @install
@@ -126,12 +127,12 @@ async def add(
     project: Project,
     plugin: tuple[str, ...],
     install_plugins: InstallPlugins,
-    plugin_type: PluginType | None = None,
-    inherit_from: str | None = None,
-    variant: str | None = None,
-    as_name: str | None = None,
-    plugin_yaml: dict | None = None,
-    python: str | None = None,
+    plugin_type: PluginType | None,
+    inherit_from: str | None,
+    variant: str | None,
+    as_name: str | None,
+    plugin_yaml: dict | None,
+    python: str | None,
     **flags: bool,
 ) -> None:
     """Add a plugin to your project.

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -111,6 +111,7 @@ def _load_yaml_from_ref(
     is_flag=True,
     default=True,
     help="Update an existing plugin.",
+    hidden=True,
 )
 @install
 @no_install

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -19,12 +19,12 @@ from meltano.core.error import MeltanoConfigurationError
 from meltano.core.logging import setup_logging
 from meltano.core.plugin.base import PluginDefinition, PluginType
 from meltano.core.plugin.error import InvalidPluginDefinitionError, PluginNotFoundError
-from meltano.core.plugin_lock_service import LockfileAlreadyExistsError
 from meltano.core.project_add_service import (
     PluginAddedReason,
     PluginAlreadyAddedException,
     ProjectAddService,
 )
+from meltano.core.project_plugins_service import AddedPluginFlags
 from meltano.core.setting_definition import SettingKind
 from meltano.core.tracking.contexts import CliContext, CliEvent, ProjectContext
 
@@ -68,7 +68,7 @@ def print_added_plugin(
     plugin: ProjectPlugin,
     reason: PluginAddedReason = PluginAddedReason.USER_REQUEST,
     *,
-    update: bool = False,
+    flags: AddedPluginFlags = AddedPluginFlags.ADDED,
 ) -> None:
     """Print added plugin."""
     descriptor = plugin.type.descriptor
@@ -77,17 +77,14 @@ def print_added_plugin(
     elif reason is PluginAddedReason.REQUIRED:
         descriptor = f"required {descriptor}"
 
-    action, preposition = (
-        (
-            "Updated" if plugin.should_add_to_file() else "Updating",
-            "in",
-        )
-        if update
-        else (
-            "Added" if plugin.should_add_to_file() else "Adding",
-            "to",
-        )
-    )
+    if flags == AddedPluginFlags.ADDED:
+        action, preposition = "Added", "in"
+    elif flags == AddedPluginFlags.UPDATED:
+        action, preposition = "Updated", "in"
+    elif flags == AddedPluginFlags.NOT_ADDED:
+        action, preposition = "Not added", "to"
+    else:  # pragma: no cover
+        t.assert_never(flags)
 
     click.secho(
         f"{action} {descriptor} '{plugin.name}' {preposition} your project",
@@ -310,10 +307,8 @@ def add_plugin(  # noqa: ANN201
         plugin_name = plugin_attrs.pop("name")
         variant = plugin_attrs.pop("variant", variant)
 
-    plugin: ProjectContext | PluginRef
-
     try:
-        plugin = add_service.add(
+        plugin, flags = add_service.add_with_flags(
             plugin_type,
             plugin_name,
             variant=variant,
@@ -323,9 +318,9 @@ def add_plugin(  # noqa: ANN201
             python=python,
             **plugin_attrs,
         )
-        print_added_plugin(plugin, update=update)
+        print_added_plugin(plugin, flags=flags)
     except PluginAlreadyAddedException as err:
-        plugin = err.plugin
+        plugin = err.plugin  # type: ignore[assignment]
         click.secho(
             (
                 f"{plugin_type.descriptor.capitalize()} '{plugin_name}' "
@@ -369,17 +364,6 @@ def add_plugin(  # noqa: ANN201
                 f"\tmeltano add {plugin_type.singular} {plugin.name}--new "
                 f"--inherit-from {plugin.name}",
             )
-    except LockfileAlreadyExistsError as exc:
-        # TODO: This is a BasePlugin, not a ProjectPlugin, as this method
-        # should return! Results in `KeyError: venv_name`
-        plugin = exc.plugin
-        click.secho(
-            f"Plugin definition is already locked at {exc.path}.",
-            fg="yellow",
-        )
-        click.echo(
-            "You can remove the file manually to avoid using a stale definition.",
-        )
 
     click.echo()
 

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -78,11 +78,11 @@ def print_added_plugin(
         descriptor = f"required {descriptor}"
 
     if flags == AddedPluginFlags.ADDED:
-        action, preposition = "Added", "in"
+        action, preposition = "Added", "to"
     elif flags == AddedPluginFlags.UPDATED:
         action, preposition = "Updated", "in"
     elif flags == AddedPluginFlags.NOT_ADDED:
-        action, preposition = "Not added", "to"
+        action, preposition = "Initialized", "in"
     else:  # pragma: no cover
         t.assert_never(flags)
 

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -89,7 +89,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         commands: dict[str, Command] | None = None,
         requires: dict[PluginType, list[PluginRequirement]] | None = None,
         config: dict[str, t.Any] | None = None,
-        default_variant: str = Variant.ORIGINAL_NAME,
+        default_variant: str = Variant.DEFAULT_NAME,
         env: dict[str, str] | None = None,
         **extras,  # noqa: ANN003
     ):

--- a/src/meltano/core/project_add_service.py
+++ b/src/meltano/core/project_add_service.py
@@ -9,6 +9,7 @@ import typing as t
 from meltano.core.plugin import BasePlugin, PluginType, Variant
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project_plugins_service import (
+    AddedPluginFlags,
     DefinitionSource,
     PluginAlreadyAddedException,
 )
@@ -50,7 +51,7 @@ class ProjectAddService:
         """
         self.project = project
 
-    def add(
+    def add_with_flags(
         self,
         plugin_type: PluginType,
         plugin_name: str,
@@ -58,7 +59,7 @@ class ProjectAddService:
         lock: bool = True,
         update: bool = False,
         **attrs: t.Any,
-    ) -> ProjectPlugin:
+    ) -> tuple[ProjectPlugin, AddedPluginFlags]:
         """Add a new plugin to the project.
 
         Args:
@@ -69,7 +70,7 @@ class ProjectAddService:
             attrs: Additional attributes to add to the plugin.
 
         Returns:
-            The added plugin.
+            The added plugin and flags.
         """
         plugin = ProjectPlugin(
             plugin_type,
@@ -88,13 +89,10 @@ class ProjectAddService:
                 plugin.variant = parent.variant
                 plugin.pip_url = parent.pip_url
 
-            if update:
-                plugin, _outdated = self.project.plugins.update_plugin(
-                    plugin,
-                    keep_config=True,
-                )
-            else:
-                plugin = self.project.plugins.add_to_file(plugin)
+            plugin, flags = self.project.plugins.add_to_file_with_flags(
+                plugin,
+                update=update,
+            )
 
             if lock and not plugin.is_custom():
                 self.project.plugins.lock_service.save(
@@ -102,7 +100,37 @@ class ProjectAddService:
                     exists_ok=update or plugin.inherit_from is not None,
                 )
 
-            return plugin
+            return plugin, flags
+
+    def add(
+        self,
+        plugin_type: PluginType,
+        plugin_name: str,
+        *,
+        lock: bool = True,
+        update: bool = False,
+        **attrs: t.Any,
+    ) -> ProjectPlugin:
+        """Add a plugin to the project.
+
+        Args:
+            plugin_type: The type of the plugin to add.
+            plugin_name: The name of the plugin to add.
+            lock: Whether to generate a lockfile for the plugin.
+            update: Whether to update the plugin.
+            attrs: Additional attributes to add to the plugin.
+
+        Returns:
+            The added plugin.
+        """
+        plugin, _flags = self.add_with_flags(
+            plugin_type,
+            plugin_name,
+            lock=lock,
+            update=update,
+            **attrs,
+        )
+        return plugin
 
     def add_required(
         self,

--- a/src/meltano/core/project_add_service.py
+++ b/src/meltano/core/project_add_service.py
@@ -95,10 +95,7 @@ class ProjectAddService:
             )
 
             if lock and not plugin.is_custom():
-                self.project.plugins.lock_service.save(
-                    plugin,
-                    exists_ok=update or plugin.inherit_from is not None,
-                )
+                self.project.plugins.lock_service.save(plugin, exists_ok=True)
 
             return plugin, flags
 

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -43,6 +43,8 @@ if t.TYPE_CHECKING:
 
     from requests.adapters import BaseAdapter
 
+    from meltano.core.plugin.project_plugin import ProjectPlugin
+
 current_dir = Path(__file__).parent
 
 
@@ -1914,7 +1916,7 @@ def plugin_invoker_factory(project, plugin_settings_service_factory):
 
 
 @pytest.fixture(scope="class")
-def tap(project_add_service):
+def tap(project_add_service: ProjectAddService):
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1926,7 +1928,7 @@ def tap(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def alternative_tap(project_add_service, tap):
+def alternative_tap(project_add_service: ProjectAddService, tap: ProjectPlugin):
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1939,7 +1941,7 @@ def alternative_tap(project_add_service, tap):
 
 
 @pytest.fixture(scope="class")
-def inherited_tap(project_add_service, tap):
+def inherited_tap(project_add_service: ProjectAddService, tap: ProjectPlugin):
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1955,7 +1957,7 @@ def inherited_tap(project_add_service, tap):
 
 
 @pytest.fixture(scope="class")
-def nonpip_tap(project_add_service):
+def nonpip_tap(project_add_service: ProjectAddService):
     try:
         return project_add_service.add(
             PluginType.EXTRACTORS,
@@ -1967,7 +1969,7 @@ def nonpip_tap(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def target(project_add_service):
+def target(project_add_service: ProjectAddService):
     try:
         return project_add_service.add(PluginType.LOADERS, "target-mock")
     except PluginAlreadyAddedException as err:
@@ -1975,7 +1977,7 @@ def target(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def alternative_target(project_add_service):
+def alternative_target(project_add_service: ProjectAddService):
     # We don't load the `target` fixture here since this ProjectPlugin should
     # have a BasePlugin parent, not the `target` ProjectPlugin
     try:
@@ -1989,7 +1991,7 @@ def alternative_target(project_add_service):
 
 
 @pytest.fixture(scope="class")
-def dbt(project_add_service):
+def dbt(project_add_service: ProjectAddService):
     try:
         return project_add_service.add(PluginType.TRANSFORMERS, "dbt")
     except PluginAlreadyAddedException as err:
@@ -2005,7 +2007,7 @@ def transformer(project_add_service: ProjectAddService):
 
 
 @pytest.fixture(scope="class")
-def utility(project_add_service):
+def utility(project_add_service: ProjectAddService):
     try:
         return project_add_service.add(PluginType.UTILITIES, "utility-mock")
     except PluginAlreadyAddedException as err:
@@ -2139,7 +2141,7 @@ def project_files(tmp_path_factory: pytest.TempPathFactory, compatible_copy_tree
 
 
 @pytest.fixture(scope="class")
-def mapper(project_add_service):
+def mapper(project_add_service: ProjectAddService):
     try:
         return project_add_service.add(
             PluginType.MAPPERS,

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import contextlib
-import json
 import os
 import platform
 import shutil
 import typing as t
-from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -126,10 +124,7 @@ class TestCliAdd:
             )
 
             assert res.exit_code == 0, res.stdout
-            assert (
-                "Extractor 'tap-gitlab' already exists in your Meltano project"
-                in res.stderr
-            )
+            assert "Updated extractor 'tap-gitlab'" in res.stdout
             assert "Added extractor 'tap-adwords'" in res.stdout
             assert "Added extractor 'tap-facebook'" in res.stdout
 
@@ -847,7 +842,7 @@ class TestCliAdd:
         )
 
     @pytest.mark.usefixtures("reset_project_context")
-    def test_add_update(self, cli_runner) -> None:
+    def test_add_no_update(self, cli_runner) -> None:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock"])
@@ -861,36 +856,15 @@ class TestCliAdd:
             assert res.exit_code == 0, res.stdout
             assert "Updated extractor 'tap-mock" in res.stdout
 
-    @pytest.mark.usefixtures("reset_project_context")
-    def test_add_update_not_in_project(self, cli_runner) -> None:
-        res = cli_runner.invoke(cli, ["add", "extractor", "tap-mock", "--update"])
-
-        assert res.exit_code == 1
-        assert res.exception
-        assert str(res.exception) == "Extractor 'tap-mock' is not known to Meltano"
-
-    @pytest.mark.usefixtures("reset_project_context")
-    def test_lockfile_exists(self, cli_runner) -> None:
-        plugins_dir = Path("plugins/utilities")
-        plugins_dir.mkdir(parents=True, exist_ok=True)
-        lockfile = plugins_dir / "utility-mock--original.lock"
-        lockfile.write_text(
-            json.dumps(
-                {
-                    "plugin_type": "utilities",
-                    "name": "utility-mock",
-                    "namespace": "utility_mock",
-                },
-            ),
-        )
-        lockfile.touch()
-
-        with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
-            install_plugin_mock.return_value = True
-            res = cli_runner.invoke(cli, ["add", "utility", "utility-mock"])
+            res = cli_runner.invoke(
+                cli,
+                ["add", "extractor", "tap-mock", "--no-update"],
+            )
             assert res.exit_code == 0, res.stdout
-            assert "Plugin definition is already locked at" in res.stdout
-            assert "You can remove the file manually" in res.stdout
+            assert (
+                "Extractor 'tap-mock' already exists in your Meltano project"
+                in res.stderr
+            )
 
     @pytest.mark.usefixtures("reset_project_context")
     def test_add_multiple_no_plugin_type(self, project: Project, cli_runner) -> None:

--- a/tests/meltano/cli/test_remove.py
+++ b/tests/meltano/cli/test_remove.py
@@ -8,7 +8,10 @@ import pytest
 from asserts import assert_cli_runner
 from meltano.cli import cli
 from meltano.core.plugin import PluginType
-from meltano.core.project_add_service import PluginAlreadyAddedException
+from meltano.core.project_add_service import (
+    PluginAlreadyAddedException,
+    ProjectAddService,
+)
 
 if t.TYPE_CHECKING:
     from meltano.core.plugin.project_plugin import ProjectPlugin
@@ -16,7 +19,7 @@ if t.TYPE_CHECKING:
 
 class TestCliRemove:
     @pytest.fixture(scope="class")
-    def tap_gitlab(self, project_add_service):
+    def tap_gitlab(self, project_add_service: ProjectAddService):
         try:
             return project_add_service.add(PluginType.EXTRACTORS, "tap-gitlab")
         except PluginAlreadyAddedException as err:

--- a/tests/meltano/core/plugin/test_plugin.py
+++ b/tests/meltano/core/plugin/test_plugin.py
@@ -301,7 +301,7 @@ class TestProjectPlugin:
         plugin = ProjectPlugin(PluginType.EXTRACTORS, **self.ATTRS["minimal"])
 
         assert plugin.name == "tap-example"
-        assert plugin.variant is Variant.ORIGINAL_NAME
+        assert plugin.variant is Variant.DEFAULT_NAME
         assert plugin.pip_url is None
         assert not plugin.config
         assert not plugin.is_custom()
@@ -450,7 +450,7 @@ class TestProjectPlugin:
     def test_variant(self, project: Project) -> None:
         # Without a variant set, the "original" name is used
         plugin: ProjectPlugin = ProjectPlugin(PluginType.EXTRACTORS, name="tap-mock")
-        assert plugin.variant == Variant.ORIGINAL_NAME
+        assert plugin.variant == Variant.DEFAULT_NAME
 
         base_plugin = project.hub_service.find_base_plugin(
             PluginType.EXTRACTORS,

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -71,7 +71,7 @@ def env_var():
 
 
 @pytest.fixture(scope="class")
-def custom_tap(project):
+def custom_tap(project: Project):
     expected = {"test": "custom", "start_date": None, "secure": None}
     tap = ProjectPlugin(
         PluginType.EXTRACTORS,

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -21,6 +21,7 @@ from meltano.core.schedule_service import (
 )
 
 if t.TYPE_CHECKING:
+    from meltano.core.project import Project
     from meltano.core.schedule_service import ScheduleService
 
 
@@ -58,7 +59,7 @@ def create_job_schedule():
 
 
 @pytest.fixture(scope="class")
-def custom_tap(project):
+def custom_tap(project: Project):
     tap = ProjectPlugin(
         PluginType.EXTRACTORS,
         name="tap-custom",


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

`meltano add` now updates the existing plugin definition in `meltano.yml`. This is in line with, for example, how `uv add` works.



## Related Issues

* https://github.com/meltano/meltano/issues/9390
* https://github.com/meltano/meltano/issues/3380

## Summary by Sourcery

Enable the `meltano add` command to update existing plugins by default and unify flag handling across the add workflow.

New Features:
- Add `--update/--no-update` flag (defaulting to update) to `meltano add` so existing plugins are updated by default

Enhancements:
- Introduce `add_with_flags` method and `AddedPluginFlags` enum to signal added, updated, or not added status
- Refactor `add_to_file` to support in-place updates and return status flags
- Update `print_added_plugin` to use status flags for messaging
- Change default plugin variant name from "original" to "default"

Tests:
- Adjust tests to expect update behavior and new messages for added or updated plugins

## Summary by Sourcery

Make the `meltano add` command idempotent by updating existing plugins by default and unify flag handling across the add workflow

New Features:
- Add `--update/--no-update` flag (default enabled) to `meltano add` so existing plugins are updated instead of erroring
- Make `meltano add` idempotent: rerunning the command on an existing plugin refreshes its definition without overwriting user configuration

Enhancements:
- Introduce AddedPluginFlags enum to signal ADDED, UPDATED, or NOT_ADDED outcomes
- Refactor add_to_file into add_to_file_with_flags to return status flags and support in-place updates
- Add add_with_flags method in ProjectAddService and delegate add to it
- Update print_added_plugin to use status flags for consistent messaging
- Change default plugin variant name from “original” to “default”

Documentation:
- Update CLI reference to describe idempotent add behavior and the new `--update/--no-update` flag

Tests:
- Adjust tests to expect default update behavior and verify new add/update messages