### PR TITLE
refactor: Simplify `--timeout` validation

### DIFF
--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -104,7 +104,7 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
 )
 @click.option(
     "--timeout",
-    type=click.INT,
+    type=click.IntRange(min=1),
     envvar="MELTANO_RUN_TIMEOUT",
     help=(
         "Maximum duration in seconds for the pipeline run. After this time, "
@@ -211,9 +211,6 @@ async def run(
     )
 
     if timeout is not None:
-        if timeout <= 0:
-            tracker.track_command_event(CliEvent.aborted)
-            raise CliError("Timeout must be a positive integer")  # noqa: EM101
         logger.info("Run timeout configured", timeout_seconds=timeout)
 
     run_start_time = time.perf_counter()

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -1596,12 +1596,8 @@ class TestCliRunScratchpadOne:
         args = ["run", "--no-install", "--timeout", "0", tap.name, target.name]
 
         result = cli_runner.invoke(cli, args, catch_exceptions=True)
-        assert result.exit_code == 1
-        # CliError messages appear in result.output (stdout/stderr combined)
-        assert (
-            "Timeout must be a positive integer" in result.output
-            or "Timeout must be a positive integer" in str(result.exception)
-        )
+        assert result.exit_code == 2
+        assert "Invalid value for '--timeout'" in result.output
 
     @pytest.mark.backend("sqlite")
     @pytest.mark.usefixtures(


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Simplify the validation logic for the --timeout CLI option by leveraging click’s built-in IntRange and updating tests to expect click’s validation behavior

Enhancements:
- Use click.IntRange(min=1) for the --timeout option instead of manual checks
- Remove custom positive-integer validation and error-raising code in the run command

Tests:
- Update tests to expect exit code 2 and the default click validation error message for invalid timeout values