### PR TITLE
refactor: Improve docstrings and test coverage for Singer catalog manipulation

### DIFF
--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -1,4 +1,13 @@
-from __future__ import annotations  # noqa: D100
+"""Catalog executor classes for traversing and manipulating Singer catalog structures.
+
+This module provides a set of classes that implement the visitor pattern for
+traversing and processing Singer catalog nodes. The classes are organized into
+a hierarchy, with the base `CatalogExecutor` class providing the core traversal
+and dispatch functionality, and specialized executors for specific catalog
+manipulation tasks (e.g., metadata, selection, schema).
+"""
+
+from __future__ import annotations
 
 import dataclasses
 import fnmatch
@@ -12,6 +21,11 @@ import structlog
 
 from meltano.core.behavior.visitor import visit_with
 
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias  # noqa: ICN003
+else:
+    from typing_extensions import TypeAlias
+
 if sys.version_info >= (3, 11):
     from enum import StrEnum
     from typing import Self  # noqa: ICN003
@@ -19,15 +33,26 @@ else:
     from backports.strenum import StrEnum
     from typing_extensions import Self
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
 
 logger = structlog.stdlib.get_logger(__name__)
 
-Node = dict[str, t.Any]
+Node: TypeAlias = dict[str, t.Any]
 
 
 UNESCAPED_DOT = re.compile(r"(?<!\\)\.")
+PROP_DELIMITER = "."
+PROPERTIES_KEY = "properties"
+SCHEMA_KEY = "schema"
+INCLUSION_KEY = "inclusion"
+SELECTED_KEY = "selected"
+SELECTED_BY_DEFAULT_KEY = "selected-by-default"
 
 
 class CatalogDict(t.TypedDict):
@@ -78,8 +103,8 @@ class _CatalogRuleProtocol(t.Protocol):
         # If provided, the breadcrumb should still match, even on negated rules
         if breadcrumb is not None:
             result = result and fnmatch.fnmatch(
-                ".".join(breadcrumb),
-                ".".join(self.breadcrumb),
+                PROP_DELIMITER.join(breadcrumb),
+                PROP_DELIMITER.join(self.breadcrumb),
             )
 
         return result
@@ -156,7 +181,7 @@ class SelectPattern(t.NamedTuple):
             prop = None
 
         return cls(
-            stream_pattern=stream.replace(r"\.", "."),
+            stream_pattern=stream.replace(r"\.", PROP_DELIMITER),
             property_pattern=prop,
             negated=negated,
             raw=raw,
@@ -188,19 +213,19 @@ def select_metadata_rules(patterns: Iterable[str]) -> list[MetadataRule]:
                 MetadataRule(
                     tap_stream_id=parsed_pattern.stream_pattern,
                     breadcrumb=[],
-                    key="selected",
+                    key=SELECTED_KEY,
                     value=selected,
                 ),
             )
 
         if prop_pattern:
-            props = prop_pattern.split(".")
+            props = prop_pattern.split(PROP_DELIMITER)
 
             rules.append(
                 MetadataRule(
                     tap_stream_id=parsed_pattern.stream_pattern,
                     breadcrumb=property_breadcrumb(props),
-                    key="selected",
+                    key=SELECTED_KEY,
                     value=selected,
                 ),
             )
@@ -223,14 +248,14 @@ def select_filter_metadata_rules(patterns: Iterable[str]) -> list[MetadataRule]:
         negated=True,
         tap_stream_id=[],
         breadcrumb=[],
-        key="selected",
+        key=SELECTED_KEY,
         value=False,
     )
     # Or if it matches one of the exclusion patterns
     exclude_rule = MetadataRule(
         tap_stream_id=[],
         breadcrumb=[],
-        key="selected",
+        key=SELECTED_KEY,
         value=False,
     )
 
@@ -268,7 +293,7 @@ def path_property(path: str) -> str:
     """
     prop_regex = r"properties\.([^.]+)+"
     components = re.findall(prop_regex, path)
-    return ".".join(components)
+    return PROP_DELIMITER.join(components)
 
 
 def property_breadcrumb(props: list[str]) -> list[str]:
@@ -286,12 +311,18 @@ def property_breadcrumb(props: list[str]) -> list[str]:
     """
     breadcrumb = []
     for prop in props:
-        breadcrumb.extend(["properties", prop])
+        breadcrumb.extend([PROPERTIES_KEY, prop])
 
     return breadcrumb
 
 
