### PR TITLE
fix: Update the error message when the executable is not found to use `--plugin-type` option

### DIFF
--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -100,7 +100,7 @@ class ExecutableNotFoundError(InvokerError):
             f"Executable '{executable}' could not be found. "
             f"{plugin_type_descriptor} '{plugin.name}' may not have "
             "been installed yet using "
-            f"`meltano install {plugin_type} {plugin.name}`, "
+            f"`meltano install --plugin-type {plugin_type} {plugin.name}`, "
             "or the executable name may be incorrect.",
         )
 

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -354,4 +354,4 @@ class TestPluginInvoker:
         error_msg = str(error)
         assert "Executable 'missing-executable' could not be found" in error_msg
         assert "Extractor 'test-tap'" in error_msg
-        assert "meltano install extractor test-tap" in error_msg
+        assert "meltano install --plugin-type extractor test-tap" in error_msg


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Related Issues

NA

## Summary by Sourcery

Bug Fixes:
- Use the `--plugin-type` flag in the `meltano install` command within the executable not found error message