### PR TITLE
feat: Slim Docker images

### DIFF
--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -23,6 +23,10 @@ inputs:
   python-version:
     description: 'The version of Python that will be installed on the image'
     required: true
+  slim:
+    description: 'Whether to build the slim variant of the image'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -51,11 +55,21 @@ runs:
         name: Packages
         path: dist
 
+    - name: Set Dockerfile path
+      id: dockerfile-path
+      shell: bash
+      run: |
+        if [[ "${{ inputs.slim }}" == "true" ]]; then
+          echo "path=docker/meltano/Dockerfile.slim" >> $GITHUB_OUTPUT
+        else
+          echo "path=docker/meltano/Dockerfile" >> $GITHUB_OUTPUT
+        fi
+
     - name: Build the image for all supported architectures
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: .
-        file: docker/meltano/Dockerfile
+        file: ${{ steps.dockerfile-path.outputs.path }}
         build-args: |
           PYTHON_VERSION=${{ inputs.python-version }}
         tags: ${{ steps.prepare-tags.outputs.tags }}
@@ -72,7 +86,7 @@ runs:
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: .
-        file: docker/meltano/Dockerfile
+        file: ${{ steps.dockerfile-path.outputs.path }}
         build-args: |
           PYTHON_VERSION=${{ inputs.python-version }}
         tags: ${{ steps.prepare-tags.outputs.tags }}
