### PR TITLE
break: Change order of positional arguments of `meltano config` subcommands

### DIFF
--- a/docs/docs/guide/configuration.md
+++ b/docs/docs/guide/configuration.md
@@ -15,9 +15,9 @@ because Meltano will generate them on the fly whenever an extractor or loader is
 If the plugin you'd like to use and configure is [supported out of the box](/concepts/plugins#discoverable-plugins), Meltano already knows what settings it supports.
 If you're adding a [custom plugin](/concepts/plugins#custom-plugins), on the other hand, you will be asked to provide the names of the supported configuration options yourself.
 
-You can use [`meltano config <plugin> list`](/reference/command-line-interface#config) to list all available settings for a plugin with their names, [environment variables](#environment-variables), and current values. [`meltano config <plugin>`](/reference/command-line-interface#config) will print the current configuration in JSON format.
+You can use [`meltano config list <plugin>`](/reference/command-line-interface#config) to list all available settings for a plugin with their names, [environment variables](#environment-variables), and current values. [`meltano config print <plugin>`](/reference/command-line-interface#config) will print the current configuration in JSON format.
 
-If supported by the plugin type, its configuration can be tested using [`meltano config <plugin> test`](/reference/command-line-interface#config).
+If supported by the plugin type, its configuration can be tested using [`meltano config test <plugin>`](/reference/command-line-interface#config).
 
 Meltano itself can be configured as well. To learn more, refer to the [Settings Reference](/reference/settings).
 
@@ -26,23 +26,23 @@ Meltano itself can be configured as well. To learn more, refer to the [Settings 
 To determine the values of settings, Meltano will look in 4 main places (and one optional one), with each taking precedence over the next:
 
 1. [**Environment variables**](#configuring-settings), set through [your shell at `meltano run` runtime](/guide/integration#pipeline-specific-configuration), your project's [`.env` file](/concepts/project#env), a [scheduled pipeline's `env` dictionary](/concepts/project#schedules), or any other method.
-   - You can use [`meltano config <plugin> list`](/reference/command-line-interface#config) to list the available variable names, which typically have the format `<PLUGIN_NAME>_<SETTING_NAME>`.
+   - You can use [`meltano config list <plugin>`](/reference/command-line-interface#config) to list the available variable names, which typically have the format `<PLUGIN_NAME>_<SETTING_NAME>`.
 2. **Your [`meltano.yml` project file](/concepts/project#meltano-yml-project-file)**, under the plugin's `config` key.
    - Inside values, [environment variables can be referenced](#expansion-in-setting-values) as `$VAR` (as a single word) or `${VAR}` (inside a word).
    - Note that configuration for Meltano itself is stored at the root level of `meltano.yml`.
    - You can use [Meltano Environments](/concepts/environments) to manage different configurations depending on your testing and deployment strategy. If values for plugin settings are provided in both the top-level plugin configuration _and_ the environment-level plugin configuration, the value at the environment level will take precedence.
-3. **Your project's [system database](/concepts/project#system-database)**, which (among other things) stores configuration set using [`meltano config <plugin> set`](/reference/command-line-interface#config) when the project is [deployed as read-only](/reference/settings#project-readonly).
+3. **Your project's [system database](/concepts/project#system-database)**, which (among other things) stores configuration set using [`meltano config set <plugin>`](/reference/command-line-interface#config) when the project is [deployed as read-only](/reference/settings#project-readonly).
    - Note that configuration for Meltano itself cannot be stored in the system database.
 4. _If the plugin [inherits from another plugin](/concepts/plugins#plugin-inheritance) in your project_: **The parent plugin's own configuration**
 5. **The default `value`s** set in the plugin's [`settings` metadata](/reference/settings).
    - Definitions of [discoverable plugins](/concepts/plugins#discoverable-plugins) can be found on [Meltano Hub](/contribute/plugins#discoverable-plugins).
    - [Custom plugin definitions](/concepts/project#plugins) can be found in your [`meltano.yml` project file](/concepts/project#meltano-yml-project-file).
-   - `meltano config <plugin> list` will list the default values.
+   - `meltano config list <plugin>` will list the default values.
 
 Configuration that is _not_ environment-specific or sensitive should be stored in `meltano.yml` and checked into version
 control. Sensitive values like passwords and tokens are most appropriately stored in the environment, `.env`, or the system database.
 
-[`meltano config <plugin> set`](/reference/command-line-interface#config) will automatically store configuration in `meltano.yml` or `.env` as appropriate.
+[`meltano config set <plugin>`](/reference/command-line-interface#config) will automatically store configuration in `meltano.yml` or `.env` as appropriate.
 
 You can customize how `meltano.yml` is formatted (indentation, spacing, etc.) using Meltano's [user YAML configuration](/guide/user-yaml-config).
 
@@ -238,18 +238,18 @@ export <PLUGIN_NAME>_<SETTING_NAME>=<value>
 export TAP_GITLAB_API_URL=https://gitlab.example.com
 ```
 
-Plugins can also specify alternative variables ([aliases](#aliases) for their settings, to match existing usage or variables expected by plugin executables. You can use [`meltano config <plugin> list`](/reference/command-line-interface#config) to list all available settings for a plugin along with their variables, in order of precedence.
+Plugins can also specify alternative variables ([aliases](#aliases) for their settings, to match existing usage or variables expected by plugin executables. You can use [`meltano config list <plugin>`](/reference/command-line-interface#config) to list all available settings for a plugin along with their variables, in order of precedence.
 
 Since environment variable values are always strings, Meltano will cast values to the appropriate type before passing them on to the plugin.
 
-To verify that any environment variables you've set will be picked up by Meltano as you intended, you can test them with [`meltano config <plugin>`](/reference/command-line-interface#config) before running [`meltano run`](/reference/command-line-interface#run) or [`meltano invoke`](/reference/command-line-interface#invoke).
+To verify that any environment variables you've set will be picked up by Meltano as you intended, you can test them with [`meltano config print <plugin>`](/reference/command-line-interface#config) before running [`meltano run`](/reference/command-line-interface#run) or [`meltano invoke`](/reference/command-line-interface#invoke).
 
 To learn how to use environment variables to specify pipeline-specific configuration, refer to the [Data Integration (EL) guide](/guide/integration#pipeline-specific-configuration).
 
 #### Settings Aliases
 
 Aliases allow for configuration values to be set via one of multiple keys.
-Environment variable aliases are listed next to the canonical names for the variable in the output of the [`meltano config <plugin> list`](/reference/command-line-interface#config) command.
+Environment variable aliases are listed next to the canonical names for the variable in the output of the [`meltano config list <plugin>`](/reference/command-line-interface#config) command.
 They can be defined via the `aliases` key in a custom plugin's `settings` configuration.
 For example, the following defines a `my_custom_username` setting with aliases `custom_tap_username` and `username`:
 
@@ -282,20 +282,20 @@ The configuration setting could also be set via the [`meltano config set`](/refe
 
 ```bash
 # The canonical name
-meltano config my-custom-tap set my_custom_tap_username some_value
+meltano config set my-custom-tap my_custom_tap_username some_value
 
 # Alias 1
-meltano config my-custom-tap set custom_tap_username some_value
+meltano config set my-custom-tap custom_tap_username some_value
 
 # Alias 2
-meltano config my-custom-tap set username some_value
+meltano config set my-custom-tap username some_value
 ```
 
-To see what name or alias a setting's value is being derived from, you can run `meltano config <plugin-name> list`:
+To see what name or alias a setting's value is being derived from, you can run `meltano config list <plugin-name>`:
 
 ```shell
 $ export MY_CUSTOM_TAP_USERNAME=some_username
-$ meltano config my-custom-tap list
+$ meltano config list my-custom-tap
 2024-06-22T10:00:00Z [info     ] Environment 'dev' is active
 password [env: MY_CUSTOM_TAP_PASSWORD] current value: (redacted) (from the MY_CUSTOM_TAP_PASSWORD variable in `.env`)
 my_custom_tap_username [env: MY_CUSTOM_TAP_MY_CUSTOM_TAP_USERNAME, MY_CUSTOM_TAP_CUSTOM_TAP_USERNAME, MY_CUSTOM_TAP_USERNAME] current value: 'some_username' (from the MY_CUSTOM_TAP_USERNAME variable in the environment)
@@ -306,7 +306,7 @@ If a setting's value is being set via multiple environment variables, the result
 ```shell
 $ export MY_CUSTOM_TAP_USERNAME=some_username
 $ export MY_CUSTOM_TAP_CUSTOM_TAP_USERNAME=some_username
-$ meltano config my-custom-tap
+$ meltano config print my-custom-tap
 Setting value set via multiple environment variables: ['MY_CUSTOM_TAP_CUSTOM_TAP_USERNAME', 'MY_CUSTOM_TAP_USERNAME']
 ```
 
@@ -315,7 +315,7 @@ If the values for the multiple environment variables differ, the error message w
 ```shell
 $ export MY_CUSTOM_TAP_USERNAME=some_username
 $ export MY_CUSTOM_TAP_CUSTOM_TAP_USERNAME=some_other_username
-$ meltano config my-custom-tap
+$ meltano config print my-custom-tap
 Conflicting values for setting found in: ['MY_CUSTOM_TAP_CUSTOM_TAP_USERNAME', 'MY_CUSTOM_TAP_USERNAME']
 ```
 
@@ -333,7 +333,7 @@ The following variables can be referenced from any setting:
 
 Additionally, the following variables can be referenced from plugin settings (as opposed to [Meltano settings](/reference/settings)):
 
-- `MELTANO_<SETTING_NAME>`: Variables describing [Meltano's current configuration](/reference/settings), discoverable using [`meltano config --format=env meltano`](/reference/command-line-interface#config)
+- `MELTANO_<SETTING_NAME>`: Variables describing [Meltano's current configuration](/reference/settings), discoverable using [`meltano config print --format=env meltano`](/reference/command-line-interface#config)
 - `MELTANO_<PLUGIN_TYPE>_NAME`: The plugin's `name`, e.g. `MELTANO_EXTRACTOR_NAME` as `tap-gitlab` for extractor `tap-gitlab`
 - `MELTANO_<PLUGIN_TYPE>_NAMESPACE`: The plugin's `namespace`, e.g. `MELTANO_EXTRACTOR_NAMESPACE` as `tap_gitlab` for extractor `tap-gitlab`
 
@@ -342,7 +342,7 @@ are available to loaders and transformers that describe the extractor and loader
 When a plugin is invoked outside the context of a pipeline, these variables will be unset and any references to them will expand to empty strings.
 
 Inside the values of [plugin extras](#plugin-extras), additional variables describing the plugin's current configuration are available,
-as discoverable using [`meltano config --format=env <plugin>`](/reference/command-line-interface#config).
+as discoverable using [`meltano config print --format=env <plugin>`](/reference/command-line-interface#config).
 Generic `MELTANO_<PLUGIN_TYPE_VERB>_<SETTING_NAME>` variables can be used when the plugin name isn't known, e.g. `MELTANO_LOAD_SCHEMA` for a loader's `schema` setting.
 
 #### How to use
@@ -373,7 +373,7 @@ extractors:
 
 ### Accessing from plugins
 
-When Meltano invokes a plugin's executable as part of [`meltano run`](/reference/command-line-interface#run) or [`meltano invoke`](/reference/command-line-interface#invoke), it populates the environment with the same [variables that can be referenced from settings](#available-environment-variables), as well as those describing the plugin's current configuration (including [extras](#plugin-extras)), as discoverable using [`meltano config --format=env <plugin>`](/reference/command-line-interface#config).
+When Meltano invokes a plugin's executable as part of [`meltano run`](/reference/command-line-interface#run) or [`meltano invoke`](/reference/command-line-interface#invoke), it populates the environment with the same [variables that can be referenced from settings](#available-environment-variables), as well as those describing the plugin's current configuration (including [extras](#plugin-extras)), as discoverable using [`meltano config print --format=env <plugin>`](/reference/command-line-interface#config).
 
 These can then be accessed from inside the plugin using the mechanism provided by the standard library, e.g. Python's [`os.environ`](https://docs.python.org/3/library/os.html#os.environ).
 
@@ -445,7 +445,7 @@ plugins:
 To configure `tap-postgres`'s `password` setting, you would typically set the `TAP_POSTGRES_PASSWORD` [environment variable](#configuring-settings),
 but that will not work here as it would not be clear which plugin the password was intended for.
 
-Instead, as [`meltano config <name> list`](/reference/command-line-interface#config) would tell you,
+Instead, as [`meltano config list <name>`](/reference/command-line-interface#config) would tell you,
 both plugins get their own unique environment variables with prefixes derived from their names:
 `TAP_POSTGRES__BILLING_PASSWORD` and `TAP_POSTGRES__EVENTS_PASSWORD`.
 
@@ -453,7 +453,7 @@ To learn how to add an inheriting plugin to your project, refer to the [Plugin M
 
 ## Custom settings
 
-Meltano keeps track of the settings a plugin supports using [`settings` metadata](/reference/settings), and will list them all when you run [`meltano config <plugin> list`](/reference/command-line-interface#config).
+Meltano keeps track of the settings a plugin supports using [`settings` metadata](/reference/settings), and will list them all when you run [`meltano config list <plugin>`](/reference/command-line-interface#config).
 
 If you've added a [discoverable plugin](/concepts/plugins#discoverable-plugins) to your project, this metadata will already be known to Meltano.
 If we're dealing with a [custom plugin](/concepts/plugins#custom-plugins) instead, you will have been asked to provide the names of the supported configuration options yourself.
@@ -461,10 +461,10 @@ If we're dealing with a [custom plugin](/concepts/plugins#custom-plugins) instea
 If a plugin supports a setting that is not yet known to Meltano (because it may have been added after the `settings` metadata was specified, for example),
 you do not need to modify the `settings` metadata to be able to use it.
 
-Instead, you can define a custom setting by adding the setting name (key) to your plugin's `config` object in your [`meltano.yml` project file](/concepts/project#meltano-yml-project-file) with the desired value (or simply `null`), by manually editing the file or using `meltano config <plugin> set <key> <value>`:
+Instead, you can define a custom setting by adding the setting name (key) to your plugin's `config` object in your [`meltano.yml` project file](/concepts/project#meltano-yml-project-file) with the desired value (or simply `null`), by manually editing the file or using `meltano config set <plugin> <key> <value>`:
 
 ```bash
-meltano config tap-example set custom_setting value
+meltano config set tap-example custom_setting value
 ```
 
 ```yaml
@@ -475,7 +475,7 @@ extractors:
     custom_setting: value
 ```
 
-As long as the custom setting exists in `meltano.yml`, it will behave and can be interacted with just like any regular (known) setting. It will show up in `meltano config <plugin> list` and `meltano config <plugin>`, and the value that will be passed on to the plugin can be [overridden using an environment variable](/guide/configuration#configuring-settings):
+As long as the custom setting exists in `meltano.yml`, it will behave and can be interacted with just like any regular (known) setting. It will show up in `meltano config list <plugin>` and `meltano config print <plugin>`, and the value that will be passed on to the plugin can be [overridden using an environment variable](/guide/configuration#configuring-settings):
 
 ```bash
 export TAP_EXAMPLE_CUSTOM_SETTING=overridden_value
@@ -523,7 +523,7 @@ and [environment variables](#configuring-settings) and
 
 ## Configuration testing
 
-The configuration of a plugin can be tested using [`meltano config <plugin> test`](/reference/command-line-interface#config).
+The configuration of a plugin can be tested using [`meltano config test <plugin>`](/reference/command-line-interface#config).
 
 :::danger
 

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -344,6 +344,15 @@ The `meltano config` command structure changed in Meltano v4. The subcommand now
 
 :::
 
+:::info Print Subcommand Required
+
+To view a plugin's configuration, you must now use the explicit `print` subcommand:
+
+- **New format**: `meltano config print <plugin>` or `meltano config print <plugin> --format=env`
+- **Old format**: `meltano config <plugin>` or `meltano config <plugin> --format=env`
+
+:::
+
 Enables you to manage the [configuration](/guide/configuration) of Meltano itself or any of its plugins, as well as [plugin extras](#how-to-use-plugin-extras).
 
 When no explicit `--store` is specified, `meltano config set <plugin>` will automatically store the value in the [most appropriate location](/guide/configuration#configuration-layers):

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -335,16 +335,25 @@ To only compile the no-environment manifest JSON file, i.e. `meltano-manifest.js
 
 ## `config`
 
+:::warning Command Structure Changed
+
+The `meltano config` command structure changed in Meltano v4. The subcommand now comes _before_ the plugin name:
+
+- **New format**: `meltano config list <plugin>`, `meltano config set <plugin> <setting> <value>`
+- **Old format**: `meltano config <plugin> list`, `meltano config <plugin> set <setting> <value>`
+
+:::
+
 Enables you to manage the [configuration](/guide/configuration) of Meltano itself or any of its plugins, as well as [plugin extras](#how-to-use-plugin-extras).
 
-When no explicit `--store` is specified, `meltano config <plugin> set` will automatically store the value in the [most appropriate location](/guide/configuration#configuration-layers):
+When no explicit `--store` is specified, `meltano config set <plugin>` will automatically store the value in the [most appropriate location](/guide/configuration#configuration-layers):
 
 - the [system database](/concepts/project#system-database), if the project is [deployed as read-only](/reference/settings#project-readonly);
 - the current location, if a setting's default value has already been overwritten;
 - [`.env`](/concepts/project#env), if a setting is sensitive or environment-specific (defined as `sensitive: true` or `env_specific: true`);
 - [`meltano.yml`](/concepts/project#meltano-yml-project-file) otherwise.
 
-If supported by the plugin type, its configuration can be tested using [`meltano config <plugin> test`](/reference/command-line-interface#config).
+If supported by the plugin type, its configuration can be tested using [`meltano config test <plugin>`](/reference/command-line-interface#config).
 
 ### How to use
 
@@ -353,49 +362,50 @@ To manage the configuration of Meltano itself, specify `meltano` as the plugin n
 ```bash
 # List all settings for Meltano itself with their names,
 # environment variables, and current values
-meltano config meltano list
+meltano config list meltano
 
 # List all settings for the specified plugin with their names,
 # environment variables, and current values
-meltano config <plugin> list
+meltano config list <plugin>
 
 # View the plugin's current configuration.
-meltano config <plugin>
+meltano config print <plugin>
 
 # Sets the configuration's setting `<name>` to `<value>`.
-meltano config <plugin> set <name> <value>
+meltano config set <plugin> <name> <value>
 
 # Values are parsed as JSON, and interpreted as simple strings when invalid
-meltano config <plugin> set <name> <string>             # String with no meaning in JSON
-meltano config <plugin> set <name> "<word> <word> ..."  # Multi-word string with no meaning in JSON
-meltano config <plugin> set <name> <json>               # JSON that fits in a single word
-meltano config <plugin> set <name> '<json>'             # JSON in a string argument
-meltano config <plugin> set <name> '"<string>"'         # JSON string
-meltano config <plugin> set <name> <number>             # JSON number, e.g. 100 or 3.14
-meltano config <plugin> set <name> <true/false>         # Boolean True or False
-meltano config <plugin> set <name> '[<elem>, ...]'      # Array
-meltano config <plugin> set <name> '{"<key>": <value>, ...}' # JSON object
+meltano config set <plugin> <name> <string>             # String with no meaning in JSON
+meltano config set <plugin> <name> "<word> <word> ..."  # Multi-word string with no meaning in JSON
+meltano config set <plugin> <name> <json>               # JSON that fits in a single word
+meltano config set <plugin> <name> '<json>'             # JSON in a string argument
+meltano config set <plugin> <name> '"<string>"'         # JSON string
+meltano config set <plugin> <name> <number>             # JSON number, e.g. 100 or 3.14
+meltano config set <plugin> <name> <true/false>         # Boolean True or False
+meltano config set <plugin> <name> '[<elem>, ...]'      # Array
+meltano config set <plugin> <name> '{"<key>": <value>, ...}' # JSON object
 
 # Remove the configuration's setting `<name>`.
-meltano config <plugin> unset <name>
+meltano config unset <plugin> <name>
 
 # Clear the configuration (back to defaults).
-meltano config <plugin> reset
+meltano config reset <plugin>
 
 # Set, unset, or reset in a specific location
-meltano config <plugin> set --store=meltano_yml <name> <value> # set in `meltano.yml`
-meltano config <plugin> unset --store=dotenv <name> # unset in `.env`
-meltano config <plugin> reset --store=db # reset in system database
+meltano config set <plugin> --store=meltano_yml <name> <value> # set in `meltano.yml`
+meltano config unset <plugin> --store=dotenv <name> # unset in `.env`
+meltano config reset <plugin> --store=db # reset in system database
 
 # Test the plugin's current configuration, if supported.
-meltano config <plugin> test
-meltano config --no-install <plugin> test # prevent auto-install of plugin
+meltano config test <plugin>
+meltano config --no-install test <plugin> # prevent auto-install of plugin
 ```
 
 If multiple plugins share the same name, you can provide an additional `--plugin-type` argument to disambiguate:
 
 ```bash
-meltano config --plugin-type=<type> <plugin> ...
+meltano config list --plugin-type=<type> <plugin>
+meltano config set --plugin-type=<type> <plugin> <name> <value>
 ```
 
 When setting a config value that contains the character `$`, you can avoid expansion by

--- a/integration/example-library/meltano-annotations/index.md
+++ b/integration/example-library/meltano-annotations/index.md
@@ -19,14 +19,14 @@ meltano job set gitlab-to-jsonl --tasks '[tap-gitlab target-jsonl]'
 ## Configure meltano to use local filesystem for state.
 
 ```shell
-meltano config meltano set state_backend.uri "file:///`pwd`/.meltano/state"
+meltano config set meltano state_backend.uri "file:///`pwd`/.meltano/state"
 ```
 
 ## Configure the tap and target
 
 ```shell
-meltano config tap-gitlab set start_date 2022-11-01T00:00:01Z
-meltano config target-jsonl set do_timestamp_file false
+meltano config set tap-gitlab start_date 2022-11-01T00:00:01Z
+meltano config set target-jsonl do_timestamp_file false
 ```
 
 ## Run a job

--- a/integration/example-library/meltano-basics/index.md
+++ b/integration/example-library/meltano-basics/index.md
@@ -17,8 +17,8 @@ an explicit start_date from which you would like tap-gitlab to start importing d
 that the resulting jsonl files NOT actually include timestamps in their file names:
 
 ```shell
-meltano config tap-gitlab set start_date 2022-04-25T00:00:01Z
-meltano config target-jsonl set do_timestamp_file false
+meltano config set tap-gitlab start_date 2022-04-25T00:00:01Z
+meltano config set target-jsonl do_timestamp_file false
 ```
 
 ## Running a task

--- a/integration/example-library/meltano-config/index.md
+++ b/integration/example-library/meltano-config/index.md
@@ -28,11 +28,11 @@ echo 'plugins:
 ## Set plugin settings
 
 ```shell
-meltano config example set a_string -- -86.75
-meltano config example set an_integer '42'
-meltano config example set a_number 3.1415
-meltano config example set an_object '{"foo": "bar"}'
-meltano config example set an_array '["foo", "bar"]'
+meltano config set example a_string -- -86.75
+meltano config set example an_integer '42'
+meltano config set example a_number 3.1415
+meltano config set example an_object '{"foo": "bar"}'
+meltano config set example an_array '["foo", "bar"]'
 ```
 
 ## Check plugin settings

--- a/integration/example-library/meltano-config/index.md
+++ b/integration/example-library/meltano-config/index.md
@@ -38,7 +38,7 @@ meltano config set example an_array '["foo", "bar"]'
 ## Check plugin settings
 
 ```shell
-meltano config example
+meltano config print example
 ```
 
 You should see the following output:

--- a/integration/example-library/meltano-run/index.md
+++ b/integration/example-library/meltano-run/index.md
@@ -13,7 +13,7 @@ The installed meltano.yml already includes a configured instance of the `tap-git
 the configuration of the extractor by running:
 
 ```shell !
-meltano config tap-gitlab list
+meltano config list tap-gitlab
 ```
 
 ## Configure a loader
@@ -22,11 +22,11 @@ Next we'll need to configure a loader to store our gitlab data. We'll use [`targ
 which was installed by the `meltano install` command but may require tweaking of the configuration to match your environment:
 
 ```shell
-meltano --environment=dev config target-postgres set user postgres
-meltano --environment=dev config target-postgres set password postgres
-meltano --environment=dev config target-postgres set host localhost
-meltano --environment=dev config target-postgres set database warehouse
-meltano --environment=dev config target-postgres set default_target_schema public
+meltano --environment=dev config set target-postgres user postgres
+meltano --environment=dev config set target-postgres password postgres
+meltano --environment=dev config set target-postgres host localhost
+meltano --environment=dev config set target-postgres database warehouse
+meltano --environment=dev config set target-postgres default_target_schema public
 ```
 
 Note that sensitive config options such as `password` [aren't stored in your `meltano.yml` but in `.env` instead](https://docs.meltano.com/guide/configuration#configuration-layers). Print out the config to make sure it looks as expected:
@@ -65,12 +65,12 @@ The meltano.yml didn't include dbt, so let's install that and get it configured 
 
 ```shell
 meltano add dbt-postgres
-meltano --environment=dev config dbt-postgres set host localhost
-meltano --environment=dev config dbt-postgres set user postgres
-meltano --environment=dev config dbt-postgres set password postgres
-meltano --environment=dev config dbt-postgres set port 5432
-meltano --environment=dev config dbt-postgres set dbname warehouse
-meltano --environment=dev config dbt-postgres set schema analytics
+meltano --environment=dev config set dbt-postgres host localhost
+meltano --environment=dev config set dbt-postgres user postgres
+meltano --environment=dev config set dbt-postgres password postgres
+meltano --environment=dev config set dbt-postgres port 5432
+meltano --environment=dev config set dbt-postgres dbname warehouse
+meltano --environment=dev config set dbt-postgres schema analytics
 ```
 
 ### Prep the `dbt` transform for this demo

--- a/integration/example-library/meltano-state-local/index.md
+++ b/integration/example-library/meltano-state-local/index.md
@@ -9,14 +9,14 @@ meltano install
 ## Configure meltano to use local filesystem for state.
 
 ```shell
-meltano config meltano set state_backend.uri "file:///`pwd`/.meltano/state"
+meltano config set meltano state_backend.uri "file:///`pwd`/.meltano/state"
 ```
 
 ## Configure the tap and target
 
 ```shell
-meltano config tap-gitlab set start_date 2022-11-01T00:00:01Z
-meltano config target-jsonl set do_timestamp_file false
+meltano config set tap-gitlab start_date 2022-11-01T00:00:01Z
+meltano config set target-jsonl do_timestamp_file false
 ```
 
 ## Run a job

--- a/integration/example-library/meltano-state-s3/index.md
+++ b/integration/example-library/meltano-state-s3/index.md
@@ -39,18 +39,18 @@ client.create_bucket(Bucket="meltano")
 ## Configure meltano to use S3 for state.
 
 ```shell
-meltano config meltano set state_backend.uri "s3://meltano/state"
+meltano config set meltano state_backend.uri "s3://meltano/state"
 
-meltano config meltano set state_backend.s3.aws_access_key_id "minioadmin"
-meltano config meltano set state_backend.s3.aws_secret_access_key "minioadmin"
-meltano config meltano set state_backend.s3.endpoint_url "http://127.0.0.1:9000"
+meltano config set meltano state_backend.s3.aws_access_key_id "minioadmin"
+meltano config set meltano state_backend.s3.aws_secret_access_key "minioadmin"
+meltano config set meltano state_backend.s3.endpoint_url "http://127.0.0.1:9000"
 ```
 
 ## Configure the tap and target
 
 ```shell
-meltano config tap-gitlab set start_date 2022-11-01T00:00:01Z
-meltano config target-jsonl set do_timestamp_file false
+meltano config set tap-gitlab start_date 2022-11-01T00:00:01Z
+meltano config set target-jsonl do_timestamp_file false
 ```
 
 ## Run a job

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -332,7 +332,7 @@ def print_config(
                 dotenv_content = path.read_text()
 
             click.echo(dotenv_content)
-        case _:
+        case _:  # pragma: no cover
             t.assert_never(config_format)
 
 

--- a/src/meltano/cli/config.py
+++ b/src/meltano/cli/config.py
@@ -137,10 +137,7 @@ def _get_invoker(
     Raises:
         PluginNotFoundError: If plugin is not found and not 'meltano'
     """
-    if plugin is not None:
-        return PluginInvoker(project, plugin)
-
-    return None
+    return PluginInvoker(project, plugin) if plugin is not None else None
 
 
 def _get_ctx_arg(*args: t.Any) -> click.Context:

--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -31,7 +31,10 @@ from meltano.core.settings_store import StoreNotSupportedError
 from meltano.core.tracking.contexts import CliEvent
 
 if t.TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from meltano.core.project import Project
+    from meltano.core.tracking.tracker import Tracker
 
 PLUGIN_COLOR = "magenta"
 ENVIRONMENT_COLOR = "orange1"
@@ -67,19 +70,29 @@ To learn more about configuration options, see the [link=https://docs.meltano.co
 class InteractiveConfig:
     """Manage Config interactively."""
 
-    def __init__(self, ctx, store, *, extras=False, max_width=None) -> None:  # noqa: ANN001
+    def __init__(
+        self,
+        *,
+        store: SettingValueStore,
+        project: Project,
+        settings: SettingsService,
+        safe: bool,
+        session: Session,
+        tracker: Tracker,
+        extras: bool = False,
+        max_width: int | None = None,
+    ) -> None:
         """Initialise InteractiveConfig instance."""
-        self.ctx = ctx
         self.store = store
         self.extras = extras
-        self.project: Project = self.ctx.obj["project"]
-        self.settings: SettingsService = self.ctx.obj["settings"]
-        self.session = self.ctx.obj["session"]
-        self.tracker = self.ctx.obj["tracker"]
+        self.project: Project = project
+        self.settings: SettingsService = settings
+        self.session: Session = session
+        self.tracker = tracker
         self.environment_service = EnvironmentService(self.project)
         self.max_width = max_width or 75
         self.console = Console()
-        self.safe: bool = ctx.obj["safe"]
+        self.safe: bool = safe
 
     @property
     def configurable_settings(self):  # noqa: ANN201

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -310,8 +310,9 @@ class TestCli:
                     "--env-file",
                     str(dotenv_path),
                     "config",
-                    "--format=env",
+                    "print",
                     "meltano",
+                    "--format=env",
                 ),
             )
             assert result.exit_code == 0
@@ -326,8 +327,9 @@ class TestCli:
                     "--env-file",
                     "prod.env",
                     "config",
-                    "--format=env",
+                    "print",
                     "meltano",
+                    "--format=env",
                 ),
             )
             assert result.exit_code == 0
@@ -337,7 +339,7 @@ class TestCli:
         "command_args",
         (
             ("invoke", "example"),
-            ("config", "example"),
+            ("config", "print", "example"),
             ("job", "list"),
             ("environment", "list"),
             ("add", "utility", "example"),
@@ -573,7 +575,7 @@ class TestLargeConfigProject:
         assert (
             cli_runner.invoke(
                 cli,
-                ["--no-environment", "config", "target-with-large-config", "list"],
+                ["--no-environment", "config", "list", "target-with-large-config"],
             ).exit_code
             == 0
         )

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -20,13 +20,14 @@ if t.TYPE_CHECKING:
     from click.testing import CliRunner
 
     from meltano.core.project import Project
+    from tests.fixtures.cli import MeltanoCliRunner
 
 
 class TestCliConfig:
     @pytest.mark.usefixtures("project")
     def test_config(
         self,
-        cli_runner: CliRunner,
+        cli_runner: MeltanoCliRunner,
         tap,
         session,
         plugin_settings_service_factory,
@@ -44,6 +45,26 @@ class TestCliConfig:
         json_config = json.loads(result.stdout)
         assert json_config["test"] == "mock"
         assert json_config["secure"] == "*****"
+
+    @pytest.mark.parametrize(
+        "subcommand",
+        (
+            "list",
+            "print",
+            "reset",
+            "set",
+            "test",
+            "unset",
+        ),
+    )
+    def test_config_help_outside_project(
+        self,
+        cli_runner: MeltanoCliRunner,
+        subcommand: str,
+    ) -> None:
+        """Confirm that `config <subcommand> --help` works outside of a project."""
+        result = cli_runner.invoke(cli, ["config", subcommand, "--help"])
+        assert_cli_runner(result)
 
     @pytest.mark.usefixtures("project")
     def test_config_extras(self, cli_runner, tap) -> None:

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -19,8 +19,8 @@ if t.TYPE_CHECKING:
 
     from click.testing import CliRunner
 
+    from fixtures.cli import MeltanoCliRunner
     from meltano.core.project import Project
-    from tests.fixtures.cli import MeltanoCliRunner
 
 
 class TestCliConfig:

--- a/tests/meltano/cli/test_config.py
+++ b/tests/meltano/cli/test_config.py
@@ -38,7 +38,7 @@ class TestCliConfig:
             store=SettingValueStore.DOTENV,
             session=session,
         )
-        result = cli_runner.invoke(cli, ["config", tap.name])
+        result = cli_runner.invoke(cli, ["config", "print", tap.name])
         assert_cli_runner(result)
 
         json_config = json.loads(result.stdout)
@@ -47,7 +47,7 @@ class TestCliConfig:
 
     @pytest.mark.usefixtures("project")
     def test_config_extras(self, cli_runner, tap) -> None:
-        result = cli_runner.invoke(cli, ["config", "--extras", tap.name])
+        result = cli_runner.invoke(cli, ["config", "print", "--extras", tap.name])
         assert_cli_runner(result)
 
         json_config = json.loads(result.stdout)
@@ -68,7 +68,7 @@ class TestCliConfig:
             store=SettingValueStore.DOTENV,
             session=session,
         )
-        result = cli_runner.invoke(cli, ["config", "--format=env", tap.name])
+        result = cli_runner.invoke(cli, ["config", "print", "--format=env", tap.name])
         assert_cli_runner(result)
 
         env_config = dotenv.dotenv_values(stream=io.StringIO(result.stdout))
@@ -77,7 +77,7 @@ class TestCliConfig:
 
     @pytest.mark.usefixtures("project")
     def test_config_meltano(self, cli_runner, engine_uri) -> None:
-        result = cli_runner.invoke(cli, ["config", "meltano"])
+        result = cli_runner.invoke(cli, ["config", "print", "meltano"])
         assert_cli_runner(result)
 
         json_config = json.loads(result.stdout)
@@ -88,7 +88,7 @@ class TestCliConfig:
     def test_config_meltano_set(self, cli_runner) -> None:
         result = cli_runner.invoke(
             cli,
-            ["config", "meltano", "set", "cli.log_config", "log_config.yml"],
+            ["config", "set", "meltano", "cli.log_config", "log_config.yml"],
         )
         assert_cli_runner(result)
         assert (
@@ -111,7 +111,7 @@ class TestCliConfig:
             "meltano.core.plugin_invoker.PluginInvoker.invoke_async",
             return_value=mock_invoke,
         ) as mocked_invoke:
-            result = cli_runner.invoke(cli, ["config", tap.name, "test"])
+            result = cli_runner.invoke(cli, ["config", "test", tap.name])
             assert mocked_invoke.assert_called_once
             assert_cli_runner(result)
 
@@ -119,7 +119,7 @@ class TestCliConfig:
 
     @pytest.mark.usefixtures("project")
     def test_config_meltano_test(self, cli_runner) -> None:
-        result = cli_runner.invoke(cli, ["config", "meltano", "test"])
+        result = cli_runner.invoke(cli, ["config", "test", "meltano"])
 
         assert result.exit_code == 1
         assert (
@@ -143,7 +143,7 @@ class TestCliConfig:
             session=session,
         )
 
-        result = cli_runner.invoke(cli, ["config", tap.name, "list"])
+        result = cli_runner.invoke(cli, ["config", "list", tap.name])
         assert_cli_runner(result)
 
         assert (
@@ -168,7 +168,7 @@ class TestCliConfig:
             session=session,
         )
 
-        result = cli_runner.invoke(cli, ["config", inherited_tap.name, "list"])
+        result = cli_runner.invoke(cli, ["config", "list", inherited_tap.name])
         assert_cli_runner(result)
 
         assert (
@@ -194,7 +194,7 @@ class TestCliConfig:
             session=session,
         )
 
-        result = cli_runner.invoke(cli, ["config", "--unsafe", tap.name, "list"])
+        result = cli_runner.invoke(cli, ["config", "--unsafe", "list", tap.name])
         assert_cli_runner(result)
 
         assert (
@@ -208,7 +208,7 @@ class TestCliConfigSet:
     def test_config_set_redacted(self, cli_runner, tap) -> None:
         result = cli_runner.invoke(
             cli,
-            ["config", tap.name, "set", "secure", "thisisatest"],
+            ["config", "set", tap.name, "secure", "thisisatest"],
         )
         assert_cli_runner(result)
 
@@ -223,7 +223,7 @@ class TestCliConfigSet:
 
         result = cli_runner.invoke(
             cli,
-            ["config", "--unsafe", tap.name, "set", "secure", value],
+            ["config", "--unsafe", "set", tap.name, "secure", value],
         )
         assert_cli_runner(result)
 
@@ -236,7 +236,7 @@ class TestCliConfigSet:
     def test_config_set_from_file(self, cli_runner, tap, tmp_path: Path) -> None:
         result = cli_runner.invoke(
             cli,
-            ["config", tap.name, "set", "private_key", "--from-file", "-"],
+            ["config", "set", tap.name, "private_key", "--from-file", "-"],
             input="content-from-stdin",
         )
         assert_cli_runner(result)
@@ -251,7 +251,7 @@ class TestCliConfigSet:
 
         result = cli_runner.invoke(
             cli,
-            ["config", tap.name, "set", "private_key", "--from-file", filepath],
+            ["config", "set", tap.name, "private_key", "--from-file", filepath],
         )
         assert_cli_runner(result)
 
@@ -269,7 +269,7 @@ class TestCliConfigSet:
         # set base config in `meltano.yml`
         result = cli_runner.invoke(
             cli,
-            ["--no-environment", "config", "tap-mock", "set", "test", "base-mock"],
+            ["--no-environment", "config", "set", "tap-mock", "test", "base-mock"],
         )
         assert_cli_runner(result)
         base_tap_config = next(
@@ -285,7 +285,7 @@ class TestCliConfigSet:
         # set base config in `meltano.yml` -- ignore default environment
         result = cli_runner.invoke(
             cli,
-            ["config", "tap-mock", "set", "test", "base-mock-no-default"],
+            ["config", "set", "tap-mock", "test", "base-mock-no-default"],
         )
         assert_cli_runner(result)
         base_tap_config = next(
@@ -301,7 +301,7 @@ class TestCliConfigSet:
         # set dev environment config in `meltano.yml`
         result = cli_runner.invoke(
             cli,
-            ["--environment=dev", "config", "tap-mock", "set", "test", "dev-mock"],
+            ["--environment=dev", "config", "set", "tap-mock", "test", "dev-mock"],
         )
         assert_cli_runner(result)
         dev_env = next(
@@ -325,7 +325,7 @@ class TestCliConfigUnset:
         secure_value = "thisisatest"
         set_default_result = cli_runner.invoke(
             cli,
-            ["config", tap.name, "set", "secure", secure_value],
+            ["config", "set", tap.name, "secure", secure_value],
         )
         assert_cli_runner(set_default_result)
 
@@ -334,8 +334,8 @@ class TestCliConfigUnset:
             cli,
             [
                 "config",
-                tap.name,
                 "set",
+                tap.name,
                 "--store=meltano_yml",
                 "secure",
                 meltano_yml_value,
@@ -345,7 +345,7 @@ class TestCliConfigUnset:
 
         unset_result = cli_runner.invoke(
             cli,
-            ["config", tap.name, "unset", "--store=meltano_yml", "secure"],
+            ["config", "unset", tap.name, "--store=meltano_yml", "secure"],
         )
         assert_cli_runner(unset_result)
         assert (

--- a/tests/meltano/cli/test_logs.py
+++ b/tests/meltano/cli/test_logs.py
@@ -91,11 +91,11 @@ class TestLogsShow:
             result = cli_runner.invoke(cli, ["logs", "show", str(job.run_id)])
 
         assert result.exit_code == 0
-        assert "Latest log content" in result.output
-        assert "With multiple lines" in result.output
-        assert f"Job: {job.job_name}" in result.output
-        assert f"Run ID: {job.run_id}" in result.output
-        assert "State: SUCCESS" in result.output
+        assert "Latest log content" in result.stdout
+        assert "With multiple lines" in result.stdout
+        assert f"Job: {job.job_name}" in result.stdout
+        assert f"Run ID: {job.run_id}" in result.stdout
+        assert "State: SUCCESS" in result.stdout
 
     def test_show_specific_run(
         self,
@@ -119,8 +119,8 @@ class TestLogsShow:
             )
 
         assert result.exit_code == 0
-        assert "First run log" in result.output
-        assert "Second run log" not in result.output
+        assert "First run log" in result.stdout
+        assert "Second run log" not in result.stdout
 
     def test_list_runs(
         self,
@@ -143,14 +143,14 @@ class TestLogsShow:
             result = cli_runner.invoke(cli, ["logs", "list"])
 
         assert result.exit_code == 0
-        assert "Recent job runs" in result.output
-        assert str(job1.run_id) in result.output
-        assert str(job2.run_id) in result.output
-        assert str(job3.run_id) in result.output
-        assert str(job4.run_id) in result.output
-        assert result.output.count("✓") == 2  # Success marker
-        assert result.output.count("✗") == 1  # Fail marker
-        assert result.output.count("→") == 1  # Running marker
+        assert "Recent job runs" in result.stdout
+        assert str(job1.run_id) in result.stdout
+        assert str(job2.run_id) in result.stdout
+        assert str(job3.run_id) in result.stdout
+        assert str(job4.run_id) in result.stdout
+        assert result.stdout.count("✓") == 2  # Success marker
+        assert result.stdout.count("✗") == 1  # Fail marker
+        assert result.stdout.count("→") == 1  # Running marker
 
     def test_list_runs_json_format(
         self,
@@ -171,7 +171,7 @@ class TestLogsShow:
             )
 
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert "runs" in data
         assert len(data["runs"]) >= 1
         run_ids = [run["log_id"] for run in data["runs"]]
@@ -203,7 +203,7 @@ class TestLogsShow:
         first_idx = max(100 - tail + 1, 1)
         lines_present = [f"Line {i}" for i in range(first_idx, 100)]
         lines_not_present = [f"Line {i}" for i in range(1, first_idx)]
-        log_lines = result.output.splitlines()
+        log_lines = result.stdout.splitlines()
         assert all(line in log_lines for line in lines_present)
         assert all(line not in log_lines for line in lines_not_present)
 
@@ -242,7 +242,7 @@ class TestLogsShow:
 
         # Should succeed but show no runs message
         assert result.exit_code == 0
-        assert "No job runs found." in result.output
+        assert "No job runs found." in result.stdout
 
     @pytest.mark.usefixtures("project")
     def test_missing_run_id(self, cli_runner: MeltanoCliRunner):
@@ -279,9 +279,9 @@ class TestLogsShow:
             )
 
         assert result.exit_code == 0
-        assert "Log file is large" in result.output
-        assert "Do you want to display it anyway?" in result.output
-        assert "Log file path:" in result.output
+        assert "Log file is large" in result.stdout
+        assert "Do you want to display it anyway?" in result.stdout
+        assert "Log file path:" in result.stdout
 
         # Test accepting confirmation
         with mock.patch(
@@ -295,7 +295,7 @@ class TestLogsShow:
             )
 
         assert result.exit_code == 0
-        assert "Log file is large" in result.output
+        assert "Log file is large" in result.stdout
         # The large content would be displayed
 
     def test_json_format_with_log_display(
@@ -318,7 +318,7 @@ class TestLogsShow:
 
         assert result.exit_code == 0
         # Job info should be in JSON format
-        lines = result.output.strip().split("\n")
+        lines = result.stdout.strip().split("\n")
         json_end = next((i for i, line in enumerate(lines) if line == "}"), None)
         assert json_end is not None
         json_str = "\n".join(lines[: json_end + 1])

--- a/tests/meltano/cli/test_select.py
+++ b/tests/meltano/cli/test_select.py
@@ -39,7 +39,7 @@ class TestCliSelect:
         # first, reset to defaults
         result = cli_runner.invoke(
             cli,
-            [*environment_flag, "config", tap.name, "reset"],
+            [*environment_flag, "config", "reset", tap.name],
             input="y\n",
         )
         assert_cli_runner(result)
@@ -52,7 +52,7 @@ class TestCliSelect:
         # verify pattern was added
         result = cli_runner.invoke(
             cli,
-            [*environment_flag, "config", "--extras", tap.name],
+            [*environment_flag, "config", "print", "--extras", tap.name],
         )
         assert_cli_runner(result)
         json_config = json.loads(result.stdout)
@@ -66,7 +66,7 @@ class TestCliSelect:
         # verify select pattern removed
         result = cli_runner.invoke(
             cli,
-            [*environment_flag, "config", "--extras", tap.name],
+            [*environment_flag, "config", "print", "--extras", tap.name],
         )
         assert_cli_runner(result)
         json_config = json.loads(result.stdout)
@@ -90,7 +90,7 @@ class TestCliSelect:
         # first, reset to defaults
         result = cli_runner.invoke(
             cli,
-            [*environment_flag, "config", tap.name, "reset"],
+            [*environment_flag, "config", "reset", tap.name],
             input="y\n",
         )
         assert_cli_runner(result)
@@ -102,7 +102,7 @@ class TestCliSelect:
         assert_cli_runner(result)
         result = cli_runner.invoke(
             cli,
-            [*environment_flag, "config", "--extras", tap.name],
+            [*environment_flag, "config", "print", "--extras", tap.name],
         )
         assert_cli_runner(result)
         json_config = json.loads(result.stdout)
@@ -126,7 +126,7 @@ class TestCliSelect:
         # verify patterns were added
         result = cli_runner.invoke(
             cli,
-            [*environment_flag, "config", "--extras", tap.name],
+            [*environment_flag, "config", "print", "--extras", tap.name],
         )
         assert_cli_runner(result)
         json_config = json.loads(result.stdout)
@@ -142,7 +142,7 @@ class TestCliSelect:
         # verify all select patterns were removed (reverted to default)
         result = cli_runner.invoke(
             cli,
-            [*environment_flag, "config", "--extras", tap.name],
+            [*environment_flag, "config", "print", "--extras", tap.name],
         )
         assert_cli_runner(result)
         json_config = json.loads(result.stdout)

--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -207,10 +207,9 @@ class TestCliUpgrade:
             cli,
             [
                 "config",
-                "--plugin-type",
-                "files",
-                "airflow",
                 "set",
+                "--plugin-type=files",
+                "airflow",
                 "_update",
                 "orchestrate/dags/meltano.py",
                 "false",
@@ -234,10 +233,9 @@ class TestCliUpgrade:
             cli,
             [
                 "config",
-                "--plugin-type",
-                "files",
-                "airflow",
                 "unset",
+                "--plugin-type=files",
+                "airflow",
                 "_update",
                 "orchestrate/dags/meltano.py",
             ],
@@ -268,10 +266,9 @@ class TestCliUpgrade:
             cli,
             [
                 "config",
-                "--plugin-type",
-                "files",
-                "airflow",
                 "set",
+                "--plugin-type=files",
+                "airflow",
                 "_update",
                 json.dumps(
                     {


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #7136

## Summary by Sourcery

Refactor the Meltano CLI config commands to invert the order of subcommand and plugin arguments, introducing shared helper functions for plugin retrieval, settings, and invoker setup, and updating code, documentation, and tests to use the new command structure.

Enhancements:
- Invert the positional arguments for all `meltano config` subcommands so the subcommand now precedes the plugin name (e.g., `meltano config list <plugin>`).
- Introduce internal helper functions (`_get_plugin`, `_get_settings`, `_get_invoker`) to consolidate plugin/context setup across config commands.
- Centralize and simplify session, tracker, and safe‐flag handling in the config CLI logic, and refactor the InteractiveConfig initializer accordingly.
- Update documentation and tests to align with the new `meltano config <subcommand> <plugin>` command format.