### PR TITLE
fix: Remove deprecated `meltano lock --all` flag

### DIFF
--- a/docs/docs/reference/command-line-interface.mdx
+++ b/docs/docs/reference/command-line-interface.mdx
@@ -1083,9 +1083,6 @@ meltano lock <name> <name_two> --plugin-type=<type>
 # Use --update in combination with any of the above to update the lock file
 # with the latest definition from MeltanoHub
 meltano lock --update
-
-# Note: --all flag is deprecated but still supported
-meltano lock --all  # deprecated, use 'meltano lock' instead
 ```
 
 ### Using `lock` with Environments

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import typing as t
-import warnings
 
 import click
 import structlog
@@ -30,13 +29,6 @@ logger = structlog.get_logger(__name__)
 
 @click.command(cls=PartialInstrumentedCmd, short_help="Lock plugin definitions.")
 @click.option(
-    "--all",
-    "all_plugins",
-    is_flag=True,
-    hidden=True,
-    help="DEPRECATED: All plugins are now locked by default.",
-)
-@click.option(
     "--plugin-type",
     type=PluginTypeArg(),
     help="Lock only the plugins of the given type.",
@@ -49,7 +41,6 @@ def lock(
     project: Project,
     ctx: click.Context,
     *,
-    all_plugins: bool,
     plugin_type: PluginType | None,
     plugin_name: tuple[str, ...],
     update: bool,
@@ -60,13 +51,6 @@ def lock(
     Read more at https://docs.meltano.com/reference/command-line-interface#lock
     """  # noqa: D301
     tracker: Tracker = ctx.obj["tracker"]
-
-    if all_plugins:
-        warnings.warn(
-            "The --all flag is deprecated and is no longer needed",
-            DeprecationWarning,
-            stacklevel=0,
-        )
 
     lock_service = PluginLockService(project)
 

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -21,12 +21,6 @@ if t.TYPE_CHECKING:
 class TestLock:
     @pytest.mark.order(0)
     @pytest.mark.usefixtures("project")
-    def test_lock_all_deprecation(self, cli_runner: CliRunner) -> None:
-        with pytest.warns(DeprecationWarning, match="The --all flag is deprecated"):
-            cli_runner.invoke(cli, ["lock", "--all"])
-
-    @pytest.mark.order(1)
-    @pytest.mark.usefixtures("project")
     def test_lock_no_plugins(self, cli_runner: CliRunner) -> None:
         exception_message = "No matching plugin(s) found"
 
@@ -36,7 +30,7 @@ class TestLock:
         result = cli_runner.invoke(cli, ["lock", "--update"])
         assert exception_message == str(result.exception)
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(1)
     @pytest.mark.usefixtures("tap", "target")
     def test_lockfile_exists(
         self,
@@ -52,7 +46,7 @@ class TestLock:
         assert "Lockfile exists for loader target-mock" in result.stdout
         assert "Locked definition" not in result.stdout
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(2)
     def test_lockfile_update(
         self,
         cli_runner: CliRunner,
@@ -88,7 +82,7 @@ class TestLock:
         assert new_setting.name == "foo"
         assert new_setting.value == "bar"
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(3)
     @pytest.mark.usefixtures("tap", "inherited_tap", "hub_endpoints")
     def test_lockfile_update_extractors(
         self,


### PR DESCRIPTION
For v4.

## Summary by Sourcery

Remove the deprecated --all flag from the meltano lock command and clean up related code, tests, and documentation

Enhancements:
- Remove --all click option, all_plugins parameter, and deprecation warning from the lock command implementation

Documentation:
- Remove all mentions of the deprecated --all flag from the CLI reference documentation

Tests:
- Remove deprecation warning test for --all flag and renumber remaining lock command tests