### PR TITLE
feat(cli): Log a more detailed reason for skipping a plugin's installation

### DIFF
--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -129,7 +129,7 @@ class PluginInstallState:
             case PluginInstallStatus.SKIPPED:
                 return "Skipped installing"
             case _:
-                return "Errored"
+                return "Installation failed"
 
 
 def with_semaphore(func):  # noqa: ANN001, ANN201
@@ -388,10 +388,7 @@ class PluginInstallService:
                 plugin=plugin,
                 reason=reason,
                 status=PluginInstallStatus.ERROR,
-                message=(
-                    f"{plugin.type.descriptor.capitalize()} '{plugin.name}' "
-                    f"could not be installed: {err}"
-                ),
+                message=str(err),
                 details=await err.stderr,
             )
             self.status_cb(state)
@@ -558,7 +555,12 @@ def install_status_update(install_state: PluginInstallState) -> None:
         case PluginInstallStatus.RUNNING | PluginInstallStatus.SUCCESS:
             logger.info("%s %s '%s'", install_state.verb, desc, plugin.name)
         case PluginInstallStatus.ERROR:
-            logger.error(install_state.message, details=install_state.details)
+            logger.error(
+                "%s. %s.",
+                install_state.verb,
+                install_state.message,
+                details=install_state.details,
+            )
         case PluginInstallStatus.WARNING:  # pragma: no cover
             logger.warning(install_state.message)
         case _:  # pragma: no cover

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -556,7 +556,7 @@ class VenvService:
             self.pip_log_path,
         )
         return AsyncSubprocessError(
-            f"Failed to install plugin '{self.name}'.",
+            f"Failed to install plugin '{self.name}'",
             err.process,
             stderr=await err.stderr,
         )
@@ -726,7 +726,7 @@ class UvVenvService(VenvService):
                 self.pip_log_path,
             )
         return AsyncSubprocessError(
-            f"Failed to install plugin '{self.name}'.",
+            f"Failed to install plugin '{self.name}'",
             err.process,
             stderr=await err.stderr,
         )


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

For this project

```yaml
version: 1
default_environment: dev
environments:
- name: dev
plugins:
  extractors:
  - name: tap-fedidb
    variant: edgarrmondragon
    pip_url: tap-fedidb
  - name: tap-fedidb--child
    inherit_from: tap-fedidb
```

the output is

```console
$ meltano install
2025-09-12T17:39:25.308381Z [info     ] Installing 2 plugins
2025-09-12T17:39:25.308623Z [info     ] Skipped installing extractor 'tap-fedidb--child'. Plugin 'tap-fedidb--child' does not require installation: reusing parent virtualenv.
2025-09-12T17:39:25.315321Z [info     ] Installing extractor 'tap-fedidb'
2025-09-12T17:39:25.462257Z [info     ] Installed extractor 'tap-fedidb'
2025-09-12T17:39:25.462751Z [info     ] Installed 1/2 plugins
2025-09-12T17:39:25.462841Z [info     ] Skipped installing 1/2 plugins
```

And for this project

```yaml
version: 1
default_environment: dev
environments:
- name: dev
plugins:
  extractors:
  - name: tap-fedidb
    variant: edgarrmondragon
    pip_url: tap-fedidb
  - name: tap-fedidb--child
    pip_url: tap-fedidb python-json-logger  # notice this is different
    inherit_from: tap-fedidb
```

this is the output

```console
$ meltano install
2025-09-12T17:41:30.763630Z [info     ] Installing 2 plugins
2025-09-12T17:41:30.770836Z [info     ] Installing extractor 'tap-fedidb'
2025-09-12T17:41:30.784475Z [info     ] Installing extractor 'tap-fedidb--child'
2025-09-12T17:41:30.855497Z [info     ] Installed extractor 'tap-fedidb--child'
2025-09-12T17:41:30.855824Z [info     ] Installed extractor 'tap-fedidb'
2025-09-12T17:41:30.855945Z [info     ] Installed 2/2 plugins
```


## Related Issues

* Closes #6501

## Summary by Sourcery

Use pattern matching for install status handling and enhance skip logic to include explicit reasons in logs

New Features:
- Log detailed skip reasons when a plugin’s installation is skipped

Enhancements:
- Refactor plugin status verb resolution and logging to use pattern matching
- Update _requires_install to return a message describing why installation was skipped
- Streamline plugin install summary by introducing a total count for reporting