### PR TITLE
refactor: Do not display traceback when timeout is exceeded

### DIFF
--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -232,9 +232,9 @@ async def run(
             timeout_seconds=timeout,
             duration_seconds=round(total_duration, 3),
         )
-        tracker.track_command_event(CliEvent.failed)
-        msg = f"Run exceeded timeout of {timeout} seconds and was terminated"
-        raise CliError(msg) from None
+        tracker.track_command_event(CliEvent.aborted)
+        logger.error("Run exceeded timeout and was terminated", timeout_seconds=timeout)
+        ctx.exit(1)
     except Exception as err:
         tracker.track_command_event(CliEvent.failed)
         raise err

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock
 import pytest
 
 from meltano.cli import cli
-from meltano.cli.utils import CliError
 from meltano.core.block.ioblock import IOBlock
 from meltano.core.logging.job_logging_service import MissingJobLogException
 from meltano.core.logging.utils import default_config
@@ -1489,11 +1488,8 @@ class TestCliRunScratchpadOne:
             result = cli_runner.invoke(cli, args, catch_exceptions=True)
             assert result.exit_code == 1
 
-            exc = result.exception
-            assert isinstance(exc, CliError)
-            assert "Run exceeded timeout of 1 seconds and was terminated" in str(exc)
-
             matcher = EventMatcher(result.stderr)
+            assert matcher.event_matches("Run exceeded timeout and was terminated")
 
             events = matcher.find_by_event("Run timeout configured")
             assert len(events) == 1
@@ -1529,11 +1525,8 @@ class TestCliRunScratchpadOne:
             result = cli_runner.invoke(cli, args, catch_exceptions=True)
             assert result.exit_code == 1
 
-            exc = result.exception
-            assert isinstance(exc, CliError)
-            assert "Run exceeded timeout of 1 seconds and was terminated" in str(exc)
-
             matcher = EventMatcher(result.stderr)
+            assert matcher.event_matches("Run exceeded timeout and was terminated")
 
             events = matcher.find_by_event("Run timeout configured")
             assert len(events) == 1


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor the CLI run command to suppress tracebacks on timeouts by exiting cleanly and adjust related event tracking and tests

Enhancements:
- Abort the run command with ctx.exit(1) and logger.error on timeout instead of raising a CliError to avoid displaying tracebacks
- Switch timeout event tracking from CliEvent.failed to CliEvent.aborted

Tests:
- Update timeout tests to remove exception checks and verify the new error message and exit behavior