### PR TITLE
chore: Use structural pattern matching (PEP 634) for exhaustive enum checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,9 @@ testing = [
 ]
 typing = [
   { include-group = "testing" },
+  "backports-strenum",  # TODO: Drop once the runtime dependency is dropped
   "boto3-stubs[essential]>=1.35,<1.39",
+  "importlib-metadata",  # TODO: Drop once the runtime dependency is dropped
   "mypy>=1.16.0,<2",
   "types-dateparser>=1.2.0.20250208",
   "types-jsonschema>=4.23.0.20240813,<5",

--- a/src/meltano/cli/select_entities.py
+++ b/src/meltano/cli/select_entities.py
@@ -27,20 +27,18 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
 
 def selection_color(selection: SelectionType) -> str:
     """Return the appropriate colour for given SelectionType."""
-    # TODO: Use a match statement when we drop Python 3.9 support
-    if selection is SelectionType.SELECTED:
-        return "bright_green"
-    if selection is SelectionType.AUTOMATIC:
-        return "bright_white"
-    if selection is SelectionType.EXCLUDED:
-        return "red"
-    if selection is SelectionType.UNSUPPORTED:
-        return "black"
-
-    t.assert_never(selection)
+    match selection:
+        case SelectionType.SELECTED:
+            return "bright_green"
+        case SelectionType.AUTOMATIC:
+            return "bright_white"
+        case SelectionType.EXCLUDED:
+            return "red"
+        case SelectionType.UNSUPPORTED:
+            return "black"
 
 
-def selection_mark(selection) -> str:  # noqa: ANN001
+def selection_mark(selection: SelectionType) -> str:
     """Return the mark to indicate the selection type of an attribute.
 
     Examples:

--- a/src/meltano/cli/select_entities.py
+++ b/src/meltano/cli/select_entities.py
@@ -36,6 +36,8 @@ def selection_color(selection: SelectionType) -> str:
             return "red"
         case SelectionType.UNSUPPORTED:
             return "black"
+        case _:  # pragma: no cover
+            t.assert_never(selection)
 
 
 def selection_mark(selection: SelectionType) -> str:

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -84,6 +84,8 @@ def print_added_plugin(
             action, preposition = "Updated", "in"
         case AddedPluginFlags.NOT_ADDED:
             action, preposition = "Initialized", "in"
+        case _:  # pragma: no cover
+            t.assert_never(flags)
 
     click.secho(
         f"{action} {descriptor} '{plugin.name}' {preposition} your project",

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -77,14 +77,13 @@ def print_added_plugin(
     elif reason is PluginAddedReason.REQUIRED:
         descriptor = f"required {descriptor}"
 
-    if flags == AddedPluginFlags.ADDED:
-        action, preposition = "Added", "to"
-    elif flags == AddedPluginFlags.UPDATED:
-        action, preposition = "Updated", "in"
-    elif flags == AddedPluginFlags.NOT_ADDED:
-        action, preposition = "Initialized", "in"
-    else:  # pragma: no cover
-        t.assert_never(flags)
+    match flags:
+        case AddedPluginFlags.ADDED:
+            action, preposition = "Added", "to"
+        case AddedPluginFlags.UPDATED:
+            action, preposition = "Updated", "in"
+        case AddedPluginFlags.NOT_ADDED:
+            action, preposition = "Initialized", "in"
 
     click.secho(
         f"{action} {descriptor} '{plugin.name}' {preposition} your project",

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -103,75 +103,74 @@ def default_config(
     max_frames = 100 if log_level == "DEBUG" else 2
     foreign_pre_chain = get_default_foreign_pre_chain()
 
-    if log_format == LogFormat.colored:
-        no_color = get_no_color_flag()
+    match log_format:
+        case LogFormat.colored:
+            no_color = get_no_color_flag()
 
-        if no_color:
-            formatter = rich_exception_formatter_factory(
-                no_color=True,
-                max_frames=max_frames,
-            )
-        else:
-            formatter = rich_exception_formatter_factory(
-                color_system="truecolor",
-                max_frames=max_frames,
-            )
-        formatter_config = {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(
-                colors=not no_color,
-                exception_formatter=formatter,
-            ),
-            "foreign_pre_chain": foreign_pre_chain,
-        }
-
-    elif log_format == LogFormat.json:
-        formatter_config = {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processors": [
-                structlog.processors.dict_tracebacks,
-                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                structlog.processors.JSONRenderer(),
-            ],
-            "foreign_pre_chain": foreign_pre_chain,
-        }
-    elif log_format == LogFormat.key_value:
-        formatter_config = {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.processors.KeyValueRenderer(
-                key_order=["timestamp", "level", "event", "logger"],
-            ),
-            "foreign_pre_chain": foreign_pre_chain,
-        }
-    elif log_format == LogFormat.uncolored:
-        formatter_config = {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(
-                colors=False,
-                exception_formatter=rich_exception_formatter_factory(
+            if no_color:
+                formatter = rich_exception_formatter_factory(
                     no_color=True,
                     max_frames=max_frames,
+                )
+            else:
+                formatter = rich_exception_formatter_factory(
+                    color_system="truecolor",
+                    max_frames=max_frames,
+                )
+            formatter_config = {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.dev.ConsoleRenderer(
+                    colors=not no_color,
+                    exception_formatter=formatter,
                 ),
-            ),
-            "foreign_pre_chain": foreign_pre_chain,
-        }
-    elif log_format == LogFormat.plain:
-        formatter_config = {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processors": [
-                structlog.stdlib.filter_by_level,
-                structlog.stdlib.add_logger_name,
-                structlog.stdlib.add_log_level,
-                structlog.stdlib.PositionalArgumentsFormatter(),
-                structlog.processors.StackInfoRenderer(),
-                structlog.processors.format_exc_info,
-                structlog.processors.UnicodeDecoder(),
-                lambda _logger, _name, event_dict: event_dict["event"],
-            ],
-            "foreign_pre_chain": foreign_pre_chain,
-        }
-    else:
-        t.assert_never(log_format)
+                "foreign_pre_chain": foreign_pre_chain,
+            }
+
+        case LogFormat.json:
+            formatter_config = {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processors": [
+                    structlog.processors.dict_tracebacks,
+                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                    structlog.processors.JSONRenderer(),
+                ],
+                "foreign_pre_chain": foreign_pre_chain,
+            }
+        case LogFormat.key_value:
+            formatter_config = {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.processors.KeyValueRenderer(
+                    key_order=["timestamp", "level", "event", "logger"],
+                ),
+                "foreign_pre_chain": foreign_pre_chain,
+            }
+        case LogFormat.uncolored:
+            formatter_config = {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.dev.ConsoleRenderer(
+                    colors=False,
+                    exception_formatter=rich_exception_formatter_factory(
+                        no_color=True,
+                        max_frames=max_frames,
+                    ),
+                ),
+                "foreign_pre_chain": foreign_pre_chain,
+            }
+        case LogFormat.plain:
+            formatter_config = {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processors": [
+                    structlog.stdlib.filter_by_level,
+                    structlog.stdlib.add_logger_name,
+                    structlog.stdlib.add_log_level,
+                    structlog.stdlib.PositionalArgumentsFormatter(),
+                    structlog.processors.StackInfoRenderer(),
+                    structlog.processors.format_exc_info,
+                    structlog.processors.UnicodeDecoder(),
+                    lambda _logger, _name, event_dict: event_dict["event"],
+                ],
+                "foreign_pre_chain": foreign_pre_chain,
+            }
 
     return {
         "version": 1,

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -171,6 +171,8 @@ def default_config(
                 ],
                 "foreign_pre_chain": foreign_pre_chain,
             }
+        case _:  # pragma: no cover
+            t.assert_never(log_format)
 
     return {
         "version": 1,

--- a/uv.lock
+++ b/uv.lock
@@ -1032,7 +1032,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1264,10 +1264,12 @@ coverage = [
     { name = "coverage", extra = ["toml"] },
 ]
 dev = [
+    { name = "backports-strenum" },
     { name = "boto3-stubs", extra = ["essential"] },
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
     { name = "faker" },
+    { name = "importlib-metadata" },
     { name = "moto" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1310,10 +1312,12 @@ testing = [
     { name = "time-machine" },
 ]
 typing = [
+    { name = "backports-strenum" },
     { name = "boto3-stubs", extra = ["essential"] },
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
     { name = "faker" },
+    { name = "importlib-metadata" },
     { name = "moto" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1383,10 +1387,12 @@ provides-extras = ["azure", "containers", "gcs", "mssql", "postgres", "psycopg2"
 [package.metadata.requires-dev]
 coverage = [{ name = "coverage", extras = ["toml"], specifier = ">=7.10" }]
 dev = [
+    { name = "backports-strenum" },
     { name = "boto3-stubs", extras = ["essential"], specifier = ">=1.35,<1.39" },
     { name = "colorama", specifier = ">=0.4.4,<0.5" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.10" },
     { name = "faker", specifier = ">=37.4.2" },
+    { name = "importlib-metadata" },
     { name = "moto", specifier = ">=5.0.21,<6" },
     { name = "mypy", specifier = ">=1.16.0,<2" },
     { name = "pytest", specifier = ">=8.3.3,<9" },
@@ -1427,10 +1433,12 @@ testing = [
     { name = "time-machine", specifier = ">=2.15.0,<3" },
 ]
 typing = [
+    { name = "backports-strenum" },
     { name = "boto3-stubs", extras = ["essential"], specifier = ">=1.35,<1.39" },
     { name = "colorama", specifier = ">=0.4.4,<0.5" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.10" },
     { name = "faker", specifier = ">=37.4.2" },
+    { name = "importlib-metadata" },
     { name = "moto", specifier = ">=5.0.21,<6" },
     { name = "mypy", specifier = ">=1.16.0,<2" },
     { name = "pytest", specifier = ">=8.3.3,<9" },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor enum-based conditional logic to Python 3.10’s structural pattern matching across logging and CLI modules, ensuring exhaustive handling of enum cases.

Enhancements:
- Replace nested if/elif chains for LogFormat in default_config with match/case and remove unreachable branches
- Convert selection_color in select_entities and flags handling in print_added_plugin to match/case for exhaustive enum checks

Build:
- Add backports-strenum and importlib-metadata to typing dependencies for backports compatibility