### PR TITLE
chore: Use `PluginTypeArg` in more places

### DIFF
--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -13,11 +13,11 @@ from meltano.cli.utils import (
     CliEnvironmentBehavior,
     CliError,
     PartialInstrumentedCmd,
+    PluginTypeArg,
     propagate_stop_signals,
 )
 from meltano.core.db import project_engine
 from meltano.core.error import AsyncSubprocessError
-from meltano.core.plugin import PluginType
 from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin_install_service import PluginInstallReason
 from meltano.core.plugin_invoker import (
@@ -31,6 +31,7 @@ from meltano.core.utils import run_async
 if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from meltano.core.plugin import PluginType
     from meltano.core.project import Project
     from meltano.core.tracking import Tracker
 
@@ -55,7 +56,7 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
 )
 @click.option(
     "--plugin-type",
-    type=click.Choice(PluginType.cli_arguments()),
+    type=PluginTypeArg(),
     default=None,
 )
 @click.option(
@@ -85,7 +86,7 @@ async def invoke(
     project: Project,
     ctx: click.Context,
     *,
-    plugin_type: str,
+    plugin_type: PluginType | None,
     dump: str,
     list_commands: bool,
     plugin_name: str,
@@ -106,14 +107,12 @@ async def invoke(
     except ValueError:
         command_name = None
 
-    ptype = PluginType.from_cli_argument(plugin_type) if plugin_type else None
-
     _, Session = project_engine(project)  # noqa: N806
     session = Session()
     try:
         plugin = project.plugins.find_plugin(
             plugin_name,
-            plugin_type=ptype,
+            plugin_type=plugin_type,
             invokable=True,
         )
         tracker.add_contexts(PluginsTrackingContext([(plugin, command_name)]))

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -8,8 +8,7 @@ import click
 import structlog
 
 from meltano.cli.params import pass_project
-from meltano.cli.utils import CliError, PartialInstrumentedCmd
-from meltano.core.plugin import PluginType
+from meltano.cli.utils import CliError, PartialInstrumentedCmd, PluginTypeArg
 from meltano.core.plugin_lock_service import (
     LockfileAlreadyExistsError,
     PluginLockService,
@@ -18,6 +17,7 @@ from meltano.core.project_plugins_service import DefinitionSource
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 if t.TYPE_CHECKING:
+    from meltano.core.plugin import PluginType
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
     from meltano.core.tracking import Tracker
@@ -36,7 +36,7 @@ logger = structlog.get_logger(__name__)
 )
 @click.option(
     "--plugin-type",
-    type=click.Choice(PluginType.cli_arguments()),
+    type=PluginTypeArg(),
     help="Lock only the plugins of the given type.",
 )
 @click.argument("plugin_name", nargs=-1, required=False)
@@ -48,7 +48,7 @@ def lock(
     ctx: click.Context,
     *,
     all_plugins: bool,
-    plugin_type: str | None,
+    plugin_type: PluginType | None,
     plugin_name: tuple[str, ...],
     update: bool,
 ) -> None:
@@ -75,8 +75,7 @@ def lock(
     if plugin_name:
         plugins = [plugin for plugin in plugins if plugin.name in plugin_name]
 
-    if plugin_type:
-        plugin_type = PluginType.from_cli_argument(plugin_type)
+    if plugin_type is not None:
         plugins = [plugin for plugin in plugins if plugin.type == plugin_type]
 
     tracked_plugins: list[tuple[ProjectPlugin, str | None]] = []


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Streamline plugin type handling in CLI commands by introducing PluginTypeArg and removing redundant manual parsing.

Enhancements:
- Use PluginTypeArg as the click type for --plugin-type in config, invoke, and lock commands
- Update plugin_type parameters to PluginType | None and eliminate manual PluginType.from_cli_argument conversions
- Simplify plugin lookup logic to filter by plugin_type directly without conditional parsing