### PR TITLE
refactor: Avoid so much exception handling when finding a setting

### DIFF
--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -77,7 +77,8 @@ class EnvVar:
         return str(not utils.truthy(value)) if self.negated else value
 
 
-class SettingMissingError(Error):
+# TODO: No longer used, consider removing
+class SettingMissingError(Error):  # pragma: no cover
     """A setting is missing."""
 
     def __init__(self, name: str) -> None:

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -8,14 +8,13 @@ import sys
 import typing as t
 import warnings
 from abc import ABCMeta, abstractmethod
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 
 import structlog
 
 from meltano.core.setting_definition import (
     SettingDefinition,
     SettingKind,
-    SettingMissingError,
 )
 from meltano.core.settings_store import SettingValueStore
 from meltano.core.utils import EnvVarMissingBehavior, flatten
@@ -336,8 +335,7 @@ class SettingsService(metaclass=ABCMeta):
         Returns:
             a tuple of the setting value and metadata
         """
-        with suppress(SettingMissingError):
-            setting_def = setting_def or self.find_setting(name)
+        setting_def = setting_def or self.find_setting(name)
         if setting_def:
             name = setting_def.name
 
@@ -502,11 +500,9 @@ class SettingsService(metaclass=ABCMeta):
 
         name = ".".join(path)
 
-        try:
-            setting_def = self.find_setting(name)
-        except SettingMissingError:
+        setting_def = self.find_setting(name)
+        if setting_def is None:
             warnings.warn(f"Unknown setting {name!r}", RuntimeWarning, stacklevel=2)
-            setting_def = None
 
         metadata: dict[str, t.Any] = {
             "name": name,
@@ -573,11 +569,7 @@ class SettingsService(metaclass=ABCMeta):
             path = [path]
 
         name = ".".join(path)
-
-        try:
-            setting_def = self.find_setting(name)
-        except SettingMissingError:
-            setting_def = None
+        setting_def = self.find_setting(name)
 
         metadata = {
             "name": name,
@@ -635,27 +627,27 @@ class SettingsService(metaclass=ABCMeta):
 
         return self._setting_defs
 
-    def find_setting(self, name: str) -> SettingDefinition:
+    def find_setting(self, name: str) -> SettingDefinition | None:
         """Find a setting by name.
 
         Args:
             name:the name or alias of the setting to return
 
         Returns:
-            the setting definition matching the given name
+            the setting definition matching the given name or None if not found
 
         Raises:
             SettingMissingError: if the setting is not found
 
         """
-        try:
-            return next(
+        return next(
+            (
                 setting
                 for setting in self.definitions()
                 if setting.name == name or name in setting.aliases
-            )
-        except StopIteration as err:
-            raise SettingMissingError(name) from err
+            ),
+            None,
+        )
 
     # TODO: The `for_writing` parameter is unused, but referenced elsewhere.
     # Callers should be updated to not use it, and then it should be removed.

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -19,7 +19,6 @@ import structlog
 from meltano.core.environment import NoActiveEnvironment
 from meltano.core.error import MeltanoError, ProjectReadonly
 from meltano.core.setting import Setting
-from meltano.core.setting_definition import SettingDefinition, SettingMissingError
 from meltano.core.utils import flatten, pop_at_path, set_at_path
 
 if sys.version_info >= (3, 11):
@@ -32,7 +31,7 @@ if t.TYPE_CHECKING:
 
     from sqlalchemy.orm import Session
 
-    from meltano.core.setting_definition import EnvVar
+    from meltano.core.setting_definition import EnvVar, SettingDefinition
     from meltano.core.settings_service import SettingsService
 
 
@@ -1536,7 +1535,4 @@ class AutoStoreManager(SettingsStoreManager):
         Returns:
             A matching SettingDefinition, if found, else None.
         """
-        try:
-            return self.settings_service.find_setting(name)
-        except SettingMissingError:
-            return None
+        return self.settings_service.find_setting(name)


### PR DESCRIPTION
Anyway it's always either suppressed, or handled and used to set the setting
definition to `None`.

<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor setting lookup to return None for missing settings and simplify exception handling across SettingsService and SettingsStore

Enhancements:
- Change find_setting to return None instead of raising SettingMissingError
- Remove try/except and suppression blocks around find_setting in get_with_metadata, set_with_metadata, and unset
- Emit a RuntimeWarning for unknown settings in set_with_metadata instead of using exceptions
- Prune redundant SettingMissingError imports and exception handling in SettingsStore