### PR TITLE
chore: Update syntax for Python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ testing = [
   "time-machine>=2.15.0,<3",
 ]
 typing = [
+  { include-group = "testing" },
   "boto3-stubs[essential]>=1.35,<1.39",
   "mypy>=1.16.0,<2",
   "types-dateparser>=1.2.0.20250208",
@@ -324,7 +325,7 @@ build-backend = "hatchling.build"
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 ignore = [

--- a/src/meltano/core/_types.py
+++ b/src/meltano/core/_types.py
@@ -3,4 +3,4 @@ from __future__ import annotations
 import os
 import typing as t
 
-StrPath: t.TypeAlias = t.Union[str, os.PathLike[str]]
+StrPath: t.TypeAlias = str | os.PathLike[str]

--- a/src/meltano/core/behavior/canonical.py
+++ b/src/meltano/core/behavior/canonical.py
@@ -171,9 +171,9 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
                 return as_commented_map
             return as_dict
 
-        if isinstance(target, (list, set, CommentedSet)):
+        if isinstance(target, list | set | CommentedSet):
             as_list = [cls._canonize(val) for val in target]
-            if isinstance(target, (CommentedSet, CommentedSeq)):
+            if isinstance(target, CommentedSet | CommentedSeq):
                 as_commented_seq = CommentedSeq(as_list)
                 target.copy_attributes(as_commented_seq)
                 return as_commented_seq

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -411,7 +411,7 @@ class Job(SystemModel):
         if isinstance(err, SystemExit):
             return "The process was terminated"
 
-        if isinstance(err, (KeyboardInterrupt, asyncio.CancelledError)):
+        if isinstance(err, KeyboardInterrupt | asyncio.CancelledError):
             return "The process was interrupted"
 
         if str(err):

--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -22,7 +22,7 @@ from meltano.core.runner import RunnerError
 from .formatters import get_default_foreign_pre_chain
 from .utils import capture_subprocess_output
 
-StrPath: t.TypeAlias = t.Union[str, os.PathLike[str]]
+StrPath: t.TypeAlias = str | os.PathLike[str]
 
 
 class OutputLogger:

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -344,7 +344,7 @@ class SettingDefinition(NameEq, Canonical):
             kind = SettingKind.BOOLEAN
         elif isinstance(value, int):
             kind = SettingKind.INTEGER
-        elif isinstance(value, (Decimal, float)):
+        elif isinstance(value, Decimal | float):
             kind = SettingKind.DECIMAL
         elif isinstance(value, dict):
             kind = SettingKind.OBJECT
@@ -477,7 +477,7 @@ class SettingDefinition(NameEq, Canonical):
         Raises:
             ValueError: If value is not of the expected type.
         """
-        value = value.isoformat() if isinstance(value, (date, datetime)) else value
+        value = value.isoformat() if isinstance(value, date | datetime) else value
 
         if isinstance(value, str):
             if self.kind == SettingKind.BOOLEAN:

--- a/src/meltano/core/sqlalchemy.py
+++ b/src/meltano/core/sqlalchemy.py
@@ -73,7 +73,7 @@ class IntFlag(TypeDecorator):  # noqa: D101
         return int(value) if value is not None else value
 
 
-class GUID(TypeDecorator[t.Union[uuid.UUID, str]]):
+class GUID(TypeDecorator[uuid.UUID | str]):
     """Platform-independent GUID type.
 
     Uses PostgreSQL's UUID type, otherwise uses

--- a/src/meltano/core/tracking/contexts/cli.py
+++ b/src/meltano/core/tracking/contexts/cli.py
@@ -72,7 +72,7 @@ class CliContext(SelfDescribingJson):
         """
         options = {
             key: val
-            if isinstance(val, (bool, int, float)) or val is None
+            if isinstance(val, bool | int | float) or val is None
             else hash_sha256(repr(val))
             for key, val in ctx.params.items()
         }

--- a/src/meltano/core/tracking/contexts/exception.py
+++ b/src/meltano/core/tracking/contexts/exception.py
@@ -19,7 +19,7 @@ if t.TYPE_CHECKING:
 
 BASE_PATHS = (sys.prefix, sys.exec_prefix, sys.base_prefix, sys.base_exec_prefix)
 
-TracebackLevelsJSON = list[dict[str, t.Union[str, int]]]
+TracebackLevelsJSON = list[dict[str, str | int]]
 ExceptionContextJSON = dict[
     str,
     t.Union[str, TracebackLevelsJSON, "ExceptionContextJSON"],

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -413,7 +413,7 @@ class Tracker:  # - too many (public) methods
                     else tuple(
                         ctx
                         for ctx in self.contexts
-                        if isinstance(ctx, (EnvironmentContext, ProjectContext))
+                        if isinstance(ctx, EnvironmentContext | ProjectContext)
                     ),
                 ),
             )

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -527,7 +527,7 @@ def expand_env_vars(
     """
     if_missing = EnvVarMissingBehavior(if_missing)
 
-    if not isinstance(raw_value, (str, Mapping, list)):
+    if not isinstance(raw_value, str | Mapping | list):
         return raw_value
 
     def replacer(match: re.Match) -> str:
@@ -568,7 +568,7 @@ def _expand_env_vars(
             return {k: ENV_VAR_PATTERN.sub(replacer, v) for k, v in raw_value.items()}
         return {
             k: _expand_env_vars(v, replacer, flat=flat)
-            if isinstance(v, (str, Mapping, list))
+            if isinstance(v, str | Mapping | list)
             else v
             for k, v in raw_value.items()
         }
@@ -577,7 +577,7 @@ def _expand_env_vars(
         # for lists anyway, so we don't support it here.
         return [
             _expand_env_vars(v, replacer, flat=flat)
-            if isinstance(v, (str, Mapping, list))
+            if isinstance(v, str | Mapping | list)
             else v
             for v in raw_value
         ]

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -39,7 +39,7 @@ else:
 
 logger = structlog.stdlib.get_logger(__name__)
 
-StdErrExtractor: t.TypeAlias = Callable[[Process], Awaitable[t.Union[str, None]]]
+StdErrExtractor: t.TypeAlias = Callable[[Process], Awaitable[str | None]]
 
 
 @cache

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -17,23 +17,16 @@ import time_machine
 
 from meltano.core.logging import formatters
 
-if sys.version_info < (3, 11):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias  # noqa: ICN003
-
 if t.TYPE_CHECKING:
     from pathlib import Path
 
 ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
-ExcInfo: TypeAlias = t.Union[
-    tuple[type[BaseException], BaseException, TracebackType],
-    tuple[None, None, None],
-]
+ExcInfo: t.TypeAlias = tuple[type[BaseException], BaseException, TracebackType]
+OptExcInfo: t.TypeAlias = ExcInfo | tuple[None, None, None]
 
 
 @pytest.fixture
-def exc_info() -> ExcInfo:
+def exc_info() -> OptExcInfo:
     """Fake a valid exc_info."""
     my_var = "my_value"  # noqa: F841
     try:
@@ -43,7 +36,7 @@ def exc_info() -> ExcInfo:
 
 
 @pytest.fixture
-def deep_exc_info() -> ExcInfo:
+def deep_exc_info() -> OptExcInfo:
     """Create a deeper call stack for testing max_frames."""
 
     def level_5():

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -1319,7 +1319,7 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
         assert len(stream_only_rules) == len(stream_star_rules) == 2
 
         # Both should create identical rules
-        for rule1, rule2 in zip(stream_only_rules, stream_star_rules):
+        for rule1, rule2 in zip(stream_only_rules, stream_star_rules, strict=False):
             assert rule1.tap_stream_id == rule2.tap_stream_id
             assert rule1.breadcrumb == rule2.breadcrumb
             assert rule1.key == rule2.key

--- a/uv.lock
+++ b/uv.lock
@@ -1032,7 +1032,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1311,7 +1311,23 @@ testing = [
 ]
 typing = [
     { name = "boto3-stubs", extra = ["essential"] },
+    { name = "colorama" },
+    { name = "coverage", extra = ["toml"] },
+    { name = "faker" },
+    { name = "moto" },
     { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-docker" },
+    { name = "pytest-order" },
+    { name = "pytest-randomly" },
+    { name = "pytest-structlog" },
+    { name = "pytest-subtests" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "requests-mock" },
+    { name = "setproctitle" },
+    { name = "time-machine" },
     { name = "types-dateparser" },
     { name = "types-jsonschema" },
     { name = "types-psutil" },
@@ -1412,7 +1428,23 @@ testing = [
 ]
 typing = [
     { name = "boto3-stubs", extras = ["essential"], specifier = ">=1.35,<1.39" },
+    { name = "colorama", specifier = ">=0.4.4,<0.5" },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.10" },
+    { name = "faker", specifier = ">=37.4.2" },
+    { name = "moto", specifier = ">=5.0.21,<6" },
     { name = "mypy", specifier = ">=1.16.0,<2" },
+    { name = "pytest", specifier = ">=8.3.3,<9" },
+    { name = "pytest-asyncio", specifier = ">=1" },
+    { name = "pytest-docker", specifier = "~=3.1" },
+    { name = "pytest-order", specifier = "~=1.3" },
+    { name = "pytest-randomly", specifier = "~=3.16" },
+    { name = "pytest-structlog", specifier = "~=1.1" },
+    { name = "pytest-subtests", specifier = ">=0.14.2" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = "~=3.6" },
+    { name = "requests-mock", specifier = ">=1.12.1,<2" },
+    { name = "setproctitle", specifier = "~=1.3" },
+    { name = "time-machine", specifier = ">=2.15.0,<3" },
     { name = "types-dateparser", specifier = ">=1.2.0.20250208" },
     { name = "types-jsonschema", specifier = ">=4.23.0.20240813,<5" },
     { name = "types-psutil", specifier = ">=7.0.0.20250218,<8" },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update the codebase to leverage Python 3.10+ typing features, simplify type checks, and bump linting target.

Enhancements:
- Use native union types (X|Y) instead of typing.Union and pattern-match type hints with new syntax
- Replace typing_extensions.TypeAlias import and typing.TypeAlias with built-in TypeAlias
- Refactor isinstance checks to use the | union syntax

Build:
- Update ruff target-version from py39 to py310
- Include testing group in the typing requirements in pyproject.toml

Tests:
- Adjust test fixtures to use the new optional exception info type alias
- Update zip call in test to use strict=False for Python 3.10 compatibility