### PR TITLE
refactor: Deprecate the `--all` flag of `meltano lock` and make it the default behavior

### DIFF
--- a/docs/docs/guide/v3-migration.md
+++ b/docs/docs/guide/v3-migration.md
@@ -49,7 +49,7 @@ meltano install
 3. Generate all lock files for your project:
 
 ```bash
-meltano lock --all
+meltano lock
 ```
 
 4. (Optional) Remove the `ff.plugin_locks_required` feature flag after upgrading to Meltano v3, since it has no effect in Meltano v3.

--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -1023,11 +1023,11 @@ meltano invoke --print-var <PLUGIN_ENVIRONMENT_VARIABLE_1> --print-var <PLUGIN_E
 ### How to use
 
 ```bash
-# Lock all plugins
-meltano lock --all
+# Lock all plugins (default behavior)
+meltano lock
 
 # Lock all plugins of a certain type
-meltano lock --all --plugin-type=<type>
+meltano lock --plugin-type=<type>
 
 # Lock specific plugins
 meltano lock <name> <name_two>
@@ -1037,7 +1037,10 @@ meltano lock <name> <name_two> --plugin-type=<type>
 
 # Use --update in combination with any of the above to update the lock file
 # with the latest definition from MeltanoHub
-meltano lock --all --update
+meltano lock --update
+
+# Note: --all flag is deprecated but still supported
+meltano lock --all  # deprecated, use 'meltano lock' instead
 ```
 
 ### Using `lock` with Environments

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -30,9 +30,10 @@ logger = structlog.get_logger(__name__)
 @click.command(cls=PartialInstrumentedCmd, short_help="Lock plugin definitions.")
 @click.option(
     "--all",
-    "all_plugins",
     is_flag=True,
-    help="Lock all the plugins of the project.",
+    deprecated=True,
+    hidden=True,
+    help="DEPRECATED: All plugins are now locked by default.",
 )
 @click.option(
     "--plugin-type",
@@ -47,7 +48,7 @@ def lock(
     project: Project,
     ctx: click.Context,
     *,
-    all_plugins: bool,
+    all: bool,  # noqa: A002, ARG001
     plugin_type: PluginType | None,
     plugin_name: tuple[str, ...],
     update: bool,
@@ -58,11 +59,7 @@ def lock(
     Read more at https://docs.meltano.com/reference/command-line-interface#lock
     """  # noqa: D301
     tracker: Tracker = ctx.obj["tracker"]
-
     lock_service = PluginLockService(project)
-    if (all_plugins and plugin_name) or not (all_plugins or plugin_name):
-        tracker.track_command_event(CliEvent.aborted)
-        raise CliError("Exactly one of --all or plugin name must be specified.")  # noqa: EM101
 
     try:
         with project.plugins.use_preferred_source(DefinitionSource.ANY):

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -98,7 +98,7 @@ class PluginDefinitionNotFoundError(MeltanoError):
             instruction = "Check https://hub.meltano.com/ for available plugins"
         else:
             instruction = (
-                "Try running `meltano lock --update --all` to ensure your plugins are "
+                "Try running `meltano lock --update` to ensure your plugins are "
                 "up to date, or add a `namespace` to your plugin if it is a custom one"
             )
 

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -21,22 +21,19 @@ if t.TYPE_CHECKING:
 class TestLock:
     @pytest.mark.order(0)
     @pytest.mark.usefixtures("project")
-    @pytest.mark.parametrize(
-        "args",
-        (
-            ["lock"],
-            ["lock", "--all", "tap-mock"],
-        ),
-        ids=("noop", "all-and-plugin-name"),
-    )
-    def test_lock_invalid_options(self, cli_runner: CliRunner, args: list[str]) -> None:
-        result = cli_runner.invoke(cli, args)
-        assert result.exit_code == 1
-
-        exception_message = "Exactly one of --all or plugin name must be specified."
-        assert exception_message == str(result.exception)
+    def test_lock_all_deprecation(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(cli, ["lock", "--all"])
+        deprecation_message = "The option 'all' is deprecated"
+        assert deprecation_message in result.stderr
 
     @pytest.mark.order(1)
+    @pytest.mark.usefixtures("project")
+    def test_lock_no_plugins(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(cli, ["lock"])
+        exception_message = "No matching plugin(s) found"
+        assert exception_message == str(result.exception)
+
+    @pytest.mark.order(2)
     @pytest.mark.usefixtures("tap", "target")
     def test_lockfile_exists(
         self,
@@ -46,13 +43,13 @@ class TestLock:
         lockfiles = list(project.root_plugins_dir().glob("./*/*.lock"))
         assert len(lockfiles) == 2
 
-        result = cli_runner.invoke(cli, ["lock", "--all"])
+        result = cli_runner.invoke(cli, ["lock"])
         assert result.exit_code == 0
         assert "Lockfile exists for extractor tap-mock" in result.stdout
         assert "Lockfile exists for loader target-mock" in result.stdout
         assert "Locked definition" not in result.stdout
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(3)
     def test_lockfile_update(
         self,
         cli_runner: CliRunner,
@@ -74,7 +71,7 @@ class TestLock:
             },
         )
 
-        result = cli_runner.invoke(cli, ["lock", "--all", "--update"])
+        result = cli_runner.invoke(cli, ["lock", "--update"])
         assert result.exit_code == 0
         assert result.stdout.count("Lockfile exists") == 0
         assert result.stdout.count("Locked definition") == 2
@@ -88,7 +85,7 @@ class TestLock:
         assert new_setting.name == "foo"
         assert new_setting.value == "bar"
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(4)
     @pytest.mark.usefixtures("tap", "inherited_tap", "hub_endpoints")
     def test_lockfile_update_extractors(
         self,
@@ -101,7 +98,7 @@ class TestLock:
 
         result = cli_runner.invoke(
             cli,
-            ["lock", "--all", "--update", "--plugin-type", "extractor"],
+            ["lock", "--update", "--plugin-type", "extractor"],
         )
         assert result.exit_code == 0
         assert "Lockfile exists" not in result.stdout

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -29,8 +29,12 @@ class TestLock:
     @pytest.mark.order(1)
     @pytest.mark.usefixtures("project")
     def test_lock_no_plugins(self, cli_runner: CliRunner) -> None:
-        result = cli_runner.invoke(cli, ["lock"])
         exception_message = "No matching plugin(s) found"
+
+        result = cli_runner.invoke(cli, ["lock"])
+        assert exception_message == str(result.exception)
+
+        result = cli_runner.invoke(cli, ["lock", "--update"])
         assert exception_message == str(result.exception)
 
     @pytest.mark.order(2)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This gets rids of the annoying and arguably unexpected error when running `meltano lock`.

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Deprecate and hide the --all option in the `meltano lock` command and make locking all plugins the default behavior, updating CLI implementation, tests, and documentation accordingly.

Enhancements:
- Deprecate and hide the `--all` flag in `meltano lock` and simplify command logic to lock all plugins by default
- Remove explicit validation requiring `--all` or plugin names for lock operations
- Update tests to expect the default all behavior and deprecation warning for `--all`

Documentation:
- Revise CLI reference and v3 migration guide to remove or deprecate `--all` in examples and usage notes

Tests:
- Refactor lock command tests to remove `--all` usage, add test for deprecation message