### PR TITLE
fix: Correctly skip auto-installing plugins by fixing virtualenv fingerprint

### DIFF
--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -42,10 +42,7 @@ def _install_plugins_fn(
     else:
         behavior = value
 
-    behavior = value or ctx.obj.get(
-        "auto_install_behaviour",
-        AutoInstallBehavior.install,
-    )
+    behavior = value or AutoInstallBehavior.install
     if behavior == AutoInstallBehavior.no_install:
         return async_noop
     if behavior == AutoInstallBehavior.only_install:


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

For example, `meltano run ...` always reinstalls plugins regardless of whether they've been previously installed.

## Related Issues

* https://github.com/meltano/meltano/issues/9390
* https://github.com/meltano/meltano/pull/9394

## Summary by Sourcery

Consolidate fingerprint-based install checks in the VirtualEnv API, refactor plugin installation paths to use the new methods, and correct the logic to properly skip plugin reinstalls when requirements haven’t changed.

New Features:
- Add VirtualEnv.from_plugin classmethod for consistent venv initialization
- Introduce VirtualEnv.get_fingerprint method to centralize fingerprint computation for pip installs

Bug Fixes:
- Fix auto-install skipping logic by comparing against the correct virtualenv fingerprint to prevent unnecessary plugin reinstalls

Enhancements:
- Refactor plugin_install_service and VenvService/UvVenvService to use the new from_plugin API and unified fingerprint calls
- Simplify CLI auto-install behavior default setting to always use install unless explicitly disabled