### PR TITLE
break: Print fewer keys in the default console output

### DIFF
--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -56,7 +56,13 @@ A few key points to note:
    - Plugin subprocess keys: `string_id`
    - Plugin structured logging keys: `plugin_exception`, `metric_info`
 
-   You can control this behavior using the `all_keys` and `include_keys` parameters in your logging configuration.
+   You can control this behavior using the `all_keys` and `include_keys` parameters in your logging configuration. When both `all_keys` and `include_keys` are specified,
+   **`include_keys` takes precedence**. The behavior is:
+
+   1. If `include_keys` is set (regardless of `all_keys`): Shows default keys + specified keys
+   2. If only `all_keys: true` is set: Shows all keys
+   3. If neither is set (default): Shows only default keys
+
 3. Different loggers can use different handlers and log at different log levels.
 4. We support all the [standard python logging handlers](https://docs.python.org/3/library/logging.handlers.html#) (e.g. rotating files, syslog, etc).
 5. If a logging config file is found, it will take precedence over the `--log-format` and `--log-level` CLI options.

--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -47,13 +47,19 @@ A logging.yaml contains a few key sections that you should be aware of.
 A few key points to note:
 
 1. Different handlers can use different formats. Meltano ships with [3 formatters](https://github.com/meltano/meltano/blob/main/src/meltano/core/logging/formatters.py):
-   - `meltano.core.logging.console_log_formatter` - A formatter that renders lines for the console, with optional colorization. When colorization is enabled, tracebacks are formatted with the `rich` python library. Supports `colors` (bool), `show_locals` (bool), `max_frames` (int, default: 2), and `utc` (bool) parameters.
+   - `meltano.core.logging.console_log_formatter` - A formatter that renders lines for the console, with optional colorization. When colorization is enabled, tracebacks are formatted with the `rich` python library. Supports `colors` (bool), `show_locals` (bool), `max_frames` (int, default: 2), `all_keys` (bool), and `include_keys` (set[str]) parameters. By default, only essential keys are displayed for cleaner output.
    - `meltano.core.logging.json_log_formatter` - A formatter that renders lines in JSON format.
    - `meltano.core.logging.key_value` - A formatter that renders lines in key=value format.
    - `meltano.core.logging.plain_formatter` - A formatter that renders lines in a plain text format.
-2. Different loggers can use different handlers and log at different log levels.
-3. We support all the [standard python logging handlers](https://docs.python.org/3/library/logging.handlers.html#) (e.g. rotating files, syslog, etc).
-4. If a logging config file is found, it will take precedence over the `--log-format` and `--log-level` CLI options.
+2. **Console output filtering**: By default, the console formatter displays only essential log keys for cleaner output. The default keys include:
+   - Base keys: `timestamp`, `level`, `event`, `logger`, `logger_name`
+   - Plugin subprocess keys: `string_id`
+   - Plugin structured logging keys: `plugin_exception`, `metric_info`
+
+   You can control this behavior using the `all_keys` and `include_keys` parameters in your logging configuration.
+3. Different loggers can use different handlers and log at different log levels.
+4. We support all the [standard python logging handlers](https://docs.python.org/3/library/logging.handlers.html#) (e.g. rotating files, syslog, etc).
+5. If a logging config file is found, it will take precedence over the `--log-format` and `--log-level` CLI options.
 
 Here's an annotated example of a logging.yaml file:
 
@@ -67,6 +73,10 @@ formatters:
   structured_colored:
     (): meltano.core.logging.console_log_formatter
     colors: true
+  structured_colored_all_keys: # log format with colored output showing all log keys
+    (): meltano.core.logging.console_log_formatter
+    colors: true
+    all_keys: true # displays all log keys instead of just the default set
   structured_plain_no_locals: # log format for structured plain text logs without colored output and without local variables
     (): meltano.core.logging.console_log_formatter
     colors: false # also disables `rich` traceback formatting

--- a/integration/meltano-run/validate.sh
+++ b/integration/meltano-run/validate.sh
@@ -7,9 +7,9 @@ LOG_FILE="./integration/example-library/meltano-run/integration-test.log"
 # Custom validations for the `meltano-run` guide/test.
 
 # test that meltano run saw dbt:test (set=1) as successfully completed
-grep "Block run completed            block_type=InvokerCommand.*err=None.*set_number=1.*success=True" $LOG_FILE
+grep "Block run completed" $LOG_FILE
 # test that we see dbt:run output
-grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1 cmd_type=command.*name=dbt-postgres.*stdio=stderr" $LOG_FILE
+grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1" $LOG_FILE
 
 # we could also run psql statements
 # check for the existance of files

--- a/integration/meltano-run/validate.sh
+++ b/integration/meltano-run/validate.sh
@@ -9,7 +9,7 @@ LOG_FILE="./integration/example-library/meltano-run/integration-test.log"
 # test that meltano run saw dbt:test (set=1) as successfully completed
 grep "Block run completed" $LOG_FILE
 # test that we see dbt:run output
-grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1 *name=dbt-postgres*" $LOG_FILE
+grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1 .*name=dbt-postgres" $LOG_FILE
 
 # we could also run psql statements
 # check for the existance of files

--- a/integration/meltano-run/validate.sh
+++ b/integration/meltano-run/validate.sh
@@ -9,7 +9,7 @@ LOG_FILE="./integration/example-library/meltano-run/integration-test.log"
 # test that meltano run saw dbt:test (set=1) as successfully completed
 grep "Block run completed" $LOG_FILE
 # test that we see dbt:run output
-grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1" $LOG_FILE
+grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1 *name=dbt-postgres*" $LOG_FILE
 
 # we could also run psql statements
 # check for the existance of files

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -517,7 +517,14 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
             RunnerError: if failures are encountered during execution or if the
                 underlying pipeline/job is already running.
         """
+        assert self.context.job  # noqa: S101
+
         job = self.context.job
+        logger.info(
+            "Running job with name '%s' and run ID '%s'",
+            job.job_name,
+            job.run_id,
+        )
         fail_stale_jobs(self.context.session, job.job_name)
         if self.context.force:
             logger.warning("Force option is enabled, ignoring stale job check.")

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -158,7 +158,7 @@ def console_log_formatter(
     callsite_parameters: bool = False,
     show_locals: bool = False,
     max_frames: int = 2,
-    include_keys: set[str] | None = None,
+    include_keys: Sequence[str] | None = None,
     all_keys: bool | None = None,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter for console rendering that supports colorization.
@@ -168,7 +168,7 @@ def console_log_formatter(
         callsite_parameters: Whether to include callsite parameters in the output.
         show_locals: Whether to show local variables in the traceback.
         max_frames: Maximum number of frames to show in a traceback, 0 for no maximum.
-        include_keys: Whether to include specific keys in the output.
+        include_keys: Include these keys in the output.
         all_keys: Whether to include all keys in the output.
 
     Returns:
@@ -191,11 +191,12 @@ def console_log_formatter(
 
     return _process_formatter(
         *_processors_from_kwargs(callsite_parameters=callsite_parameters),
+        structlog.stdlib.ExtraAdder(),
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         MeltanoConsoleRenderer(
             colors=colors,
             exception_formatter=exception_formatter,
-            include_keys=include_keys,
+            include_keys=set(include_keys) if include_keys else None,
             all_keys=all_keys,
         ),
     )
@@ -224,6 +225,7 @@ def key_value_formatter(
     """
     return _process_formatter(
         *_processors_from_kwargs(callsite_parameters=callsite_parameters),
+        structlog.stdlib.ExtraAdder(),
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         structlog.processors.KeyValueRenderer(
             sort_keys=sort_keys,
@@ -256,6 +258,7 @@ def json_formatter(
             show_locals=show_locals,
         ),
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+        structlog.stdlib.ExtraAdder(),
         structlog.processors.JSONRenderer(),
     )
 
@@ -298,6 +301,7 @@ def plain_formatter(
         A configured simple formatter.
     """
     return _process_formatter(
+        structlog.stdlib.ExtraAdder(),
         structlog.stdlib.filter_by_level,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -158,6 +158,8 @@ def console_log_formatter(
     callsite_parameters: bool = False,
     show_locals: bool = False,
     max_frames: int = 2,
+    include_keys: set[str] | None = None,
+    all_keys: bool | None = None,
 ) -> structlog.stdlib.ProcessorFormatter:
     """Create a logging formatter for console rendering that supports colorization.
 
@@ -166,6 +168,8 @@ def console_log_formatter(
         callsite_parameters: Whether to include callsite parameters in the output.
         show_locals: Whether to show local variables in the traceback.
         max_frames: Maximum number of frames to show in a traceback, 0 for no maximum.
+        include_keys: Whether to include specific keys in the output.
+        all_keys: Whether to include all keys in the output.
 
     Returns:
         A configured console log formatter.
@@ -191,6 +195,8 @@ def console_log_formatter(
         MeltanoConsoleRenderer(
             colors=colors,
             exception_formatter=exception_formatter,
+            include_keys=include_keys,
+            all_keys=all_keys,
         ),
     )
 

--- a/src/meltano/core/logging/renderers.py
+++ b/src/meltano/core/logging/renderers.py
@@ -173,7 +173,7 @@ class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
         "exception",
         "exc_info",
         # Plugin subprocess
-        "string_id",
+        "name",
         # Plugin structured logging
         "plugin_exception",
         "metric_info",

--- a/src/meltano/core/logging/renderers.py
+++ b/src/meltano/core/logging/renderers.py
@@ -169,6 +169,9 @@ class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
         "event",
         "logger",
         "logger_name",
+        "stack",
+        "exception",
+        "exc_info",
         # Plugin subprocess
         "string_id",
         # Plugin structured logging

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -152,6 +152,25 @@ class TestLogFormatters:
         assert "frames hidden" not in output_zero
         assert output_zero.count("in level_") == 5
 
+    def test_console_log_formatter_include_keys(self, record) -> None:
+        record.foo = "bar"
+        record.baz = "qux"
+
+        formatter = formatters.console_log_formatter()
+        output = formatter.format(record)
+        assert "foo=bar" not in output
+        assert "baz=qux" not in output
+
+        formatter = formatters.console_log_formatter(include_keys=["foo"])
+        output = formatter.format(record)
+        assert "foo=bar" in output
+        assert "baz=qux" not in output
+
+        formatter = formatters.console_log_formatter(all_keys=True)
+        output = formatter.format(record)
+        assert "foo=bar" in output
+        assert "baz=qux" in output
+
     def test_key_value_formatter(self, record):
         formatter = formatters.key_value_formatter()
         output = formatter.format(record)

--- a/tests/meltano/core/logging/test_renderers.py
+++ b/tests/meltano/core/logging/test_renderers.py
@@ -259,7 +259,7 @@ class TestMeltanoConsoleRenderer:
                 "level": "info",
                 "event": "Something happened",
                 # Plugin subprocess
-                "string_id": "tap-mock",
+                "name": "tap-mock",
                 # Plugin structured logging
                 "plugin_exception": exception,
                 "metric_info": {"key": "value"},
@@ -274,7 +274,7 @@ class TestMeltanoConsoleRenderer:
             renderer = make_renderer()
             result = renderer(None, "info", event_dict)
             # Preserved keys
-            assert "string_id=tap-mock" in result
+            assert "name=tap-mock" in result
             # Auto-added keys
             assert "plugin_exc_message=" in result
             assert "plugin_exc_type=" in result
@@ -288,7 +288,7 @@ class TestMeltanoConsoleRenderer:
             renderer = make_renderer(all_keys=True)
             result = renderer(None, "info", event_dict)
             # Preserved keys
-            assert "string_id=tap-mock" in result
+            assert "name=tap-mock" in result
             # Auto-added keys
             assert "plugin_exc_message=" in result
             assert "plugin_exc_type=" in result
@@ -303,7 +303,7 @@ class TestMeltanoConsoleRenderer:
             renderer = make_renderer(include_keys=include_keys)
             result = renderer(None, "info", event_dict)
             # Preserved keys
-            assert "string_id=tap-mock" in result
+            assert "name=tap-mock" in result
             # Auto-added keys
             assert "plugin_exc_message=" in result
             assert "plugin_exc_type=" in result

--- a/tests/meltano/core/logging/test_renderers.py
+++ b/tests/meltano/core/logging/test_renderers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import json
 import typing as t
 from io import StringIO
@@ -236,7 +237,81 @@ class TestMeltanoConsoleRenderer:
         return MeltanoConsoleRenderer(
             plugin_exception_renderer=formatter,
             colors=False,
+            all_keys=True,
         )
+
+    def test_included_keys(
+        self,
+        formatter: StructuredExceptionFormatter,
+        exception: PluginException,
+        subtests: SubTests,
+    ) -> None:
+        make_renderer = functools.partial(
+            MeltanoConsoleRenderer,
+            plugin_exception_renderer=formatter,
+            colors=False,
+        )
+
+        def get_event_dict() -> dict:
+            return {
+                # Base keys
+                "timestamp": "2021-01-01T00:00:00Z",
+                "level": "info",
+                "event": "Something happened",
+                # Plugin subprocess
+                "string_id": "tap-mock",
+                # Plugin structured logging
+                "plugin_exception": exception,
+                "metric_info": {"key": "value"},
+                # Extra keys
+                "job_name": "dev:tap-mock-to-target-mock",
+                "run_id": "123e4567-e89b-12d3-a456-426614174000",
+                "foo": "bar",
+            }
+
+        event_dict = get_event_dict()
+        with subtests.test(msg="default"):
+            renderer = make_renderer()
+            result = renderer(None, "info", event_dict)
+            # Preserved keys
+            assert "string_id=tap-mock" in result
+            # Auto-added keys
+            assert "plugin_exc_message=" in result
+            assert "plugin_exc_type=" in result
+            # Extra keys (not included)
+            assert "job_name=dev:tap-mock-to-target-mock" not in result
+            assert "run_id=123e4567-e89b-12d3-a456-426614174000" not in result
+            assert "foo=bar" not in result
+
+        event_dict = get_event_dict()
+        with subtests.test(msg="all keys"):
+            renderer = make_renderer(all_keys=True)
+            result = renderer(None, "info", event_dict)
+            # Preserved keys
+            assert "string_id=tap-mock" in result
+            # Auto-added keys
+            assert "plugin_exc_message=" in result
+            assert "plugin_exc_type=" in result
+            # Extra keys (included)
+            assert "job_name=dev:tap-mock-to-target-mock" in result
+            assert "run_id=123e4567-e89b-12d3-a456-426614174000" in result
+            assert "foo=bar" in result
+
+        event_dict = get_event_dict()
+        include_keys = {"foo"}
+        with subtests.test(msg="include keys"):
+            renderer = make_renderer(include_keys=include_keys)
+            result = renderer(None, "info", event_dict)
+            # Preserved keys
+            assert "string_id=tap-mock" in result
+            # Auto-added keys
+            assert "plugin_exc_message=" in result
+            assert "plugin_exc_type=" in result
+            # Extra keys (not included)
+            assert "job_name=dev:tap-mock-to-target-mock" not in result
+            assert "run_id=123e4567-e89b-12d3-a456-426614174000" not in result
+            # Extra keys (included)
+            assert "foo=bar" in result
 
     def test_console_output(
         self,


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

A common UX issue is that users can sometimes be overwhelmed by the amount of information displayed in the console. This PR address this by reducing the number of keys that are printed by default to some essential ones. We can add more such keys in the future.

This only affects the console logs formatters, so the JSON formatter still contains all keys.

## Related Issues

- https://github.com/meltano/meltano/pull/9506
- https://github.com/meltano/meltano/pull/9521
- https://github.com/meltano/meltano/pull/9524

## Summary by Sourcery

Improve console logging by limiting default output to essential keys and adding options to include all or specific keys; update documentation and tests; add job run info logging.

New Features:
- Add all_keys and include_keys parameters to the Meltano console formatter to control which log keys are displayed
- Log job name and run ID when executing a job in extract_load

Enhancements:
- Restrict default console output to a predefined set of essential log keys for cleaner output

Documentation:
- Document default key filtering and the all_keys and include_keys options in the logging guide and add examples

Tests:
- Add tests for default, all_keys, and include_keys behaviors in the console renderer