@@ -129,7 +143,7 @@ runs:
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: .
-        file: docker/meltano/Dockerfile
+        file: ${{ steps.dockerfile-path.outputs.path }}
         build-args: |
           PYTHON_VERSION=${{ inputs.python-version }}
         tags: ${{ steps.prepare-tags.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,9 @@ jobs:
         - "3.11"
         - "3.12"
         - "3.13"
+        slim:
+        - false
+        - true
 
     steps:
     - name: Set the workflow inputs
@@ -114,6 +117,7 @@ jobs:
         --python-version ${{ matrix.python-version }}
         --default-python ${{ env.DEFAULT_PYTHON }}
         --registry ${STEPS_SET_INPUTS_OUTPUTS_REGISTRY}
+        ${{ matrix.slim && '--slim' || '' }}
         > tags
       env:
         NEEDS_BUILD_OUTPUTS_VERSION: ${{ needs.build.outputs.version }}
@@ -157,6 +161,7 @@ jobs:
         username: ${{ steps.user-and-pass.outputs.username }}
         password: ${{ steps.user-and-pass.outputs.password }}
         python-version: ${{ matrix.python-version }}
+        slim: ${{ matrix.slim }}
 
   pypi_release:
     name: Publish to PyPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       id: baipp
 
   build_docker:
-    name: Docker Images
+    name: Docker Images (${{ matrix.slim && 'Slim' || 'Full' }}, Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: build
     permissions:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ Installation
 
 If you're ready to build your ideal data platform and start running data workflows across multiple tools, start by following the [Installation guide](https://docs.meltano.com/getting-started/installation) to have Meltano up and running in your device.
 
+### Docker Images
+
+Meltano is available as Docker images on [Docker Hub](https://hub.docker.com/r/meltano/meltano):
+
+- **Slim images** (recommended): `meltano/meltano:latest-slim` - optimized size, includes cloud storage support
+- **Full images**: `meltano/meltano:latest` - includes all database connectors and build tools
+
+```bash
+# Quick start with slim image
+docker run --rm meltano/meltano:latest-slim --version
+
+# For projects needing MSSQL/PostgreSQL
+docker run --rm meltano/meltano:latest --version
+```
+
+See our [Containerization guide](https://docs.meltano.com/guide/containerization) for detailed usage instructions.
+
 Documentation
 -------------
 

--- a/docker/meltano/Dockerfile.slim
+++ b/docker/meltano/Dockerfile.slim
@@ -1,0 +1,27 @@
+ARG PYTHON_VERSION="3.13"
+
+FROM python:${PYTHON_VERSION}-slim
+
+# Meltano project directory - this is where you should mount your Meltano project
+ARG WORKDIR="/project"
+
+ENV PIP_NO_CACHE_DIR=1
+
+RUN mkdir "${WORKDIR}" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git && \
+    pip install --no-cache-dir uv && \
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+
+WORKDIR "${WORKDIR}"
+
+# Create a virtual environment, and activate it
+RUN uv venv /venv
+ENV PATH="/venv/bin:${PATH}"
+
+# Installing the application from a pre-built wheel in the dist directory
+RUN --mount=type=bind,source=dist,target=/tmp/meltano-dist \
+    uv pip install "meltano[azure,gcs,s3] @ file://$(ls /tmp/meltano-dist/meltano-*.whl)"
+
+ENTRYPOINT ["meltano"]

--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -68,21 +68,25 @@ successfully installed meltano
 
 We maintain [the `meltano/meltano` Docker image on Docker Hub](https://hub.docker.com/r/meltano/meltano/tags), which comes with Python and Meltano pre-installed.
 
-To get the latest version of Meltano, pull the latest tag. Images for specific versions of Meltano are tagged `v<major>.<minor>.<patch>`, e.g. `v3.8.0`. Add a `-python3.X` suffix to the image tag to change the python version, e.g. `latest-python3.13`. To get the latest minor or patch version, omit that value from the version number, e.g. `v3` for the latest Meltano `v3.*.*` image, or `v3.8` for the latest Meltano `v3.8.*` image
+**Image Variants:**
+- **Slim images** (recommended): Add `-slim` suffix, e.g. `latest-slim` - optimized size, includes cloud storage support
+- **Full images**: Default tags like `latest` - includes all database connectors and build tools
+
+To get the latest version of Meltano, pull the latest tag. Images for specific versions of Meltano are tagged `v<major>.<minor>.<patch>`, e.g. `v3.8.0` or `v3.8.0-slim`. Add a `-python3.X` suffix to the image tag to change the python version, e.g. `latest-python3.13-slim`. To get the latest minor or patch version, omit that value from the version number, e.g. `v3-slim` for the latest Meltano `v3.*.*` slim image.
 
 <br/>
 
 <Termy>
 
 ```console
-$ docker pull meltano/meltano
-latest: Pulling from meltano/meltano
+$ docker pull meltano/meltano:latest-slim
+latest-slim: Pulling from meltano/meltano
 ---> 100%
-Status: Downloaded newer image for meltano/meltano:latest
-docker.io/meltano/meltano:latest
+Status: Downloaded newer image for meltano/meltano:latest-slim
+docker.io/meltano/meltano:latest-slim
 
-$ docker run meltano/meltano --version
-meltano, version 2.19.0
+$ docker run meltano/meltano:latest-slim --version
+meltano, version 3.9.1
 
 ```
 

--- a/docs/docs/guide/containerization.md
+++ b/docs/docs/guide/containerization.md
@@ -52,7 +52,56 @@ docker build --tag meltano-demo-project:dev .
 
 Files added to your project include a `Dockerfile` inheriting `FROM` the public [`meltano/meltano:latest`](https://hub.docker.com/r/meltano/meltano/tags) image available on [Docker Hub](https://hub.docker.com).
 
-This can be customized to use another public mirror, a private mirror (e.g. `your-company/meltano:latest`), a specific version of Meltano (e.g. `meltano/meltano:v3.5-python3.12`), or Python 3.11 or 3.12 (e.g. `meltano/meltano:latest-python3.12` or `meltano/meltano:v3.5-python3.12`) by modifying the `Dockerfile` or overriding the `MELTANO_IMAGE` [`--build-arg`](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg). We currently publish release images to [Docker Hub](https://hub.docker.com/r/meltano/meltano). Using an alternative public mirror, or creating a private one, can avoid issues during your Docker build stage relating to registry rate limits.
+## Image Variants
+
+Meltano provides two types of Docker images to suit different use cases:
+
+### Full Images (Default)
+- **Tags**: `latest`, `v3.9.1`, `latest-python3.11`, etc.
+- **Includes**: All database connectors (PostgreSQL, MSSQL), build tools, and system dependencies
+- **Use when**: You need MSSQL or PostgreSQL connectivity, or require plugins with complex system dependencies
+
+### Slim Images (Recommended)
+- **Tags**: `latest-slim`, `v3.9.1-slim`, `latest-python3.11-slim`, etc.
+- **Includes**: Azure, GCS, and S3 connectors with minimal dependencies
+- **Excludes**: MSSQL/PostgreSQL connectors, build tools (gcc, make, etc.)
+- **Use when**: You primarily use cloud storage backends and want faster downloads and smaller deployments
+
+### Choosing the Right Image
+
+**Use slim images if you:**
+- Primarily use cloud storage (S3, GCS, Azure Blob Storage)
+- Want faster container startup and deployment times
+- Don't require MSSQL or PostgreSQL database connectivity
+- Are using plugins that don't need compilation or complex system dependencies
+
+**Use full images if you:**
+- Need MSSQL or PostgreSQL database connectivity
+- Use plugins requiring build tools or complex system dependencies
+- Need the complete set of database connectors and system tools
+
+## Customizing the Base Image
+
+You can customize the base image by modifying the `Dockerfile` or overriding the `MELTANO_IMAGE` [`--build-arg`](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg):
+
+- **Public mirror**: `your-company/meltano:latest`
+- **Specific version**: `meltano/meltano:v3.9.1` or `meltano/meltano:v3.9.1-slim`
+- **Python version**: `meltano/meltano:latest-python3.12` or `meltano/meltano:latest-python3.12-slim`
+
+### Examples
+
+```bash
+# Use slim image (recommended for most use cases)
+docker build --build-arg MELTANO_IMAGE=meltano/meltano:latest-slim --tag my-project:dev .
+
+# Use specific version with Python 3.11
+docker build --build-arg MELTANO_IMAGE=meltano/meltano:v3.9.1-python3.11-slim --tag my-project:dev .
+
+# Use full image for MSSQL/PostgreSQL support
+docker build --build-arg MELTANO_IMAGE=meltano/meltano:latest --tag my-project:dev .
+```
+
+We currently publish release images to [Docker Hub](https://hub.docker.com/r/meltano/meltano). Using an alternative public mirror, or creating a private one, can avoid issues during your Docker build stage relating to registry rate limits.
 
 The built image's [entrypoint](https://docs.docker.com/engine/reference/builder/#entrypoint)
 will be [the `meltano` command](/reference/command-line-interface),

--- a/scripts/generate_docker_tags.py
+++ b/scripts/generate_docker_tags.py
@@ -27,41 +27,47 @@ def main() -> None:
     parser.add_argument("-p", "--python-version", required=True)
     parser.add_argument("-d", "--default-python", required=True)
     parser.add_argument("--git-sha")
+    parser.add_argument(
+        "--slim", action="store_true", help="Generate tags for slim images"
+    )
     args = parser.parse_args()
 
     is_default_python = args.default_python == args.python_version
     version = Version(args.package_version)
     tags = []
 
+    # Add suffix for slim images
+    suffix = "-slim" if args.slim else ""
+
     # To save space, only publish the `latest` tag for each
     # images to the GitHub registry
     if args.registry != "ghcr.io":
-        tags.append(f"v{version}-python{args.python_version}")
+        tags.append(f"v{version}-python{args.python_version}{suffix}")
 
         if not version.is_prerelease:
             tags.extend(
                 (
-                    f"v{version.major}-python{args.python_version}",
-                    f"v{version.major}.{version.minor}-python{args.python_version}",
+                    f"v{version.major}-python{args.python_version}{suffix}",
+                    f"v{version.major}.{version.minor}-python{args.python_version}{suffix}",
                 ),
             )
             if is_default_python:
                 tags.extend(
                     (
-                        f"SHA-{args.git_sha}",
-                        f"v{version.major}",
-                        f"v{version.major}.{version.minor}",
-                        f"v{version}",
+                        f"SHA-{args.git_sha}{suffix}",
+                        f"v{version.major}{suffix}",
+                        f"v{version.major}.{version.minor}{suffix}",
+                        f"v{version}{suffix}",
                     ),
                 )
 
     # ghcr.io: publish `latest` for ALL versions
     # docker.io: only publish `latest` for final releases
     if not version.is_prerelease or args.registry == "ghcr.io":
-        tags.append(f"latest-python{args.python_version}")
+        tags.append(f"latest-python{args.python_version}{suffix}")
 
         if is_default_python:
-            tags.append("latest")
+            tags.append(f"latest{suffix}")
 
     print("\n".join(tags))  # noqa: T201
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Updated docs: https://deploy-preview-9481--meltano.netlify.app/guide/containerization/#full-images-default

## Related Issues

* Closes #7661 

## Summary by Sourcery

Add support for building and publishing slim variants of the Docker images by extending the tag generator, CI workflows, and providing a dedicated slim Dockerfile.

New Features:
- Introduce slim Dockerfile to create minimal Python images.
- Enable building and publishing slim Docker image variants in the CI pipeline.

Enhancements:
- Extend Docker tag generator with `--slim` flag and suffix logic.
- Update CI action to dynamically select between standard and slim Dockerfiles.
- Expand build workflow matrix to include a slim dimension and pass the slim flag to jobs.