### PR TITLE
refactor: Remove missing import handling for state backends now that they are loaded dynamically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,6 +273,7 @@ incremental = false # Disabled until https://github.com/python/mypy/issues/12664
 files = [
   "src/meltano/",
 ]
+follow_untyped_imports = true
 exclude = [
   "src/meltano/migrations/",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,25 +91,25 @@ meltano = "meltano.cli:main"
 
 [project.entry-points."meltano.settings"]
 # AWS S3 state backend settings
-s3_aws_access_key_id = "meltano.core.state_store.s3:AWS_ACCESS_KEY_ID"
-s3_aws_secret_access_key = "meltano.core.state_store.s3:AWS_SECRET_ACCESS_KEY"
-s3_endpoint_url = "meltano.core.state_store.s3:ENDPOINT_URL"
+s3_aws_access_key_id = "meltano.core.state_store.s3.settings:AWS_ACCESS_KEY_ID"
+s3_aws_secret_access_key = "meltano.core.state_store.s3.settings:AWS_SECRET_ACCESS_KEY"
+s3_endpoint_url = "meltano.core.state_store.s3.settings:ENDPOINT_URL"
 # Azure state backend settings
-azure_connection_string = "meltano.core.state_store.azure:CONNECTION_STRING"
-azure_storage_account_url = "meltano.core.state_store.azure:STORAGE_ACCOUNT_URL"
+azure_connection_string = "meltano.core.state_store.azure.settings:CONNECTION_STRING"
+azure_storage_account_url = "meltano.core.state_store.azure.settings:STORAGE_ACCOUNT_URL"
 # Google Cloud Storage state backend settings
-google_application_credentials = "meltano.core.state_store.google:APPLICATION_CREDENTIALS"  # Deprecated! Remove in Meltano v4
-google_application_credentials_path = "meltano.core.state_store.google:APPLICATION_CREDENTIALS_PATH"
-google_application_credentials_json = "meltano.core.state_store.google:APPLICATION_CREDENTIALS_JSON"
+google_application_credentials = "meltano.core.state_store.google.settings:APPLICATION_CREDENTIALS"  # Deprecated! Remove in Meltano v4
+google_application_credentials_path = "meltano.core.state_store.google.settings:APPLICATION_CREDENTIALS_PATH"
+google_application_credentials_json = "meltano.core.state_store.google.settings:APPLICATION_CREDENTIALS_JSON"
 
 [project.entry-points."meltano.state_backends"]
 # These keys should match the expected scheme for URIs of
 # the given type. E.g., filesystem state backends have a
 # file://<path>/<to>/<state directory> URI
-azure = "meltano.core.state_store.azure:AZStorageStateStoreManager"
+azure = "meltano.core.state_store.azure.backend:AZStorageStateStoreManager"
 file = "meltano.core.state_store.filesystem:LocalFilesystemStateStoreManager"
-gs = "meltano.core.state_store.google:GCSStateStoreManager"
-s3 = "meltano.core.state_store.s3:S3StateStoreManager"
+gs = "meltano.core.state_store.google.backend:GCSStateStoreManager"
+s3 = "meltano.core.state_store.s3.backend:S3StateStoreManager"
 
 [dependency-groups]
 coverage = [

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
 
-import fasteners  # type: ignore[import-untyped]
+import fasteners
 import structlog
 from dotenv import dotenv_values
 

--- a/src/meltano/core/state_store/azure/__init__.py
+++ b/src/meltano/core/state_store/azure/__init__.py
@@ -1,0 +1,1 @@
+"""Azure state store."""

--- a/src/meltano/core/state_store/azure/settings.py
+++ b/src/meltano/core/state_store/azure/settings.py
@@ -1,0 +1,22 @@
+"""Azure state backend settings."""
+
+from __future__ import annotations
+
+from meltano.core.setting_definition import SettingDefinition, SettingKind
+
+CONNECTION_STRING = SettingDefinition(
+    name="state_backend.azure.connection_string",
+    label="Connection String",
+    description="Connection string for the Azure Blob Storage account",
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
+
+STORAGE_ACCOUNT_URL = SettingDefinition(
+    name="state_backend.azure.storage_account_url",
+    label="Storage Account URL",
+    description="URL for the Azure Blob Storage account",
+    kind=SettingKind.STRING,
+    env_specific=True,
+)

--- a/src/meltano/core/state_store/google/__init__.py
+++ b/src/meltano/core/state_store/google/__init__.py
@@ -1,0 +1,1 @@
+"""Google state store."""

--- a/src/meltano/core/state_store/google/settings.py
+++ b/src/meltano/core/state_store/google/settings.py
@@ -1,0 +1,39 @@
+"""Google Cloud Storage state backend settings."""
+
+from __future__ import annotations
+
+from meltano.core.setting_definition import SettingDefinition, SettingKind
+
+APPLICATION_CREDENTIALS = SettingDefinition(
+    name="state_backend.gcs.application_credentials",
+    label="Application Credentials",
+    description=(
+        "Path to the credential file to use in authenticating to Google Cloud Storage"
+    ),
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
+
+APPLICATION_CREDENTIALS_PATH = SettingDefinition(
+    name="state_backend.gcs.application_credentials_path",
+    label="Application Credentials Path",
+    description=(
+        "Path to the credential file to use in authenticating to Google Cloud Storage"
+    ),
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
+
+APPLICATION_CREDENTIALS_JSON = SettingDefinition(
+    name="state_backend.gcs.application_credentials_json",
+    label="Application Credentials JSON",
+    description=(
+        "JSON object containing the service account credentials for "
+        "Google Cloud Storage"
+    ),
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)

--- a/src/meltano/core/state_store/s3/__init__.py
+++ b/src/meltano/core/state_store/s3/__init__.py
@@ -1,0 +1,1 @@
+"""S3 state store."""

--- a/src/meltano/core/state_store/s3/backend.py
+++ b/src/meltano/core/state_store/s3/backend.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import typing as t
-from contextlib import contextmanager
 from functools import cached_property
 
-from meltano.core.setting_definition import SettingDefinition, SettingKind
+import boto3
+
 from meltano.core.state_store.filesystem import (
     CloudStateStoreManager,
     InvalidStateBackendConfigurationException,
@@ -16,65 +16,6 @@ if t.TYPE_CHECKING:
     from collections.abc import Generator
 
     from mypy_boto3_s3 import S3Client
-
-BOTO_INSTALLED = True
-
-try:
-    import boto3
-except ImportError:
-    BOTO_INSTALLED = False
-
-
-class MissingBoto3Error(Exception):
-    """Raised when boto3 is required but not installed."""
-
-    def __init__(self) -> None:
-        """Initialize a MissingBoto3Error."""
-        super().__init__(
-            "boto3 required but not installed. Install meltano[s3] to use S3 as a state backend.",  # noqa: E501
-        )
-
-
-@contextmanager
-def requires_boto3() -> Generator[None, None, None]:
-    """Raise MissingBoto3Error if boto3 is required but missing in context.
-
-    Raises:
-        MissingBoto3Error: if boto3 is not installed.
-
-    Yields:
-        None
-    """
-    if not BOTO_INSTALLED:
-        raise MissingBoto3Error
-    yield
-
-
-AWS_ACCESS_KEY_ID = SettingDefinition(
-    name="state_backend.s3.aws_access_key_id",
-    label="AWS Access Key ID",
-    description="AWS Access Key ID",
-    kind=SettingKind.STRING,
-    sensitive=True,
-    env_specific=True,
-)
-
-AWS_SECRET_ACCESS_KEY = SettingDefinition(
-    name="state_backend.s3.aws_secret_access_key",
-    label="AWS Secret Access Key",
-    description="AWS Secret Access Key",
-    kind=SettingKind.STRING,
-    sensitive=True,
-    env_specific=True,
-)
-
-ENDPOINT_URL = SettingDefinition(
-    name="state_backend.s3.endpoint_url",
-    label="Endpoint URL",
-    description="URL for the AWS S3 or S3-compatible storage service",
-    kind=SettingKind.STRING,
-    env_specific=True,
-)
 
 
 class S3StateStoreManager(CloudStateStoreManager):
@@ -150,23 +91,22 @@ class S3StateStoreManager(CloudStateStoreManager):
             InvalidStateBackendConfigurationException: when configured AWS
                 settings are invalid.
         """
-        with requires_boto3():
-            if self.aws_secret_access_key and self.aws_access_key_id:
-                session = boto3.Session(
-                    aws_access_key_id=self.aws_access_key_id,
-                    aws_secret_access_key=self.aws_secret_access_key,
-                )
-                return session.client("s3", endpoint_url=self.endpoint_url)
-            if self.aws_secret_access_key:
-                raise InvalidStateBackendConfigurationException(
-                    "AWS secret access key configured, but not AWS access key ID.",  # noqa: EM101
-                )
-            if self.aws_access_key_id:
-                raise InvalidStateBackendConfigurationException(
-                    "AWS access key ID configured, but no AWS secret access key.",  # noqa: EM101
-                )
-            session = boto3.Session()
-            return session.client("s3")
+        if self.aws_secret_access_key and self.aws_access_key_id:
+            session = boto3.Session(
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+            )
+            return session.client("s3", endpoint_url=self.endpoint_url)
+        if self.aws_secret_access_key:
+            raise InvalidStateBackendConfigurationException(
+                "AWS secret access key configured, but not AWS access key ID.",  # noqa: EM101
+            )
+        if self.aws_access_key_id:
+            raise InvalidStateBackendConfigurationException(
+                "AWS access key ID configured, but no AWS secret access key.",  # noqa: EM101
+            )
+        session = boto3.Session()
+        return session.client("s3")
 
     def delete_file(self, file_path: str) -> None:
         """Delete the file/blob at the given path.

--- a/src/meltano/core/state_store/s3/settings.py
+++ b/src/meltano/core/state_store/s3/settings.py
@@ -1,0 +1,31 @@
+"""S3 state backend settings."""
+
+from __future__ import annotations
+
+from meltano.core.setting_definition import SettingDefinition, SettingKind
+
+AWS_ACCESS_KEY_ID = SettingDefinition(
+    name="state_backend.s3.aws_access_key_id",
+    label="AWS Access Key ID",
+    description="AWS Access Key ID",
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
+
+AWS_SECRET_ACCESS_KEY = SettingDefinition(
+    name="state_backend.s3.aws_secret_access_key",
+    label="AWS Secret Access Key",
+    description="AWS Secret Access Key",
+    kind=SettingKind.STRING,
+    sensitive=True,
+    env_specific=True,
+)
+
+ENDPOINT_URL = SettingDefinition(
+    name="state_backend.s3.endpoint_url",
+    label="Endpoint URL",
+    description="URL for the AWS S3 or S3-compatible storage service",
+    kind=SettingKind.STRING,
+    env_specific=True,
+)

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -27,13 +27,13 @@ from botocore.stub import Stubber
 from google.cloud.storage import Blob, Bucket
 
 from meltano.core.state_store import MeltanoState
-from meltano.core.state_store.azure import AZStorageStateStoreManager
+from meltano.core.state_store.azure.backend import AZStorageStateStoreManager
 from meltano.core.state_store.filesystem import (
     _LocalFilesystemStateStoreManager,
     _WindowsFilesystemStateStoreManager,
 )
-from meltano.core.state_store.google import GCSStateStoreManager
-from meltano.core.state_store.s3 import S3StateStoreManager
+from meltano.core.state_store.google.backend import GCSStateStoreManager
+from meltano.core.state_store.s3.backend import S3StateStoreManager
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterator
@@ -334,7 +334,7 @@ class TestAZStorageStateStoreManager:
     @pytest.fixture
     def mock_client(self):
         with patch(
-            "meltano.core.state_store.azure.BlobServiceClient",
+            "meltano.core.state_store.azure.backend.BlobServiceClient",
         ) as mock_client:
             yield mock_client
 
@@ -413,7 +413,7 @@ class TestS3StateStoreManager:
     @contextmanager
     def stubber(self) -> Iterator[Stubber]:
         with patch(
-            "meltano.core.state_store.s3.S3StateStoreManager.client",
+            "meltano.core.state_store.s3.backend.S3StateStoreManager.client",
             new_callable=PropertyMock,
         ) as mock_client:
             mock_client.return_value = client("s3")

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -26,10 +26,10 @@ from meltano.core.state_store import (
     StateBackendNotFoundError,
     state_store_manager_from_project_settings,
 )
-from meltano.core.state_store.azure import AZStorageStateStoreManager
+from meltano.core.state_store.azure.backend import AZStorageStateStoreManager
 from meltano.core.state_store.filesystem import _LocalFilesystemStateStoreManager
-from meltano.core.state_store.google import GCSStateStoreManager
-from meltano.core.state_store.s3 import S3StateStoreManager
+from meltano.core.state_store.google.backend import GCSStateStoreManager
+from meltano.core.state_store.s3.backend import S3StateStoreManager
 
 if t.TYPE_CHECKING:
     from pathlib import Path


### PR DESCRIPTION
Take 2 for https://github.com/meltano/meltano/pull/9475.

<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor state storage backends to drop hard-coded missing‐dependency guards, extract setting definitions into dedicated modules, and simplify client initialization while updating entry points and tests to match the new structure.

New Features:
- Raise InvalidStateBackendConfigurationException for S3 clients missing access key ID or secret key

Enhancements:
- Remove Missing*Error classes and requires_* context managers from Google, S3, and Azure backends
- Extract all state backend SettingDefinition entries into new settings modules under core/state_store
- Simplify GCS, S3, and Azure client() methods by removing import guards and relying on dynamic imports
- Update pyproject.toml entry points to reference the new settings and backend module paths
- Enable follow_untyped_imports in mypy config

Tests:
- Update tests to import backends and settings from new paths
- Add tests for missing AWS access key ID and secret access key error scenarios