### PR TITLE
packaging: Require Click 8.2+ and use new generic `click.Choice` support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "anyio>=4.4.0,<5",
   "backports-strenum>=1.3.1,<2 ; python_version < '3.11'",
   "check-jsonschema~=0.33.0",
-  "click>=8.1,<8.3,!=8.2.2",
+  "click>=8.2,<8.3,!=8.2.2",
   "click-default-group>=1.2.4,<2",
   "click-didyoumean>=0.3.1,<0.4",
   "dateparser>=1.2.1",

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -63,7 +63,7 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
 )
 @click.option(
     "--log-format",
-    type=click.Choice(tuple(LogFormat)),
+    type=click.Choice(LogFormat),
     help="A shortcut for setting the format of the log output.",
 )
 @click.option(

--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -118,11 +118,9 @@ class ELOptions:
     )
     state_strategy = click.option(
         "--state-strategy",
-        # TODO: use click.Choice(StateStrategy) once we drop support for Python 3.9 and
-        # use click 8.2+ exclusively
-        type=click.Choice([strategy.value for strategy in StateStrategy]),
+        type=click.Choice(StateStrategy),
         help="Strategy to use for state updates.",
-        default=StateStrategy.AUTO.value,
+        default=StateStrategy.auto.value,
     )
     run_id = click.option(
         "--run-id",

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -91,10 +91,8 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
 )
 @click.option(
     "--state-strategy",
-    # TODO: use click.Choice(StateStrategy) once we drop support for Python 3.9 and use
-    # click 8.2+ exclusively
-    type=click.Choice([strategy.value for strategy in StateStrategy]),
-    default=StateStrategy.AUTO.value,
+    type=click.Choice(StateStrategy),
+    default=StateStrategy.auto.value,
     help="Strategy to use for state updates.",
 )
 @click.option(

--- a/src/meltano/core/_protocols/el_context.py
+++ b/src/meltano/core/_protocols/el_context.py
@@ -16,8 +16,8 @@ class ELContextProtocol(t.Protocol):
         """Check whether the EL state is incomplete and should be merged."""
         return (
             self.full_refresh is True  # Full refresh implies merging states
-            and self.state_strategy == StateStrategy.AUTO
-        ) or self.state_strategy == StateStrategy.MERGE
+            and self.state_strategy == StateStrategy.auto
+        ) or self.state_strategy == StateStrategy.merge
 
     def should_refresh_catalog(self) -> bool:
         """Check whether the catalog should be refreshed or used from cache."""

--- a/src/meltano/core/_state.py
+++ b/src/meltano/core/_state.py
@@ -16,9 +16,9 @@ logger = structlog.stdlib.get_logger()
 class StateStrategy(StrEnum):
     """Strategy to use for state management."""
 
-    AUTO = enum.auto()
-    MERGE = enum.auto()
-    OVERWRITE = enum.auto()
+    auto = enum.auto()
+    merge = enum.auto()
+    overwrite = enum.auto()
 
     @classmethod
     def from_cli_args(
@@ -27,7 +27,7 @@ class StateStrategy(StrEnum):
         merge_state: bool,
         state_strategy: str,
     ) -> StateStrategy:
-        if merge_state and state_strategy != StateStrategy.AUTO.value:
+        if merge_state and state_strategy != StateStrategy.auto.value:
             import click
 
             msg = "Cannot use both --merge-state and --state-strategy"
@@ -38,6 +38,6 @@ class StateStrategy(StrEnum):
                 "The --merge-state option is deprecated and will be removed in a "
                 "future version. Use --state-strategy=merge instead.",
             )
-            return StateStrategy.MERGE
+            return StateStrategy.merge
 
         return StateStrategy(state_strategy)

--- a/src/meltano/core/block/block_parser.py
+++ b/src/meltano/core/block/block_parser.py
@@ -80,7 +80,7 @@ class BlockParser:  # noqa: D101
         no_state_update: bool | None = False,
         force: bool | None = False,
         state_id_suffix: str | None = None,
