### PR TITLE
refactor: Raise a more specific exception when the configured state backend can not be found

### DIFF
--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -10,6 +10,7 @@ from structlog.stdlib import get_logger
 
 from meltano.core.behavior.addon import MeltanoAddon
 from meltano.core.db import project_engine
+from meltano.core.error import MeltanoError
 from meltano.core.state_store.base import MeltanoState, StateStoreManager
 from meltano.core.state_store.db import DBStateStoreManager
 
@@ -41,6 +42,23 @@ __all__ = [
 logger = get_logger(__name__)
 
 SYSTEMDB = "systemdb"
+
+
+class StateBackendNotFoundError(MeltanoError):
+    """No state backend found for the given scheme."""
+
+    def __init__(self, scheme: str):
+        """Create a new NoStateBackendFoundError.
+
+        Args:
+            scheme: The scheme of the StateBackend.
+        """
+        self.scheme = scheme
+        super().__init__(
+            f"No state backend found for scheme '{scheme}', available backends are: "
+            ", ".join(StateBackend.backends()),
+            instruction="Install the add-on that provides it",
+        )
 
 
 class StateBackend:
@@ -83,9 +101,7 @@ class StateBackend:
         try:
             manager = self.addon.get(self.scheme)
         except KeyError:
-            msg = f"No state backend found for scheme '{self.scheme}'. "
-            msg += "Available backends: " + ", ".join(self.backends())
-            raise ValueError(msg) from None
+            raise StateBackendNotFoundError(self.scheme) from None
 
         logger.info("Using %s add-on state backend", manager.__name__)
         return manager

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -23,6 +23,7 @@ from meltano.core.state_store import (
     DBStateStoreManager,
     MeltanoState,
     StateBackend,
+    StateBackendNotFoundError,
     state_store_manager_from_project_settings,
 )
 from meltano.core.state_store.azure import AZStorageStateStoreManager
@@ -43,7 +44,10 @@ else:
 
 def test_unknown_state_backend_scheme(project: Project):
     project.settings.set(["state_backend", "uri"], "unknown://")
-    with pytest.raises(ValueError, match="No state backend found for scheme"):
+    with pytest.raises(
+        StateBackendNotFoundError,
+        match="No state backend found for scheme",
+    ):
         state_store_manager_from_project_settings(project.settings)
 
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Raise a specialized StateBackendNotFoundError when resolving a nonexistent state backend and update tests to expect this new exception

Enhancements:
- Introduce StateBackendNotFoundError to provide a specific error when no state backend is found
- Replace generic ValueError with StateBackendNotFoundError in StateBackend.manager

Tests:
- Update test to expect StateBackendNotFoundError instead of ValueError for unknown state backend scheme