### PR TITLE
feat(core): Add log file support for uv venv backend installation errors

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -740,7 +740,9 @@ class UvVenvService(VenvService):
         stderr_content = await err.stderr
 
         async with await anyio.open_file(
-            self.pip_log_path, "a", encoding="utf-8"
+            self.pip_log_path,
+            "a",
+            encoding="utf-8",
         ) as log_file:
             if stderr_content:
                 await log_file.write(stderr_content)

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -748,13 +748,9 @@ class UvVenvService(VenvService):
             await log_file.write(
                 f"\n--- Installation attempt failed at {timestamp} ---\n"
             )
-            if hasattr(err.process, "args") and err.process.args:
-                command_str = " ".join(str(arg) for arg in err.process.args)
-                await log_file.write(f"Command: {command_str}\n")
-            else:
-                await log_file.write(
-                    f"Command: {self.uv} pip install --python={python_path}\n"
-                )
+            await log_file.write(
+                f"Command: {self.uv} pip install --python={python_path}\n"
+            )
 
             if stderr_content:
                 await log_file.write(f"Error output:\n{stderr_content}\n")

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -13,7 +13,6 @@ import sys
 import typing as t
 from asyncio.subprocess import Process
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
 from functools import cache, cached_property
 
 import structlog
@@ -739,23 +738,12 @@ class UvVenvService(VenvService):
         import anyio
 
         stderr_content = await err.stderr
-        timestamp = datetime.now(timezone.utc).isoformat()
-        python_path = self.exec_path("python")
 
         async with await anyio.open_file(
             self.pip_log_path, "a", encoding="utf-8"
         ) as log_file:
-            await log_file.write(
-                f"\n--- Installation attempt failed at {timestamp} ---\n"
-            )
-            await log_file.write(
-                f"Command: {self.uv} pip install --python={python_path}\n"
-            )
-
             if stderr_content:
-                await log_file.write(f"Error output:\n{stderr_content}\n")
-
-            await log_file.write("--- End of error log ---\n\n")
+                await log_file.write(stderr_content)
 
     @override
     async def create_venv(

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -722,11 +722,11 @@ class UvVenvService(VenvService):
                 self.pip_log_path,
                 log_err,
             )