-        state_strategy: StateStrategy = StateStrategy.AUTO,
+        state_strategy: StateStrategy = StateStrategy.auto,
         run_id: uuid.UUID | None = None,
     ):
         """Parse a meltano run command invocation into a list of blocks.

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -61,7 +61,7 @@ class ELBContext(ELContextProtocol):
         update_state: bool | None = True,
         state_id_suffix: str | None = None,
         base_output_logger: OutputLogger | None = None,
-        state_strategy: StateStrategy = StateStrategy.AUTO,
+        state_strategy: StateStrategy = StateStrategy.auto,
         run_id: uuid.UUID | None = None,
     ):
         """Use an ELBContext to pass information on to ExtractLoadBlocks.
@@ -123,7 +123,7 @@ class ELBContextBuilder:
         self._state_id_suffix = None
         self._env = {}
         self._blocks = []
-        self._state_strategy = StateStrategy.AUTO
+        self._state_strategy = StateStrategy.auto
         self._run_id: uuid.UUID | None = None
 
         self._base_output_logger = None

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -106,7 +106,7 @@ class ELTContext(ELContextProtocol):
         catalog: str | None = None,
         state: str | None = None,
         base_output_logger: OutputLogger | None = None,
-        state_strategy: StateStrategy = StateStrategy.AUTO,
+        state_strategy: StateStrategy = StateStrategy.auto,
         run_id: uuid.UUID | None = None,
     ):
         """Initialise ELT Context instance.
@@ -246,7 +246,7 @@ class ELTContextBuilder:
         self._catalog: str | None = None
         self._state: str | None = None
         self._base_output_logger: OutputLogger | None = None
-        self._state_strategy: StateStrategy = StateStrategy.AUTO
+        self._state_strategy: StateStrategy = StateStrategy.auto
 
     def with_session(self, session: Session) -> ELTContextBuilder:
         """Include session when building context.

--- a/tests/meltano/core/protocols/test_el_context.py
+++ b/tests/meltano/core/protocols/test_el_context.py
@@ -15,7 +15,7 @@ if t.TYPE_CHECKING:
 @dataclass
 class MyContext(ELContextProtocol):
     full_refresh: bool | None = None
-    state_strategy: StateStrategy = StateStrategy.AUTO
+    state_strategy: StateStrategy = StateStrategy.auto
     refresh_catalog: bool | None = None
 
 
@@ -25,22 +25,22 @@ class TestELContextProtocol:
             return MyContext(full_refresh, state_strategy)
 
         with subtests.test("Full refresh & auto → merge"):
-            assert _(True, StateStrategy.AUTO).should_merge_states()
+            assert _(True, StateStrategy.auto).should_merge_states()
 
         with subtests.test("Full refresh & merge → merge"):
-            assert _(True, StateStrategy.MERGE).should_merge_states()
+            assert _(True, StateStrategy.merge).should_merge_states()
 
         with subtests.test("Full refresh & overwrite → overwrite"):
-            assert not _(True, StateStrategy.OVERWRITE).should_merge_states()
+            assert not _(True, StateStrategy.overwrite).should_merge_states()
 
         with subtests.test("Incremental & auto → overwrite"):
-            assert not _(False, StateStrategy.AUTO).should_merge_states()
+            assert not _(False, StateStrategy.auto).should_merge_states()
 
         with subtests.test("Incremental & merge → merge"):
-            assert _(False, StateStrategy.MERGE).should_merge_states()
+            assert _(False, StateStrategy.merge).should_merge_states()
 
         with subtests.test("Incremental & overwrite → overwrite"):
-            assert not _(False, StateStrategy.OVERWRITE).should_merge_states()
+            assert not _(False, StateStrategy.overwrite).should_merge_states()
 
     def test_should_refresh_catalog(self, subtests: SubTests):
         def _(full_refresh: bool, refresh_catalog: bool):

