### PR TITLE
chore: Use `typing.Self` where possible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,6 +356,7 @@ select = [
   "PIE",   # flake8-pie
   "PT",    # flake8-pytest-style
   "PTH",   # flake8-use-pathlib
+  "PYI",   # flake8-pyi
   "Q",     # flake8-quotes
   "RET",   # flake8-return
   "RSE",   # flake8-raise

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -66,7 +66,7 @@ cli.add_command(job.job)
 
 # Holds the exit code for error reporting during process exiting. In
 # particular, a function registered by the `atexit` module uses this value.
-exit_code: None | int = None
+exit_code: int | None = None
 
 atexit_handler_registered = False
 exit_code_reported = False

--- a/src/meltano/cli/interactive/utils.py
+++ b/src/meltano/cli/interactive/utils.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import enum
 import sys
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 
 class InteractionStatus(StrEnum):

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -28,10 +28,10 @@ from meltano.core.project_plugins_service import AddedPluginFlags
 from meltano.core.setting_definition import SettingKind
 from meltano.core.tracking.contexts import CliContext, CliEvent, ProjectContext
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 if t.TYPE_CHECKING:
     from meltano.core.plugin.base import PluginRef

--- a/src/meltano/core/_state.py
+++ b/src/meltano/core/_state.py
@@ -5,10 +5,10 @@ import sys
 
 import structlog
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 logger = structlog.stdlib.get_logger()
 

--- a/src/meltano/core/_types.py
+++ b/src/meltano/core/_types.py
@@ -4,7 +4,7 @@ import os
 import sys
 import typing as t
 
-if sys.version_info < (3, 10):
+if sys.version_info >= (3, 10):
     from typing import TypeAlias  # noqa: ICN003
 else:
     from typing_extensions import TypeAlias

--- a/src/meltano/core/behavior/addon.py
+++ b/src/meltano/core/behavior/addon.py
@@ -6,10 +6,10 @@ import sys
 import typing as t
 from functools import cached_property
 
-if sys.version_info < (3, 12):
-    from importlib_metadata import EntryPoints, entry_points
-else:
+if sys.version_info >= (3, 12):
     from importlib.metadata import EntryPoints, entry_points
+else:
+    from importlib_metadata import EntryPoints, entry_points
 
 T = t.TypeVar("T")
 

--- a/src/meltano/core/behavior/canonical.py
+++ b/src/meltano/core/behavior/canonical.py
@@ -4,18 +4,22 @@ from __future__ import annotations
 
 import copy
 import json
+import sys
 import typing as t
 from functools import lru_cache
 
 import ruamel.yaml as yaml
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
 
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: ICN003
+else:
+    from typing_extensions import Self
+
 if t.TYPE_CHECKING:
     from os import PathLike
 
     from ruamel.yaml import Representer
-
-T = t.TypeVar("T", bound="Canonical")  # (name too short)
 
 
 class IdHashBox:
@@ -38,7 +42,7 @@ class IdHashBox:
         """
         return id(self.content)
 
-    def __eq__(self, other: t.Any) -> bool:  # noqa: ANN401
+    def __eq__(self, other: object) -> bool:
         """Check equality of this instance and some other object.
 
         Parameters:
@@ -137,7 +141,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
 
     @classmethod
     def as_canonical(
-        cls: type[T],
+        cls,
         target: t.Any,  # noqa: ANN401
     ) -> dict | list | CommentedMap | CommentedSeq | t.Any:  # noqa: ANN401
         """Return a canonical representation of the given instance.
@@ -185,7 +189,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         """
         return type(self).as_canonical(self)
 
-    def with_attrs(self: T, *args: t.Any, **kwargs: t.Any) -> T:
+    def with_attrs(self, *args: t.Any, **kwargs: t.Any) -> Self:
         """Return a new instance with the given attributes set.
 
         Args:
@@ -198,7 +202,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         return type(self)(*args, **{**self.canonical(), **kwargs})
 
     @classmethod
-    def parse(cls: type[T], obj: t.Any) -> T:  # noqa: ANN401
+    def parse(cls, obj: t.Any) -> Self:  # noqa: ANN401
         """Parse a 'Canonical' object from a dictionary or return the instance.
 
         Args:
@@ -211,7 +215,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
 
     @classmethod
     @lru_cache(maxsize=CANONICAL_PARSE_CACHE_SIZE)
-    def _parse(cls: type[T], boxed_obj: IdHashBox) -> T:
+    def _parse(cls, boxed_obj: IdHashBox) -> Self:
         """Parse a `Canonical` object from a dictionary or return the instance.
 
         Args:
@@ -421,7 +425,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
         )
 
     @classmethod
-    def parse_json_file(cls: type[T], path: PathLike[str]) -> T:
+    def parse_json_file(cls, path: PathLike[str]) -> Self:
         """Parse a plugin definition from a JSON file.
 
         Args:

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import sys
 import typing as t
 
 from meltano.core.behavior import NameEq
@@ -12,6 +13,11 @@ from meltano.core.plugin import PluginType
 from meltano.core.plugin.base import PluginRef
 from meltano.core.setting_definition import SettingDefinition
 from meltano.core.utils import NotFound
+
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: ICN003
+else:
+    from typing_extensions import Self
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -190,7 +196,7 @@ class Environment(NameEq, Canonical):
         self.state_id_suffix = state_id_suffix
 
     @classmethod
-    def find(cls: type[TEnv], objects: Iterable[TEnv], name: str) -> TEnv:
+    def find(cls, objects: Iterable[Self], name: str) -> Self:
         """Lookup an environment by name from an iterable.
 
         Args:

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -22,8 +22,6 @@ else:
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
 
-TEnv = t.TypeVar("TEnv", bound="Environment")
-
 
 class NoActiveEnvironment(Exception):
     """Exception raised when invocation has no active environment."""

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -13,10 +13,10 @@ from rich.traceback import Traceback, install
 
 from meltano.core.utils import get_boolean_env_var, get_no_color_flag
 
-if sys.version_info < (3, 11):
-    from typing_extensions import Unpack
-else:
+if sys.version_info >= (3, 11):
     from typing import Unpack  # noqa: ICN003
+else:
+    from typing_extensions import Unpack
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable, Sequence

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -67,7 +67,7 @@ class LoggingFeatures(t.TypedDict, total=False):
 def _processors_from_kwargs(
     **features: Unpack[LoggingFeatures],
 ) -> t.Generator[Processor, None, None]:
-    if features.get("callsite_parameters", False):
+    if features.get("callsite_parameters"):
         yield structlog.processors.CallsiteParameterAdder(
             parameters=(
                 structlog.processors.CallsiteParameter.PATHNAME,

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -67,7 +67,7 @@ class LoggingFeatures(t.TypedDict, total=False):
 def _processors_from_kwargs(
     **features: Unpack[LoggingFeatures],
 ) -> t.Generator[Processor, None, None]:
-    if features.get("callsite_parameters"):
+    if features.get("callsite_parameters", False):
         yield structlog.processors.CallsiteParameterAdder(
             parameters=(
                 structlog.processors.CallsiteParameter.PATHNAME,

--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -23,7 +23,7 @@ from .formatters import get_default_foreign_pre_chain
 from .utils import capture_subprocess_output
 
 if t.TYPE_CHECKING:
-    if sys.version_info < (3, 10):
+    if sys.version_info >= (3, 10):
         from typing import TypeAlias  # noqa: ICN003
     else:
         from typing_extensions import TypeAlias

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -22,10 +22,10 @@ from meltano.core.utils import get_no_color_flag
 
 logger = structlog.getLogger(__name__)
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 
 if t.TYPE_CHECKING:

--- a/src/meltano/core/plugin/requirements.py
+++ b/src/meltano/core/plugin/requirements.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-import typing as t
+import sys
 
 from meltano.core.behavior import NameEq
 from meltano.core.behavior.canonical import Canonical
 
-TReq = t.TypeVar("TReq", bound="PluginRequirement")
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: ICN003
+else:
+    from typing_extensions import Self
 
 
 class PluginRequirement(NameEq, Canonical):
@@ -23,7 +26,7 @@ class PluginRequirement(NameEq, Canonical):
         super().__init__(name=name, variant=variant)
 
     @classmethod
-    def parse_all(cls: type[TReq], obj: dict | None) -> dict[str, list[TReq]]:
+    def parse_all(cls, obj: dict | None) -> dict[str, list[Self]]:
         """Deserialize requirements data into a dict of PluginRequirement.
 
         Args:

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -12,10 +12,12 @@ import structlog
 
 from meltano.core.behavior.visitor import visit_with
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+    from typing import Self  # noqa: ICN003
+else:
+    from backports.strenum import StrEnum
+    from typing_extensions import Self
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -23,7 +25,6 @@ if t.TYPE_CHECKING:
 logger = structlog.stdlib.get_logger(__name__)
 
 Node = dict[str, t.Any]
-T = t.TypeVar("T", bound="_CatalogRuleProtocol")
 
 
 UNESCAPED_DOT = re.compile(r"(?<!\\)\.")
@@ -44,11 +45,11 @@ class _CatalogRuleProtocol(t.Protocol):
 
     @classmethod
     def matching(
-        cls: type[T],
-        rules: list[T],
+        cls,
+        rules: list[Self],
         tap_stream_id: str,
         breadcrumb: list[str] | None = None,
-    ) -> list[T]:
+    ) -> list[Self]:
         """Filter rules that match a given breadcrumb."""
         return [rule for rule in rules if rule.match(tap_stream_id, breadcrumb)]
 

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -36,10 +36,10 @@ from meltano.core.venv_service import (
     fingerprint,
 )
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -20,12 +20,12 @@ from meltano.core.tracking import Tracker
 from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars, uuid7
 from meltano.core.venv_service import VenvService, VirtualEnv
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-    from typing_extensions import Unpack
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
     from typing import Unpack  # noqa: ICN003
