### PR TITLE
fix(cli): Remove deprecated plugin type positional argument from the CLI

### DIFF
--- a/docs/docs/getting-started/index.mdx
+++ b/docs/docs/getting-started/index.mdx
@@ -215,16 +215,16 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
     - If an extractor is **supported out of the box**, add it to your project using [`meltano add`](/reference/command-line-interface#add):
 
     ```bash
-    meltano add extractor <plugin name>
+    meltano add <plugin name>
 
     # For example:
-    meltano add extractor tap-gitlab
+    meltano add tap-gitlab
 
     # If you have a preference for a non-default variant, select it using `--variant`:
-    meltano add extractor tap-gitlab --variant=singer-io
+    meltano add tap-gitlab --variant=singer-io
 
     # If you're using Docker, don't forget to mount the project directory:
-    docker run -v $(pwd):/project -w /project meltano/meltano add extractor tap-gitlab
+    docker run -v $(pwd):/project -w /project meltano/meltano add tap-gitlab
     ```
 
     This will add the new plugin to your [`meltano.yml` project file](/concepts/project#plugins):
@@ -250,15 +250,15 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
     - If a Singer tap for your data source is **available**, add it to your project as a [custom plugin](/concepts/plugins#custom-plugins) using [`meltano add --custom`](/reference/command-line-interface#add):
 
     ```bash
-    meltano add --custom extractor <tap name>
+    meltano add --custom <tap name>
 
     # For example:
-    meltano add --custom extractor tap-covid-19
+    meltano add --custom tap-covid-19
 
     # If you're using Docker, don't forget to mount the project directory,
     # and ensure that interactive mode is enabled so that Meltano can ask you
     # additional questions about the plugin and get your answers over STDIN:
-    docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom extractor tap-covid-19
+    docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom tap-covid-19
     ```
 
     Meltano will now ask you some additional questions to learn more about the plugin.
@@ -609,14 +609,14 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
             - If a loader is **supported out of the box**, add it to your project using [`meltano add`](/reference/command-line-interface#add):
 
                   ```bash
-                  meltano add loader <plugin name>
+                  meltano add <plugin name>
 
                   # For this example, we'll use the default variant:
-                  meltano add loader target-postgres
+                  meltano add target-postgres
 
                   # Or if you just want to use a non-default variant you can use this,
                   # selected using `--variant`:
-                  meltano add loader target-postgres --variant=datamill-co
+                  meltano add target-postgres --variant=datamill-co
                   ```
 
 :::info
@@ -644,15 +644,15 @@ _To learn more about adding plugins to your project, refer to the [Plugin Manage
         - If a Singer target for your data destination is **available**, add it to your project as a [custom plugin](/concepts/plugins#custom-plugins) using [`meltano add --custom`](/reference/command-line-interface#add):
 
               ```bash
-              meltano add --custom loader <target name>
+              meltano add --custom <target name>
 
               # For example:
-              meltano add --custom loader target-bigquery
+              meltano add --custom target-bigquery
 
               # If you're using Docker, don't forget to mount the project directory,
               # and ensure that interactive mode is enabled so that Meltano can ask you
               # additional questions about the plugin and get your answers over STDIN:
-              docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom loader target-bigquery
+              docker run --interactive -v $(pwd):/project -w /project meltano/meltano add --custom target-bigquery
               ```
 
               Meltano will now ask you some additional questions to learn more about the plugin.
@@ -921,7 +921,7 @@ schedules:
 1. Add the [Apache Airflow](https://airflow.apache.org/) orchestrator to your project using [`meltano add`](/reference/command-line-interface#add), which will be responsible for managing the schedule and executing the appropriate `meltano run` commands:
 
    ```bash
-   meltano add utility airflow
+   meltano add airflow
    ```
 
    This will add the new plugin to your [`meltano.yml` project file](/concepts/project#plugins):
@@ -985,7 +985,7 @@ Refer to the [transformers page](https://hub.meltano.com/transformers/) on Melta
 1. Install the dbt transformer to your project:
 
    ```bash
-   meltano add transformer dbt-postgres
+   meltano add dbt-postgres
    ```
 
 1. Configure dbt-postgres

--- a/docs/docs/getting-started/part3.mdx
+++ b/docs/docs/getting-started/part3.mdx
@@ -80,7 +80,7 @@ dbt uses different [adapters](https://docs.getdbt.com/docs/supported-data-platfo
 <Termy>
 
 ```console
-$ meltano add utility dbt-postgres
+$ meltano add dbt-postgres
 2024-09-22T11:32:35.601357Z [info     ] Environment 'dev' is active
 Added utility 'dbt-postgres' to your Meltano project
 ...

--- a/docs/docs/guide/complete_tutorial.md
+++ b/docs/docs/guide/complete_tutorial.md
@@ -214,16 +214,16 @@ docker run -v $(pwd):/project -w /project meltano/meltano add tap-gitlab
 ```
 
 ```bash
-meltano add extractor <plugin name>
+meltano add <plugin name>
 
 # For example:
-meltano add extractor tap-gitlab
+meltano add tap-gitlab
 
 # If you have a preference for a non-default variant, select it using `--variant`:
-meltano add extractor tap-gitlab --variant=singer-io
+meltano add tap-gitlab --variant=singer-io
 
 # If you're using Docker, don't forget to mount the project directory:
-docker run -v $(pwd):/project -w /project meltano/meltano add extractor tap-gitlab
+docker run -v $(pwd):/project -w /project meltano/meltano add tap-gitlab
 ```
 
 ```mdx-code-block
@@ -678,14 +678,14 @@ meltano add --plugin-type loader target-postgres
 ```
 
 ```bash
-meltano add loader <plugin name>
+meltano add <plugin name>
 
 # For this example, we'll use the default variant:
-meltano add loader target-postgres
+meltano add target-postgres
 
 # Or if you just want to use a non-default variant you can use this,
 # selected using `--variant`:
-meltano add loader target-postgres --variant=datamill-co
+meltano add target-postgres --variant=datamill-co
 ```
 
 ```mdx-code-block
@@ -1054,7 +1054,7 @@ meltano add --plugin-type utility airflow
 ```
 
 ```bash
-meltano add utility airflow
+meltano add airflow
 ```
 
 ```mdx-code-block
@@ -1123,7 +1123,7 @@ Refer to the [transformers page](https://hub.meltano.com/transformers/) on Melta
 1. Install the dbt transformer to your project:
 
    ```bash
-   meltano add transformer dbt-postgres
+   meltano add dbt-postgres
    ```
 
 1. Configure dbt-postgres

--- a/docs/docs/guide/plugin-management.md
+++ b/docs/docs/guide/plugin-management.md
@@ -77,13 +77,13 @@ meltano add --plugin-type utility airflow
 ```
 
 ```bash
-meltano add <type> <name>
+meltano add <name>
 
 # For example:
-meltano add extractor tap-gitlab
-meltano add loader target-postgres
-meltano add utility dbt-snowflake
-meltano add utility airflow
+meltano add tap-gitlab
+meltano add target-postgres
+meltano add dbt-snowflake
+meltano add airflow
 ```
 
 ```mdx-code-block

--- a/docs/docs/guide/transformation.md
+++ b/docs/docs/guide/transformation.md
@@ -30,9 +30,6 @@ meltano add dbt-snowflake  # Automatically detected as utility
 
 # Explicit plugin type for disambiguation:
 # meltano add --plugin-type utility dbt-snowflake
-
-# Deprecated positional syntax:
-# meltano add utility dbt-snowflake
 ```
 
 After dbt is installed you can configure it using `config` CLI commands, [Meltano environments](/concepts/environments) or environment variables:

--- a/docs/docs/reference/command-line-interface.mdx
+++ b/docs/docs/reference/command-line-interface.mdx
@@ -103,16 +103,6 @@ meltano add --plugin-type extractor tap-gitlab
 meltano add --plugin-type loader target-postgres
 ```
 
-The original positional syntax is still supported but deprecated:
-
-```bash
-# Deprecated syntax (still works but will be removed in v4)
-meltano add <type> <name>
-
-# For example:
-meltano add extractor tap-gitlab  # Will show deprecation warning
-meltano add loader target-postgres
-```
 
 :::info Automatic Plugin Type Detection
 Meltano automatically detects plugin types based on naming conventions:
@@ -139,9 +129,6 @@ meltano add target-postgres --variant transferwise
 
 # With explicit type specification for disambiguation
 meltano add --plugin-type loader target-postgres --variant transferwise
-
-# Deprecated positional syntax
-meltano add loader target-postgres --variant transferwise
 ```
 
 To add a [custom plugin](/concepts/plugins#custom-plugins) using a [custom plugin definition](/concepts/project#custom-plugin-definitions), use the `--custom` flag:
@@ -155,9 +142,6 @@ meltano add --custom tap-covid-19  # Automatically detected as extractor
 
 # With explicit type specification for disambiguation
 meltano add --custom --plugin-type extractor tap-covid-19
-
-# Deprecated positional syntax
-meltano add --custom extractor tap-covid-19
 
 # If you're using Docker, don't forget to mount the project directory,
 # and ensure that interactive mode is enabled so that Meltano can ask you
@@ -176,9 +160,6 @@ meltano add tap-ga--client-foo --inherit-from tap-google-analytics  # Automatica
 
 # With explicit type specification for disambiguation
 meltano add --plugin-type extractor tap-ga--client-foo --inherit-from tap-google-analytics
-
-# Deprecated positional syntax
-meltano add extractor tap-ga--client-foo --inherit-from tap-google-analytics
 ```
 
 To add a plugin from a [plugin definition](/concepts/project#custom-plugin-definitions) YAML file as a [custom plugin](/concepts/plugins#custom-plugins), use the `--from-ref` option referencing a URL or local path:
@@ -199,9 +180,6 @@ meltano add tap-shopify --from-ref tap-shopify--matatika.yml
 
 # With explicit type specification for disambiguation
 meltano add --plugin-type extractor tap-shopify --from-ref https://raw.githubusercontent.com/meltano/hub/main/_data/meltano/extractors/tap-shopify/matatika.yml
-
-# Deprecated positional syntax
-meltano add extractor tap-shopify --from-ref https://raw.githubusercontent.com/meltano/hub/main/_data/meltano/extractors/tap-shopify/matatika.yml
 
 # The plugin name specified in the command is superseded by the value in the
 # plugin definition file - using the same name is just a formality
@@ -224,10 +202,10 @@ This will update the plugin lock file and `meltano.yml` entry, without overwriti
 By default, `meltano add` will attempt to install the plugin after adding it. Use `--no-install` to skip this behavior:
 
 ```bash
-meltano add <type> <name> --no-install
+meltano add <name> --no-install
 
 # For example:
-meltano add extractor tap-shopify --no-install
+meltano add tap-shopify --no-install
 ```
 
 By default, plugins that use Python use the version of Python that was used to run Meltano. This behavior can be overridden using the `python` attribute, which can be set [for all plugins](/reference/settings#project-python), or on a [per-plugin basis](/reference/settings#plugin-python).
@@ -235,13 +213,13 @@ By default, plugins that use Python use the version of Python that was used to r
 When adding a new plugin, the Python version can be specified using the `--python` option:
 
 ```bash
-meltano add <type> <name> --python <Python version or path>
+meltano add <name> --python <Python version or path>
 ```
 
 For example, to add `tap-github` using Python 3.12 (assuming `python3.12` is installed and on your `$PATH`):
 
 ```bash
-meltano add extractor tap-github --python python3.12
+meltano add tap-github --python python3.12
 ```
 
 Then regardless of the Python version used when the plugin is installed, `tap-gitlab` and any plugin which inherits from it will use Python 3.12.
@@ -960,9 +938,8 @@ meltano install tap-gitlab
 
 # Install plugins by type
 meltano install --plugin-type=extractor tap-gitlab
-meltano install extractors  # Deprecated syntax
+meltano install --plugin-type=extractors  # Install all extractors
 meltano install --plugin-type=extractor tap-gitlab tap-adwords
-meltano install extractors tap-gitlab tap-adwords  # Deprecated syntax
 
 # Install plugins for a specific schedule
 meltano install --schedule=<schedule_name>
@@ -1177,13 +1154,9 @@ Specifically, [plugins](/concepts/plugins#project-plugins) will be removed from 
 ### How to Use
 
 ```bash
-# New syntax (recommended) - plugin type is automatically inferred
+# Plugin type is automatically inferred
 meltano remove <name>
 meltano remove <name> <name_two>
-
-# Deprecated syntax - will be removed in v4
-meltano remove <type> <name>
-meltano remove <type> <name> <name_two>
 ```
 
 ### Using `remove` with Environments
@@ -1193,13 +1166,9 @@ The `remove` command does not run relative to a [Meltano Environment](https://do
 ### Examples
 
 ```bash
-# New syntax - plugin type is automatically inferred
+# Plugin type is automatically inferred
 meltano remove tap-gitlab
 meltano remove target-postgres target-csv
-
-# Deprecated syntax - will be removed in v4
-meltano remove extractor tap-gitlab
-meltano remove loader target-postgres target-csv
 ```
 
 ## `run`

--- a/docs/docs/tutorials/custom-extractor.md
+++ b/docs/docs/tutorials/custom-extractor.md
@@ -237,7 +237,7 @@ meltano add target-jsonl
 ```
 
 ```bash
-meltano add loader target-jsonl
+meltano add target-jsonl
 ```
 
 ```mdx-code-block
@@ -348,7 +348,7 @@ meltano add --custom tap-jsonplaceholder
 ```
 
 ```bash
-meltano add --custom extractor tap-jsonplaceholder
+meltano add --custom tap-jsonplaceholder
 ```
 
 ```mdx-code-block
@@ -407,7 +407,7 @@ meltano add --from-ref tap-jsonplaceholder.yml tap-jsonplaceholder
 ```
 
 ```bash
-meltano add --from-ref tap-jsonplaceholder.yml extractor tap-jsonplaceholder
+meltano add --from-ref tap-jsonplaceholder.yml tap-jsonplaceholder
 ```
 
 ```mdx-code-block
@@ -448,7 +448,7 @@ meltano add --update --from-ref tap-jsonplaceholder.yml tap-jsonplaceholder
 ```
 
 ```bash
-meltano add --update --from-ref tap-jsonplaceholder.yml extractor tap-jsonplaceholder
+meltano add --update --from-ref tap-jsonplaceholder.yml tap-jsonplaceholder
 ```
 
 ```mdx-code-block
@@ -482,7 +482,7 @@ meltano add target-jsonl
 ```
 
 ```bash
-meltano add loader target-jsonl
+meltano add target-jsonl
 ```
 
 ```mdx-code-block

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,6 @@ filterwarnings = [
   "ignore: Parsing dates involving a day of month without a year specified is:DeprecationWarning:dateparser.*",  # https://github.com/scrapinghub/dateparser/issues/1246
   "ignore::pytest.PytestUnraisableExceptionWarning",
   "ignore::ResourceWarning",
-  "ignore:Passing the plugin type as the first positional argument is deprecated and will be removed in Meltano v4:DeprecationWarning",  # https://github.com/meltano/meltano/issues/7066
 ]
 log_cli = true
 log_cli_format = "%(message)s"

--- a/src/meltano/cli/add.py
+++ b/src/meltano/cli/add.py
@@ -17,7 +17,6 @@ from meltano.cli.utils import (
     add_required_plugins,
     check_dependencies_met,
     infer_plugin_type,
-    validate_plugin_type_args,
 )
 from meltano.core.plugin import PluginRef, PluginType
 from meltano.core.plugin_install_service import PluginInstallReason
@@ -143,7 +142,7 @@ async def add(
     """  # noqa: D301
     tracker: Tracker = ctx.obj["tracker"]
 
-    plugin_names, plugin_type = validate_plugin_type_args(plugin, plugin_type, ctx)
+    plugin_names = plugin
 
     if as_name:
         # `add <type> <inherit-from> --as <name>``

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -11,7 +11,6 @@ from meltano.cli.params import PluginTypeArg, pass_project
 from meltano.cli.utils import (
     CliError,
     PartialInstrumentedCmd,
-    validate_plugin_type_args,
 )
 from meltano.core.block.block_parser import BlockParser
 from meltano.core.plugin import PluginType
@@ -79,7 +78,7 @@ async def install(
     Read more at https://docs.meltano.com/reference/command-line-interface#install
     """  # noqa: D301
     tracker: Tracker = ctx.obj["tracker"]
-    plugin_names, plugin_type = validate_plugin_type_args(plugin, plugin_type, ctx)
+    plugin_names = plugin
 
     try:
         if plugin_type:

--- a/src/meltano/cli/remove.py
+++ b/src/meltano/cli/remove.py
@@ -10,7 +10,6 @@ from meltano.cli.params import PluginTypeArg, pass_project
 from meltano.cli.utils import (
     InstrumentedCmd,
     infer_plugin_type,
-    validate_plugin_type_args,
 )
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_location_remove import DbRemoveManager
@@ -27,11 +26,9 @@ if t.TYPE_CHECKING:
 @click.command(cls=InstrumentedCmd, short_help="Remove plugins from your project.")
 @click.argument("plugin", nargs=-1, required=True)
 @click.option("--plugin-type", type=PluginTypeArg())
-@click.pass_context
 @pass_project()
 def remove(
     project: Project,
-    ctx: click.Context,
     plugin: tuple[str, ...],
     plugin_type: PluginType | None,
 ) -> None:
@@ -40,7 +37,7 @@ def remove(
     \b
     Read more at https://docs.meltano.com/reference/command-line-interface#remove
     """  # noqa: D301
-    plugin_names, plugin_type = validate_plugin_type_args(plugin, plugin_type, ctx)
+    plugin_names = plugin
 
     plugins = [
         ProjectPlugin(

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -6,7 +6,6 @@ import os
 import signal
 import sys
 import typing as t
-import warnings
 from contextlib import contextmanager
 from enum import Enum, auto
 
@@ -665,41 +664,3 @@ def infer_plugin_type(plugin_name: str) -> PluginType:
         return PluginType.LOADERS
 
     return PluginType.UTILITIES
-
-
-def validate_plugin_type_args(
-    plugin: tuple[str, ...],
-    plugin_type: PluginType | None,
-    ctx: click.Context,
-) -> tuple[tuple[str, ...], PluginType | None]:
-    """Validate plugin type arguments and return processed values.
-
-    Raises click.UsageError if both positional plugin type and --plugin-type flag
-    are provided. Returns tuple of (plugin_names, plugin_type).
-
-    Args:
-        plugin: The plugin arguments tuple
-        plugin_type: The plugin type from --plugin-type flag
-        ctx: Click context
-        support_any: Whether to support the "-" (ANY) argument for install command
-    """
-    if not plugin:
-        return plugin, plugin_type
-
-    if plugin[0] in PluginType.cli_arguments():
-        if plugin_type is not None:
-            msg = "Use only --plugin-type to specify plugin type"
-            raise click.UsageError(msg, ctx=ctx)
-
-        plugin_names = plugin[1:]
-        plugin_type = PluginType.from_cli_argument(plugin[0])
-        warnings.warn(
-            "Passing the plugin type as the first positional argument is deprecated "
-            "and will be removed in Meltano v4. "
-            "Please use the --plugin-type option instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return plugin_names, plugin_type
-
-    return plugin, plugin_type

--- a/tests/meltano/cli/test_install.py
+++ b/tests/meltano/cli/test_install.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import typing as t
 from unittest import mock
 
 import pytest
@@ -11,9 +10,6 @@ from asserts import assert_cli_runner
 from meltano.cli import cli
 from meltano.core.plugin import PluginType
 from meltano.core.project_add_service import PluginAlreadyAddedException
-
-if t.TYPE_CHECKING:
-    from fixtures.cli import MeltanoCliRunner
 
 
 class TestCliInstall:
@@ -53,43 +49,19 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
             install_plugin_mock_e.return_value = True
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
-            ):
-                result = cli_runner.invoke(cli, ["install", "extractors"])
-            assert_cli_runner(result)
-
-            install_plugin_mock_e.assert_called_once_with(
-                project,
-                [tap, tap_gitlab],
-                parallelism=None,
-                clean=False,
-                force=False,
-            )
-
-        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
-            install_plugin_mock_e.return_value = True
-
             result = cli_runner.invoke(cli, ["install", "--plugin-type=extractors"])
             assert_cli_runner(result)
 
-            install_plugin_mock_e.assert_called_once_with(
-                project,
-                [tap, tap_gitlab],
-                parallelism=None,
-                clean=False,
-                force=False,
-            )
+            install_plugin_mock_e.assert_called_once()
+            call_args = install_plugin_mock_e.call_args
+            assert call_args[0][0] == project
+            assert set(call_args[0][1]) == {tap, tap_gitlab}
+            assert call_args[1] == {"parallelism": None, "clean": False, "force": False}
 
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_l:
             install_plugin_mock_l.return_value = True
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
-            ):
-                result = cli_runner.invoke(cli, ["install", "loaders"])
+            result = cli_runner.invoke(cli, ["install", "--plugin-type=loaders"])
             assert_cli_runner(result)
 
             install_plugin_mock_l.assert_called_once_with(
@@ -103,11 +75,7 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_m:
             install_plugin_mock_m.return_value = True
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
-            ):
-                result = cli_runner.invoke(cli, ["install", "mappers"])
+            result = cli_runner.invoke(cli, ["install", "--plugin-type=mappers"])
             assert_cli_runner(result)
 
             assert install_plugin_mock_m.call_count == 1
@@ -133,24 +101,6 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
             install_plugin_mock_e.return_value = True
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
-            ):
-                result = cli_runner.invoke(cli, ["install", "extractor", tap.name])
-            assert_cli_runner(result)
-
-            install_plugin_mock_e.assert_called_once_with(
-                project,
-                [tap],
-                parallelism=None,
-                clean=False,
-                force=False,
-            )
-
-        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_e:
-            install_plugin_mock_e.return_value = True
-
             result = cli_runner.invoke(
                 cli,
                 ["install", "--plugin-type=extractors", tap.name],
@@ -168,11 +118,10 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_l:
             install_plugin_mock_l.return_value = True
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
-            ):
-                result = cli_runner.invoke(cli, ["install", "loader", target.name])
+            result = cli_runner.invoke(
+                cli,
+                ["install", "--plugin-type=loaders", target.name],
+            )
             assert_cli_runner(result)
 
             install_plugin_mock_l.assert_called_once_with(
@@ -186,11 +135,10 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock_m:
             install_plugin_mock_m.return_value = True
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
-            ):
-                result = cli_runner.invoke(cli, ["install", "mapper", mapper.name])
+            result = cli_runner.invoke(
+                cli,
+                ["install", "--plugin-type=mappers", mapper.name],
+            )
             assert_cli_runner(result)
 
             assert install_plugin_mock_m.call_count == 1
@@ -209,40 +157,17 @@ class TestCliInstall:
         with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="Passing the plugin type as the first positional argument is deprecated",  # noqa: E501
-            ):
-                result = cli_runner.invoke(
-                    cli,
-                    ["install", "extractors", tap.name, tap_gitlab.name],
-                )
-            assert_cli_runner(result)
-
-            install_plugin_mock.assert_called_once_with(
-                project,
-                [tap, tap_gitlab],
-                parallelism=None,
-                clean=False,
-                force=False,
-            )
-
-        with mock.patch("meltano.cli.install.install_plugins") as install_plugin_mock:
-            install_plugin_mock.return_value = True
-
             result = cli_runner.invoke(
                 cli,
                 ["install", "--plugin-type=extractors", tap.name, tap_gitlab.name],
             )
             assert_cli_runner(result)
 
-            install_plugin_mock.assert_called_once_with(
-                project,
-                [tap, tap_gitlab],
-                parallelism=None,
-                clean=False,
-                force=False,
-            )
+            install_plugin_mock.assert_called_once()
+            call_args = install_plugin_mock.call_args
+            assert call_args[0][0] == project
+            assert set(call_args[0][1]) == {tap, tap_gitlab}
+            assert call_args[1] == {"parallelism": None, "clean": False, "force": False}
 
     @pytest.mark.usefixtures("dbt")
     def test_install_multiple_any_type(
@@ -430,25 +355,6 @@ class TestCliInstall:
             assert install_plugin_mock.mock_calls[0].kwargs["parallelism"] is None
             assert install_plugin_mock.mock_calls[0].kwargs["clean"] is False
             assert install_plugin_mock.mock_calls[0].kwargs["force"] is False
-
-    def test_install_conflicting_plugin_type_and_positional_argument(
-        self,
-        tap,
-        cli_runner: MeltanoCliRunner,
-    ) -> None:
-        result = cli_runner.invoke(
-            cli,
-            ["install", "--plugin-type=extractors", "extractors", tap.name],
-        )
-        assert result.exit_code == 2
-        assert "Use only --plugin-type to specify plugin type" in result.stderr
-
-        result = cli_runner.invoke(
-            cli,
-            ["install", "extractors", "--plugin-type=extractors", "-", tap.name],
-        )
-        assert result.exit_code == 2
-        assert "Use only --plugin-type to specify plugin type" in result.stderr
 
 
 # un_engine_uri forces us to create a new project, we must do this before the

--- a/tests/meltano/cli/test_remove.py
+++ b/tests/meltano/cli/test_remove.py
@@ -25,11 +25,10 @@ class TestCliRemove:
 
     def test_remove(self, project, tap: ProjectPlugin, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
-            with pytest.warns(
-                DeprecationWarning,
-                match="plugin type as the first positional argument is deprecated",
-            ):
-                result = cli_runner.invoke(cli, ["remove", tap.type.value, tap.name])
+            result = cli_runner.invoke(
+                cli,
+                ["remove", f"--plugin-type={tap.type.value}", tap.name],
+            )
 
             assert_cli_runner(result)
 
@@ -37,35 +36,29 @@ class TestCliRemove:
 
     def test_remove_multiple(self, project, tap, tap_gitlab, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
-            with pytest.warns(
-                DeprecationWarning,
-                match="plugin type as the first positional argument is deprecated",
-            ):
-                result = cli_runner.invoke(
-                    cli,
-                    ["remove", "extractors", tap.name, tap_gitlab.name],
-                )
+            result = cli_runner.invoke(
+                cli,
+                ["remove", "--plugin-type=extractors", tap.name, tap_gitlab.name],
+            )
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_once_with(project, [tap, tap_gitlab])
 
     def test_remove_type_name(self, project, tap, target, cli_runner) -> None:
         with mock.patch("meltano.cli.remove.remove_plugins") as remove_plugins_mock:
-            with pytest.warns(
-                DeprecationWarning,
-                match="plugin type as the first positional argument is deprecated",
-            ):
-                result = cli_runner.invoke(cli, ["remove", "extractor", tap.name])
+            result = cli_runner.invoke(
+                cli,
+                ["remove", "--plugin-type=extractor", tap.name],
+            )
 
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_with(project, [tap])
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="plugin type as the first positional argument is deprecated",
-            ):
-                result = cli_runner.invoke(cli, ["remove", "loader", target.name])
+            result = cli_runner.invoke(
+                cli,
+                ["remove", "--plugin-type=loader", target.name],
+            )
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_with(project, [target])
@@ -100,22 +93,3 @@ class TestCliRemove:
             assert_cli_runner(result)
 
             remove_plugins_mock.assert_called_once_with(project, [tap, tap_gitlab])
-
-    def test_remove_conflicting_plugin_type_and_positional_argument(
-        self,
-        tap,
-        cli_runner,
-    ) -> None:
-        result = cli_runner.invoke(
-            cli,
-            ["remove", "--plugin-type=extractors", "extractors", tap.name],
-        )
-        assert result.exit_code == 2
-        assert "Use only --plugin-type to specify plugin type" in result.stderr
-
-        result = cli_runner.invoke(
-            cli,
-            ["remove", "extractors", "--plugin-type=extractors", tap.name],
-        )
-        assert result.exit_code == 2
-        assert "Use only --plugin-type to specify plugin type" in result.stderr

--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -166,7 +166,7 @@ class TestCliUpgrade:
 
         assert "Nothing to update" in result.stdout
 
-        result = cli_runner.invoke(cli, ["add", "files", "airflow"])
+        result = cli_runner.invoke(cli, ["add", "--plugin-type=files", "airflow"])
         output = result.stdout + result.stderr
         assert_cli_runner(result)
 
@@ -255,7 +255,7 @@ class TestCliUpgrade:
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
             )
 
-        result = cli_runner.invoke(cli, ["add", "files", "airflow"])
+        result = cli_runner.invoke(cli, ["add", "--plugin-type=files", "airflow"])
         assert_cli_runner(result)
 
         file_path = project.root_dir("orchestrate/dags/meltano.py")


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This removes support for plugin type as a positional argument in

- `meltano add`
- `meltano install`
- `meltano remove`

## Related Issues

* https://github.com/meltano/meltano/issues/7066

## Summary by Sourcery

Remove deprecated positional plugin type argument support from CLI commands and update implementations, tests, and documentation to use the --plugin-type option or automatic inference.

Enhancements:
- Remove deprecated support for specifying plugin type as the first positional argument in add, install, and remove commands and drop related validation and warnings.
- Refactor CLI command implementations to rely on the --plugin-type flag or automatic type inference instead of positional syntax.
- Revise test suite to replace positional type arguments with --plugin-type flag and remove deprecation warning assertions.
- Cleanup documentation by removing deprecated positional syntax examples and updating command reference to the new idiomatic usage.