### PR TITLE
refactor: Remove redundant timeout log

### DIFF
--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -233,7 +233,6 @@ async def run(
             duration_seconds=round(total_duration, 3),
         )
         tracker.track_command_event(CliEvent.aborted)
-        logger.error("Run exceeded timeout and was terminated", timeout_seconds=timeout)
         ctx.exit(1)
     except Exception as err:
         tracker.track_command_event(CliEvent.failed)

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -1489,13 +1489,10 @@ class TestCliRunScratchpadOne:
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
-            assert matcher.event_matches("Run exceeded timeout and was terminated")
-
             events = matcher.find_by_event("Run timeout configured")
             assert len(events) == 1
             timeout_config = events[0]
             assert timeout_config["timeout_seconds"] == 1
-
             assert matcher.event_matches("Run timed out")
 
     @pytest.mark.backend("sqlite")
@@ -1526,13 +1523,10 @@ class TestCliRunScratchpadOne:
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
-            assert matcher.event_matches("Run exceeded timeout and was terminated")
-
             events = matcher.find_by_event("Run timeout configured")
             assert len(events) == 1
             timeout_config = events[0]
             assert timeout_config["timeout_seconds"] == 1
-
             assert matcher.event_matches("Run timed out")
 
     @pytest.mark.backend("sqlite")


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Related Issues

NA.

## Summary by Sourcery

Remove redundant timeout error log in run command and update tests accordingly

Enhancements:
- Remove unnecessary logger.error call when run exceeds timeout

Tests:
- Update tests to stop expecting the removed timeout log message