### PR TITLE
feat: Implement UUIDv7 for time-ordered job run IDs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ pre-commit = [
 testing = [
   { include-group = "coverage" },
   "colorama>=0.4.4,<0.5",
+  "faker>=37.4.2",
   "moto>=5.0.21,<6",
   "pytest>=8.3.3,<9",
   "pytest-asyncio>=1",

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import platform
 import typing as t
-import uuid
 from contextlib import asynccontextmanager, nullcontext, suppress
 from datetime import datetime, timezone
 
@@ -32,9 +31,11 @@ from meltano.core.runner import RunnerError
 from meltano.core.runner.dbt import DbtRunner
 from meltano.core.runner.singer import SingerRunner
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
-from meltano.core.utils import run_async
+from meltano.core.utils import run_async, uuidv7
 
 if t.TYPE_CHECKING:
+    import uuid
+
     from sqlalchemy.orm import Session
 
     from meltano.core.plugin.base import PluginDefinition
@@ -333,7 +334,7 @@ async def _run_el_command(
     select_filter = [*select, *(f"!{entity}" for entity in exclude)]
 
     # Bind run_id at the start of the CLI entrypoint
-    run_id = run_id or uuid.uuid4()
+    run_id = run_id or uuidv7()
     structlog.contextvars.bind_contextvars(run_id=str(run_id))
 
     _state_strategy = StateStrategy.from_cli_args(

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -31,7 +31,7 @@ from meltano.core.runner import RunnerError
 from meltano.core.runner.dbt import DbtRunner
 from meltano.core.runner.singer import SingerRunner
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
-from meltano.core.utils import run_async, uuidv7
+from meltano.core.utils import run_async, uuid7
 
 if t.TYPE_CHECKING:
     import uuid
@@ -334,7 +334,7 @@ async def _run_el_command(
     select_filter = [*select, *(f"!{entity}" for entity in exclude)]
 
     # Bind run_id at the start of the CLI entrypoint
-    run_id = run_id or uuidv7()
+    run_id = run_id or uuid7()
     structlog.contextvars.bind_contextvars(run_id=str(run_id))
 
     _state_strategy = StateStrategy.from_cli_args(

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -31,7 +31,7 @@ from meltano.core.runner import RunnerError
 from meltano.core.runner.dbt import DbtRunner
 from meltano.core.runner.singer import SingerRunner
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
-from meltano.core.utils import run_async, uuid7
+from meltano.core.utils import new_run_id, run_async
 
 if t.TYPE_CHECKING:
     import uuid
@@ -334,7 +334,7 @@ async def _run_el_command(
     select_filter = [*select, *(f"!{entity}" for entity in exclude)]
 
     # Bind run_id at the start of the CLI entrypoint
-    run_id = run_id or uuid7()
+    run_id = run_id or new_run_id()
     structlog.contextvars.bind_contextvars(run_id=str(run_id))
 
     _state_strategy = StateStrategy.from_cli_args(

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -26,7 +26,7 @@ from meltano.core.runner import RunnerError
 from meltano.core.tracking import BlockEvents, Tracker
 from meltano.core.tracking.contexts import CliEvent
 from meltano.core.tracking.contexts.plugins import PluginsTrackingContext
-from meltano.core.utils import run_async, uuidv7
+from meltano.core.utils import run_async, uuid7
 
 if t.TYPE_CHECKING:
     import uuid
@@ -156,7 +156,7 @@ async def run(
         change_console_log_level()
 
     # Bind run_id at the start of the CLI entrypoint
-    run_id = run_id or uuidv7()
+    run_id = run_id or uuid7()
     structlog.contextvars.bind_contextvars(run_id=str(run_id))
 
     tracker: Tracker = ctx.obj["tracker"]

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import time
 import typing as t
-import uuid
 
 import click
 import structlog
@@ -27,9 +26,11 @@ from meltano.core.runner import RunnerError
 from meltano.core.tracking import BlockEvents, Tracker
 from meltano.core.tracking.contexts import CliEvent
 from meltano.core.tracking.contexts.plugins import PluginsTrackingContext
-from meltano.core.utils import run_async
+from meltano.core.utils import run_async, uuidv7
 
 if t.TYPE_CHECKING:
+    import uuid
+
     from meltano.core.project import Project
 
 logger = structlog.getLogger(__name__)
@@ -155,7 +156,7 @@ async def run(
         change_console_log_level()
 
     # Bind run_id at the start of the CLI entrypoint
-    run_id = run_id or uuid.uuid4()
+    run_id = run_id or uuidv7()
     structlog.contextvars.bind_contextvars(run_id=str(run_id))
 
     tracker: Tracker = ctx.obj["tracker"]

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -26,7 +26,7 @@ from meltano.core.runner import RunnerError
 from meltano.core.tracking import BlockEvents, Tracker
 from meltano.core.tracking.contexts import CliEvent
 from meltano.core.tracking.contexts.plugins import PluginsTrackingContext
-from meltano.core.utils import run_async, uuid7
+from meltano.core.utils import new_run_id, run_async
 
 if t.TYPE_CHECKING:
     import uuid
@@ -156,7 +156,7 @@ async def run(
         change_console_log_level()
 
     # Bind run_id at the start of the CLI entrypoint
-    run_id = run_id or uuid7()
+    run_id = run_id or new_run_id()
     structlog.contextvars.bind_contextvars(run_id=str(run_id))
 
     tracker: Tracker = ctx.obj["tracker"]

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -6,7 +6,6 @@ import asyncio
 import os
 import signal
 import typing as t
-import uuid
 from contextlib import asynccontextmanager, contextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from enum import Enum, IntEnum
@@ -25,6 +24,7 @@ from meltano.core.sqlalchemy import (
     IntPK,
     JSONEncodedDict,
 )
+from meltano.core.utils import uuidv7
 
 if t.TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -132,7 +132,7 @@ class Job(SystemModel):
         """
         kwargs["_state"] = kwargs.pop("state", State.IDLE).name
         kwargs["payload"] = kwargs.get("payload", {})
-        kwargs["run_id"] = kwargs.get("run_id") or uuid.uuid4()
+        kwargs["run_id"] = kwargs.get("run_id") or uuidv7()
         super().__init__(**kwargs)
 
     @hybrid_property

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -24,7 +24,7 @@ from meltano.core.sqlalchemy import (
     IntPK,
     JSONEncodedDict,
 )
-from meltano.core.utils import uuid7
+from meltano.core.utils import new_run_id
 
 if t.TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -132,7 +132,7 @@ class Job(SystemModel):
         """
         kwargs["_state"] = kwargs.pop("state", State.IDLE).name
         kwargs["payload"] = kwargs.get("payload", {})
-        kwargs["run_id"] = kwargs.get("run_id") or uuid7()
+        kwargs["run_id"] = kwargs.get("run_id") or new_run_id()
         super().__init__(**kwargs)
 
     @hybrid_property

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -24,7 +24,7 @@ from meltano.core.sqlalchemy import (
     IntPK,
     JSONEncodedDict,
 )
-from meltano.core.utils import uuidv7
+from meltano.core.utils import uuid7
 
 if t.TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator
@@ -132,7 +132,7 @@ class Job(SystemModel):
         """
         kwargs["_state"] = kwargs.pop("state", State.IDLE).name
         kwargs["payload"] = kwargs.get("payload", {})
-        kwargs["run_id"] = kwargs.get("run_id") or uuidv7()
+        kwargs["run_id"] = kwargs.get("run_id") or uuid7()
         super().__init__(**kwargs)
 
     @hybrid_property

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -10,7 +10,7 @@ import structlog
 
 from meltano.core.behavior.hookable import hook
 from meltano.core.plugin import BasePlugin
-from meltano.core.utils import nest_object, uuidv7
+from meltano.core.utils import nest_object, uuid7
 
 if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -167,5 +167,5 @@ class SingerPlugin(BasePlugin):  # noqa: D101
     def instance_uuid(self) -> str:
         """Multiple processes running at the same time have a unique value to use."""
         if not self._instance_uuid:
-            self._instance_uuid = str(uuidv7())
+            self._instance_uuid = str(uuid7())
         return self._instance_uuid

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -4,14 +4,13 @@ import json
 import logging
 import typing as t
 from textwrap import dedent
-from uuid import uuid4
 
 import anyio
 import structlog
 
 from meltano.core.behavior.hookable import hook
 from meltano.core.plugin import BasePlugin
-from meltano.core.utils import nest_object
+from meltano.core.utils import nest_object, uuidv7
 
 if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -168,5 +167,5 @@ class SingerPlugin(BasePlugin):  # noqa: D101
     def instance_uuid(self) -> str:
         """Multiple processes running at the same time have a unique value to use."""
         if not self._instance_uuid:
-            self._instance_uuid = str(uuid4())
+            self._instance_uuid = str(uuidv7())
         return self._instance_uuid

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -17,7 +17,7 @@ from meltano.core.plugin.config_service import PluginConfigService
 from meltano.core.plugin.settings_service import PluginSettingsService
 from meltano.core.settings_service import FeatureFlags
 from meltano.core.tracking import Tracker
-from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars, uuidv7
+from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars, uuid7
 from meltano.core.venv_service import VenvService, VirtualEnv
 
 if sys.version_info < (3, 11):
@@ -545,7 +545,7 @@ class PluginInvoker:
         logger.debug("Running containerized command", command=plugin_command)
         async with self._invoke(*args, **kwargs) as (_proc_args, _, proc_env):
             plugin_name = self.plugin.name
-            random_id = uuidv7()
+            random_id = uuid7()
             name = f"meltano-{plugin_name}--{plugin_command}-{random_id}"
 
             info = await service.run_container(spec, name, env=proc_env)

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -7,7 +7,6 @@ import enum
 import os
 import sys
 import typing as t
-import uuid
 from contextlib import asynccontextmanager
 
 from structlog.stdlib import get_logger
@@ -18,7 +17,7 @@ from meltano.core.plugin.config_service import PluginConfigService
 from meltano.core.plugin.settings_service import PluginSettingsService
 from meltano.core.settings_service import FeatureFlags
 from meltano.core.tracking import Tracker
-from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars
+from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars, uuidv7
 from meltano.core.venv_service import VenvService, VirtualEnv
 
 if sys.version_info < (3, 11):
@@ -546,7 +545,7 @@ class PluginInvoker:
         logger.debug("Running containerized command", command=plugin_command)
         async with self._invoke(*args, **kwargs) as (_proc_args, _, proc_env):
             plugin_name = self.plugin.name
-            random_id = uuid.uuid4()
+            random_id = uuidv7()
             name = f"meltano-{plugin_name}--{plugin_command}-{random_id}"
 
             info = await service.run_container(spec, name, env=proc_env)

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import typing as t
-import uuid
 from pathlib import Path
 
 import click
@@ -14,6 +13,7 @@ from meltano.core.db import project_engine
 from meltano.core.plugin.meltano_file import MeltanoFilePlugin
 from meltano.core.project import Project
 from meltano.core.project_settings_service import SettingValueStore
+from meltano.core.utils import uuidv7
 
 if t.TYPE_CHECKING:
     import os
@@ -82,7 +82,7 @@ class ProjectInitService:
 
         project.settings.set(
             "project_id",
-            str(uuid.uuid4()),
+            str(uuidv7()),
             store=SettingValueStore.MELTANO_YML,
         )
         self.set_send_anonymous_usage_stats(project)

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -13,7 +13,7 @@ from meltano.core.db import project_engine
 from meltano.core.plugin.meltano_file import MeltanoFilePlugin
 from meltano.core.project import Project
 from meltano.core.project_settings_service import SettingValueStore
-from meltano.core.utils import uuid7
+from meltano.core.utils import new_project_id
 
 if t.TYPE_CHECKING:
     import os
@@ -82,7 +82,7 @@ class ProjectInitService:
 
         project.settings.set(
             "project_id",
-            str(uuid7()),
+            str(new_project_id()),
             store=SettingValueStore.MELTANO_YML,
         )
         self.set_send_anonymous_usage_stats(project)

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -13,7 +13,7 @@ from meltano.core.db import project_engine
 from meltano.core.plugin.meltano_file import MeltanoFilePlugin
 from meltano.core.project import Project
 from meltano.core.project_settings_service import SettingValueStore
-from meltano.core.utils import uuidv7
+from meltano.core.utils import uuid7
 
 if t.TYPE_CHECKING:
     import os
@@ -82,7 +82,7 @@ class ProjectInitService:
 
         project.settings.set(
             "project_id",
-            str(uuidv7()),
+            str(uuid7()),
             store=SettingValueStore.MELTANO_YML,
         )
         self.set_send_anonymous_usage_stats(project)

--- a/src/meltano/core/sqlalchemy.py
+++ b/src/meltano/core/sqlalchemy.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.types import CHAR, INTEGER, VARCHAR, DateTime, TypeDecorator
 
-from meltano.core.utils import uuidv7
+from meltano.core.utils import uuid7
 
 if t.TYPE_CHECKING:
     from sqlalchemy.engine.interfaces import Dialect
@@ -173,7 +173,7 @@ class DateTimeUTC(TypeDecorator[datetime.datetime]):
         return value
 
 
-GUIDType = t.Annotated[uuid.UUID, mapped_column(GUID, default=uuidv7)]
+GUIDType = t.Annotated[uuid.UUID, mapped_column(GUID, default=uuid7)]
 StateType = t.Annotated[
     dict[str, str],
     mapped_column(MutableDict.as_mutable(JSONEncodedDict)),

--- a/src/meltano/core/sqlalchemy.py
+++ b/src/meltano/core/sqlalchemy.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.types import CHAR, INTEGER, VARCHAR, DateTime, TypeDecorator
 
+from meltano.core.utils import uuidv7
+
 if t.TYPE_CHECKING:
     from sqlalchemy.engine.interfaces import Dialect
     from sqlalchemy.types import TypeEngine
@@ -171,7 +173,7 @@ class DateTimeUTC(TypeDecorator[datetime.datetime]):
         return value
 
 
-GUIDType = t.Annotated[uuid.UUID, mapped_column(GUID, default=uuid.uuid4)]
+GUIDType = t.Annotated[uuid.UUID, mapped_column(GUID, default=uuidv7)]
 StateType = t.Annotated[
     dict[str, str],
     mapped_column(MutableDict.as_mutable(JSONEncodedDict)),

--- a/src/meltano/core/tracking/contexts/base.py
+++ b/src/meltano/core/tracking/contexts/base.py
@@ -1,0 +1,19 @@
+"""Base context helpers for the Snowplow tracker."""
+
+from __future__ import annotations
+
+import typing as t
+
+from meltano.core.utils import uuid7
+
+if t.TYPE_CHECKING:
+    import uuid
+
+
+def new_context_uuid() -> uuid.UUID:
+    """Generate a new context UUID.
+
+    Returns:
+        A new context UUID.
+    """
+    return uuid7()

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -19,13 +19,9 @@ from structlog.stdlib import get_logger
 
 import meltano
 from meltano.core.tracking.schemas import EnvironmentContextSchema
-from meltano.core.utils import (
-    get_boolean_env_var,
-    hash_sha256,
-    safe_hasattr,
-    strtobool,
-    uuid7,
-)
+from meltano.core.utils import get_boolean_env_var, hash_sha256, safe_hasattr, strtobool
+
+from .base import new_context_uuid
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -93,7 +89,7 @@ class EnvironmentContext(SelfDescribingJson):
         super().__init__(
             EnvironmentContextSchema.url,
             {
-                "context_uuid": str(uuid7()),
+                "context_uuid": str(new_context_uuid()),
                 "parent_context_uuid": _get_parent_context_uuid_str(),
                 "meltano_version": meltano.__version__,
                 "is_dev_build": not release_marker_path.is_file(),

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -24,7 +24,7 @@ from meltano.core.utils import (
     hash_sha256,
     safe_hasattr,
     strtobool,
-    uuidv7,
+    uuid7,
 )
 
 if t.TYPE_CHECKING:
@@ -93,7 +93,7 @@ class EnvironmentContext(SelfDescribingJson):
         super().__init__(
             EnvironmentContextSchema.url,
             {
-                "context_uuid": str(uuidv7()),
+                "context_uuid": str(uuid7()),
                 "parent_context_uuid": _get_parent_context_uuid_str(),
                 "meltano_version": meltano.__version__,
                 "is_dev_build": not release_marker_path.is_file(),

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -19,7 +19,13 @@ from structlog.stdlib import get_logger
 
 import meltano
 from meltano.core.tracking.schemas import EnvironmentContextSchema
-from meltano.core.utils import get_boolean_env_var, hash_sha256, safe_hasattr, strtobool
+from meltano.core.utils import (
+    get_boolean_env_var,
+    hash_sha256,
+    safe_hasattr,
+    strtobool,
+    uuidv7,
+)
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -87,7 +93,7 @@ class EnvironmentContext(SelfDescribingJson):
         super().__init__(
             EnvironmentContextSchema.url,
             {
-                "context_uuid": str(uuid.uuid4()),
+                "context_uuid": str(uuidv7()),
                 "parent_context_uuid": _get_parent_context_uuid_str(),
                 "meltano_version": meltano.__version__,
                 "is_dev_build": not release_marker_path.is_file(),

--- a/src/meltano/core/tracking/contexts/exception.py
+++ b/src/meltano/core/tracking/contexts/exception.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from snowplow_tracker import SelfDescribingJson
 
 from meltano.core.tracking.schemas import ExceptionContextSchema
-from meltano.core.utils import hash_sha256, uuid7
+from meltano.core.utils import hash_sha256
+
+from .base import new_context_uuid
 
 if t.TYPE_CHECKING:
     from types import TracebackType
@@ -33,7 +35,7 @@ class ExceptionContext(SelfDescribingJson):
         super().__init__(
             ExceptionContextSchema.url,
             {
-                "context_uuid": str(uuid7()),
+                "context_uuid": str(new_context_uuid()),
                 "exception": None if ex is None else get_exception_json(ex),
             },
         )

--- a/src/meltano/core/tracking/contexts/exception.py
+++ b/src/meltano/core/tracking/contexts/exception.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from snowplow_tracker import SelfDescribingJson
 
 from meltano.core.tracking.schemas import ExceptionContextSchema
-from meltano.core.utils import hash_sha256, uuidv7
+from meltano.core.utils import hash_sha256, uuid7
 
 if t.TYPE_CHECKING:
     from types import TracebackType
@@ -33,7 +33,7 @@ class ExceptionContext(SelfDescribingJson):
         super().__init__(
             ExceptionContextSchema.url,
             {
-                "context_uuid": str(uuidv7()),
+                "context_uuid": str(uuid7()),
                 "exception": None if ex is None else get_exception_json(ex),
             },
         )

--- a/src/meltano/core/tracking/contexts/exception.py
+++ b/src/meltano/core/tracking/contexts/exception.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import sys
 import typing as t
-import uuid
 from contextlib import suppress
 from pathlib import Path
 
 from snowplow_tracker import SelfDescribingJson
 
 from meltano.core.tracking.schemas import ExceptionContextSchema
-from meltano.core.utils import hash_sha256
+from meltano.core.utils import hash_sha256, uuidv7
 
 if t.TYPE_CHECKING:
     from types import TracebackType
@@ -34,7 +33,7 @@ class ExceptionContext(SelfDescribingJson):
         super().__init__(
             ExceptionContextSchema.url,
             {
-                "context_uuid": str(uuid.uuid4()),
+                "context_uuid": str(uuidv7()),
                 "exception": None if ex is None else get_exception_json(ex),
             },
         )

--- a/src/meltano/core/tracking/contexts/plugins.py
+++ b/src/meltano/core/tracking/contexts/plugins.py
@@ -10,7 +10,7 @@ from snowplow_tracker import SelfDescribingJson
 from meltano.core.block.blockset import BlockSet
 from meltano.core.block.plugin_command import PluginCommandBlock
 from meltano.core.tracking.schemas import PluginsContextSchema
-from meltano.core.utils import hash_sha256, safe_hasattr, uuidv7
+from meltano.core.utils import hash_sha256, safe_hasattr, uuid7
 
 if t.TYPE_CHECKING:
     from meltano.core.elt_context import ELTContext
@@ -58,7 +58,7 @@ class PluginsTrackingContext(SelfDescribingJson):
         super().__init__(
             PluginsContextSchema.url,
             {
-                "context_uuid": str(uuidv7()),
+                "context_uuid": str(uuid7()),
                 "plugins": [_from_plugin(plugin, cmd) for plugin, cmd in plugins],
             },
         )

--- a/src/meltano/core/tracking/contexts/plugins.py
+++ b/src/meltano/core/tracking/contexts/plugins.py
@@ -10,7 +10,9 @@ from snowplow_tracker import SelfDescribingJson
 from meltano.core.block.blockset import BlockSet
 from meltano.core.block.plugin_command import PluginCommandBlock
 from meltano.core.tracking.schemas import PluginsContextSchema
-from meltano.core.utils import hash_sha256, safe_hasattr, uuid7
+from meltano.core.utils import hash_sha256, safe_hasattr
+
+from .base import new_context_uuid
 
 if t.TYPE_CHECKING:
     from meltano.core.elt_context import ELTContext
@@ -58,7 +60,7 @@ class PluginsTrackingContext(SelfDescribingJson):
         super().__init__(
             PluginsContextSchema.url,
             {
-                "context_uuid": str(uuid7()),
+                "context_uuid": str(new_context_uuid()),
                 "plugins": [_from_plugin(plugin, cmd) for plugin, cmd in plugins],
             },
         )

--- a/src/meltano/core/tracking/contexts/plugins.py
+++ b/src/meltano/core/tracking/contexts/plugins.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import typing as t
-import uuid
 
 import structlog
 from snowplow_tracker import SelfDescribingJson
@@ -11,7 +10,7 @@ from snowplow_tracker import SelfDescribingJson
 from meltano.core.block.blockset import BlockSet
 from meltano.core.block.plugin_command import PluginCommandBlock
 from meltano.core.tracking.schemas import PluginsContextSchema
-from meltano.core.utils import hash_sha256, safe_hasattr
+from meltano.core.utils import hash_sha256, safe_hasattr, uuidv7
 
 if t.TYPE_CHECKING:
     from meltano.core.elt_context import ELTContext
@@ -59,7 +58,7 @@ class PluginsTrackingContext(SelfDescribingJson):
         super().__init__(
             PluginsContextSchema.url,
             {
-                "context_uuid": str(uuid.uuid4()),
+                "context_uuid": str(uuidv7()),
                 "plugins": [_from_plugin(plugin, cmd) for plugin, cmd in plugins],
             },
         )

--- a/src/meltano/core/tracking/contexts/project.py
+++ b/src/meltano/core/tracking/contexts/project.py
@@ -11,7 +11,9 @@ from snowplow_tracker import SelfDescribingJson
 from structlog.stdlib import get_logger
 
 from meltano.core.tracking.schemas import ProjectContextSchema
-from meltano.core.utils import hash_sha256, uuid7
+from meltano.core.utils import hash_sha256, new_project_id
+
+from .base import new_context_uuid
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -51,7 +53,7 @@ class ProjectContext(SelfDescribingJson):
         super().__init__(
             ProjectContextSchema.url,
             {
-                "context_uuid": str(uuid7()),
+                "context_uuid": str(new_context_uuid()),
                 "project_uuid": str(self.project_uuid),
                 "project_uuid_source": self.project_uuid_source.name,
                 "client_uuid": str(client_id),
@@ -117,7 +119,7 @@ class ProjectContext(SelfDescribingJson):
             else:
                 self._project_uuid_source = ProjectUUIDSource.explicit
         else:
-            project_id = uuid7()
+            project_id = new_project_id()
             self._project_uuid_source = ProjectUUIDSource.random
 
         return project_id

--- a/src/meltano/core/tracking/contexts/project.py
+++ b/src/meltano/core/tracking/contexts/project.py
@@ -11,7 +11,7 @@ from snowplow_tracker import SelfDescribingJson
 from structlog.stdlib import get_logger
 
 from meltano.core.tracking.schemas import ProjectContextSchema
-from meltano.core.utils import hash_sha256, uuidv7
+from meltano.core.utils import hash_sha256, uuid7
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -51,7 +51,7 @@ class ProjectContext(SelfDescribingJson):
         super().__init__(
             ProjectContextSchema.url,
             {
-                "context_uuid": str(uuidv7()),
+                "context_uuid": str(uuid7()),
                 "project_uuid": str(self.project_uuid),
                 "project_uuid_source": self.project_uuid_source.name,
                 "client_uuid": str(client_id),
@@ -117,7 +117,7 @@ class ProjectContext(SelfDescribingJson):
             else:
                 self._project_uuid_source = ProjectUUIDSource.explicit
         else:
-            project_id = uuidv7()
+            project_id = uuid7()
             self._project_uuid_source = ProjectUUIDSource.random
 
         return project_id

--- a/src/meltano/core/tracking/contexts/project.py
+++ b/src/meltano/core/tracking/contexts/project.py
@@ -11,7 +11,7 @@ from snowplow_tracker import SelfDescribingJson
 from structlog.stdlib import get_logger
 
 from meltano.core.tracking.schemas import ProjectContextSchema
-from meltano.core.utils import hash_sha256
+from meltano.core.utils import hash_sha256, uuidv7
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -51,7 +51,7 @@ class ProjectContext(SelfDescribingJson):
         super().__init__(
             ProjectContextSchema.url,
             {
-                "context_uuid": str(uuid.uuid4()),
+                "context_uuid": str(uuidv7()),
                 "project_uuid": str(self.project_uuid),
                 "project_uuid_source": self.project_uuid_source.name,
                 "client_uuid": str(client_id),
@@ -117,7 +117,7 @@ class ProjectContext(SelfDescribingJson):
             else:
                 self._project_uuid_source = ProjectUUIDSource.explicit
         else:
-            project_id = uuid.uuid4()
+            project_id = uuidv7()
             self._project_uuid_source = ProjectUUIDSource.random
 
         return project_id

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -30,7 +30,7 @@ from meltano.core.tracking.schemas import (
     ExitEventSchema,
     TelemetryStateChangeEventSchema,
 )
-from meltano.core.utils import format_exception
+from meltano.core.utils import format_exception, uuidv7
 
 if t.TYPE_CHECKING:
     from collections.abc import Mapping
@@ -206,7 +206,7 @@ class Tracker:  # - too many (public) methods
                 )
         if stored_telemetry_settings.client_id is not None:
             return stored_telemetry_settings.client_id
-        return uuid.uuid4()
+        return uuidv7()
 
     @property
     def contexts(self) -> tuple[SelfDescribingJson]:

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -30,7 +30,7 @@ from meltano.core.tracking.schemas import (
     ExitEventSchema,
     TelemetryStateChangeEventSchema,
 )
-from meltano.core.utils import format_exception, uuidv7
+from meltano.core.utils import format_exception, uuid7
 
 if t.TYPE_CHECKING:
     from collections.abc import Mapping
@@ -206,7 +206,7 @@ class Tracker:  # - too many (public) methods
                 )
         if stored_telemetry_settings.client_id is not None:
             return stored_telemetry_settings.client_id
-        return uuidv7()
+        return uuid7()
 
     @property
     def contexts(self) -> tuple[SelfDescribingJson]:

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -75,6 +75,15 @@ def check_url(url: str) -> bool:
     return bool(re.match(URL_REGEX, url))
 
 
+def new_client_id() -> uuid.UUID:
+    """Generate a new client ID.
+
+    Returns:
+        A new client ID.
+    """
+    return uuid7()
+
+
 class TelemetrySettings(t.NamedTuple):
     """Settings which control telemetry and anonymous usage stats.
 
@@ -206,7 +215,7 @@ class Tracker:  # - too many (public) methods
                 )
         if stored_telemetry_settings.client_id is not None:
             return stored_telemetry_settings.client_id
-        return uuid7()
+        return new_client_id()
 
     @property
     def contexts(self) -> tuple[SelfDescribingJson]:

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -955,3 +955,12 @@ def parse_date(date_string: str) -> str:
         return _parsed.isoformat()
 
     return date_string
+
+
+def new_project_id() -> uuid.UUID:
+    """Generate a new project ID.
+
+    Returns:
+        A new project ID.
+    """
+    return uuid7()

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -9,6 +9,7 @@ import math
 import os
 import platform
 import re
+import sys
 import time as _time
 import traceback
 import typing as t
@@ -29,6 +30,44 @@ import structlog
 from requests.auth import HTTPBasicAuth
 
 from meltano.core.error import MeltanoError
+
+if sys.version_info >= (3, 14):
+    from uuid import uuid7
+else:
+
+    def uuid7() -> uuid.UUID:
+        """Generate a UUIDv7 with time-ordering capability.
+
+        UUIDv7 encodes a timestamp in the first 48 bits, making them lexicographically
+        sortable by creation time. This is useful for job run IDs that need to be
+        ordered chronologically. Sourced from https://github.com/nalgeon/uuidv7/blob/main/src/uuidv7.py
+
+        Returns:
+            A UUID object with version 7 encoding.
+        """
+        # Get current timestamp in milliseconds
+        timestamp = int(_time.time() * 1000)
+
+        # Generate 16 random bytes
+        value = bytearray(os.urandom(16))
+
+        # Encode timestamp into first 6 bytes (48 bits)
+        value[0] = (timestamp >> 40) & 0xFF
+        value[1] = (timestamp >> 32) & 0xFF
+        value[2] = (timestamp >> 24) & 0xFF
+        value[3] = (timestamp >> 16) & 0xFF
+        value[4] = (timestamp >> 8) & 0xFF
+        value[5] = timestamp & 0xFF
+
+        # Set version (7) in bits 12-15 of the time_hi_and_version field
+        value[6] = (value[6] & 0x0F) | 0x70
+
+        # Set variant bits to '10' in the clock_seq_hi_and_reserved field
+        value[8] = (value[8] & 0x3F) | 0x80
+
+        # Create UUID from bytes
+        return uuid.UUID(bytes=bytes(value))
+
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Iterable, MutableMapping
@@ -916,37 +955,3 @@ def parse_date(date_string: str) -> str:
         return _parsed.isoformat()
 
     return date_string
-
-
-def uuidv7() -> uuid.UUID:
-    """Generate a UUIDv7 with time-ordering capability.
-
-    UUIDv7 encodes a timestamp in the first 48 bits, making them lexicographically
-    sortable by creation time. This is useful for job run IDs that need to be
-    ordered chronologically. Sourced from https://github.com/nalgeon/uuidv7/blob/main/src/uuidv7.py
-
-    Returns:
-        A UUID object with version 7 encoding.
-    """
-    # Get current timestamp in milliseconds
-    timestamp = int(_time.time() * 1000)
-
-    # Generate 16 random bytes
-    value = bytearray(os.urandom(16))
-
-    # Encode timestamp into first 6 bytes (48 bits)
-    value[0] = (timestamp >> 40) & 0xFF
-    value[1] = (timestamp >> 32) & 0xFF
-    value[2] = (timestamp >> 24) & 0xFF
-    value[3] = (timestamp >> 16) & 0xFF
-    value[4] = (timestamp >> 8) & 0xFF
-    value[5] = timestamp & 0xFF
-
-    # Set version (7) in bits 12-15 of the time_hi_and_version field
-    value[6] = (value[6] & 0x0F) | 0x70
-
-    # Set variant bits to '10' in the clock_seq_hi_and_reserved field
-    value[8] = (value[8] & 0x3F) | 0x80
-
-    # Create UUID from bytes
-    return uuid.UUID(bytes=bytes(value))

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -964,3 +964,12 @@ def new_project_id() -> uuid.UUID:
         A new project ID.
     """
     return uuid7()
+
+
+def new_run_id() -> uuid.UUID:
+    """Generate a new run ID.
+
+    Returns:
+        A new run ID.
+    """
+    return uuid7()

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -9,9 +9,11 @@ import math
 import os
 import platform
 import re
+import time as _time
 import traceback
 import typing as t
 import unicodedata
+import uuid
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from copy import copy, deepcopy
@@ -914,3 +916,37 @@ def parse_date(date_string: str) -> str:
         return _parsed.isoformat()
 
     return date_string
+
+
+def uuidv7() -> uuid.UUID:
+    """Generate a UUIDv7 with time-ordering capability.
+
+    UUIDv7 encodes a timestamp in the first 48 bits, making them lexicographically
+    sortable by creation time. This is useful for job run IDs that need to be
+    ordered chronologically. Sourced from https://github.com/nalgeon/uuidv7/blob/main/src/uuidv7.py
+
+    Returns:
+        A UUID object with version 7 encoding.
+    """
+    # Get current timestamp in milliseconds
+    timestamp = int(_time.time() * 1000)
+
+    # Generate 16 random bytes
+    value = bytearray(os.urandom(16))
+
+    # Encode timestamp into first 6 bytes (48 bits)
+    value[0] = (timestamp >> 40) & 0xFF
+    value[1] = (timestamp >> 32) & 0xFF
+    value[2] = (timestamp >> 24) & 0xFF
+    value[3] = (timestamp >> 16) & 0xFF
+    value[4] = (timestamp >> 8) & 0xFF
+    value[5] = timestamp & 0xFF
+
+    # Set version (7) in bits 12-15 of the time_hi_and_version field
+    value[6] = (value[6] & 0x0F) | 0x70
+
+    # Set variant bits to '10' in the clock_seq_hi_and_reserved field
+    value[8] = (value[8] & 0x3F) | 0x80
+
+    # Create UUID from bytes
+    return uuid.UUID(bytes=bytes(value))

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -135,6 +135,30 @@ class TestJob:
         job.save(session)
         assert job.run_id == run_id
 
+    def test_run_id_is_uuidv7(self, session) -> None:
+        """Test that job run_id uses UUIDv7 format."""
+        import time
+
+        # Create two jobs with a small time gap
+        job1 = Job()
+        time.sleep(0.001)  # Wait 1ms to ensure different timestamps
+        job2 = Job()
+
+        # Both should have UUIDv7 version
+        assert job1.run_id.version == 7
+        assert job2.run_id.version == 7
+
+        # They should be time-ordered (lexicographically sortable)
+        assert str(job1.run_id) < str(job2.run_id)
+
+        # Save and verify UUIDs persist correctly
+        job1.save(session)
+        job2.save(session)
+
+        assert job1.run_id.version == 7
+        assert job2.run_id.version == 7
+        assert str(job1.run_id) < str(job2.run_id)
+
     def test_is_stale(self) -> None:
         job = Job()
 

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 import platform
 import signal
+import typing as t
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import NoReturn  # noqa: ICN003
 
 import pytest
 
@@ -15,6 +15,9 @@ from meltano.core.job.job import (
     Job,
     State,
 )
+
+if t.TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 
 class TestJob:
@@ -77,7 +80,7 @@ class TestJob:
         assert subject.ended_at - subject.last_heartbeat_at < timedelta(seconds=2)
 
     @pytest.mark.asyncio
-    async def test_run_failed(self, session) -> NoReturn:
+    async def test_run_failed(self, session) -> None:
         # A failed run will mark the subject as FAILED an set the payload['error']
         subject = self.sample_job({"original_state": 1}).save(session)
         exception = Exception("This is a test.")
@@ -158,6 +161,18 @@ class TestJob:
         assert job1.run_id.version == 7
         assert job2.run_id.version == 7
         assert str(job1.run_id) < str(job2.run_id)
+
+    def test_legacy_uuidv4_run_id(self, session: Session) -> None:
+        """Test that a Job with a legacy UUIDv4 run_id is processed correctly."""
+        legacy_run_id = uuid.uuid4()  # Simulate a legacy UUIDv4
+        job = Job(run_id=legacy_run_id)
+        job.save(session)
+
+        # Reload the job from the database
+        loaded_job = session.query(Job).filter_by(run_id=legacy_run_id).one()
+        assert loaded_job.run_id == legacy_run_id
+        assert isinstance(loaded_job.run_id, uuid.UUID)
+        assert loaded_job.run_id.version == 4
 
     def test_is_stale(self) -> None:
         job = Job()

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -11,7 +11,6 @@ import platform
 import shutil
 import string
 import typing as t
-import uuid
 from base64 import b64encode
 from contextlib import contextmanager
 from pathlib import Path
@@ -35,6 +34,7 @@ from meltano.core.state_store.filesystem import (
 )
 from meltano.core.state_store.google import GCSStateStoreManager
 from meltano.core.state_store.s3 import S3StateStoreManager
+from meltano.core.utils import uuidv7
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterator
@@ -473,7 +473,7 @@ class TestS3StateStoreManager:
     def test_set_first_time(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         monkeypatch.delenv("AWS_PROFILE", raising=False)
-        state_id = uuid.uuid4().hex
+        state_id = uuidv7().hex
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
                 uri="s3://test_access_key_id:test_secret_access_key@meltano/state",
@@ -488,7 +488,7 @@ class TestS3StateStoreManager:
     ) -> None:
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         monkeypatch.delenv("AWS_PROFILE", raising=False)
-        state_id = uuid.uuid4().hex
+        state_id = uuidv7().hex
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
                 uri="s3://test_access_key_id:test_secret_access_key@meltano/state",

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -34,10 +34,11 @@ from meltano.core.state_store.filesystem import (
 )
 from meltano.core.state_store.google import GCSStateStoreManager
 from meltano.core.state_store.s3 import S3StateStoreManager
-from meltano.core.utils import uuid7
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterator
+
+    import faker
 
 
 def on_windows() -> bool:
@@ -470,10 +471,14 @@ class TestS3StateStoreManager:
     def test_state_path(self, subject: S3StateStoreManager) -> None:
         assert subject.state_dir == "state"
 
-    def test_set_first_time(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_set_first_time(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        faker: faker.Faker,
+    ) -> None:
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         monkeypatch.delenv("AWS_PROFILE", raising=False)
-        state_id = uuid7().hex
+        state_id = faker.pystr()
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
                 uri="s3://test_access_key_id:test_secret_access_key@meltano/state",
@@ -485,10 +490,11 @@ class TestS3StateStoreManager:
     def test_update_fail_object_in_glacier(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        faker: faker.Faker,
     ) -> None:
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         monkeypatch.delenv("AWS_PROFILE", raising=False)
-        state_id = uuid7().hex
+        state_id = faker.pystr()
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
                 uri="s3://test_access_key_id:test_secret_access_key@meltano/state",

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -34,7 +34,7 @@ from meltano.core.state_store.filesystem import (
 )
 from meltano.core.state_store.google import GCSStateStoreManager
 from meltano.core.state_store.s3 import S3StateStoreManager
-from meltano.core.utils import uuidv7
+from meltano.core.utils import uuid7
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterator
@@ -473,7 +473,7 @@ class TestS3StateStoreManager:
     def test_set_first_time(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         monkeypatch.delenv("AWS_PROFILE", raising=False)
-        state_id = uuidv7().hex
+        state_id = uuid7().hex
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
                 uri="s3://test_access_key_id:test_secret_access_key@meltano/state",
@@ -488,7 +488,7 @@ class TestS3StateStoreManager:
     ) -> None:
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         monkeypatch.delenv("AWS_PROFILE", raising=False)
-        state_id = uuidv7().hex
+        state_id = uuid7().hex
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
                 uri="s3://test_access_key_id:test_secret_access_key@meltano/state",

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -10,6 +10,7 @@ from meltano.core.utils import (
     nest,
     pop_at_path,
     set_at_path,
+    uuidv7,
 )
 
 
@@ -283,3 +284,53 @@ def test_makedirs_decorator(tmp_path) -> None:
 
     wolf = species("canis", "lupus", make_dirs=False)
     assert not wolf.exists()
+
+
+def test_uuidv7() -> None:
+    """Test UUIDv7 generation and properties."""
+    import time
+    import uuid
+
+    # Generate multiple UUIDs
+    uuid1 = uuidv7()
+    time.sleep(0.001)  # Wait 1ms to ensure different timestamps
+    uuid2 = uuidv7()
+
+    # Test that they are valid UUIDs
+    assert isinstance(uuid1, uuid.UUID)
+    assert isinstance(uuid2, uuid.UUID)
+
+    # Test that they have version 7
+    assert uuid1.version == 7
+    assert uuid2.version == 7
+
+    # Test that they are time-ordered (lexicographically sortable)
+    assert str(uuid1) < str(uuid2)
+
+    # Test that they are different
+    assert uuid1 != uuid2
+
+    # Test timestamp encoding (first 48 bits should be timestamp)
+    uuid1_bytes = uuid1.bytes
+    uuid2_bytes = uuid2.bytes
+
+    # Extract timestamps from first 6 bytes
+    timestamp1 = int.from_bytes(uuid1_bytes[:6], byteorder="big")
+    timestamp2 = int.from_bytes(uuid2_bytes[:6], byteorder="big")
+
+    # timestamp2 should be greater than timestamp1
+    assert timestamp2 > timestamp1
+
+
+def test_uuidv7_time_ordering() -> None:
+    """Test that UUIDv7s generated in sequence are time-ordered."""
+    import time
+
+    uuids = []
+    for _ in range(10):
+        uuids.append(uuidv7())
+        time.sleep(0.001)
+
+    # Convert to strings and verify they are in ascending order
+    uuid_strings = [str(u) for u in uuids]
+    assert uuid_strings == sorted(uuid_strings)

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -10,7 +10,7 @@ from meltano.core.utils import (
     nest,
     pop_at_path,
     set_at_path,
-    uuidv7,
+    uuid7,
 )
 
 
@@ -292,9 +292,9 @@ def test_uuidv7() -> None:
     import uuid
 
     # Generate multiple UUIDs
-    uuid1 = uuidv7()
+    uuid1 = uuid7()
     time.sleep(0.001)  # Wait 1ms to ensure different timestamps
-    uuid2 = uuidv7()
+    uuid2 = uuid7()
 
     # Test that they are valid UUIDs
     assert isinstance(uuid1, uuid.UUID)
@@ -328,7 +328,7 @@ def test_uuidv7_time_ordering() -> None:
 
     uuids = []
     for _ in range(10):
-        uuids.append(uuidv7())
+        uuids.append(uuid7())
         time.sleep(0.001)
 
     # Convert to strings and verify they are in ascending order

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -18,7 +18,7 @@ from meltano.core.tracking.contexts.environment import EnvironmentContext
 from meltano.core.tracking.contexts.exception import ExceptionContext
 from meltano.core.tracking.contexts.project import ProjectContext
 from meltano.core.tracking.tracker import TelemetrySettings, Tracker
-from meltano.core.utils import hash_sha256, uuidv7
+from meltano.core.utils import hash_sha256, uuid7
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator
@@ -143,7 +143,7 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", str(uuidv7()))
+        project.settings.set("project_id", str(uuid7()))
         Tracker(project).save_telemetry_settings()
 
         project.settings.set("send_anonymous_usage_stats", value=False)
@@ -151,7 +151,7 @@ class TestTracker:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 1
 
-        project.settings.set("project_id", str(uuidv7()))
+        project.settings.set("project_id", str(uuid7()))
         with mock.patch.object(Tracker, method_name) as mocked:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 0
@@ -163,11 +163,11 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", str(uuidv7()))
+        project.settings.set("project_id", str(uuid7()))
         Tracker(project).save_telemetry_settings()
 
         with delete_analytics_json(project):
-            project.settings.set("project_id", str(uuidv7()))
+            project.settings.set("project_id", str(uuid7()))
             with mock.patch.object(Tracker, method_name) as mocked:
                 Tracker(project)
                 assert mocked.call_count == 0
@@ -182,11 +182,11 @@ class TestTracker:
     @pytest.mark.parametrize(
         "analytics_json_content",
         (
-            f'{{"clientId":"{uuidv7()!s}","project_id":"{uuidv7()!s}","send_anonymous_usage_stats":true}}',
-            f'{{"client_id":"{uuidv7()!s}","projectId":"{uuidv7()!s}","send_anonymous_usage_stats":true}}',
-            f'{{"client_id":"{uuidv7()!s}","project_id":"{uuidv7()!s}","send_anon_usage_stats":true}}',
-            f'["{uuidv7()!s}","{uuidv7()!s}", true]',
-            f'client_id":"{uuidv7()!s}","project_id":"{uuidv7()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"clientId":"{uuid7()!s}","project_id":"{uuid7()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"client_id":"{uuid7()!s}","projectId":"{uuid7()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"client_id":"{uuid7()!s}","project_id":"{uuid7()!s}","send_anon_usage_stats":true}}',
+            f'["{uuid7()!s}","{uuid7()!s}", true]',
+            f'client_id":"{uuid7()!s}","project_id":"{uuid7()!s}","send_anonymous_usage_stats":true}}',
         ),
         ids=(0, 1, 2, 3, 4),
     )
@@ -341,8 +341,8 @@ class TestTracker:
 
         tracker.track_telemetry_state_change_event(
             "project_id",
-            from_value=uuidv7(),
-            to_value=uuidv7(),
+            from_value=uuid7(),
+            to_value=uuid7(),
         )
         assert passed
 
@@ -419,7 +419,7 @@ class TestTracker:
         monkeypatch,
     ) -> None:
         def get_source():
-            return ProjectContext(project, uuidv7()).to_json()["data"][
+            return ProjectContext(project, uuid7()).to_json()["data"][
                 "send_anonymous_usage_stats_source"
             ]
 
@@ -483,7 +483,7 @@ class TestTracker:
                 # Ensure it generated a random UUID as a fallback
                 uuid.UUID(str(Tracker(project).client_id))
 
-            ctx_id = uuidv7()
+            ctx_id = uuid7()
             monkeypatch.setenv("MELTANO_CLIENT_ID", str(ctx_id))
             # Ensure it takes the client ID from the env var
             assert Tracker(project).client_id == ctx_id
@@ -492,7 +492,7 @@ class TestTracker:
             # Ensure it uses the client ID stored in `analytics.json`
             assert Tracker(project).client_id == ctx_id
 
-            ctx_id_2 = uuidv7()
+            ctx_id_2 = uuid7()
             monkeypatch.setenv("MELTANO_CLIENT_ID", str(ctx_id_2))
             # Ensure the env var takes priority over `analytics.json`
             assert Tracker(project).client_id == ctx_id_2

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -17,8 +17,8 @@ from meltano.core.tracking.contexts.cli import CliEvent
 from meltano.core.tracking.contexts.environment import EnvironmentContext
 from meltano.core.tracking.contexts.exception import ExceptionContext
 from meltano.core.tracking.contexts.project import ProjectContext
-from meltano.core.tracking.tracker import TelemetrySettings, Tracker
-from meltano.core.utils import hash_sha256, uuid7
+from meltano.core.tracking.tracker import TelemetrySettings, Tracker, new_client_id
+from meltano.core.utils import hash_sha256, new_project_id
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator
@@ -143,7 +143,7 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", str(uuid7()))
+        project.settings.set("project_id", new_project_id())
         Tracker(project).save_telemetry_settings()
 
         project.settings.set("send_anonymous_usage_stats", value=False)
@@ -151,7 +151,7 @@ class TestTracker:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 1
 
-        project.settings.set("project_id", str(uuid7()))
+        project.settings.set("project_id", new_project_id())
         with mock.patch.object(Tracker, method_name) as mocked:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 0
@@ -163,11 +163,11 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", str(uuid7()))
+        project.settings.set("project_id", new_project_id())
         Tracker(project).save_telemetry_settings()
 
         with delete_analytics_json(project):
-            project.settings.set("project_id", str(uuid7()))
+            project.settings.set("project_id", new_project_id())
             with mock.patch.object(Tracker, method_name) as mocked:
                 Tracker(project)
                 assert mocked.call_count == 0
@@ -182,11 +182,11 @@ class TestTracker:
     @pytest.mark.parametrize(
         "analytics_json_content",
         (
-            f'{{"clientId":"{uuid7()!s}","project_id":"{uuid7()!s}","send_anonymous_usage_stats":true}}',
-            f'{{"client_id":"{uuid7()!s}","projectId":"{uuid7()!s}","send_anonymous_usage_stats":true}}',
-            f'{{"client_id":"{uuid7()!s}","project_id":"{uuid7()!s}","send_anon_usage_stats":true}}',
-            f'["{uuid7()!s}","{uuid7()!s}", true]',
-            f'client_id":"{uuid7()!s}","project_id":"{uuid7()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"clientId":"{new_client_id()!s}","project_id":"{new_project_id()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"client_id":"{new_client_id()!s}","projectId":"{new_project_id()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"client_id":"{new_client_id()!s}","project_id":"{new_project_id()!s}","send_anon_usage_stats":true}}',
+            f'["{new_client_id()!s}","{new_project_id()!s}", true]',
+            f'client_id":"{new_client_id()!s}","project_id":"{new_project_id()!s}","send_anonymous_usage_stats":true}}',
         ),
         ids=(0, 1, 2, 3, 4),
     )
@@ -341,8 +341,8 @@ class TestTracker:
 
         tracker.track_telemetry_state_change_event(
             "project_id",
-            from_value=uuid7(),
-            to_value=uuid7(),
+            from_value=new_project_id(),
+            to_value=new_project_id(),
         )
         assert passed
 
@@ -419,7 +419,7 @@ class TestTracker:
         monkeypatch,
     ) -> None:
         def get_source():
-            return ProjectContext(project, uuid7()).to_json()["data"][
+            return ProjectContext(project, new_project_id()).to_json()["data"][
                 "send_anonymous_usage_stats_source"
             ]
 
@@ -483,7 +483,7 @@ class TestTracker:
                 # Ensure it generated a random UUID as a fallback
                 uuid.UUID(str(Tracker(project).client_id))
 
-            ctx_id = uuid7()
+            ctx_id = new_client_id()
             monkeypatch.setenv("MELTANO_CLIENT_ID", str(ctx_id))
             # Ensure it takes the client ID from the env var
             assert Tracker(project).client_id == ctx_id
@@ -492,7 +492,7 @@ class TestTracker:
             # Ensure it uses the client ID stored in `analytics.json`
             assert Tracker(project).client_id == ctx_id
 
-            ctx_id_2 = uuid7()
+            ctx_id_2 = new_client_id()
             monkeypatch.setenv("MELTANO_CLIENT_ID", str(ctx_id_2))
             # Ensure the env var takes priority over `analytics.json`
             assert Tracker(project).client_id == ctx_id_2

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -143,7 +143,7 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", new_project_id())
+        project.settings.set("project_id", str(new_project_id()))
         Tracker(project).save_telemetry_settings()
 
         project.settings.set("send_anonymous_usage_stats", value=False)
@@ -151,7 +151,7 @@ class TestTracker:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 1
 
-        project.settings.set("project_id", new_project_id())
+        project.settings.set("project_id", str(new_project_id()))
         with mock.patch.object(Tracker, method_name) as mocked:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 0
@@ -163,11 +163,11 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", new_project_id())
+        project.settings.set("project_id", str(new_project_id()))
         Tracker(project).save_telemetry_settings()
 
         with delete_analytics_json(project):
-            project.settings.set("project_id", new_project_id())
+            project.settings.set("project_id", str(new_project_id()))
             with mock.patch.object(Tracker, method_name) as mocked:
                 Tracker(project)
                 assert mocked.call_count == 0

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -18,7 +18,7 @@ from meltano.core.tracking.contexts.environment import EnvironmentContext
 from meltano.core.tracking.contexts.exception import ExceptionContext
 from meltano.core.tracking.contexts.project import ProjectContext
 from meltano.core.tracking.tracker import TelemetrySettings, Tracker
-from meltano.core.utils import hash_sha256
+from meltano.core.utils import hash_sha256, uuidv7
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator
@@ -143,7 +143,7 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", str(uuid.uuid4()))
+        project.settings.set("project_id", str(uuidv7()))
         Tracker(project).save_telemetry_settings()
 
         project.settings.set("send_anonymous_usage_stats", value=False)
@@ -151,7 +151,7 @@ class TestTracker:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 1
 
-        project.settings.set("project_id", str(uuid.uuid4()))
+        project.settings.set("project_id", str(uuidv7()))
         with mock.patch.object(Tracker, method_name) as mocked:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 0
@@ -163,11 +163,11 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", str(uuid.uuid4()))
+        project.settings.set("project_id", str(uuidv7()))
         Tracker(project).save_telemetry_settings()
 
         with delete_analytics_json(project):
-            project.settings.set("project_id", str(uuid.uuid4()))
+            project.settings.set("project_id", str(uuidv7()))
             with mock.patch.object(Tracker, method_name) as mocked:
                 Tracker(project)
                 assert mocked.call_count == 0
@@ -182,11 +182,11 @@ class TestTracker:
     @pytest.mark.parametrize(
         "analytics_json_content",
         (
-            f'{{"clientId":"{uuid.uuid4()!s}","project_id":"{uuid.uuid4()!s}","send_anonymous_usage_stats":true}}',
-            f'{{"client_id":"{uuid.uuid4()!s}","projectId":"{uuid.uuid4()!s}","send_anonymous_usage_stats":true}}',
-            f'{{"client_id":"{uuid.uuid4()!s}","project_id":"{uuid.uuid4()!s}","send_anon_usage_stats":true}}',
-            f'["{uuid.uuid4()!s}","{uuid.uuid4()!s}", true]',
-            f'client_id":"{uuid.uuid4()!s}","project_id":"{uuid.uuid4()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"clientId":"{uuidv7()!s}","project_id":"{uuidv7()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"client_id":"{uuidv7()!s}","projectId":"{uuidv7()!s}","send_anonymous_usage_stats":true}}',
+            f'{{"client_id":"{uuidv7()!s}","project_id":"{uuidv7()!s}","send_anon_usage_stats":true}}',
+            f'["{uuidv7()!s}","{uuidv7()!s}", true]',
+            f'client_id":"{uuidv7()!s}","project_id":"{uuidv7()!s}","send_anonymous_usage_stats":true}}',
         ),
         ids=(0, 1, 2, 3, 4),
     )
@@ -341,8 +341,8 @@ class TestTracker:
 
         tracker.track_telemetry_state_change_event(
             "project_id",
-            from_value=uuid.uuid4(),
-            to_value=uuid.uuid4(),
+            from_value=uuidv7(),
+            to_value=uuidv7(),
         )
         assert passed
 
@@ -419,7 +419,7 @@ class TestTracker:
         monkeypatch,
     ) -> None:
         def get_source():
-            return ProjectContext(project, uuid.uuid4()).to_json()["data"][
+            return ProjectContext(project, uuidv7()).to_json()["data"][
                 "send_anonymous_usage_stats_source"
             ]
 
@@ -483,7 +483,7 @@ class TestTracker:
                 # Ensure it generated a random UUID as a fallback
                 uuid.UUID(str(Tracker(project).client_id))
 
-            ctx_id = uuid.uuid4()
+            ctx_id = uuidv7()
             monkeypatch.setenv("MELTANO_CLIENT_ID", str(ctx_id))
             # Ensure it takes the client ID from the env var
             assert Tracker(project).client_id == ctx_id
@@ -492,7 +492,7 @@ class TestTracker:
             # Ensure it uses the client ID stored in `analytics.json`
             assert Tracker(project).client_id == ctx_id
 
-            ctx_id_2 = uuid.uuid4()
+            ctx_id_2 = uuidv7()
             monkeypatch.setenv("MELTANO_CLIENT_ID", str(ctx_id_2))
             # Ensure the env var takes priority over `analytics.json`
             assert Tracker(project).client_id == ctx_id_2

--- a/uv.lock
+++ b/uv.lock
@@ -777,6 +777,18 @@ wheels = [
 ]
 
 [[package]]
+name = "faker"
+version = "37.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/95/da573e055608e180086e2ac3208f8c15d8b44220912f565a9821b9bff33a/faker-37.4.2.tar.gz", hash = "sha256:8e281bbaea30e5658895b8bea21cc50d27aaf3a43db3f2694409ca5701c56b0a", size = 1902890, upload-time = "2025-07-15T16:38:24.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/1c/b909a055be556c11f13cf058cfa0e152f9754d803ff3694a937efe300709/faker-37.4.2-py3-none-any.whl", hash = "sha256:b70ed1af57bfe988cbcd0afd95f4768c51eaf4e1ce8a30962e127ac5c139c93f", size = 1943179, upload-time = "2025-07-15T16:38:23.053Z" },
+]
+
+[[package]]
 name = "fasteners"
 version = "0.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1371,6 +1383,7 @@ dev = [
     { name = "boto3-stubs", extra = ["essential"] },
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
+    { name = "faker" },
     { name = "moto" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1398,6 +1411,7 @@ pre-commit = [
 testing = [
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
+    { name = "faker" },
     { name = "moto" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1474,6 +1488,7 @@ dev = [
     { name = "boto3-stubs", extras = ["essential"], specifier = ">=1.35,<1.39" },
     { name = "colorama", specifier = ">=0.4.4,<0.5" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.10" },
+    { name = "faker", specifier = ">=37.4.2" },
     { name = "moto", specifier = ">=5.0.21,<6" },
     { name = "mypy", specifier = ">=1.16.0,<2" },
     { name = "pytest", specifier = ">=8.3.3,<9" },
@@ -1498,6 +1513,7 @@ pre-commit = [{ name = "pre-commit", specifier = ">=4.0.1,<5" }]
 testing = [
     { name = "colorama", specifier = ">=0.4.4,<0.5" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.10" },
+    { name = "faker", specifier = ">=37.4.2" },
     { name = "moto", specifier = ">=5.0.21,<6" },
     { name = "pytest", specifier = ">=8.3.3,<9" },
     { name = "pytest-asyncio", specifier = ">=1" },


### PR DESCRIPTION
## Summary

Implements UUIDv7 support to enable chronological sorting of job run IDs and log directories. This addresses the need for time-ordered unique identifiers that can be lexicographically sorted by creation time.

## Changes

### Core Implementation
- **UUIDv7 Utility**: Added RFC 9562-compliant `uuidv7()` function to `src/meltano/core/utils/`
- **Job Run IDs**: Updated `Job` class to use UUIDv7 for `run_id` generation
- **CLI Integration**: Modified `meltano run` and `meltano elt` commands to generate UUIDv7 run IDs
- **Database Schema**: Updated SQLAlchemy `GUIDType` default to use UUIDv7 for new GUID columns

### System-Wide Adoption
- **Plugin System**: Container names and Singer plugin instance UUIDs now use UUIDv7
- **Tracking System**: All telemetry and tracking context UUIDs converted to UUIDv7
- **Project Initialization**: New projects receive UUIDv7 project IDs

## Technical Details

UUIDv7 encodes a 48-bit timestamp in milliseconds as the first component, enabling:
- **Lexicographic Sorting**: UUIDs generated later have lexicographically larger string representations
- **Time Ordering**: Log directories and job runs can be chronologically sorted
- **Format Compatibility**: Maintains standard UUID format and interface compatibility

## Testing

- Added comprehensive tests for UUIDv7 generation, format validation, and time-ordering behavior
- Verified all existing tests pass with no breaking changes
- Validated RFC 9562 compliance for version bits and variant encoding

## Backward Compatibility

The implementation maintains full backward compatibility:
- Existing UUIDs continue to work without modification
- All UUID interfaces remain unchanged
- No database migrations required for existing data

## Performance Impact

Minimal performance impact as UUIDv7 generation is comparable to UUID4 with added timestamp encoding.

Fixes #8919

## Summary by Sourcery

Implement time-ordered version 7 UUID support throughout the codebase by introducing a uuidv7() utility and replacing uuid4 usage in key identifiers to enable chronological sorting of job runs, logs, telemetry, and container names.

New Features:
- Add uuidv7() utility generating RFC 9562-compliant version 7 UUIDs with embedded timestamps for lexicographic sorting

Enhancements:
- Replace uuid4 defaults across the system with uuidv7 for job run IDs, CLI commands, plugin instance IDs, telemetry and tracking contexts, state store identifiers, SQLAlchemy GUID defaults, and project initialization

Tests:
- Add tests verifying uuidv7 format, version, timestamp encoding, and lexicographic ordering including integration with job run IDs