### PR TITLE
docs(core): Fix typo in `meltano --version` example

### DIFF
--- a/docs/docs/getting-started/part1.mdx
+++ b/docs/docs/getting-started/part1.mdx
@@ -21,13 +21,13 @@ We're going to take data from a "source", namely GitHub, and extract a list of c
 To test that this part works, we will dump the data into JSON files.
 In Part 2, we will then place this data into a PostgreSQL database.
 
-We'll assume you have [Meltano installed](/getting-started/installation) already. You can tell Meltano is installed and which version by running ` meltano version`
+We'll assume you have [Meltano installed](/getting-started/installation) already. You can tell Meltano is installed and which version by running `meltano --version`
 
 <Termy>
 
 ```console
 $ meltano --version
-meltano, version 3.4.0
+meltano, version 3.8.0
 ```
 
 </Termy>


### PR DESCRIPTION
## Description

fix typo in documentation

## Summary by Sourcery

Fix incorrect command and version number in the getting-started documentation

Documentation:
- Use `meltano --version` instead of `meltano version` in the example
- Update example output version from 3.4.0 to 3.8.0