### PR TITLE
fix: Recreate venv when plugin Python version is changed

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -245,23 +245,23 @@ async def exec_async(*args, extract_stderr=_extract_stderr, **kwargs) -> Process
     return run
 
 
-def fingerprint(pip_install_args: Iterable[str], python_path: str | None = None) -> str:
+def fingerprint(pip_install_args: Iterable[str], interpreter: str | None = None) -> str:
     """Generate a hash identifying pip install args and Python interpreter.
 
     Arguments are sorted and deduplicated before the hash is generated.
 
     Args:
         pip_install_args: Arguments for `pip install`.
-        python_path: Path to the Python interpreter.
+        interpreter: Python interpreter (path or command name).
 
     Returns:
         The SHA256 hash hex digest of the sorted set of pip install args and Python.
     """
     components = sorted(set(pip_install_args))
-    # Only include Python path in fingerprint if it's different from default
+    # Only include Python interpreter in fingerprint if it's different from default
     # This ensures backward compatibility while detecting Python version changes
-    if python_path and python_path != sys.executable:
-        components.append(f"python:{python_path}")
+    if interpreter and interpreter != sys.executable:
+        components.append(f"python:{interpreter}")
     return hashlib.sha256(" ".join(components).encode()).hexdigest()
 
 

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -203,7 +203,9 @@ class VirtualEnv:
         Args:
             pip_install_args: The arguments being passed to `pip install`.
         """
-        self.plugin_fingerprint_path.write_text(fingerprint(pip_install_args))
+        self.plugin_fingerprint_path.write_text(
+            fingerprint(pip_install_args, self.python_path)
+        )
 
 
 async def _extract_stderr(_) -> None:
@@ -243,18 +245,24 @@ async def exec_async(*args, extract_stderr=_extract_stderr, **kwargs) -> Process
     return run
 
 
-def fingerprint(pip_install_args: Iterable[str]) -> str:
-    """Generate a hash identifying pip install args.
+def fingerprint(pip_install_args: Iterable[str], python_path: str | None = None) -> str:
+    """Generate a hash identifying pip install args and Python interpreter.
 
     Arguments are sorted and deduplicated before the hash is generated.
 
     Args:
         pip_install_args: Arguments for `pip install`.
+        python_path: Path to the Python interpreter.
 
     Returns:
-        The SHA256 hash hex digest of the sorted set of pip install args.
+        The SHA256 hash hex digest of the sorted set of pip install args and Python.
     """
-    return hashlib.sha256(" ".join(sorted(set(pip_install_args))).encode()).hexdigest()
+    components = sorted(set(pip_install_args))
+    # Only include Python path in fingerprint if it's different from default
+    # This ensures backward compatibility while detecting Python version changes
+    if python_path and python_path != sys.executable:
+        components.append(f"python:{python_path}")
+    return hashlib.sha256(" ".join(components).encode()).hexdigest()
 
 
 class VenvService:
@@ -356,7 +364,9 @@ class VenvService:
             # The fingerprint of the venv does not match the pip install args
             existing_fingerprint = self.venv.read_fingerprint()
             yield existing_fingerprint is None
-            yield existing_fingerprint != fingerprint(pip_install_args)
+            yield existing_fingerprint != fingerprint(
+                pip_install_args, self.venv.python_path
+            )
 
         return any(checks())
 

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -11,10 +11,40 @@ import pytest
 from meltano.core.error import AsyncSubprocessError, MeltanoError
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
-from meltano.core.venv_service import UvVenvService, VenvService, VirtualEnv
+from meltano.core.venv_service import (
+    UvVenvService,
+    VenvService,
+    VirtualEnv,
+    fingerprint,
+)
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
+
+
+def test_fingerprint_with_python_path():
+    """Test that fingerprint includes Python path when provided."""
+    import sys
+
+    pip_args = ["package==1.0.0", "another-package"]
+
+    fp1 = fingerprint(pip_args)
+    fp2 = fingerprint(pip_args, "/usr/bin/python3.11")
+
+    assert fp1 != fp2
+
+    fp3 = fingerprint(pip_args, "/usr/bin/python3.11")
+    assert fp2 == fp3
+
+    fp4 = fingerprint(pip_args, "/usr/bin/python3.12")
+    assert fp2 != fp4
+
+    fp5 = fingerprint(pip_args, None)
+    assert fp1 == fp5
+
+    # Test that sys.executable doesn't change fingerprint
+    fp6 = fingerprint(pip_args, sys.executable)
+    assert fp1 == fp6
 
 
 class TestVenvService:
@@ -115,12 +145,9 @@ class TestVenvService:
         )
 
         # ensure a fingerprint file was created
