### PR TITLE
fix: Removed `meltano install - <plugin_name>` support in favor of new `meltano install <plugin_name>`

### DIFF
--- a/docs/docs/reference/command-line-interface.mdx
+++ b/docs/docs/reference/command-line-interface.mdx
@@ -5,6 +5,9 @@ layout: doc
 sidebar_position: 1
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 Meltano provides a command line interface (CLI) that makes it easy to manage your [project](/concepts/project), [plugins](/guide/plugin-management), and [EL(T) pipelines](/guide/integration).
 To quickly find the `meltano` subcommand you're looking for, use the Table of Contents in the sidebar.
 For a better understanding of command line documentation syntax, the [docopt](http://docopt.org/) standard is useful.
@@ -56,7 +59,7 @@ When adding a new plugin, it will:
 1. Look for the [plugin definition](/concepts/project#plugins) in [Meltano Hub](https://hub.meltano.com/)
 1. Add it to your [`meltano.yml` project file](/concepts/project#meltano-yml-project-file) under `plugins: <type>s:`, e.g. `plugins: extractors`
 1. Store the plugin definition in the `./plugins` directory (see [Lock Artifacts](/concepts/plugins#lock-artifacts))
-1. Assuming a valid `pip_url` is specified, install the new plugin using [`meltano install <type> <name>`](#install), which will:
+1. Assuming a valid `pip_url` is specified, install the new plugin using [`meltano install <name>`](#install), which will:
   1. Create a dedicated [Python virtual environment](https://docs.python.org/3/glossary.html#term-virtual-environment) for the plugin inside the [`.meltano` directory](/concepts/project#meltano-directory) at `.meltano/<type>s/<name>/venv`, e.g. `.meltano/extractors/tap-gitlab/venv`
   1. Install the plugin's [pip package](https://pip.pypa.io/en/stable/) into the virtual environment using `pip install <pip_url>` (given `--no-install` is not provided)
 5. If the plugin you are trying to install declares that it does not support the version of Python you are using, but you want to attempt to use it anyway, you can override the Python version restriction by providing the --force-install flag to `meltano add`.
@@ -895,25 +898,40 @@ The `init` command does not run relative to a [Meltano Environment](https://docs
 
 Installs dependencies of your project based on the **meltano.yml** file.
 
-You can install plugins by simply providing their names without specifying their type. Meltano will automatically detect the plugin type:
+The bare command will install all plugins:
 
 ```bash
-meltano install tap-github target-postgres
+meltano install
 ```
 
 Optionally, provide a plugin type argument to only (re)install plugins of a certain type.
 Additionally, plugin names can be provided to only (re)install those specific plugins.
 
-:::warning[Deprecated Syntax]
+<Tabs className="meltano-tabs" groupId="meltano-version">
+  <TabItem className="meltano-tab-content" value="v4" label="Meltano v4+" default>
 
-The following syntax forms are deprecated and will be removed in Meltano v4:
+```bash
+# Install specific plugins by name (automatically detects type)
+meltano install tap-github target-postgres
 
-| Deprecated Syntax | Use Instead |
-| --- | --- |
-| `meltano install <plugin_type> <plugin_name>` | `meltano install --plugin-type <plugin_type> <plugin_name>` |
-| `meltano install - <plugin_name>` | `meltano install <plugin_name>` |
+# Install plugins by type
+meltano install --plugin-type=extractor tap-gitlab
+```
 
-:::
+  </TabItem>
+  <TabItem className="meltano-tab-content" value="legacy" label="Legacy (pre-v4)">
+
+```bash
+# Using dash syntax
+meltano install - tap-github target-postgres
+
+# Using positional type argument
+meltano install extractor tap-gitlab
+meltano install <plugin_type> <plugin_name>
+```
+
+  </TabItem>
+</Tabs>
 
 To only install plugins for a particular schedule specify the `--schedule` argument.
 This can be useful in CI test workflows or for deployments that need to install plugins before every run.
@@ -939,7 +957,6 @@ meltano install
 # Install specific plugins (recommended - automatically detects type)
 meltano install tap-github target-postgres
 meltano install tap-gitlab
-meltano install - tap-gitlab target-postgres  # Deprecated syntax
 
 # Install plugins by type
 meltano install --plugin-type=extractor tap-gitlab

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -79,12 +79,7 @@ async def install(
     Read more at https://docs.meltano.com/reference/command-line-interface#install
     """  # noqa: D301
     tracker: Tracker = ctx.obj["tracker"]
-    plugin_names, plugin_type = validate_plugin_type_args(
-        plugin,
-        plugin_type,
-        ctx,
-        support_any=True,
-    )
+    plugin_names, plugin_type = validate_plugin_type_args(plugin, plugin_type, ctx)
 
     try:
         if plugin_type:

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -671,8 +671,6 @@ def validate_plugin_type_args(
     plugin: tuple[str, ...],
     plugin_type: PluginType | None,
     ctx: click.Context,
-    *,
-    support_any: bool = False,
 ) -> tuple[tuple[str, ...], PluginType | None]:
     """Validate plugin type arguments and return processed values.
 
@@ -699,22 +697,6 @@ def validate_plugin_type_args(
             "Passing the plugin type as the first positional argument is deprecated "
             "and will be removed in Meltano v4. "
             "Please use the --plugin-type option instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return plugin_names, plugin_type
-
-    if support_any and plugin[0] == "-":
-        if plugin_type is not None:
-            msg = "Use only --plugin-type to specify plugin type"
-            raise click.UsageError(msg, ctx=ctx)
-
-        plugin_names = plugin[1:]
-        plugin_type = None
-        warnings.warn(
-            'Using "-" to specify plugins of any type is '
-            "deprecated and will be removed in Meltano v4. "
-            "It is no longer necessary to use this argument.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -40,25 +40,6 @@ class TestCliInstall:
                 force=False,
             )
 
-        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
-            install_plugin_mock.return_value = True
-
-            with pytest.warns(
-                DeprecationWarning,
-                match='Using "-" to specify plugins of any type is deprecated',
-            ):
-                result = cli_runner.invoke(cli, ["install", "-"])
-
-            assert_cli_runner(result)
-
-            install_plugin_mock.assert_called_once_with(
-                project,
-                [tap, tap_gitlab, target, dbt],
-                parallelism=None,
-                clean=False,
-                force=False,
-            )
-
     @pytest.mark.usefixtures("dbt")
     def test_install_type(
         self,
@@ -272,27 +253,6 @@ class TestCliInstall:
         dbt,
         cli_runner,
     ) -> None:
-        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
-            install_plugin_mock.return_value = True
-
-            with pytest.warns(
-                DeprecationWarning,
-                match='Using "-" to specify plugins of any type is deprecated',
-            ):
-                result = cli_runner.invoke(
-                    cli,
-                    ["install", "-", tap.name, target.name, dbt.name],
-                )
-            assert_cli_runner(result)
-
-            install_plugin_mock.assert_called_once_with(
-                project,
-                [tap, target, dbt],
-                parallelism=None,
-                clean=False,
-                force=False,
-            )
-
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
             result = cli_runner.invoke(


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Remove support for the deprecated dash-based syntax in the install command and clean up related code, documentation, and tests.

Enhancements:
- Drop handling of the legacy ‘meltano install - <plugin>’ syntax from the install CLI and validation utilities

Documentation:
- Revise CLI reference to remove deprecated dash syntax and introduce version-specific usage tabs

Tests:
- Eliminate tests for the removed dash-based install syntax