### PR TITLE
packaging: Allow Click 8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "anyio>=4.4.0,<5",
   "backports-strenum>=1.3.1,<2 ; python_version < '3.11'",
   "check-jsonschema>=0.33,<0.35",
-  "click>=8.1,<8.3,!=8.2.2",
+  "click>=8.1,<8.4,!=8.2.2",
   "click-default-group>=1.2.4,<2",
   "click-didyoumean>=0.3.1,<0.4",
   "dateparser>=1.2.1",

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -564,7 +564,7 @@ class TestCliColors:
             result = cli_runner.invoke(cli, ["dummy"], color=True, env=env)
             assert result.exit_code == 0, result.exception
             assert result.stdout.strip() == expected_text
-            assert bool(ANSI_RE.match(result.stderr)) is log_colors_expected
+            assert bool(ANSI_RE.findall(result.stderr)) is log_colors_expected
             assert result.exception is None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -503,14 +503,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
 ]
 
 [[package]]
@@ -1376,7 +1376,7 @@ requires-dist = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1,<2" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35,<1.41" },
     { name = "check-jsonschema", specifier = ">=0.33,<0.35" },
-    { name = "click", specifier = ">=8.1,!=8.2.2,<8.3" },
+    { name = "click", specifier = ">=8.1,!=8.2.2,<8.4" },
     { name = "click-default-group", specifier = ">=1.2.4,<2" },
     { name = "click-didyoumean", specifier = ">=0.3.1,<0.4" },
     { name = "dateparser", specifier = ">=1.2.1" },


### PR DESCRIPTION
## Summary by Sourcery

Allow Click 8.3 in the packaging constraints, update the CLI test to correctly detect ANSI codes, and regenerate the lock file

Bug Fixes:
- Fix ANSI escape code detection in CLI tests by using findall instead of match

Enhancements:
- Allow Click 8.3 by updating the version constraint to <8.4

Chores:
- Regenerate uv.lock to reflect updated dependencies