### PR TITLE
docs: Document that moving start_date to the past has no effect with incremental state

### DIFF
--- a/docs/docs/guide/integration.md
+++ b/docs/docs/guide/integration.md
@@ -204,6 +204,24 @@ Meltano stores this pipeline state in its [state backend](/concepts/state_backen
 
 If you'd like to manually inspect a job's state for debugging purposes, or so that you can store it somewhere other than the system database you can use the [`meltano state`](/reference/command-line-interface#state) command to do things like list all states, get state by name, set state, etc.
 
+### Start date and incremental replication
+
+When using incremental replication, it's important to understand that the bookmark dates stored in the state take precedence over the `start_date` configuration setting. This means that if you change the `start_date` to an earlier date hoping to pull more historical data, the extractor will still start from where it left off according to the saved state.
+
+To pull historical data from before the bookmarked date, you need to perform a full refresh using the `--full-refresh` flag:
+
+```bash
+# This will ignore the saved state and use the configured start_date
+meltano run --full-refresh tap-gitlab target-postgres
+
+# Or with meltano el
+meltano el tap-gitlab target-postgres --full-refresh
+```
+
+The `--full-refresh` flag tells Meltano to ignore any previously saved state and start fresh from the configured `start_date`. After the full refresh completes, the state will be updated with the new bookmarks, and subsequent runs will continue incrementally from that point.
+
+Alternatively, you can directly manage the state using the [`meltano state`](/reference/command-line-interface#state) command.
+
 ### Internal State Merge Logic
 
 When running Extract and Load pipelines via [`run`](/reference/command-line-interface#run), Meltano will retrieve your pipeline state (see the [state backends docs](/concepts/state_backends) for details on where it's stored) for the most recently completed pipeline based on State ID.

--- a/docs/docs/guide/troubleshooting.md
+++ b/docs/docs/guide/troubleshooting.md
@@ -183,6 +183,52 @@ meltano elt tap-gitlab target-postgres --exclude project_members
 meltano elt tap-gitlab target-postgres --state-id=gitlab-to-postgres --dump=state > extract/tap-gitlab.state.json
 ```
 
+### Alternatives to `meltano run --dump`
+
+While the `--dump` flag is not supported with `meltano run`, you can achieve the same outcomes using other Meltano commands:
+
+#### Dumping State
+
+Instead of `meltano run ... --dump=state`, use:
+
+```bash
+meltano state get <STATE_ID>
+```
+
+This will output the current state for the given state ID.
+
+#### Dumping Extractor Configuration
+
+Instead of `meltano run ... --dump=extractor-config`, use:
+
+```bash
+meltano config <EXTRACTOR_NAME> list
+```
+
+Alternatively, you can use:
+
+```bash
+meltano invoke <EXTRACTOR_NAME> --dump=config
+```
+
+#### Dumping Loader Configuration
+
+Instead of `meltano run ... --dump=loader-config`, use:
+
+```bash
+meltano config <LOADER_NAME> list
+```
+
+#### Dumping Catalog
+
+Instead of `meltano run ... --dump=catalog`, use:
+
+```bash
+meltano invoke <EXTRACTOR_NAME> --dump=catalog
+```
+
+Note: In the future, this may be replaced with a native `meltano catalog` command.
+
 ### Meltano UI
 
 Early versions of Meltano promoted a simple UI feature that was used for setting up basic pipelines and viewing basic logs. Due to a refocusing of the product on the command line interface, the UI was deprioritized for continued feature enhancements. For [interactive plugin configuration](/reference/command-line-interface#how-to-use-interactive-config), we now recommend our `--interactive` config option in the CLI.


### PR DESCRIPTION
## Summary

This PR adds documentation to clarify the behavior of `start_date` when using incremental replication with saved state.

## Context

Users may expect that changing the `start_date` configuration to an earlier date will cause the extractor to pull historical data. However, when incremental replication state exists, the bookmark dates in the state take precedence over the `start_date` setting.

## Changes

Added a new subsection "Start date and incremental replication" to the integration guide that:

- Explains that bookmark dates in state take precedence over `start_date` configuration
- Documents how to use the `--full-refresh` flag to ignore saved state and start from the configured `start_date`
- References the `meltano state` command as an alternative way to manage state directly

## Testing

Documentation-only change. Verified markdown renders correctly and links are valid.

Closes #2519

## Summary by Sourcery

Clarify incremental replication behavior and improve dump command guidance in the documentation.

Documentation:
- Explain that bookmark dates in saved state take precedence over the start_date setting for incremental replication and document the use of --full-refresh and meltano state commands to override this behavior
- Provide alternatives to meltano run --dump by documenting meltano state get, meltano config list, and meltano invoke commands for dumping state, extractor configuration, loader configuration, and catalog