### PR TITLE
ci: Stabilize integration tests by setting `UV_EXCLUDE_NEWER`

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,6 +27,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: "1"
+  UV_EXCLUDE_NEWER: "2025-09-15"
+
 jobs:
   validate:
     name: Integration Tests


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Improve error handling in plugin invocation to distinguish missing executables from other file access errors, augment tests accordingly, and stabilize integration tests by setting UV_EXCLUDE_NEWER in CI

Bug Fixes:
- Differentiate between missing executables and other file access errors when catching FileNotFoundError in plugin invocation by only raising ExecutableNotFoundError for the former

Enhancements:
- Refine UnknownCommandError test assertions and import necessary types in plugin invoker tests

CI:
- Set FORCE_COLOR and UV_EXCLUDE_NEWER in integration tests workflow to stabilize CI

Tests:
- Add tests for ExecutableNotFoundError behavior and class message formatting
- Add tests to ensure FileNotFoundError is propagated for non-executable file access issues