### PR TITLE
refactor: Remove legacy warnings for configuration "profiles"

### DIFF
--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -206,12 +206,6 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
         self.config = copy.deepcopy(config or {})
         self.extras = extras
 
-        if "profiles" in extras:
-            logger.warning(
-                "Plugin configuration profiles are no longer supported, ignoring "  # noqa: G004
-                f"`profiles` in '{name}' {plugin_type.descriptor} definition.",
-            )
-
     def __repr__(self) -> str:
         """Return a string representation of the project plugin."""
         return (

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -297,13 +297,6 @@ class ProjectPluginsService:  # (too many methods, attributes)
         Raises:
             PluginNotFoundError: If the plugin is not found.
         """
-        if "@" in plugin_name:
-            plugin_name, profile_name = plugin_name.split("@", 2)
-            logger.warning(
-                "Plugin configuration profiles are no longer supported, "  # noqa: G004
-                f"ignoring `@{profile_name}` in plugin name.",
-            )
-
         for plugin in self.plugins(ensure_parent=False):
             if (
                 plugin.name == plugin_name


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

These were added _a while_ ago: https://github.com/meltano/meltano/commit/cf669755de13c1d529fe7943eeb88e9c8865c5f8.

## Related Issues

NA

## Summary by Sourcery

Remove legacy deprecation warnings related to configuration profiles in plugin lookup and initialization.

Enhancements:
- Eliminate warning handling for `@profile` suffix in plugin names within find_plugin
- Remove warning for deprecated `profiles` key in ProjectPlugin initialization