-        fingerprint = (venv_dir / ".meltano_plugin_fingerprint").read_text()
-        assert (
-            fingerprint
-            # sha256 of "example"
-            == "50d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c"
-        )
+        fingerprint_content = (venv_dir / ".meltano_plugin_fingerprint").read_text()
+        expected_fingerprint = fingerprint(["example"], subject.venv.python_path)
+        assert fingerprint_content == expected_fingerprint
 
         # ensure that log file was created and is not empty
         self.assert_pip_log_file(subject)
@@ -167,6 +194,23 @@ class TestVenvService:
         assert not subject.requires_clean_install(["example"])
         assert subject.requires_clean_install(["example==0.1.0"])
         assert subject.requires_clean_install(["example", "another-package"])
+
+    @pytest.mark.asyncio
+    async def test_requires_clean_install_python_change(
+        self, subject: VenvService
+    ) -> None:
+        await subject.install(["example"], clean=True)
+        assert not subject.requires_clean_install(["example"])
+
+        original_python = subject.venv.python_path
+        try:
+            subject.venv.python_path = "/usr/bin/python3.11"
+            assert subject.requires_clean_install(["example"])
+
+            subject.venv.python_path = original_python
+            assert not subject.requires_clean_install(["example"])
+        finally:
+            subject.venv.python_path = original_python
 
     async def test_python_setting(self, project: Project) -> None:
         plugin_python = "test-python-executable-plugin-level"

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -204,7 +204,7 @@ class TestVenvService:
 
         original_python = subject.venv.python_path
         try:
-            subject.venv.python_path = "/usr/bin/python3.11"
+            subject.venv.python_path = "/fake/test/python"
             assert subject.requires_clean_install(["example"])
 
             subject.venv.python_path = original_python


### PR DESCRIPTION
Hi! 👋🏾 I wanted to try my hand at something beyond a `good first issue` but I'm still very new to Meltano's codebase so this is very much a Draft PR. It may not even be what the team is looking for at all, as I see #9391 in the works too. 

However, I believe that this PR _could_ be complementary to the work in that one. Thank you for taking a look!

**Edit: My apologies, I just saw that https://github.com/meltano/meltano/issues/9390 doesn't have `Accepting Pull Requests` as a label so maybe you're not looking for a PR for it.** 🙏🏾

## Overview

This draft PR looks to address the core technical issue described in #9390 where virtual environments are not recreated when a plugin's Python version setting changes, causing installations to fail even after switching to a compatible Python version.

## Problem

When adding a plugin with a specific Python version that fails (e.g., `meltano add target-gcs --python 3.13`), subsequent attempts with a different Python version (e.g., `meltano add target-gcs --python 3.11`) continue to fail because the existing virtual environment fingerprint doesn't account for Python version changes.

## Solution

This draft PR enhances the virtual environment fingerprinting mechanism to include the Python interpreter path when it differs from the default, ensuring that changes to the Python version automatically trigger virtual environment recreation while maintaining backward compatibility.

### Changes Made

- Enhanced `fingerprint()` function to include Python interpreter path only when it differs from `sys.executable`
- Updated `VirtualEnv.write_fingerprint()` to pass Python path to fingerprint
- Modified `requires_clean_install()` to detect Python version changes
- Added tests

## Relationship to PR #9391

[PR #9391](https://github.com/meltano/meltano/pull/9391) by @edgarrmondragon is more expansive and improves the plugin addition workflow UX by making `meltano add` idempotent. These changes appear to be complementary:

- **PR #9391**: Improves user experience by allowing plugin configuration updates
- **This draft PR**: Looks to ensure the underlying virtual environment system responds correctly to Python version changes

Both changes address different layers of the same user problem and could potentially work together or independently. The files modified don't overlap, so there appear to be no merge conflicts.

## Testing

- Added unit tests for fingerprint function with Python path variations
- Added integration tests for Python version change detection

## Impact

This attempts to be a minimal, targeted fix that preserves all existing behavior while addressing the specific technical issue. Virtual environments created before this change work normally (no fingerprint changes for default Python), and the fix only activates when specific Python versions are explicitly set and later changed.

Looks to address #9390

## Summary by Sourcery

Extend the virtual environment fingerprint to account for custom Python interpreter paths and trigger recreation when a plugin’s Python version changes

Bug Fixes:
- Recreate virtual environments when a plugin's Python version setting changes

Enhancements:
- Include Python interpreter path in the pip install fingerprint when it differs from the default
- Update VenvService to write and compare fingerprints with the Python path

Tests:
- Add unit tests for fingerprint variations with Python path
- Add integration tests for detecting Python version changes in requires_clean_install

## Summary by Sourcery

Ensure virtual environments are recreated when a plugin’s Python version setting changes by including the Python interpreter path in the fingerprint comparison.

Bug Fixes:
- Recreate virtual environment when a plugin's Python version setting changes

Enhancements:
- Extend fingerprinting to include Python interpreter path when it differs from the default
- Update write_fingerprint and requires_clean_install to pass and compare python_path

Tests:
- Add unit tests for fingerprint behavior with different Python paths
- Add integration test for detecting Python version changes in requires_clean_install