-
-        logger.info(
-            "Logged uv pip install output to %s",
-            self.pip_log_path,
-        )
+        else:
+            logger.info(
+                "Logged uv pip install output to %s",
+                self.pip_log_path,
+            )
         return AsyncSubprocessError(
             f"Failed to install plugin '{self.name}'.",
             err.process,

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -735,7 +735,9 @@ class UvVenvService(VenvService):
 
             stderr_result = err.stderr
             stderr_content = (
-                await stderr_result if hasattr(stderr_result, "__await__") else stderr_result
+                await stderr_result
+                if hasattr(stderr_result, "__await__")
+                else stderr_result
             )
             if stderr_content:
                 log_file.write(f"Error output:\n{stderr_content}\n")

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -327,8 +327,7 @@ class TestUvVenvService(TestVenvService):
         """Test that error handling creates log file with details."""
         log_file_path = tmp_path / "pip.log"
         with mock.patch.object(subject, "pip_log_path", log_file_path):
-            process = mock.Mock()
-            process.args = ["uv", "pip", "install", "some-package"]
+            process = mock.Mock(spec=Process)
             original_err = AsyncSubprocessError(
                 "Something went wrong", process, stderr="Some error"
             )
@@ -340,26 +339,9 @@ class TestUvVenvService(TestVenvService):
             assert log_file_path.exists()
             log_content = log_file_path.read_text()
             assert "Installation attempt failed at" in log_content
-            assert "pip install some-package" in log_content
+            assert f"Command: {subject.uv} pip install --python" in log_content
             assert "Some error" in log_content
             assert "--- End of error log ---" in log_content
-
-    async def test_error_logging_no_process_args(
-        self, subject: UvVenvService, tmp_path
-    ) -> None:
-        """Test error logging when process has no args."""
-        log_file_path = tmp_path / "pip.log"
-        with mock.patch.object(subject, "pip_log_path", log_file_path):
-            process = mock.Mock()
-            process.args = None
-            original_err = AsyncSubprocessError(
-                "Another error", process, stderr="Different error"
-            )
-            await subject.handle_installation_error(original_err)
-
-            assert log_file_path.exists()
-            log_content = log_file_path.read_text()
-            assert f"Command: {subject.uv} pip install --python" in log_content
 
     async def test_error_logging_empty_stderr(
         self, subject: UvVenvService, tmp_path
@@ -367,8 +349,7 @@ class TestUvVenvService(TestVenvService):
         """Test error logging when stderr is empty."""
         log_file_path = tmp_path / "pip.log"
         with mock.patch.object(subject, "pip_log_path", log_file_path):
-            process = mock.Mock()
-            process.args = ["uv", "pip", "install", "some-package"]
+            process = mock.Mock(spec=Process)
             process.stderr = None
 
             # Create AsyncSubprocessError and simulate empty stderr

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -322,14 +322,18 @@ class TestUvVenvService(TestVenvService):
             await subject.install(["cowsay"])
 
     async def test_error_logging_creates_log_file(
-        self, subject: UvVenvService, tmp_path
+        self,
+        subject: UvVenvService,
+        tmp_path: Path,
     ) -> None:
         """Test that error handling creates log file with details."""
         log_file_path = tmp_path / "pip.log"
         with mock.patch.object(subject, "pip_log_path", log_file_path):
             process = mock.Mock(spec=Process)
             original_err = AsyncSubprocessError(
-                "Something went wrong", process, stderr="Some error"
+                "Something went wrong",
+                process,
+                stderr="Some error",
             )
             result_err = await subject.handle_installation_error(original_err)
 
@@ -340,7 +344,9 @@ class TestUvVenvService(TestVenvService):
             assert "Some error" in log_file_path.read_text()
 
     async def test_error_logging_empty_stderr(
-        self, subject: UvVenvService, tmp_path
+        self,
+        subject: UvVenvService,
+        tmp_path: Path,
     ) -> None:
         """Test error logging when stderr is empty."""
         log_file_path = tmp_path / "pip.log"
@@ -355,7 +361,8 @@ class TestUvVenvService(TestVenvService):
             assert log_file_path.read_text() == ""
 
     async def test_error_logging_handles_write_failure(
-        self, subject: UvVenvService
+        self,
+        subject: UvVenvService,
     ) -> None:
         """Test that log write failures are handled gracefully."""
         process = mock.Mock(spec=Process)
@@ -363,7 +370,9 @@ class TestUvVenvService(TestVenvService):
 
         # Mock the log writing to fail
         with mock.patch.object(
-            subject, "_write_error_log", side_effect=OSError("Permission denied")
+            subject,
+            "_write_error_log",
+            side_effect=OSError("Permission denied"),
         ):
             original_err = AsyncSubprocessError("Something went wrong", process)
             result_err = await subject.handle_installation_error(original_err)

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -297,7 +297,7 @@ class TestUvVenvService(TestVenvService):
             log_content = log_file_path.read_text()
             assert "Installation attempt failed at" in log_content
             assert "Command: " in log_content
-            assert "uv pip install" in log_content
+            assert "pip install" in log_content
             assert "Some error" in log_content
             assert "--- End of error log ---" in log_content
 


### PR DESCRIPTION
## Summary

This PR implements log file creation and user notification for the `uv` venv backend when plugin installation fails, bringing it to parity with the existing `pip` backend behavior. This change improves the developer experience by providing the same helpful debugging information for both venv backends, making it easier to troubleshoot plugin installation issues.

## Background

Previously, when plugin installation failed using the `uv` venv backend, users received only a generic error message without being pointed to a log file for debugging. The `pip` backend already provided this functionality by using pip's `--log` flag and informing users of the log file location.

Since `uv` doesn't currently support a `--log` CLI option (tracked in [astral-sh/uv#9850](https://github.com/astral-sh/uv/issues/9850)), this PR implements a workaround by manually creating detailed log files when installation errors occur.

## Changes

### Core Implementation (`src/meltano/core/venv_service.py`)

1. **Enhanced `UvVenvService.handle_installation_error()`** to create log files and inform users:
   - Creates log directory if it doesn't exist
   - Writes detailed error information to the same log path as pip backend
   - Informs users about the log file location via `logger.info()`

2. **Added `UvVenvService._write_error_log()` helper method** for clean separation of concerns:
   - Captures timestamp of failure
   - Records the exact command that failed
   - Includes full error output from uv
   - Uses structured, readable format

### Test Coverage (`tests/meltano/core/test_venv_service.py`)

1. **Enhanced existing test** to verify log file creation and content
2. **Added new test** for graceful handling of log write failures

## User Experience

### Before
```
ERROR: Failed to install plugin 'tap-csv'.
```

### After
```
ERROR: Failed to install plugin 'tap-csv'.
INFO: Logged uv pip install output to /path/to/project/.meltano/logs/pip/extractors/tap-csv/pip.log
```

### Log File Content Example
```
--- Installation attempt failed at 2025-01-21T15:30:45.123456 ---
Command: uv pip install --python=/path/to/venv/bin/python
Error output:
ERROR: Could not find a version that satisfies the requirement invalid-package
--- End of error log ---
```

## Implementation Details

- **Consistent with pip backend**: Uses identical log file paths and user messaging
- **Robust error handling**: Gracefully handles log write failures with debug logging

## Manual Testing

To test this feature:

1. **Setup dev environment:**
   ```bash
   uv pip install -e .
   uv run meltano init test-project && cd test-project
   echo "venv_backend: uv" >> meltano.yml
   ```

2. **Trigger installation failure:**
   ```bash
   uv run meltano add extractor tap-csv
   # Edit meltano.yml: change pip_url to "nonexistent-package==99.99.99"
   uv run meltano install extractor tap-csv
   ```

3. **Verify log file creation:**
   - Look for info message pointing to log file path

> 2025-07-22T02:56:40.746882Z [info     ] Logged uv pip install output to /Users/mahangu/code/meltano3/worktrees/9016/test-uv-demo/demo-project/.meltano/logs/pip/extractors/tap-csv/pip.log

   - Examine log file for timestamp, command, and error details

> cat /Users/mahangu/code/meltano3/worktrees/9016/test-uv-demo/demo-project/.meltano/logs/pip/extract
ors/tap-csv/pip.log

> --- Installation attempt failed at 2025-07-22T02:56:40.746705+00:00 ---
Command: /Users/mahangu/code/meltano3/worktrees/9016/.venv/bin/uv pip install --python=/Users/mahangu/code/meltano3/worktrees/9016/test-uv-demo/demo-project/.meltano/extractors/tap-csv/venv/bin/python
Error output:
Using Python 3.12.9 environment at: .meltano/extractors/tap-csv/venv
   Updating https://github.com/MeltanoLabs/tap-csv.gitz (HEAD)
error: Git operation failed
  Caused by: failed to clone into: /Users/mahangu/.cache/uv/git-v0/db/5e90adcedfb4e007
  Caused by: process didn't exit successfully: `/usr/bin/git fetch --force --update-head-ok 'https://github.com/MeltanoLabs/tap-csv.gitz' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
--- stderr
fatal: could not read Username for 'https://github.com': terminal prompts disabled
> --- End of error log ---

----

Closes #9016

## Summary by Sourcery

Enable detailed logging and user notification for installation failures in the uv venv backend, aligning its behavior with the pip backend.

New Features:
- Log installation errors to a timestamped log file and inform users of its location for the uv venv backend

Enhancements:
- Add _write_error_log helper to capture timestamp, failed command, and stderr output
- Handle log writing failures gracefully to prevent cascading errors

Tests:
- Add tests for log file creation on installation error and graceful handling of log write failures