### PR TITLE
refactor: Represent UUID instances in YAML as strings

### DIFF
--- a/src/meltano/core/yaml.py
+++ b/src/meltano/core/yaml.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import typing as t
+import uuid
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
@@ -30,10 +31,16 @@ def _represent_decimal(dumper: Dumper, node: Decimal) -> ScalarNode:
     return dumper.represent_scalar("tag:yaml.org,2002:float", str(node))
 
 
+def _represent_uuid(dumper: Dumper, node: uuid.UUID) -> ScalarNode:
+    """Represent a uuid.UUID instance in YAML."""
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(node))
+
+
 yaml.register_class(Canonical)
 yaml.register_class(PluginType)
 yaml.register_class(SettingKind)
 yaml.representer.add_representer(Decimal, _represent_decimal)
+yaml.representer.add_representer(uuid.UUID, _represent_uuid)
 
 
 @dataclass

--- a/tests/meltano/core/test_yaml.py
+++ b/tests/meltano/core/test_yaml.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import typing as t
+import uuid
 from decimal import Decimal
 
 from ruamel.yaml import YAML, CommentedMap
@@ -47,6 +48,16 @@ def test_decimal_in_nested_structure() -> None:
     assert "99.99" in output
     assert "0.15" in output
     assert "42.0" in output
+
+
+def test_uuid_representation() -> None:
+    """Test that UUID values are properly represented in YAML."""
+    data = CommentedMap()
+    data["uuid_value"] = uuid.uuid4()
+
+    stream = io.StringIO()
+    yaml.dump(data, stream)
+    assert str(data["uuid_value"]) in stream.getvalue()
 
 
 def test_load_and_dump_with_decimals(tmp_path: Path):

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -143,7 +143,7 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", str(uuid.uuid4()))
+        project.settings.set("project_id", uuid.uuid4())
         Tracker(project).save_telemetry_settings()
 
         project.settings.set("send_anonymous_usage_stats", value=False)
@@ -151,7 +151,7 @@ class TestTracker:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 1
 
-        project.settings.set("project_id", str(uuid.uuid4()))
+        project.settings.set("project_id", uuid.uuid4())
         with mock.patch.object(Tracker, method_name) as mocked:
             Tracker(project).save_telemetry_settings()
             assert mocked.call_count == 0
@@ -163,11 +163,11 @@ class TestTracker:
         method_name = "track_telemetry_state_change_event"
 
         project.settings.set("send_anonymous_usage_stats", value=True)
-        project.settings.set("project_id", str(uuid.uuid4()))
+        project.settings.set("project_id", uuid.uuid4())
         Tracker(project).save_telemetry_settings()
 
         with delete_analytics_json(project):
-            project.settings.set("project_id", str(uuid.uuid4()))
+            project.settings.set("project_id", uuid.uuid4())
             with mock.patch.object(Tracker, method_name) as mocked:
                 Tracker(project)
                 assert mocked.call_count == 0


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Add support for representing uuid.UUID values as plain strings in YAML dumps and update related tests to use UUID instances directly

New Features:
- Add YAML representer for uuid.UUID to serialize UUID instances as strings

Enhancements:
- Update tracking tests to set project_id with uuid.UUID instances instead of strings

Tests:
- Add test ensuring UUID values are serialized correctly in YAML