### PR TITLE
break: Remove `psycopg2` extra from the Docker images

### DIFF
--- a/docker/meltano/Dockerfile
+++ b/docker/meltano/Dockerfile
@@ -34,6 +34,6 @@ ENV PATH="/venv/bin:${PATH}"
 
 # Installing the application from a pre-built wheel in the dist directory
 RUN --mount=type=bind,source=dist,target=/tmp/meltano-dist \
-    uv pip install "meltano[azure,gcs,mssql,postgres,psycopg2,s3] @ file://$(ls /tmp/meltano-dist/meltano-*.whl)"
+    uv pip install "meltano[azure,gcs,mssql,postgres,s3] @ file://$(ls /tmp/meltano-dist/meltano-*.whl)"
 
 ENTRYPOINT ["meltano"]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This does not remove support for this SQLAlchemy dialect, it just removes the dependency from the Docker images.

`psycopg2`[^1] is still maintained, but not receiving new features. Those are being added to `psycopg3`[^2] instead, which is still supported installed all the Docker images.

For example:

- https://github.com/psycopg/psycopg/pull/1116 (https://neon.com/postgresql/postgresql-18/oauth-authentication)

## Related Issues

NA

[^1]: https://github.com/psycopg/psycopg2/
[^2]: https://github.com/psycopg/psycopg/