### PR TITLE
break: Rename subprocess logger to `meltano.plugins.<stream>.<type>.<name>` (split stdout and stderr streams into separate loggers)

### DIFF
--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -329,7 +329,7 @@ cat meltano.log | jq -c 'select(.string_id == "tap-gitlab" and .stdio == "stderr
 
 ### Exclude plugin stdout logs
 
-When DEBUG level logging is enabled, a plugin's stdout logs can be very verbose. For extractors, these can include the raw [Singer](/reference/glossary/#singer) messages. To exclude them, you can set the `meltano.core.block.extract_load` logger to `INFO` level.
+When DEBUG level logging is enabled, a plugin's stdout logs can be very verbose. For extractors, these can include the raw [Singer](/reference/glossary/#singer) messages. To exclude them, you can set the `meltano.plugins` logger to the `INFO` level.
 
 ```yaml
 version: 1
@@ -337,8 +337,9 @@ disable_existing_loggers: no
 
 loggers:
   # Disable logging of tap and target stdout
-  meltano.core.block.extract_load:
+  meltano.plugins:
     level: INFO
+    propagate: no
   root:
     level: DEBUG
     handlers: [console]

--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -337,7 +337,7 @@ disable_existing_loggers: no
 
 loggers:
   # Disable logging of tap and target stdout
-  meltano.plugins:
+  meltano.plugins.stdout:
     level: INFO
     propagate: no
   root:

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -641,14 +641,14 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
             BlockSetValidationError: if consumer does not have an upstream producer.
         """
         for idx, block in enumerate(self.blocks):
-            logger_base = logger.bind(
+            logger_base = block.invoker.logger.bind(
                 consumer=block.consumer,
                 producer=block.producer,
                 string_id=block.string_id,
                 cmd_type="elb",
                 job_name=self.context.job.job_name if self.context.job else None,
             )
-            if logger.isEnabledFor(logging.DEBUG):
+            if block.invoker.logger.isEnabledFor(logging.DEBUG):
                 block.stdout_link(
                     self.output_logger.out(
                         block.string_id,

--- a/src/meltano/core/block/plugin_command.py
+++ b/src/meltano/core/block/plugin_command.py
@@ -184,10 +184,9 @@ def plugin_command_invoker(
         run_dir=run_dir,
         plugin_settings_service=ctx.settings_service,
     )
-    stderr_log = invoker.stdout_logger.bind(stdio="stderr", cmd_type="command")
     invoker_log = output_logger.out(
         plugin.name,
-        stderr_log,
+        invoker.stderr_logger.bind(cmd_type="command"),
         log_parser=invoker.get_log_parser(),
     )
 

--- a/src/meltano/core/block/plugin_command.py
+++ b/src/meltano/core/block/plugin_command.py
@@ -166,11 +166,6 @@ def plugin_command_invoker(
     Returns:
         InvokerCommand
     """
-    stderr_log = logger.bind(
-        stdio="stderr",
-        cmd_type="command",
-    )
-
     _, session_maker = project_engine(project)
     session = session_maker()
 
@@ -189,6 +184,7 @@ def plugin_command_invoker(
         run_dir=run_dir,
         plugin_settings_service=ctx.settings_service,
     )
+    stderr_log = invoker.logger.bind(stdio="stderr", cmd_type="command")
     invoker_log = output_logger.out(
         plugin.name,
         stderr_log,

--- a/src/meltano/core/block/plugin_command.py
+++ b/src/meltano/core/block/plugin_command.py
@@ -184,7 +184,7 @@ def plugin_command_invoker(
         run_dir=run_dir,
         plugin_settings_service=ctx.settings_service,
     )
-    stderr_log = invoker.logger.bind(stdio="stderr", cmd_type="command")
+    stderr_log = invoker.stdout_logger.bind(stdio="stderr", cmd_type="command")
     invoker_log = output_logger.out(
         plugin.name,
         stderr_log,

--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -78,7 +78,7 @@ class OutputLogger:
 class LineWriter:
     """Line Writer."""
 
-    def __init__(self, out) -> None:  # noqa: ANN001
+    def __init__(self, out: Out) -> None:
         """Instantiate a Line Writer.
 
         Args:

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -39,11 +39,11 @@ def _get_sdk_logging(
                 "class": "logging.StreamHandler",
                 "formatter": "singer_formatter",
                 "stream": "ext://sys.stderr",
-                "level": level,
             },
         },
         "root": {
             "handlers": ["console"],
+            "level": level,
         },
     }
 
@@ -140,7 +140,8 @@ class SingerPlugin(BasePlugin):
         singer_sdk_logging = plugin_invoker.files["singer_sdk_logging"]
         pipelinewise_logging = plugin_invoker.files["pipelinewise_singer_logging"]
 
-        log_level = logging.getLevelName(plugin_invoker.logger.getEffectiveLevel())
+        logger = plugin_invoker.stderr_logger
+        log_level = logging.getLevelName(logger.getEffectiveLevel())
 
         # Check if structured logging is enabled
         log_parser = plugin_invoker.get_log_parser()

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -48,7 +48,9 @@ def _get_sdk_logging(
     }
 
 
-class SingerPlugin(BasePlugin):  # noqa: D101
+class SingerPlugin(BasePlugin):
+    """Base class for all Singer plugins."""
+
     EXTRA_SETTINGS: t.ClassVar[list[SettingDefinition]] = [
         SettingDefinition(name="_log_parser", value=LOG_PARSER_SINGER_SDK),
     ]
@@ -111,14 +113,14 @@ class SingerPlugin(BasePlugin):  # noqa: D101
             config = invoker.plugin_config_processed
             await config_file.write(json.dumps(config, indent=2))
 
-        logger.debug(f"Created configuration at {config_path}")  # noqa: G004
+        logger.debug("Created configuration at %s", config_path)
 
     @hook("before_cleanup")
     async def before_cleanup(self, invoker: PluginInvoker) -> None:
         """Delete configuration file."""
         config_path = invoker.files["config"]
         config_path.unlink()
-        logger.debug(f"Deleted configuration at {config_path}")  # noqa: G004
+        logger.debug("Deleted configuration at %s", config_path)
 
     @hook("before_invoke")
     async def setup_logging_hook(
@@ -138,7 +140,7 @@ class SingerPlugin(BasePlugin):  # noqa: D101
         singer_sdk_logging = plugin_invoker.files["singer_sdk_logging"]
         pipelinewise_logging = plugin_invoker.files["pipelinewise_singer_logging"]
 
-        log_level = logging.getLevelName(logger.getEffectiveLevel())
+        log_level = logging.getLevelName(plugin_invoker.logger.getEffectiveLevel())
 
         # Check if structured logging is enabled
         log_parser = plugin_invoker.get_log_parser()

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -503,7 +503,10 @@ class SingerTap(SingerPlugin):
                         asyncio.ensure_future(_stream_redirect(handle.stdout, catalog)),
                         asyncio.ensure_future(handle.wait()),
                     ]
-                    if logger.isEnabledFor(logging.DEBUG) and handle.stderr:
+                    if (
+                        plugin_invoker.stderr_logger.isEnabledFor(logging.DEBUG)
+                        and handle.stderr is not None
+                    ):
                         invoke_futures.append(
                             _debug_logging_handler(
                                 self.name,

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -20,6 +20,8 @@ import anyio
 import structlog
 
 from meltano.core.behavior.hookable import hook
+from meltano.core.logging import capture_subprocess_output
+from meltano.core.logging.output_logger import OutputLogger
 from meltano.core.plugin.error import PluginExecutionError, PluginLacksCapabilityError
 from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.state_service import SINGER_STATE_KEY, StateService
@@ -37,7 +39,6 @@ from .catalog import (
 )
 
 if t.TYPE_CHECKING:
-    from asyncio.streams import StreamReader
     from pathlib import Path
 
     from sqlalchemy.orm import Session
@@ -70,52 +71,6 @@ async def _stream_redirect(
                 await file_like_obj.write(data.decode(encoding) if write_str else data)
             else:
                 file_like_obj.write(data.decode(encoding) if write_str else data)
-
-
-def _debug_logging_handler(
-    name: str,
-    plugin_invoker: PluginInvoker,
-    stderr: StreamReader,
-    *other_dsts,  # noqa: ANN002
-) -> asyncio.Task[None]:
-    """Route debug log lines.
-
-    Routes to stderr, or an `OutputLogger` if one is present in our invocation
-    context.
-
-    Args:
-        name: name of the plugin
-        plugin_invoker: the PluginInvoker to route log lines for
-        stderr: stderr StreamReader to route to
-        other_dsts: other destinations that the stream should be routed too
-            along with logging output
-
-    Returns:
-        asyncio.Task which performs the routing of log lines
-    """
-    if not plugin_invoker.context or not plugin_invoker.context.base_output_logger:
-        return asyncio.ensure_future(
-            _stream_redirect(
-                stderr,
-                sys.stderr,
-                *other_dsts,
-                write_str=True,
-            ),
-        )
-
-    out = plugin_invoker.context.base_output_logger.out(
-        name,
-        logger.bind(type="discovery", stdio="stderr"),
-    )
-    with out.line_writer() as outerr:
-        return asyncio.ensure_future(
-            _stream_redirect(
-                stderr,
-                outerr,
-                *other_dsts,
-                write_str=True,
-            ),
-        )
 
 
 def config_metadata_rules(config: dict[str, t.Any]) -> list[MetadataRule]:
@@ -507,14 +462,13 @@ class SingerTap(SingerPlugin):
                         plugin_invoker.stderr_logger.isEnabledFor(logging.DEBUG)
                         and handle.stderr is not None
                     ):
-                        invoke_futures.append(
-                            _debug_logging_handler(
-                                self.name,
-                                plugin_invoker,
-                                handle.stderr,
-                                stderr_buff,
-                            ),
+                        out = OutputLogger(None).out(
+                            self.name,
+                            plugin_invoker.stderr_logger.bind(type="discovery"),
+                            log_parser=plugin_invoker.get_log_parser(),
                         )
+                        future = capture_subprocess_output(handle.stderr, out)
+                        invoke_futures.append(asyncio.ensure_future(future))
                     else:
                         invoke_futures.append(
                             asyncio.ensure_future(

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -503,10 +503,7 @@ class SingerTap(SingerPlugin):
                         asyncio.ensure_future(_stream_redirect(handle.stdout, catalog)),
                         asyncio.ensure_future(handle.wait()),
                     ]
-                    if (
-                        plugin_invoker.stderr_logger.isEnabledFor(logging.DEBUG)
-                        and handle.stderr is not None
-                    ):
+                    if logger.isEnabledFor(logging.DEBUG) and handle.stderr:
                         invoke_futures.append(
                             _debug_logging_handler(
                                 self.name,

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -462,7 +462,7 @@ class SingerTap(SingerPlugin):
                         plugin_invoker.stderr_logger.isEnabledFor(logging.DEBUG)
                         and handle.stderr is not None
                     ):
-                        out = OutputLogger(None).out(
+                        out = OutputLogger("discovery.log").out(
                             self.name,
                             plugin_invoker.stderr_logger.bind(type="discovery"),
                             log_parser=plugin_invoker.get_log_parser(),

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -598,13 +598,28 @@ class PluginInvoker:
             self.output_handlers = {src: [handler]}
 
     @property
-    def logger(self) -> BoundLogger:
-        """Get the logger for the plugin.
+    def stdout_logger(self) -> BoundLogger:
+        """Get the logger for the plugin stdout.
 
         Returns:
-            The logger for the plugin.
+            The logger for the plugin stdout.
         """
-        return get_logger(f"meltano.plugin.{self.plugin.type}.{self.plugin.name}")
+        return get_logger(
+            f"meltano.plugin.stdout.{self.plugin.type}.{self.plugin.name}",
+            stdio="stdout",
+        )
+
+    @property
+    def stderr_logger(self) -> BoundLogger:
+        """Get the logger for the plugin stderr.
+
+        Returns:
+            The logger for the plugin stderr.
+        """
+        return get_logger(
+            f"meltano.plugin.stderr.{self.plugin.type}.{self.plugin.name}",
+            stdio="stderr",
+        )
 
     def get_log_parser(self) -> str | None:
         """Get the log parser for the plugin.

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -33,6 +33,7 @@ if t.TYPE_CHECKING:
     from pathlib import Path
 
     from sqlalchemy.orm import Session
+    from structlog.stdlib import BoundLogger
 
     from meltano.core.block.extract_load import ELBContext
     from meltano.core.elt_context import ELTContext, PluginContext
@@ -595,6 +596,15 @@ class PluginInvoker:
             self.output_handlers[src].append(handler)
         else:
             self.output_handlers = {src: [handler]}
+
+    @property
+    def logger(self) -> BoundLogger:
+        """Get the logger for the plugin.
+
+        Returns:
+            The logger for the plugin.
+        """
+        return get_logger(f"meltano.plugin.{self.plugin.type}.{self.plugin.name}")
 
     def get_log_parser(self) -> str | None:
         """Get the log parser for the plugin.

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -306,7 +306,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
 
         for plugin in self.plugins(ensure_parent=False):
             if (
-                plugin.name == plugin_name  # (with too much logic)
+                plugin.name == plugin_name
                 and (plugin_type is None or plugin.type == plugin_type)
                 and (
                     invokable is None

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -23,6 +23,7 @@ from meltano.core.plugin.singer.catalog import (
     property_breadcrumb,
     select_metadata_rules,
 )
+from meltano.core.plugin_invoker import PluginInvoker
 from meltano.core.state_service import InvalidJobStateError, StateService
 
 if t.TYPE_CHECKING:
@@ -32,7 +33,6 @@ if t.TYPE_CHECKING:
 
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.plugin.singer.catalog import CatalogDict, MetadataRule, SchemaRule
-    from meltano.core.plugin_invoker import PluginInvoker
     from meltano.core.project import Project
     from meltano.core.project_add_service import ProjectAddService
 
@@ -1018,9 +1018,11 @@ class TestSingerTap:
         catalog_path = invoker.files["catalog"]
 
         with (
-            mock.patch(
-                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
-                return_value=False,
+            mock.patch.object(
+                PluginInvoker,
+                "stderr_logger",
+                new_callable=mock.PropertyMock,
+                return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=False)),
             ),
             mock.patch(
                 "meltano.core.plugin.singer.tap._stream_redirect",
@@ -1030,9 +1032,11 @@ class TestSingerTap:
             assert stream_mock.call_count == 2
 
         with (
-            mock.patch(
-                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
-                return_value=True,
+            mock.patch.object(
+                PluginInvoker,
+                "stderr_logger",
+                new_callable=mock.PropertyMock,
+                return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=True)),
             ),
             mock.patch(
                 "meltano.core.plugin.singer.tap._stream_redirect",
@@ -1046,9 +1050,11 @@ class TestSingerTap:
         original_level = discovery_logger.getEffectiveLevel()
         discovery_logger.setLevel(logging.INFO)
         with (
-            mock.patch(
-                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
-                return_value=True,
+            mock.patch.object(
+                PluginInvoker,
+                "stderr_logger",
+                new_callable=mock.PropertyMock,
+                return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=True)),
             ),
             mock.patch(
                 "meltano.core.plugin.singer.tap._stream_redirect",
@@ -1111,9 +1117,11 @@ class TestSingerTap:
 
         assert sys.getdefaultencoding() == "utf-8"
 
-        with mock.patch(
-            "meltano.core.plugin.singer.tap.logger.isEnabledFor",
-            return_value=True,
+        with mock.patch.object(
+            PluginInvoker,
+            "stderr_logger",
+            new_callable=mock.PropertyMock,
+            return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=True)),
         ):
             await subject.run_discovery(invoker, catalog_path)
 

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -1043,7 +1043,7 @@ class TestSingerTap:
             ) as stream_mock2,
         ):
             await subject.run_discovery(invoker, catalog_path)
-            assert stream_mock2.call_count == 2
+            assert stream_mock2.call_count == 1
 
         # ensure stderr is redirected to devnull if we don't need it
         discovery_logger = logging.getLogger("meltano.core.plugin.singer.tap")  # noqa: TID251
@@ -1059,12 +1059,16 @@ class TestSingerTap:
             mock.patch(
                 "meltano.core.plugin.singer.tap._stream_redirect",
             ) as stream_mock3,
+            mock.patch(
+                "meltano.core.plugin.singer.tap.capture_subprocess_output",
+            ) as capture_subprocess_output_mock,
         ):
             await subject.run_discovery(invoker, catalog_path)
 
-            assert stream_mock3.call_count == 2
+            assert stream_mock3.call_count == 1
             call_kwargs = invoker.invoke_async.call_args_list[0][1]
             assert call_kwargs.get("stderr") is subprocess.PIPE
+            assert capture_subprocess_output_mock.call_count == 1
 
         discovery_logger.setLevel(original_level)
 

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock
 
 import anyio
 import pytest
+import structlog
 
 from meltano.core.job import Job, Payload
 from meltano.core.plugin import PluginType
@@ -63,6 +64,10 @@ class TestSingerTap:
     @pytest.fixture(scope="class")
     def subject(self, project_add_service: ProjectAddService) -> SingerTap:
         return project_add_service.add(PluginType.EXTRACTORS, "tap-mock")
+
+    @pytest.fixture(scope="class", autouse=True)
+    def fixture_configure_structlog(self) -> None:
+        structlog.stdlib.recreate_defaults(log_level=logging.INFO)
 
     @pytest.mark.order(0)
     @pytest.mark.asyncio

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -1014,7 +1014,7 @@ class TestSingerTap:
 
         with (
             mock.patch(
-                "meltano.core.plugin_invoker.PluginInvoker.stderr_logger.isEnabledFor",
+                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
                 return_value=False,
             ),
             mock.patch(
@@ -1026,7 +1026,7 @@ class TestSingerTap:
 
         with (
             mock.patch(
-                "meltano.core.plugin_invoker.PluginInvoker.stderr_logger.isEnabledFor",
+                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
                 return_value=True,
             ),
             mock.patch(
@@ -1042,7 +1042,7 @@ class TestSingerTap:
         discovery_logger.setLevel(logging.INFO)
         with (
             mock.patch(
-                "meltano.core.plugin_invoker.PluginInvoker.stderr_logger.isEnabledFor",
+                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
                 return_value=True,
             ),
             mock.patch(
@@ -1107,7 +1107,7 @@ class TestSingerTap:
         assert sys.getdefaultencoding() == "utf-8"
 
         with mock.patch(
-            "meltano.core.plugin_invoker.PluginInvoker.stderr_logger.isEnabledFor",
+            "meltano.core.plugin.singer.tap.logger.isEnabledFor",
             return_value=True,
         ):
             await subject.run_discovery(invoker, catalog_path)

--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -1014,7 +1014,7 @@ class TestSingerTap:
 
         with (
             mock.patch(
-                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
+                "meltano.core.plugin_invoker.PluginInvoker.stderr_logger.isEnabledFor",
                 return_value=False,
             ),
             mock.patch(
@@ -1026,7 +1026,7 @@ class TestSingerTap:
 
         with (
             mock.patch(
-                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
+                "meltano.core.plugin_invoker.PluginInvoker.stderr_logger.isEnabledFor",
                 return_value=True,
             ),
             mock.patch(
@@ -1042,7 +1042,7 @@ class TestSingerTap:
         discovery_logger.setLevel(logging.INFO)
         with (
             mock.patch(
-                "meltano.core.plugin.singer.tap.logger.isEnabledFor",
+                "meltano.core.plugin_invoker.PluginInvoker.stderr_logger.isEnabledFor",
                 return_value=True,
             ),
             mock.patch(
@@ -1107,7 +1107,7 @@ class TestSingerTap:
         assert sys.getdefaultencoding() == "utf-8"
 
         with mock.patch(
-            "meltano.core.plugin.singer.tap.logger.isEnabledFor",
+            "meltano.core.plugin_invoker.PluginInvoker.stderr_logger.isEnabledFor",
             return_value=True,
         ):
             await subject.run_discovery(invoker, catalog_path)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This PR also addresses an issue where discovery logs (enabled when running Meltano in debug  mode) were printed raw instead of being parsed like other plugin logs (see #9506).

## Related Issues

* #9506 

## Summary by Sourcery

Rename subprocess loggers to the standardized `meltano.plugins.<stream>.<type>.<name>` format and update code and documentation to use the new logger properties.

Enhancements:
- Add stdout_logger and stderr_logger properties to PluginInvoker for consistent plugin I/O stream logging
- Refactor extract-load, plugin-command, and Singer tap modules to leverage the new PluginInvoker loggers
- Simplify SingerPlugin’s logging setup and switch debug messages to parameterized logging
- Add docstring to SingerPlugin and introduce a type annotation for LineWriter

Documentation:
- Update the logging guide to reference the new `meltano.plugins.stdout` logger and disable its propagation