### PR TITLE
feat: Add `--clear` option to select command

### DIFF
--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -1361,7 +1361,7 @@ meltano schedule set gitlab-to-jsonl --loader target-csv
 
 Use the `select` command to add select patterns to a specific extractor in your Meltano project.
 
-- `meltano select [--list] [--all] <tap_name> [ENTITIES_PATTERN] [ATTRIBUTE_PATTERN]`: Manage the selected entities/attributes for a specific tap.
+- `meltano select [--list] [--all] [--clear] <tap_name> [ENTITIES_PATTERN] [ATTRIBUTE_PATTERN]`: Manage the selected entities/attributes for a specific tap.
 
 Selection rules will be stored in the extractor's [`select` extra](/concepts/plugins#select-extra).
 
@@ -1384,6 +1384,8 @@ Use `--list` or `--json` to list the currently selected tap attributes.
 > Note: `--all` can be used to show all the tap attributes with their selected status.
 
 Use `--rm` or `--remove` to remove previously added select patterns.
+
+Use `--clear` to remove all select patterns for the extractor, reverting to the default behavior of the extractor.
 
 ### Using `select` with Environments
 
@@ -1448,6 +1450,13 @@ Remove patterns (`--rm` or `--remove`):
 meltano select tap-gitlab --rm tags "*"
 meltano select tap-gitlab --rm --exclude "*" "*_url"
 meltano select tap-gitlab --rm commits id
