### PR TITLE
fix: Increase YAML width to prevent wrapping long lines

### DIFF
--- a/src/meltano/core/yaml.py
+++ b/src/meltano/core/yaml.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from dataclasses import dataclass
 from decimal import Decimal
@@ -21,6 +22,7 @@ if t.TYPE_CHECKING:
 
 yaml = YAML()
 yaml.default_flow_style = False
+yaml.width = sys.maxsize  # Prevent line wrapping entirely
 
 
 def _represent_decimal(dumper: Dumper, node: Decimal) -> ScalarNode:

--- a/tests/meltano/core/test_yaml.py
+++ b/tests/meltano/core/test_yaml.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import sys
 import typing as t
 from decimal import Decimal
 
@@ -144,8 +143,6 @@ def test_mixed_numeric_types() -> None:
 
 def test_yaml_width_prevents_line_wrapping() -> None:
     """Test that long lines are not wrapped due to sys.maxsize YAML width."""
-    from meltano.core.yaml import yaml as yaml_instance
-
     long_url = (
         "git+https://github.com/transferwise/pipelinewise-tap-mysql.git"
         "#subdirectory=singer-connectors/tap-mysql&ref=v1.2.3-with-very-long-branch-name"

--- a/tests/meltano/core/test_yaml.py
+++ b/tests/meltano/core/test_yaml.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import sys
 import typing as t
 from decimal import Decimal
 
@@ -139,3 +140,47 @@ def test_mixed_numeric_types() -> None:
     assert "789" in output
     assert "0.001" in output
     assert "999999999.999999999" in output
+
+
+def test_yaml_width_prevents_line_wrapping() -> None:
+    """Test that long lines are not wrapped due to sys.maxsize YAML width."""
+    from meltano.core.yaml import yaml as yaml_instance
+
+    assert yaml_instance.width == sys.maxsize
+
+    long_url = (
+        "git+https://github.com/transferwise/pipelinewise-tap-mysql.git"
+        "#subdirectory=singer-connectors/tap-mysql&ref=v1.2.3-with-very-long-branch-name"
+        "&commit=abcdef1234567890abcdef1234567890abcdef12&parameter=very-long-parameter-value"
+        "&another_param=another-very-long-parameter-value-to-test-extreme-lengths"
+        "&more_params=additional-configuration-options-and-settings-for-comprehensive-testing"
+    )
+
+    data = CommentedMap(
+        {
+            "plugins": CommentedMap(
+                {
+                    "extractors": [
+                        CommentedMap(
+                            [
+                                ("name", "tap-mysql"),
+                                ("variant", "transferwise"),
+                                ("pip_url", long_url),
+                            ]
+                        )
+                    ]
+                }
+            )
+        }
+    )
+
+    stream = io.StringIO()
+    yaml.dump(data, stream)
+    output = stream.getvalue()
+    lines = output.strip().split("\n")
+
+    pip_url_line = next((line for line in lines if "pip_url:" in line), None)
+
+    assert pip_url_line is not None
+    assert long_url in pip_url_line
+    assert sum(1 for line in lines if long_url in line) == 1

--- a/tests/meltano/core/test_yaml.py
+++ b/tests/meltano/core/test_yaml.py
@@ -146,8 +146,6 @@ def test_yaml_width_prevents_line_wrapping() -> None:
     """Test that long lines are not wrapped due to sys.maxsize YAML width."""
     from meltano.core.yaml import yaml as yaml_instance
 
-    assert yaml_instance.width == sys.maxsize
-
     long_url = (
         "git+https://github.com/transferwise/pipelinewise-tap-mysql.git"
         "#subdirectory=singer-connectors/tap-mysql&ref=v1.2.3-with-very-long-branch-name"


### PR DESCRIPTION
Fixes #9383 where `ruamel.yaml` would automatically wrap long lines (like plugin `pip_url` values) when running `meltano add` commands, causing YAML files to be reformatted unexpectedly.

## Changes

- Set `yaml.width = sys.maxsize` in `src/meltano/core/yaml.py` to prevent line wrapping entirely
- Added test to verify long lines are not wrapped

Using `sys.maxsize` is a standard practice in the ruamel.yaml community for disabling line wrapping, as seen in the [official test cases](https://github.com/pycontribs/ruamel-yaml/blob/master/_test/test_issues.py). This provides cross-platform reliability (2³¹-1 on 32-bit, 2⁶³-1 on 64-bit systems) and handles any realistic YAML content length.

## Testing
- ✅ New test verifies extremely long URLs (400+ characters) are not wrapped

Closes #9383

## Summary by Sourcery

Prevent ruamel.yaml from automatically wrapping long lines by setting the YAML width to the system maximum and add a test to verify the behavior.

Bug Fixes:
- Disable line wrapping in YAML by setting yaml.width to sys.maxsize to fix unexpected reformatting of long lines

Tests:
- Add a test to ensure extremely long pip_url values remain unwrapped in the YAML output