-class CatalogNode(Enum):  # noqa: D101
+class CatalogNode(Enum):
+    """Enumeration of catalog node types encountered during traversal.
+
+    Defines the three fundamental node types in a Singer catalog structure
+    that executors can process during catalog traversal and manipulation.
+    """
+
     STREAM = auto()
     PROPERTY = auto()
     METADATA = auto()
@@ -305,10 +336,36 @@ class SelectionType(StrEnum):
     AUTOMATIC = auto()
     UNSUPPORTED = auto()
 
-    def __bool__(self) -> bool:  # noqa: D105
-        return self not in {self.__class__.EXCLUDED, self.__class__.UNSUPPORTED}
+    def __bool__(self) -> bool:
+        """Truth value of the selection type.
 
-    def __add__(self, other: SelectionType) -> SelectionType:  # type: ignore[override] # noqa: D105
+        Examples:
+        >>> for selection_type in SelectionType:
+        ...     if selection_type:
+        ...         print(selection_type)
+        selected
+        automatic
+        """
+        return self not in {SelectionType.EXCLUDED, SelectionType.UNSUPPORTED}
+
+    def __add__(self, other: object) -> SelectionType:
+        """Combine two selection types.
+
+        Args:
+            other: Another selection type.
+
+        Returns:
+            The combined selection type.
+
+        Examples:
+        >>> SelectionType.SELECTED + SelectionType.AUTOMATIC
+        <SelectionType.AUTOMATIC: 'automatic'>
+        >>> SelectionType.EXCLUDED + SelectionType.UNSUPPORTED
+        <SelectionType.EXCLUDED: 'excluded'>
+        """
+        if not isinstance(other, SelectionType):
+            return NotImplemented
+
         if self is SelectionType.EXCLUDED or other is SelectionType.EXCLUDED:
             return SelectionType.EXCLUDED
 
@@ -322,11 +379,12 @@ class SelectionType(StrEnum):
 
 
 @singledispatch