+else:
+    from backports.strenum import StrEnum
+    from typing_extensions import Unpack
 
 if t.TYPE_CHECKING:
     from collections.abc import AsyncGenerator

--- a/src/meltano/core/project_add_service.py
+++ b/src/meltano/core/project_add_service.py
@@ -14,10 +14,10 @@ from meltano.core.project_plugins_service import (
     PluginAlreadyAddedException,
 )
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -17,10 +17,10 @@ from meltano.core.behavior import NameEq
 from meltano.core.behavior.canonical import Canonical
 from meltano.core.error import Error
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable, Iterable

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -21,10 +21,12 @@ from meltano.core.settings_store import SettingValueStore
 from meltano.core.utils import EnvVarMissingBehavior, flatten
 from meltano.core.utils import expand_env_vars as do_expand_env_vars
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+    from typing import Self  # noqa: ICN003
+else:
+    from backports.strenum import StrEnum
+    from typing_extensions import Self
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator, Iterable
@@ -79,9 +81,6 @@ class FeatureNotAllowedException(Exception):
             string representation of the error
         """
         return f"{self.feature} not enabled."
-
-
-_T = t.TypeVar("_T", bound="SettingsService")
 
 
 class SettingsService(metaclass=ABCMeta):
@@ -159,7 +158,7 @@ class SettingsService(metaclass=ABCMeta):
         """Return definitions of supported settings."""
 
     @property
-    def inherited_settings_service(self: _T) -> _T | None:
+    def inherited_settings_service(self) -> Self | None:
         """Return settings service to inherit configuration from."""
         return None
 

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -21,10 +21,10 @@ from meltano.core.setting import Setting
 from meltano.core.setting_definition import SettingDefinition, SettingMissingError
 from meltano.core.utils import flatten, pop_at_path, set_at_path
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -13,10 +13,10 @@ from meltano.core.db import project_engine
 from meltano.core.state_store.base import MeltanoState, StateStoreManager
 from meltano.core.state_store.db import DBStateStoreManager
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 if t.TYPE_CHECKING:
     from collections.abc import Mapping

--- a/src/meltano/core/validation_service.py
+++ b/src/meltano/core/validation_service.py
@@ -10,10 +10,12 @@ from abc import ABCMeta, abstractmethod
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_invoker import PluginInvoker, invoker_factory
 
-if sys.version_info < (3, 11):
-    from backports.strenum import StrEnum
-else:
+if sys.version_info >= (3, 11):
     from enum import StrEnum
+    from typing import Self  # noqa: ICN003
+else:
+    from backports.strenum import StrEnum
+    from typing_extensions import Self
 
 
 if t.TYPE_CHECKING:
@@ -22,8 +24,6 @@ if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 EXIT_CODE_OK = 0
-
-T = t.TypeVar("T", bound="ValidationsRunner")
 
 
 class ValidationOutcome(StrEnum):
@@ -122,11 +122,11 @@ class ValidationsRunner(metaclass=ABCMeta):
 
     @classmethod
     def collect(
-        cls: type[T],
+        cls,
         project: Project,
         *,
         select_all: bool = True,
-    ) -> dict[str, T]:
+    ) -> dict[str, Self]:
         """Collect all tests for CLI invocation.
 
         Args:

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -26,17 +26,20 @@ if t.TYPE_CHECKING:
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
 
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
+if sys.version_info >= (3, 10):
     from typing import TypeAlias  # noqa: ICN003
