### PR TITLE
fix: Nuanced error detection for `FileNotFoundError` in plugin execution

### DIFF
--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -103,23 +103,6 @@ class ExecutableNotFoundError(InvokerError):
         )
 
 
-class PluginExecutionError(InvokerError):
-    """File or directory access error during plugin execution."""
-
-    def __init__(self, plugin: PluginRef, original_error: str):
-        """Initialize PluginExecutionError.
-
-        Args:
-            plugin: Meltano plugin reference.
-            original_error: Original error message that provides context.
-        """
-        plugin_type_descriptor = plugin.type.descriptor.capitalize()
-        super().__init__(
-            f"{plugin_type_descriptor} '{plugin.name}' execution failed: "
-            f"{original_error}",
-        )
-
-
 class InvokerNotPreparedError(InvokerError):
     """Occurs when `invoke` is called before `prepare`."""
 
@@ -512,9 +495,7 @@ class PluginInvoker:
                         self.plugin,
                         self.plugin.executable,
                     ) from err
-                else:
-                    # The executable exists but couldn't access a file/directory
-                    raise PluginExecutionError(self.plugin, str(err)) from err
+                raise
 
     async def invoke_async(
         self,

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio.subprocess
 import enum
 import os
 import sys


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Handle FileNotFoundError more precisely during plugin execution by introducing ExecutableNotFoundError for missing executables and preserving original errors for other file access failures, with corresponding test coverage enhancements

New Features:
- Introduce ExecutableNotFoundError to explicitly represent missing plugin executables
- Differentiate between missing executables and plugin file access errors by inspecting FileNotFoundError.filename

Enhancements:
- Update the invocation pipeline to raise ExecutableNotFoundError only when the executable path itself is absent and rethrow other file errors unchanged
- Refactor test_unknown_command to assert on the exception instance and its command attribute

Tests:
- Add async tests for missing executable and missing plugin file scenarios
- Add direct tests to verify ExecutableNotFoundError messaging and usage