+```
+
+Clear all select patterns (`--clear`):
+
+```bash
+# Remove all select patterns and revert to default behavior
+meltano select tap-gitlab --clear
 ```
 
 :::info

--- a/src/meltano/cli/select_entities.py
+++ b/src/meltano/cli/select_entities.py
@@ -95,6 +95,11 @@ def selection_mark(selection) -> str:  # noqa: ANN001
     is_flag=True,
     help="Exclude all attributes that match specified pattern.",
 )
+@click.option(
+    "--clear",
+    is_flag=True,
+    help="Clear all select patterns for the extractor.",
+)
 @install
 @no_install
 @only_install
@@ -112,6 +117,7 @@ async def select(
     refresh_catalog: bool,
     remove: bool,
     exclude: bool,
+    clear: bool,
 ) -> None:
     """Manage extractor selection patterns.
 
@@ -119,7 +125,9 @@ async def select(
     Read more at https://docs.meltano.com/reference/command-line-interface#select
     """  # noqa: D301
     try:
-        if list_format:
+        if clear:
+            clear_selections(project, extractor)
+        elif list_format:
             await show(
                 project,
                 extractor,
@@ -139,6 +147,12 @@ async def select(
             )
     except PluginExecutionError as err:
         raise CliError(f"Cannot list the selected attributes: {err}") from err  # noqa: EM102
+
+
+def clear_selections(project: Project, extractor: str) -> None:
+    """Clear all select patterns for a specific extractor."""
+    select_service = SelectService(project, extractor)
+    select_service.clear()
 
 
 def update(

--- a/src/meltano/cli/select_entities.py
+++ b/src/meltano/cli/select_entities.py
@@ -64,6 +64,7 @@ def selection_mark(selection) -> str:  # noqa: ANN001
     "--list",
     "list_format",
     flag_value="text",
+    default=None,
     help="List the current selected tap attributes in plain text format.",
 )
 @click.option(
@@ -127,7 +128,7 @@ async def select(
     try:
         if clear:
             clear_selections(project, extractor)
-        elif list_format:
+        elif list_format is not None:
             await show(
                 project,
                 extractor,

--- a/src/meltano/core/select_service.py
+++ b/src/meltano/core/select_service.py
@@ -83,6 +83,23 @@ class SelectService:  # noqa: D101
 
         return list_all
 
+    def clear(self) -> None:
+        """Clear all select patterns for the extractor."""
+        plugin: ProjectPlugin | EnvironmentPluginConfig
+        if self.project.environment is None:
+            plugin = self.extractor
+            if "select" in plugin.extras:
+                del plugin.extras["select"]
+            self.project.plugins.update_plugin(plugin)
+        else:
+            plugin = self.project.environment.get_plugin_config(
+                self.extractor.type,
+                self.extractor.name,
+            )
+            if "select" in plugin.extras:
+                del plugin.extras["select"]
+            self.project.plugins.update_environment_plugin(plugin)
+
     def update(
         self,
         entities_filter: str,

--- a/tests/meltano/cli/test_select.py
+++ b/tests/meltano/cli/test_select.py
@@ -109,9 +109,9 @@ class TestCliSelect:
         )
         assert_cli_runner(result)
         json_config = json.loads(result.stdout)
-        # After clearing, the select extra should be removed entirely,
-        # which means it falls back to the default ["*.*"] behavior
-        assert "_select" not in json_config
+        # After clearing, custom patterns are removed and we revert to default behavior
+        # The config command shows resolved config, so _select will be ["*.*"]
+        assert json_config["_select"] == ["*.*"]
 
     @pytest.mark.usefixtures("project")
     def test_select_list(

--- a/tests/meltano/cli/test_select.py
+++ b/tests/meltano/cli/test_select.py
@@ -94,6 +94,19 @@ class TestCliSelect:
             input="y\n",
         )
         assert_cli_runner(result)
+        # clearing leaves defaults as they were
+        result = cli_runner.invoke(
+            cli,
+            [*environment_flag, "select", tap.name, "--clear"],
+        )
+        assert_cli_runner(result)
+        result = cli_runner.invoke(
+            cli,
+            [*environment_flag, "config", "--extras", tap.name],
+        )
+        assert_cli_runner(result)
+        json_config = json.loads(result.stdout)
+        assert json_config["_select"] == ["*.*"]
         # add multiple select patterns
         result = cli_runner.invoke(
             cli,

--- a/tests/meltano/cli/test_select.py
+++ b/tests/meltano/cli/test_select.py
@@ -29,8 +29,20 @@ class TestCliSelect:
         ),
     )
     @pytest.mark.usefixtures("project")
-    def test_update_select_pattern(self, cli_runner, tap, environment) -> None:
+    def test_update_select_pattern(
+        self,
+        cli_runner: MeltanoCliRunner,
+        tap: ProjectPlugin,
+        environment: str | None,
+    ) -> None:
         environment_flag = () if environment is None else ("--environment", environment)
+        # first, reset to defaults
+        result = cli_runner.invoke(
+            cli,
+            [*environment_flag, "config", tap.name, "reset"],
+            input="y\n",
+        )
+        assert_cli_runner(result)
         # add select pattern
         result = cli_runner.invoke(
             cli,
@@ -68,8 +80,20 @@ class TestCliSelect:
         ),
     )
     @pytest.mark.usefixtures("project")
-    def test_clear_select_patterns(self, cli_runner, tap, environment) -> None:
+    def test_clear_select_patterns(
+        self,
+        cli_runner: MeltanoCliRunner,
+        tap: ProjectPlugin,
+        environment: str | None,
+    ) -> None:
         environment_flag = () if environment is None else ("--environment", environment)
+        # first, reset to defaults
+        result = cli_runner.invoke(
+            cli,
+            [*environment_flag, "config", tap.name, "reset"],
+            input="y\n",
+        )
+        assert_cli_runner(result)
         # add multiple select patterns
         result = cli_runner.invoke(
             cli,

--- a/tests/meltano/core/test_select_service.py
+++ b/tests/meltano/core/test_select_service.py
@@ -96,3 +96,28 @@ async def test_select_service_list_all(
             ),
         },
     }
+
+
+@pytest.mark.usefixtures("tap")
+def test_select_service_clear(project: Project) -> None:
+    extractor = "tap-mock"
+    service = SelectService(project, extractor)
+
+    # Check if there are any initial select patterns (should be default "*.*")
+    initial_patterns = service.current_select[:]
+    assert initial_patterns == ["*.*"]
+
+    # Add some select patterns
+    service.update("users", "*", exclude=False)
+    service.update("posts", "id", exclude=False)
+    service.update("posts", "secret", exclude=True)
+
+    # Verify patterns were added (should replace default)
+    expected_patterns = ["users.*", "posts.id", "!posts.secret"]
+    assert service.current_select == expected_patterns
+
+    # Clear all patterns
+    service.clear()
+
+    # Verify all custom patterns were removed and we're back to default
+    assert service.current_select == ["*.*"]


### PR DESCRIPTION
## Summary

Implements a new `--clear` option for the `meltano select` command that removes all custom select patterns for an extractor, reverting it to the default behavior set by the tap.

## Features

- **New `--clear` flag**: Provides users with a simple way to reset extractor selection patterns
- **Complete pattern removal**: Removes the `select` extra entirely from plugin configuration
- **Environment support**: Works consistently for both regular plugins and environment-specific configurations

## Implementation

### Core Changes
- **CLI Interface**: Added `--clear` option to the select command with proper help text
- **SelectService**: Implemented `clear()` method that removes the `select` extra from plugin configuration
- **Environment Handling**: Supports clearing patterns in both regular and environment-specific contexts

## Testing

- **Comprehensive test coverage**: Tests for both CLI and service layer functionality
- **Environment testing**: Validates behavior across different environment configurations
- **Integration testing**: Ensures proper interaction between CLI and underlying services

## Documentation

Updated the command-line interface documentation 

## Usage

```bash
# Reset tap-gitlab to select all entities and attributes
meltano select tap-gitlab --clear

# Works with environments too
meltano select --environment dev tap-gitlab --clear
```

## Summary by Sourcery

Add a --clear option to the meltano select command that deletes all custom select patterns for an extractor (in both regular and environment contexts), reverting it to default behavior, with supporting tests and documentation updates.

New Features:
- Add --clear flag to the select command to remove all custom selection patterns for an extractor

Enhancements:
- Support clearing select patterns in both project-wide and environment-specific plugin configurations

Documentation:
- Update CLI reference documentation to include the --clear option

Tests:
- Add CLI and service tests to verify clearing select patterns reverts to default behavior