### PR TITLE
fix: Avoid reemitting noisy runner exception

### DIFF
--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -632,7 +632,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
             assert result.exit_code == 1
-            assert "`dbt run` failed" in str(result.exception)
+            assert "`dbt run` failed" in result.output
 
             matcher = EventMatcher(result.stderr)
             assert matcher.event_matches(
@@ -703,10 +703,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert (
-                "Run invocation could not be completed as block failed: "
-                "Extractor failed"
-            ) in str(result.exception)
+            assert "Extractor failed" in result.output
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -721,7 +718,7 @@ class TestCliRunScratchpadOne:
             assert completed_events[0]["success"] is False
             assert completed_events[0]["duration_seconds"] > 0
 
-            assert completed_events[0]["err"] == "RunnerError('Extractor failed')"
+            assert completed_events[0]["err"] == "Extractor failed"
             assert completed_events[0]["exit_codes"]["extractors"] == 1
 
             tap_stop_event = matcher.find_by_event("tap failure")
@@ -797,10 +794,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert (
-                "Run invocation could not be completed as block failed: Loader failed"
-                in str(result.exception)
-            )
+            assert "Loader failed" in result.output
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -818,7 +812,7 @@ class TestCliRunScratchpadOne:
             assert completed_events[0]["success"] is False
             assert completed_events[0]["duration_seconds"] > 0
 
-            assert completed_events[0]["err"] == "RunnerError('Loader failed')"
+            assert completed_events[0]["err"] == "Loader failed"
             assert completed_events[0]["exit_codes"]["loaders"] == 1
 
             # The tap should NOT have finished, we'll have a write of the
@@ -869,10 +863,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert (
-                "Run invocation could not be completed as block failed: Loader failed"
-                in str(result.exception)
-            )
+            assert "Loader failed" in result.output
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -888,7 +879,7 @@ class TestCliRunScratchpadOne:
             # there should only be one completed event
             assert len(completed_events) == 1
             assert completed_events[0]["success"] is False
-            assert completed_events[0]["err"] == "RunnerError('Loader failed')"
+            assert completed_events[0]["err"] == "Loader failed"
             assert completed_events[0]["exit_codes"]["loaders"] == 1
             assert completed_events[0]["duration_seconds"] > 0
 
@@ -948,10 +939,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert (
-                "Run invocation could not be completed as block failed: "
-                "Extractor and loader failed"
-            ) in str(result.exception)
+            assert "Extractor and loader failed" in result.output
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -966,10 +954,7 @@ class TestCliRunScratchpadOne:
             assert completed_events[0]["success"] is False
             assert completed_events[0]["duration_seconds"] > 0
 
-            assert (
-                completed_events[0]["err"]
-                == "RunnerError('Extractor and loader failed')"
-            )
+            assert completed_events[0]["err"] == "Extractor and loader failed"
             assert completed_events[0]["exit_codes"]["loaders"] == 1
 
             tap_stop_event = matcher.find_by_event("tap failure")
@@ -1035,10 +1020,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert (
-                "Run invocation could not be completed as block failed: "
-                "Output line length limit exceeded"
-            ) in str(result.exception)
+            assert "Output line length limit exceeded" in result.output
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -1053,10 +1035,7 @@ class TestCliRunScratchpadOne:
             assert completed_events[0]["success"] is False
             assert completed_events[0]["duration_seconds"] > 0
 
-            assert (
-                completed_events[0]["err"]
-                == "RunnerError('Output line length limit exceeded')"
-            )
+            assert completed_events[0]["err"] == "Output line length limit exceeded"
 
     @pytest.mark.backend("sqlite")
     @pytest.mark.usefixtures(
@@ -1246,7 +1225,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args, catch_exceptions=True)
 
-            assert "Mappers failed" in str(result.exception)
+            assert "Mappers failed" in result.output
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This will make the console output less noisy, and avoid showing useless information to the user, since the error in a case like this is coming from an error exit code emitted by the plugin subprocess.

Useful information will instead be displayed if the plugin supports structured logging:

- #9521

## Related Issues

* #9506
* #9521

## Summary by Sourcery

Use click context to exit on block failures and clean up error handling in the runner to suppress duplicate exception noise.

Bug Fixes:
- Stop raising a secondary CliError on block failure and call ctx.exit(1) to prevent noisy re-emitted exceptions
- Simplify tracker error payload by using the first error argument or exception class name instead of the full exception

Enhancements:
- Pass the click context into _run_blocks to enable graceful CLI exit on errors