--- a/tests/meltano/core/runner/test_runner.py
+++ b/tests/meltano/core/runner/test_runner.py
@@ -170,37 +170,37 @@ class TestSingerRunner:
         (
             pytest.param(
                 True,
-                StateStrategy.AUTO,
+                StateStrategy.auto,
                 Payload.INCOMPLETE_STATE,
                 id="full-refresh-auto--incomplete-state",
             ),
             pytest.param(
                 False,
-                StateStrategy.AUTO,
+                StateStrategy.auto,
                 Payload.STATE,
                 id="incremental-auto--complete-state",
             ),
             pytest.param(
                 True,
-                StateStrategy.OVERWRITE,
+                StateStrategy.overwrite,
                 Payload.STATE,
                 id="full-refresh-overwrite--complete-state",
             ),
             pytest.param(
                 False,
-                StateStrategy.OVERWRITE,
+                StateStrategy.overwrite,
                 Payload.STATE,
                 id="incremental-overwrite--complete-state",
             ),
             pytest.param(
                 True,
-                StateStrategy.MERGE,
+                StateStrategy.merge,
                 Payload.INCOMPLETE_STATE,
                 id="full-refresh-merge--incomplete-state",
             ),
             pytest.param(
                 False,
-                StateStrategy.MERGE,
+                StateStrategy.merge,
                 Payload.INCOMPLETE_STATE,
                 id="incremental-merge--incomplete-state",
             ),

--- a/tests/meltano/core/test_state_strategy.py
+++ b/tests/meltano/core/test_state_strategy.py
@@ -12,43 +12,43 @@ class TestStateStrategy:
         assert (
             StateStrategy.from_cli_args(
                 merge_state=True,
-                state_strategy=StateStrategy.AUTO.value,
+                state_strategy=StateStrategy.auto.value,
             )
-            is StateStrategy.MERGE
+            is StateStrategy.merge
         )
 
         assert (
             StateStrategy.from_cli_args(
                 merge_state=False,
-                state_strategy=StateStrategy.AUTO.value,
+                state_strategy=StateStrategy.auto.value,
             )
-            is StateStrategy.AUTO
+            is StateStrategy.auto
         )
 
         assert (
             StateStrategy.from_cli_args(
                 merge_state=False,
-                state_strategy=StateStrategy.MERGE,
+                state_strategy=StateStrategy.merge,
             )
-            is StateStrategy.MERGE
+            is StateStrategy.merge
         )
 
         assert (
             StateStrategy.from_cli_args(
                 merge_state=False,
-                state_strategy=StateStrategy.OVERWRITE,
+                state_strategy=StateStrategy.overwrite,
             )
-            is StateStrategy.OVERWRITE
+            is StateStrategy.overwrite
         )
 
         with pytest.raises(click.UsageError):
             StateStrategy.from_cli_args(
                 merge_state=True,
-                state_strategy=StateStrategy.MERGE,
+                state_strategy=StateStrategy.merge,
             )
 
         with pytest.raises(click.UsageError):
             StateStrategy.from_cli_args(
                 merge_state=True,
-                state_strategy=StateStrategy.OVERWRITE,
+                state_strategy=StateStrategy.overwrite,
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1347,7 +1347,7 @@ requires-dist = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1,<2" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35,<1.41" },
     { name = "check-jsonschema", specifier = "~=0.33.0" },
-    { name = "click", specifier = ">=8.1,!=8.2.2,<8.3" },
+    { name = "click", specifier = ">=8.2,!=8.2.2,<8.3" },
     { name = "click-default-group", specifier = ">=1.2.4,<2" },
     { name = "click-didyoumean", specifier = ">=0.3.1,<0.4" },
     { name = "dateparser", specifier = ">=1.2.1" },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Rename StateStrategy enum values to lowercase throughout the codebase, update corresponding tests, and leverage the new generic click.Choice support in CLI options by requiring click>=8.2

Enhancements:
- Rename StateStrategy enum members from uppercase to lowercase
- Use generic click.Choice support for enum types in state-strategy and log-format CLI options

Build:
- Bump click dependency to >=8.2 to enable generic click.Choice support

Tests:
- Update tests to reference renamed lowercase StateStrategy values