### PR TITLE
feat: New `--timeout` option for `meltano run`

### DIFF
--- a/docs/docs/reference/command-line-interface.md
+++ b/docs/docs/reference/command-line-interface.md
@@ -1218,6 +1218,7 @@ meltano run tap-gitlab one-mapping another-mapping target-postgres
 meltano run tap-gitlab target-postgres simple-job
 meltano run --state-id-suffix=<STATE_ID_SUFFIX> tap-gitlab target-postgres
 meltano run --refresh-catalog tap-salesforce target-postgres
+meltano run --timeout 3600 tap-gitlab target-postgres
 ```
 
 #### Parameters
@@ -1234,6 +1235,7 @@ meltano run --refresh-catalog tap-salesforce target-postgres
 - `--merge-state` will merge state with that of previous runs. **Deprecated**: use `--state-strategy` instead.
 - `--run-id` will use the provided UUID for the current run. This is useful when your workflow is managed by an external system and you want to track the run in Meltano.
 - `--refresh-catalog` will force a refresh of the catalog, ignoring any existing cached catalog from previous runs.
+- `--timeout` will set a maximum duration (in seconds) for the pipeline run. After this time, the pipeline will be gracefully terminated. The `MELTANO_RUN_TIMEOUT` environment variable can be used to set this behavior. This is useful for preventing pipelines from running indefinitely and allows for preview runs or limiting resource usage.
 - The `--install/--no-install/--only-install` switch controls auto-install behavior. See the [Auto-install behavior](#auto-install-behavior) section for more information.
 
 Examples:
@@ -1256,6 +1258,12 @@ meltano --environment=dev --state-id-suffix pipeline-alias run tap-gitlab hide-s
 
 # run a pipeline, merging state with that of previous runs.
 meltano --environment=dev run --state-strategy=merge tap-gitlab target-postgres
+
+# run a pipeline with a timeout of 3600 seconds (1 hour)
+meltano --environment=dev run --timeout 3600 tap-gitlab target-postgres
+
+# run a pipeline with timeout set via environment variable
+MELTANO_RUN_TIMEOUT=1800 meltano --environment=dev run tap-gitlab target-postgres
 ```
 
 ### Using `run` with Environments

--- a/src/meltano/core/block/block_parser.py
+++ b/src/meltano/core/block/block_parser.py
@@ -24,7 +24,7 @@ if t.TYPE_CHECKING:
 
     import structlog
 
-    from meltano.core.block.plugin_command import PluginCommandBlock
+    from meltano.core.block.plugin_command import InvokerCommand
     from meltano.core.block.singer import SingerBlock
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
@@ -48,7 +48,7 @@ def is_command_block(plugin: ProjectPlugin) -> bool:
 
 def validate_block_sets(
     log: structlog.BoundLogger,
-    blocks: list[BlockSet | PluginCommandBlock],
+    blocks: list[InvokerCommand | ExtractLoadBlocks],
 ) -> bool:
     """Perform validation of all blocks in a list that implement the BlockSet interface.
 
@@ -194,7 +194,7 @@ class BlockParser:  # noqa: D101
     def find_blocks(
         self,
         offset: int = 0,
-    ) -> Generator[BlockSet | PluginCommandBlock | ExtractLoadBlocks, None, None]:
+    ) -> Generator[ExtractLoadBlocks | InvokerCommand, None, None]:
         """Find all blocks in the invocation.
 
         Args:

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -543,21 +543,19 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
                 await self.execute()
 
     async def terminate(self, *, graceful: bool = False) -> None:
-        """Terminate an in flight ExtractLoad execution, potentially disruptive.
-
-        Not actually implemented yet.
+        """Terminate an in flight ExtractLoad execution.
 
         Args:
             graceful: Whether the BlockSet should try to gracefully quit.
