### PR TITLE
feat: Add 'disabled' log level to suppress all logging output

### DIFF
--- a/docs/docs/reference/settings.mdx
+++ b/docs/docs/reference/settings.mdx
@@ -526,10 +526,12 @@ These settings can be used to modify the behavior of the [`meltano` CLI](/refere
 
 - [Environment variable](/guide/configuration#configuring-settings): `MELTANO_CLI_LOG_LEVEL`.
 - `meltano` CLI option: `--log-level`
-- Options: `debug`, `info`, `warning`, `error`, `critical`
+- Options: `debug`, `info`, `warning`, `error`, `critical`, `disabled`
 - Default: `info`
 
 The granularity of CLI logging. Ignored if a local logging config is found.
+
+The `disabled` option completely suppresses all logging output, which is useful for scripts that need to parse Meltano output or for running commands in completely silent mode.
 
 #### How to use
 

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -56,7 +56,11 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
     # NOTE: This CLI option normalization applies to all subcommands.
     context_settings={"token_normalize_func": lambda x: x.replace("_", "-")},
 )
-@click.option("--log-level", type=click.Choice(tuple(LEVELS)))
+@click.option(
+    "--log-level",
+    type=click.Choice(tuple(LEVELS)),
+    help="Set the log level. 'disabled' will suppress all logging output.",
+)
 @click.option(
     "--log-format",
     type=click.Choice(tuple(LogFormat)),

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -82,6 +82,8 @@ settings:
     value: error
   - label: Critical
     value: critical
+  - label: Disabled
+    value: disabled
   value: info
   env_specific: true
   description: Log level for the CLI

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -37,6 +37,7 @@ LEVELS: dict[str, int] = {
     "warning": logging.WARNING,
     "error": logging.ERROR,
     "critical": logging.CRITICAL,
+    "disabled": logging.CRITICAL + 1,
 }
 DEFAULT_LEVEL = "info"
 FORMAT = (
@@ -96,6 +97,8 @@ def default_config(
     Returns:
          A logging config suitable for use with `logging.config.dictConfig`.
     """
+    # Convert log level to numeric value for disabled level
+    numeric_level = parse_log_level(log_level.lower())
     log_level = log_level.upper()
     max_frames = 100 if log_level == "DEBUG" else 2
     foreign_pre_chain = get_default_foreign_pre_chain()
@@ -179,7 +182,7 @@ def default_config(
         "handlers": {
             "console": {
                 "class": "logging.StreamHandler",
-                "level": log_level,
+                "level": numeric_level if log_level == "DISABLED" else log_level,
                 "formatter": log_format,
                 "stream": "ext://sys.stderr",
             },
@@ -187,7 +190,7 @@ def default_config(
         "loggers": {
             "": {
                 "handlers": ["console"],
-                "level": log_level.upper(),
+                "level": numeric_level if log_level == "DISABLED" else log_level,
                 "propagate": True,
             },
             "snowplow_tracker.emitters": {

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -341,6 +341,12 @@ class TestCli:
                 id="log-level-warning",
             ),
             pytest.param(
+                "--log-level",
+                "cli.log_level",
+                "disabled",
+                id="log-level-disabled",
+            ),
+            pytest.param(
                 "--log-config",
                 "cli.log_config",
                 "path/to/logging.yml",

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -184,14 +184,14 @@ def test_disabled_log_level():
     """Test that 'disabled' log level is properly defined and parsed."""
     # Test that 'disabled' is in LEVELS
     assert "disabled" in LEVELS
-    
+
     # Test that 'disabled' has a higher value than CRITICAL
     assert LEVELS["disabled"] > logging.CRITICAL
     assert LEVELS["disabled"] == logging.CRITICAL + 1
-    
+
     # Test that parse_log_level correctly parses 'disabled'
     assert parse_log_level("disabled") == logging.CRITICAL + 1
-    
+
     # Test that default_config accepts 'disabled' log level
     config = default_config("disabled")
     # When disabled, the numeric value should be used

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -10,9 +10,11 @@ import pytest
 import time_machine
 
 from meltano.core.logging.utils import (
+    LEVELS,
     LogFormat,
     capture_subprocess_output,
     default_config,
+    parse_log_level,
     setup_logging,
 )
 
@@ -176,3 +178,22 @@ def test_setup_logging_yml_extension_fallback(
     yaml_path.unlink()
     yml_path.write_text(yaml.dump(log_config_dict))
     test_fallback("logging.YAML", yml_path)
+
+
+def test_disabled_log_level():
+    """Test that 'disabled' log level is properly defined and parsed."""
+    # Test that 'disabled' is in LEVELS
+    assert "disabled" in LEVELS
+    
+    # Test that 'disabled' has a higher value than CRITICAL
+    assert LEVELS["disabled"] > logging.CRITICAL
+    assert LEVELS["disabled"] == logging.CRITICAL + 1
+    
+    # Test that parse_log_level correctly parses 'disabled'
+    assert parse_log_level("disabled") == logging.CRITICAL + 1
+    
+    # Test that default_config accepts 'disabled' log level
+    config = default_config("disabled")
+    # When disabled, the numeric value should be used
+    assert config["handlers"]["console"]["level"] == logging.CRITICAL + 1
+    assert config["loggers"][""]["level"] == logging.CRITICAL + 1


### PR DESCRIPTION
## Summary

This PR adds a new `disabled` log level option to Meltano that completely suppresses all logging output. This enhancement provides users with a clean way to run Meltano commands without any log messages.

Closes https://github.com/meltano/meltano/issues/6723

## Changes

- Added `disabled` to the `LEVELS` dictionary with a value of `CRITICAL + 1` to ensure it suppresses all log messages
- Updated the CLI `--log-level` option with help text explaining the new level
- Added the `disabled` option to the settings configuration in `settings.yml`
- Modified `default_config()` to properly handle the numeric level conversion for the `disabled` level
- Added comprehensive test coverage for the new log level

## Use Cases

This feature is particularly useful for:
- Automated scripts that need to parse Meltano output without log interference
- CI/CD pipelines where log output needs to be minimized
- Users who prefer completely silent operation for specific commands

## Testing

Added tests to verify:
- The `disabled` level is properly defined in the `LEVELS` dictionary
- The level value is higher than `CRITICAL` to ensure complete suppression
- The `parse_log_level()` function correctly parses the new level
- The logging configuration properly applies the disabled level

## Example Usage

```bash
meltano --log-level disabled run tap-gitlab target-postgres
```

## Summary by Sourcery

Introduce a new “disabled” log level that completely suppresses all logging output by assigning it a numeric value above CRITICAL and integrating it into the logging configuration, CLI, settings, documentation, and tests.

New Features:
- Add “disabled” log level to suppress all logging output

Enhancements:
- Integrate numeric handling for the disabled level in default_config and update CLI option help text and Settings UI configuration

Documentation:
- Document the disabled log level in CLI help text and settings reference documentation

Tests:
- Add tests to verify LEVELS entry, parse_log_level behavior, and default_config application for the disabled level