### PR TITLE
test: Decrease timeout value in tests

### DIFF
--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -65,11 +65,13 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
 @click.option(
     "--refresh-catalog",
     help="Invalidates catalog cache and forces running discovery before this run.",
+    envvar="MELTANO_RUN_REFRESH_CATALOG",
     is_flag=True,
 )
 @click.option(
     "--no-state-update",
     help="Run without state saving. Applies to all pipelines.",
+    envvar="MELTANO_RUN_NO_STATE_UPDATE",
     is_flag=True,
 )
 @click.option(
@@ -83,6 +85,7 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
 )
 @click.option(
     "--state-id-suffix",
+    envvar="MELTANO_RUN_STATE_ID_SUFFIX",
     help="Define a custom suffix to autogenerate state IDs with.",
 )
 @click.option(
@@ -95,11 +98,13 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
     "--state-strategy",
     type=click.Choice(StateStrategy),
     default=StateStrategy.auto.value,
+    envvar="MELTANO_RUN_STATE_STRATEGY",
     help="Strategy to use for state updates.",
 )
 @click.option(
     "--run-id",
     type=UUIDParamType(),
+    envvar="MELTANO_RUN_ID",
     help="Use a custom run ID.",
 )
 @click.option(

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -1511,7 +1511,7 @@ class TestCliRunScratchpadOne:
         args = ["run", "--timeout", "1", "dbt:run"]
 
         async def long_wait():
-            await asyncio.sleep(10)
+            await asyncio.sleep(5)
             return 0
 
         dbt_process.wait.side_effect = long_wait
@@ -1545,7 +1545,7 @@ class TestCliRunScratchpadOne:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that MELTANO_RUN_TIMEOUT environment variable works."""
-        monkeypatch.setenv("MELTANO_RUN_TIMEOUT", "25")
+        monkeypatch.setenv("MELTANO_RUN_TIMEOUT", "10")
         args = ["run", tap.name, target.name]
 
         create_subprocess_exec = AsyncMock(side_effect=(tap_process, target_process))
@@ -1565,7 +1565,7 @@ class TestCliRunScratchpadOne:
             events = matcher.find_by_event("Run timeout configured")
             assert len(events) == 1
             timeout_config = events[0]
-            assert timeout_config["timeout_seconds"] == 25
+            assert timeout_config["timeout_seconds"] == 10
 
     @pytest.mark.backend("sqlite")
     @pytest.mark.usefixtures(
@@ -1599,7 +1599,7 @@ class TestCliRunScratchpadOne:
         dbt_process,
     ) -> None:
         """Test timeout with plugin commands like dbt:run."""
-        args = ["run", "--timeout", "20", "dbt:run"]
+        args = ["run", "--timeout", "10", "dbt:run"]
 
         invoke_async = AsyncMock(side_effect=(dbt_process,))
 
@@ -1612,7 +1612,7 @@ class TestCliRunScratchpadOne:
             events = matcher.find_by_event("Run timeout configured")
             assert len(events) == 1
             timeout_config = events[0]
-            assert timeout_config["timeout_seconds"] == 20
+            assert timeout_config["timeout_seconds"] == 10
 
     @pytest.mark.backend("sqlite")
     @pytest.mark.usefixtures(
@@ -1631,7 +1631,7 @@ class TestCliRunScratchpadOne:
         dbt_process,
     ) -> None:
         """Test timeout with multiple blocks in sequence."""
-        args = ["run", "--timeout", "30", tap.name, target.name, "dbt:run"]
+        args = ["run", "--timeout", "10", tap.name, target.name, "dbt:run"]
 
         invoke_async = AsyncMock(
             side_effect=(tap_process, target_process, dbt_process),


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Decrease timeout values in meltano CLI run tests to speed up test execution

Enhancements:
- Reduce timeout parameters in various run command tests from 30/25/20/1 seconds to 10 seconds

Tests:
- Update assertions for configured timeout seconds to reflect the new 10-second default
- Adjust simulated long-wait sleep duration to match the lowered timeout in timeout-exceeded test