-def visit(  # noqa: D103
-    node,  # noqa: ANN001, ARG001
-    executor,  # noqa: ANN001, ARG001
+def visit(
+    node: t.Any,  # noqa: ANN401, ARG001
+    executor: CatalogExecutor,  # noqa: ARG001
     path: str = "",
 ) -> None:
+    """Visit a node in the catalog."""
     logger.debug("Skipping node at '%s'", path)
 
 
@@ -362,7 +420,23 @@ def _(node: list, executor, path: str = "") -> None:  # noqa: ANN001
 
 
 @visit_with(visit)
-class CatalogExecutor:  # noqa: D101
+class CatalogExecutor:
+    """Base executor class for traversing and processing Singer catalog nodes.
+
+    This class provides a visitor pattern implementation for traversing catalog
+    structures and dispatching processing to specific node handlers. It serves
+    as the foundation for more specialized executors that manipulate catalog
+    metadata, schema properties, and selection rules.
+
+    The executor processes three types of catalog nodes:
+    - Stream nodes: Top-level catalog entries representing data streams
+    - Property nodes: Schema property definitions within streams
+    - Metadata nodes: Selection and inclusion metadata for streams and properties
+
+    Subclasses should override the specific node processing methods to implement
+    their custom catalog manipulation logic.
+    """
+
     def execute(self, node_type: CatalogNode, node: Node, path: str) -> None:
         """Dispatch all node methods."""
         dispatch = {
@@ -395,13 +469,26 @@ class CatalogExecutor:  # noqa: D101
     def property_metadata_node(self, node: Node, path: str) -> None:
         """Process property metadata node."""
 
-    def __call__(self, node_type, node: Node, path: str):  # noqa: ANN001, ANN204
+    def __call__(self, node_type: CatalogNode, node: Node, path: str) -> None:
         """Call this instance as a function."""
         return self.execute(node_type, node, path)
 
 
-class MetadataExecutor(CatalogExecutor):  # noqa: D101
-    def __init__(self, rules: list[MetadataRule]):  # noqa: D107
+class MetadataExecutor(CatalogExecutor):
+    """Executor for applying metadata rules to catalog streams and properties.
+
+    This executor processes metadata rules that control stream and property selection,
+    inclusion settings, and other metadata attributes in Singer catalogs. It ensures
+    proper metadata structure exists and applies rule-based transformations to
+    control data extraction behavior.
+
+    The executor automatically creates missing metadata entries with appropriate
+    default inclusion settings (automatic for streams and top-level properties,
+    available for nested properties).
+    """
+
+    def __init__(self, rules: list[MetadataRule]):
+        """Initialize the MetadataExecutor with a list of metadata rules."""
         self._stream: Node | None = None
         self._rules = rules
 
@@ -434,6 +521,7 @@ class MetadataExecutor(CatalogExecutor):  # noqa: D101
 
             metadata_list.append(entry)
 
+    @override
     def stream_node(self, node: Node, path: str) -> None:
         """Process stream metadata node."""
         self._stream = node
@@ -448,17 +536,19 @@ class MetadataExecutor(CatalogExecutor):  # noqa: D101
             # Legacy catalogs have underscorized keys on the streams themselves
             self.set_metadata(node, path, rule.key.replace("-", "_"), rule.value)
 
+    @override
     def property_node(
         self,
-        node: Node,  # noqa: ARG002
+        node: Node,
         path: str,
     ) -> None:
         """Process property metadata node."""
-        breadcrumb_idx = path.index("properties")
-        breadcrumb = path[breadcrumb_idx:].split(".")
+        breadcrumb_idx = path.index(PROPERTIES_KEY)
+        breadcrumb = path[breadcrumb_idx:].split(PROP_DELIMITER)
 
         self.ensure_metadata(breadcrumb)
 
+    @override
     def metadata_node(self, node: Node, path: str) -> None:
         """Process metadata node."""
         tap_stream_id = self._stream["tap_stream_id"]  # type: ignore[index]
@@ -482,9 +572,9 @@ class MetadataExecutor(CatalogExecutor):  # noqa: D101
         """Set selection and inclusion keys in a metadata node."""
         # Unsupported fields cannot be selected
         if (
-            key == "selected"
+            key == SELECTED_KEY
             and value is True
-            and node.get("inclusion") == "unsupported"
+            and node.get(INCLUSION_KEY) == SelectionType.UNSUPPORTED
         ):
             return
 
@@ -492,19 +582,55 @@ class MetadataExecutor(CatalogExecutor):  # noqa: D101
         logger.debug("Setting '%s.%s' to '%s'", path, key, value)
 
 
-class SelectExecutor(MetadataExecutor):  # noqa: D101
-    def __init__(self, patterns: list[str]):  # noqa: D107
+class SelectExecutor(MetadataExecutor):
+    """Executor for applying stream and property selection patterns to catalog metadata.
+
+    This executor processes selection patterns (e.g., 'users', '!orders.id', 'products.*')
+    and applies the corresponding metadata rules to mark streams and properties as
+    selected or excluded in the catalog. It extends MetadataExecutor to handle the
+    conversion of pattern-based selections into catalog metadata entries.
+
+    Selection patterns support:
+    - Stream selection: 'stream_name' selects entire streams
+    - Property selection: 'stream.property' selects specific properties
+    - Wildcards: 'stream.*' selects all properties in a stream
+    - Exclusion: '!pattern' excludes matching streams/properties
+    """  # noqa: E501
+
+    def __init__(self, patterns: list[str]):
+        """Initialize the SelectExecutor with a list of selection patterns.
+
+        Args:
+            patterns: List of selection patterns to apply to the catalog.
+        """
         super().__init__(select_metadata_rules(patterns))
 
 
-class SchemaExecutor(CatalogExecutor):  # noqa: D101
-    def __init__(self, rules: list[SchemaRule]):  # noqa: D107
+class SchemaExecutor(CatalogExecutor):
+    """Executor for applying schema modifications to catalog property definitions.
+
+    This executor processes schema rules that modify the JSON schema definitions
+    of catalog properties. It can add, update, or replace schema properties based
+    on breadcrumb patterns and payload definitions, allowing for dynamic schema
+    customization during catalog processing.
+
+    The executor ensures that property nodes exist in the catalog schema tree
+    before applying modifications, creating intermediate nodes as needed. It supports
+    wildcard matching in breadcrumb patterns for bulk schema operations.
+    """
+
+    def __init__(self, rules: list[SchemaRule]):
+        """Initialize the SchemaExecutor with a list of schema rules.
+
+        Args:
+            rules: List of schema rules to apply to the catalog.
+        """
         self._stream: Node | None = None
         self._rules = rules
 
     def ensure_property(self, breadcrumb: list[str]) -> None:
         """Create nodes for the breadcrumb and schema extra that matches."""
-        next_node: dict[str, t.Any] = self._stream["schema"]  # type: ignore[index]
+        next_node: dict[str, t.Any] = self._stream[SCHEMA_KEY]  # type: ignore[index]
 
         for idx, key in enumerate(breadcrumb):
             # If the key contains shell-style wildcards,
@@ -525,27 +651,27 @@ class SchemaExecutor(CatalogExecutor):  # noqa: D101
 
             next_node = next_node[key]
 
+    @override
     def stream_node(
         self,
         node: Node,
-        path,  # noqa: ANN001, ARG002
+        path: str,
     ) -> None:
         """Process stream schema node."""
         self._stream = node
         tap_stream_id: str = self._stream["tap_stream_id"]
-
-        if "schema" not in node:
-            node["schema"] = {"type": "object"}
+        node.setdefault(SCHEMA_KEY, {"type": "object"})
 
         for rule in SchemaRule.matching(self._rules, tap_stream_id):
             self.ensure_property(rule.breadcrumb)
 
+    @override
     def property_node(self, node: Node, path: str) -> None:
         """Process property schema node."""
         tap_stream_id = self._stream["tap_stream_id"]  # type: ignore[index]
 
-        breadcrumb_idx = path.index("properties")
-        breadcrumb = path[breadcrumb_idx:].split(".")
+        breadcrumb_idx = path.index(PROPERTIES_KEY)
+        breadcrumb = path[breadcrumb_idx:].split(PROP_DELIMITER)
 
         for rule in SchemaRule.matching(self._rules, tap_stream_id, breadcrumb):
             self.set_payload(node, path, rule.payload)
@@ -557,26 +683,39 @@ class SchemaExecutor(CatalogExecutor):  # noqa: D101
         logger.debug("Setting '%s' to %r", path, payload)
 
 
-class ListExecutor(CatalogExecutor):  # noqa: D101
-    def __init__(self) -> None:  # noqa: D107
+class ListExecutor(CatalogExecutor):
+    """Executor for cataloging available streams and properties in a catalog.
+
+    This executor traverses the catalog structure to build a comprehensive
+    inventory of all available streams and their properties. It creates a
+    mapping of stream names to sets of property paths, providing visibility
+    into the complete catalog structure without regard to selection status.
+
+    Useful for discovery operations and catalog introspection tasks.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the ListExecutor."""
         # properties per stream
         self.properties: dict[str, set[str]] = {}
 
         super().__init__()
 
+    @override
     def stream_node(
         self,
         node: Node,
-        path: str,  # noqa: ARG002
+        path: str,
     ) -> None:
         """Initialize empty property set stream."""
         stream = node["tap_stream_id"]
         if stream not in self.properties:
             self.properties[stream] = set()
 
+    @override
     def property_node(
         self,
-        node: Node,  # noqa: ARG002
+        node: Node,
         path: str,
     ) -> None:
         """Add property to stream collection."""
@@ -593,8 +732,21 @@ class SelectedNode(t.NamedTuple):
     selection: SelectionType
 
 
-class ListSelectedExecutor(CatalogExecutor):  # noqa: D101
-    def __init__(self) -> None:  # noqa: D107
+class ListSelectedExecutor(CatalogExecutor):
+    """Executor for identifying selected streams and properties in a catalog.
+
+    This executor analyzes catalog metadata to determine which streams and
+    properties are currently selected for extraction. It processes selection
+    and inclusion metadata to build collections of selected nodes, distinguishing
+    between different selection types (selected, automatic, excluded, unsupported).
+
+    The executor maintains separate collections for streams and properties,
+    allowing consumers to query the current selection state and filter
+    catalogs based on selection criteria.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the ListSelectedExecutor."""
         self.streams: set[SelectedNode] = set()
         self.properties: dict[str, set[SelectedNode]] = {}
         super().__init__()
@@ -631,42 +783,45 @@ class ListSelectedExecutor(CatalogExecutor):  # noqa: D101
         except KeyError:
             return SelectionType.EXCLUDED
 
-        if metadata.get("inclusion") == "automatic":
+        if metadata.get(INCLUSION_KEY) == SelectionType.AUTOMATIC:
             return SelectionType.AUTOMATIC
-        if metadata.get("inclusion") == "unsupported":
+        if metadata.get(INCLUSION_KEY) == SelectionType.UNSUPPORTED:
             return SelectionType.UNSUPPORTED
-        if metadata.get("selected") is True or (
-            metadata.get("selected") is None
-            and metadata.get("selected-by-default", False)
+        if metadata.get(SELECTED_KEY) is True or (
+            metadata.get(SELECTED_KEY) is None
+            and metadata.get(SELECTED_BY_DEFAULT_KEY, False)
         ):
             return SelectionType.SELECTED
         return SelectionType.EXCLUDED
 
+    @override
     def stream_node(
         self,
         node: Node,
-        path: str,  # noqa: ARG002
+        path: str,
     ) -> None:
         """Initialize empty set for selected nodes in stream."""
         self._stream: str = node["tap_stream_id"]
         self.properties[self._stream] = set()
 
+    @override
     def stream_metadata_node(
         self,
         node: Node,
-        path: str,  # noqa: ARG002
+        path: str,
     ) -> None:
         """Add stream selection to tap's collection."""
         selection = SelectedNode(self._stream, self.node_selection(node))
         self.streams.add(selection)
 
+    @override
     def property_metadata_node(
         self,
         node: Node,
-        path: str,  # noqa: ARG002
+        path: str,
     ) -> None:
         """Add property selection to stream's collection."""
-        property_path = ".".join(node["breadcrumb"])
+        property_path = PROP_DELIMITER.join(node["breadcrumb"])
         prop = path_property(property_path)
         selection = SelectedNode(prop, self.node_selection(node))
 

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import typing as t
 
 import pytest
 
 from meltano.core.plugin.singer.catalog import (
+    SELECTED_KEY,
     CatalogRule,
     ListExecutor,
     ListSelectedExecutor,
@@ -14,9 +16,13 @@ from meltano.core.plugin.singer.catalog import (
     SchemaRule,
     SelectExecutor,
     SelectionType,
+    SelectPattern,
     path_property,
+    select_filter_metadata_rules,
+    select_metadata_rules,
     visit,
 )
+from meltano.core.plugin.singer.catalog import property_breadcrumb as bc
 
 LEGACY_CATALOG = """
 {
@@ -942,7 +948,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ),
         indirect=["catalog"],
     )
-    def test_select(self, catalog, attrs) -> None:
+    def test_select(self, catalog: dict[str, t.Any], attrs: set[str]) -> None:
         selector = SelectExecutor(
             [
                 "UniqueEntitiesName.code",
@@ -975,7 +981,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         ),
         indirect=["catalog"],
     )
-    def test_select_escaped(self, catalog, attrs) -> None:
+    def test_select_escaped(self, catalog: dict[str, t.Any], attrs: set[str]) -> None:
         selector = SelectExecutor(
             [
                 "Unique\\.Entities\\.Name.code",
@@ -1107,6 +1113,10 @@ class TestSelectionType:
         assert f"{SelectionType.EXCLUDED}" == "excluded"
         assert f"{SelectionType.AUTOMATIC}" == "automatic"
         assert f"{SelectionType.SELECTED}" == "selected"
+
+    def test_selection_type_addition_not_implemented(self) -> None:
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            SelectionType.SELECTED + "foo"
 
 
 class TestMetadataExecutor:
@@ -1266,3 +1276,171 @@ class TestListExecutor:
                 "payload.timestamp",
             },
         }
+
+
+class TestSelectPattern:
+    def test_parse(self) -> None:
+        parse = SelectPattern.parse
+        assert parse("users") == SelectPattern(
+            stream_pattern="users",
+            property_pattern=None,
+            negated=False,
+            raw="users",
+        )
+        assert parse("users.id") == SelectPattern(
+            stream_pattern="users",
+            property_pattern="id",
+            negated=False,
+            raw="users.id",
+        )
+        assert parse("users.*") == SelectPattern(
+            stream_pattern="users",
+            property_pattern="*",
+            negated=False,
+            raw="users.*",
+        )
+        assert parse("!users") == SelectPattern(
+            stream_pattern="users",
+            property_pattern=None,
+            negated=True,
+            raw="!users",
+        )
+        assert parse("!users.*") == SelectPattern(
+            stream_pattern="users",
+            property_pattern="*",
+            negated=True,
+            raw="!users.*",
+        )
+        assert parse("!users.id") == SelectPattern(
+            stream_pattern="users",
+            property_pattern="id",
+            negated=True,
+            raw="!users.id",
+        )
+
+
+class TestMetadataRule:
+    @pytest.mark.parametrize(
+        ("patterns", "targets"),
+        (
+            pytest.param(
+                ("my_stream.*",),
+                [
+                    ("my_stream", None),
+                    ("my_stream", bc(["prop"])),
+                ],
+                id="select all properties of a stream",
+            ),
+            pytest.param(
+                ("my\\.stream.*",),
+                [
+                    ("my.stream", None),
+                    ("my.stream", bc(["prop"])),
+                ],
+                id="escape stream with a dot",
+            ),
+            pytest.param(
+                ("my_stream.prop.*",),
+                [
+                    ("my_stream", None),
+                    ("my_stream", bc(["prop", "sub_prop"])),
+                ],
+                id="select all sub-properties of a property",
+            ),
+            pytest.param(
+                ("my_stream.prop.*",),
+                [
+                    ("my_stream", None),
+                    ("my_stream", bc(["prop"])),
+                    ("my_stream", bc(["prop", "sub_prop"])),
+                ],
+                id="auto-select parent property when selecting sub-properties",
+                marks=(
+                    pytest.mark.xfail(
+                        reason=(
+                            "Selecting sub-properties does not imply selecting the "
+                            "parent property"
+                        ),
+                        strict=True,
+                    ),
+                ),
+            ),
+            pytest.param(
+                ("my_stream.prop.*.*",),
+                [
+                    ("my_stream", None),
+                    ("my_stream", bc(["prop"])),
+                    ("my_stream", bc(["prop", "sub_prop"])),
+                    ("my_stream", bc(["prop", "sub_prop", "sub_sub_prop"])),
+                ],
+                id="auto-select parent property when selecting all sub-properties",
+                marks=(
+                    pytest.mark.xfail(
+                        reason=(
+                            "Selecting sub-properties does not imply selecting the "
+                            "parent property"
+                        ),
+                        strict=True,
+                    ),
+                ),
+            ),
+        ),
+    )
+    def test_select_metadata_rules_matches(
+        self,
+        patterns: tuple[str],
+        targets: list[tuple[str, list[str] | None]],
+    ) -> None:
+        rules = select_metadata_rules(patterns)
+        assert all(rule.key == SELECTED_KEY and rule.value is True for rule in rules)
+        assert all(
+            any(rule.match(stream, breadcrumb) for rule in rules)
+            for stream, breadcrumb in targets
+        )
+
+    @pytest.mark.parametrize(
+        ("patterns", "matches"),
+        (
+            pytest.param(
+                # Equivalent to excluding all streams other than `my_stream`
+                ("my_stream",),
+                [
+                    ("my_stream", None, False),
+                    ("other_stream", None, True),
+                ],
+                id="select one stream",
+            ),
+            pytest.param(
+                # Equivalent to excluding all streams other than `stream_1` and
+                # `stream_2`
+                ("stream_1", "stream_2"),
+                [
+                    ("stream_1", None, False),
+                    ("stream_2", None, False),
+                    ("other_stream", None, True),
+                ],
+                id="select two stream",
+            ),
+            pytest.param(
+                # Equivalent to excluding `my_stream`
+                ("!my_stream",),
+                [
+                    ("my_stream", None, True),
+                    ("other_stream", None, False),
+                ],
+                id="exclude one stream",
+            ),
+        ),
+    )
+    def test_select_filter_metadata_rules_matches(
+        self,
+        patterns: tuple[str],
+        matches: list[tuple[str, list[str] | None, bool]],
+    ) -> None:
+        rules = select_filter_metadata_rules(patterns)
+        assert all(rule.key == SELECTED_KEY and rule.value is False for rule in rules)
+        assert all(
+            rule.match(stream, breadcrumb) is match
+            for rule in rules
+            for stream, breadcrumb, match in matches
+        )


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor Singer catalog manipulation by introducing constants, improving type hints, and enriching code documentation, alongside expanded test coverage for selection patterns and metadata rules.

Enhancements:
- Introduce constants for catalog field names and property delimiters to eliminate magic strings
- Refactor code to leverage TypeAlias, override decorator, and conditional typing imports for Python version compatibility
- Add comprehensive docstrings for node types, executors, and visitor functions to clarify catalog traversal and processing
- Unify path handling by using PROP_DELIMITER across catalog matching, parsing, and breadcrumb construction

Tests:
- Add tests for SelectPattern.parse covering various stream and property patterns with negation
- Extend tests for select_metadata_rules to verify rule matching behavior
- Add tests for select_filter_metadata_rules to ensure correct exclusion rule generation