-
-if sys.version_info < (3, 12):
-    from typing_extensions import override
 else:
-    from typing import override  # noqa: ICN003
+    from typing_extensions import TypeAlias
 
-_T = t.TypeVar("_T", bound="VenvService")
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: ICN003
+else:
+    from typing_extensions import Self
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -303,7 +306,7 @@ class VenvService:
         ).resolve()
 
     @classmethod
-    def from_plugin(cls: type[_T], project: Project, plugin: ProjectPlugin) -> _T:
+    def from_plugin(cls, project: Project, plugin: ProjectPlugin) -> Self:
         """Create a service instance from a project and plugin.
 
         Args:

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -6,7 +6,7 @@ import logging
 import os
 import shutil
 import typing as t
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
@@ -2187,10 +2187,16 @@ def num_params() -> int:
     return 10
 
 
+class Payloads(t.NamedTuple):
+    mock_state_payloads: list[dict[str, dict]]
+    mock_error_payload: dict[str, str]
+    mock_empty_payload: dict[str, t.Any]
+
+
 @pytest.fixture
-def payloads(num_params):
-    mock_payloads_dict = {
-        "mock_state_payloads": [
+def payloads(num_params: int) -> Payloads:
+    return Payloads(
+        mock_state_payloads=[
             {
                 "singer_state": {
                     f"bookmark-{idx_i}": idx_i + idx_j for idx_j in range(num_params)
@@ -2198,31 +2204,34 @@ def payloads(num_params):
             }
             for idx_i in range(num_params)
         ],
-        "mock_error_payload": {"error": "failed"},
-        "mock_empty_payload": {},
-    }
-    payloads = namedtuple("payloads", mock_payloads_dict)
-    return payloads(**mock_payloads_dict)
+        mock_error_payload={"error": "failed"},
+        mock_empty_payload={},
+    )
+
+
+class StateIds(t.NamedTuple):
+    single_incomplete_state_id: str
+    single_complete_state_id: str
+    multiple_incompletes_state_id: str
+    multiple_completes_state_id: str
+    single_complete_then_multiple_incompletes_state_id: str
+    single_incomplete_then_multiple_completes_state_id: str
 
 
 @pytest.fixture
-def state_ids(
-    num_params,  # noqa: ARG001
-):
-    state_id_dict = {
-        "single_incomplete_state_id": create_state_id("single-incomplete"),
-        "single_complete_state_id": create_state_id("single-complete"),
-        "multiple_incompletes_state_id": create_state_id("multiple-incompletes"),
-        "multiple_completes_state_id": create_state_id("multiple-completes"),
-        "single_complete_then_multiple_incompletes_state_id": create_state_id(
+def state_ids():
+    return StateIds(
+        single_incomplete_state_id=create_state_id("single-incomplete"),
+        single_complete_state_id=create_state_id("single-complete"),
+        multiple_incompletes_state_id=create_state_id("multiple-incompletes"),
+        multiple_completes_state_id=create_state_id("multiple-completes"),
+        single_complete_then_multiple_incompletes_state_id=create_state_id(
             "single-complete-then-multiple-incompletes",
         ),
-        "single_incomplete_then_multiple_completes_state_id": create_state_id(
+        single_incomplete_then_multiple_completes_state_id=create_state_id(
             "single-incomplete-then-multiple-completes",
         ),
-    }
-    state_ids = namedtuple("state_ids", state_id_dict)
-    return state_ids(**state_id_dict)
+    )
 
 
 @pytest.fixture
@@ -2239,21 +2248,29 @@ def mock_time():
     return _mock_time()
 
 
+class JobArgs(t.NamedTuple):
+    complete_job_args: dict[str, t.Any]
+    incomplete_job_args: dict[str, t.Any]
+
+
 @pytest.fixture
-def job_args():
-    job_args_dict = {
-        "complete_job_args": {"state": State.SUCCESS, "payload_flags": Payload.STATE},
-        "incomplete_job_args": {
+def job_args() -> JobArgs:
+    return JobArgs(
+        complete_job_args={"state": State.SUCCESS, "payload_flags": Payload.STATE},
+        incomplete_job_args={
             "state": State.FAIL,
             "payload_flags": Payload.INCOMPLETE_STATE,
         },
-    }
-    job_args = namedtuple("job_args", job_args_dict)
-    return job_args(**job_args_dict)
+    )
 
 
 @pytest.fixture
-def state_ids_with_jobs(state_ids, job_args, payloads, mock_time):
+def state_ids_with_jobs(
+    state_ids: StateIds,
+    job_args: JobArgs,
+    payloads: Payloads,
+    mock_time: t.Generator[datetime.datetime, None, None],
+) -> dict[str, list[Job]]:
     jobs = {
         state_ids.single_incomplete_state_id: [
             Job(
@@ -2330,9 +2347,9 @@ def jobs(state_ids_with_jobs):
 
 @pytest.fixture
 def state_ids_with_expected_states(
-    state_ids,
-    payloads,
-    state_ids_with_jobs,
+    state_ids: StateIds,
+    payloads: Payloads,
+    state_ids_with_jobs: dict[str, list[Job]],
 ):
     final_state = {}
     for state in payloads.mock_state_payloads:


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

- **chore: Use `typing.Self` where possible**
- **fix: Fix some `sys.version_info` imports**
- **fix: Fix some types in core test fixtures**

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Improve type annotations and version-specific imports by standardizing use of typing.Self, refactoring test fixtures to NamedTuples, fixing Python version checks for imports, and updating lint configuration.

Bug Fixes:
- Fix conditional imports of TypeAlias, override, and StrEnum based on Python version checks
- Correct sys.version_info import conditions across core modules

Enhancements:
- Refactor core test fixtures to use NamedTuple classes with precise type annotations and return types
- Standardize use of typing.Self for class and method return types across multiple modules
- Remove redundant TypeVar declarations in favor of typing.Self
- Add flake8-pyi to the lint ignore list in pyproject.toml

Tests:
- Update pytest fixtures for payloads, state_ids, and job_args to return NamedTuple types

## Summary by Sourcery

Adopt typing.Self for return type annotations, correct Python version checks for conditional typing imports, and refactor core pytest fixtures to NamedTuple-based fixtures for explicit typing.

Bug Fixes:
- Correct Python version checks for conditional imports of TypeAlias, override, StrEnum, and Self across multiple modules

Enhancements:
- Standardize typing.Self usage for class and method return types
- Remove redundant TypeVar declarations in favor of typing.Self

Build:
- Add flake8-pyi plugin to lint ignore list in pyproject.toml

Tests:
- Refactor core pytest fixtures to use NamedTuple classes with precise type annotations and return types