-
-        Raises:
-            NotImplementedError: if graceful termination is not implemented.
+                If True, sends SIGTERM to allow cleanup. If False, sends SIGKILL.
         """
-        if graceful:
-            raise NotImplementedError
-
+        logger.info(
+            "Terminating ExtractLoadBlocks",
+            graceful=graceful,
+            block_count=len(self.blocks),
+        )
         for block in self.blocks:
-            await block.stop(kill=True)
+            await block.stop(kill=not graceful)
 
     @property
     def process_futures(self) -> list[asyncio.Task]:

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -554,8 +554,7 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
             graceful=graceful,
             block_count=len(self.blocks),
         )
-        for block in self.blocks:
-            await block.stop(kill=not graceful)
+        await asyncio.gather(*(block.stop(kill=not graceful) for block in self.blocks))
 
     @property
     def process_futures(self) -> list[asyncio.Task]:

--- a/src/meltano/core/block/singer.py
+++ b/src/meltano/core/block/singer.py
@@ -127,12 +127,17 @@ class InvokerBase:
         Args:
             kill: whether to send a SIGKILL. If false, a SIGTERM is sent.
         """
+        if self._process_handle is None:
+            return
+
         with suppress(ProcessLookupError):
             if kill:
                 self.process_handle.kill()
             else:
                 self.process_handle.terminate()
         await self.process_future
+
+        # Cancel any remaining output futures
         if self._stdout_future is not None:
             self._stdout_future.cancel()
         if self._stderr_future is not None:
@@ -342,12 +347,17 @@ class SingerBlock(InvokerBase, IOBlock):
         Args:
             kill: Whether to send a SIGKILL. If false, a SIGTERM is sent.
         """
+        if self._process_handle is None:
+            return
+
         with suppress(ProcessLookupError):
             if kill:
                 self.process_handle.kill()
             else:
                 self.process_handle.terminate()
         await self.process_future
+
+        # Cancel any remaining output futures
         if self._stdout_future is not None:
             self._stdout_future.cancel()
         if self._stderr_future is not None:

--- a/src/meltano/core/block/singer.py
+++ b/src/meltano/core/block/singer.py
@@ -127,7 +127,7 @@ class InvokerBase:
         Args:
             kill: whether to send a SIGKILL. If false, a SIGTERM is sent.
         """
-        if self._process_handle is None:
+        if self._process_handle is None:  # pragma: no cover
             return
 
         with suppress(ProcessLookupError):
@@ -347,7 +347,7 @@ class SingerBlock(InvokerBase, IOBlock):
         Args:
             kill: Whether to send a SIGKILL. If false, a SIGTERM is sent.
         """
-        if self._process_handle is None:
+        if self._process_handle is None:  # pragma: no cover
             return
 
         with suppress(ProcessLookupError):

--- a/src/meltano/core/tracking/contexts/plugins.py
+++ b/src/meltano/core/tracking/contexts/plugins.py
@@ -15,6 +15,8 @@ from meltano.core.utils import hash_sha256, safe_hasattr
 from .base import new_context_uuid
 
 if t.TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from meltano.core.elt_context import ELTContext
     from meltano.core.plugin.project_plugin import ProjectPlugin
 
@@ -117,7 +119,7 @@ class PluginsTrackingContext(SelfDescribingJson):
     @classmethod
     def from_blocks(
         cls,
-        parsed_blocks: list[BlockSet | PluginCommandBlock],
+        parsed_blocks: Sequence[BlockSet | PluginCommandBlock],
     ) -> PluginsTrackingContext:
         """Create a `PluginsTrackingContext` from blocks.
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Related Issues

* https://github.com/meltano/meltano/issues/8080
* Closes https://github.com/meltano/meltano/issues/8716

## Summary by Sourcery

Add a new --timeout option to the meltano run command to limit pipeline execution time with support for an environment variable, enforce it via asyncio.wait_for, and gracefully terminate in-flight blocks on timeout.

New Features:
- Introduce --timeout option (with MELTANO_RUN_TIMEOUT envvar) for meltano run to cap pipeline duration

Enhancements:
- Wrap run execution in asyncio.wait_for and handle TimeoutError by logging, tracking, and raising a CliError
- Implement graceful termination of the current block in _run_blocks on cancellation
- Extend ExtractLoadBlocks.terminate and SingerBlock.stop to support graceful shutdown and cancel output futures

Documentation:
- Document the --timeout option and MELTANO_RUN_TIMEOUT envvar in the CLI reference

Tests:
- Add tests for run timeout scenarios including success, timeout exceeded, plugin commands, environment variable, and zero-value rejection
- Update EventMatcher in tests with a find_first_event helper and adjust assertions accordingly