### PR TITLE
feat: Auto-lock plugin definitions

### DIFF
--- a/src/meltano/core/project_add_service.py
+++ b/src/meltano/core/project_add_service.py
@@ -8,6 +8,7 @@ import typing as t
 
 from meltano.core.plugin import BasePlugin, Variant
 from meltano.core.plugin.project_plugin import ProjectPlugin
+from meltano.core.plugin_lock_service import PluginLockBehavior
 from meltano.core.project_plugins_service import (
     DefinitionSource,
     PluginAlreadyAddedException,
@@ -96,7 +97,10 @@ class ProjectAddService:
             )
 
             if lock and not plugin.is_custom():
-                self.project.plugins.lock_service.save(plugin, exists_ok=True)
+                self.project.plugins.lock_service.save(
+                    plugin,
+                    if_exists=PluginLockBehavior.UPDATE,
+                )
 
             return plugin, flags
 

--- a/tests/meltano/core/test_plugin_lock_service.py
+++ b/tests/meltano/core/test_plugin_lock_service.py
@@ -10,6 +10,7 @@ from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin_lock_service import (
     LockfileAlreadyExistsError,
     PluginLock,
+    PluginLockBehavior,
     PluginLockService,
 )
 
@@ -110,4 +111,8 @@ class TestPluginLockService:
         with pytest.raises(LockfileAlreadyExistsError) as exc_info:
             subject.save(plugin)
 
+        assert isinstance(exc_info.value, LockfileAlreadyExistsError)
         assert exc_info.value.plugin == plugin
+
+        subject.save(plugin, if_exists=PluginLockBehavior.SKIP)
+        assert plugin_lock.path.exists()

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -10,6 +10,7 @@ import pytest
 from meltano.core.plugin import BasePlugin, PluginType
 from meltano.core.plugin.error import PluginNotFoundError, PluginParentNotFoundError
 from meltano.core.plugin.project_plugin import ProjectPlugin
+from meltano.core.plugin_lock_service import PluginLockBehavior
 from meltano.core.project_plugins_service import (
     DefinitionSource,
     PluginDefinitionNotFoundError,
@@ -45,7 +46,7 @@ def modified_lockfile(project: Project):
 class TestProjectPluginsService:
     @pytest.fixture(autouse=True)
     def setup(self, project: Project, tap) -> None:
-        project.plugins.lock_service.save(tap, exists_ok=True)
+        project.plugins.lock_service.save(tap, if_exists=PluginLockBehavior.UPDATE)
         project.plugins._prefer_source = DefinitionSource.ANY
 
     @pytest.mark.order(0)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Implement auto-locking of plugin definitions by extending PluginLockService with configurable behaviors, updating project services to persist lockfiles on parent resolution and addition, and providing a --locked flag in CLI commands to prefer local (locked) definitions.

New Features:
- Add --locked option to run and invoke commands to select locked plugin definitions

Enhancements:
- Introduce PluginLockBehavior enum to control behavior when lockfiles already exist
- Automatically persist plugin definition lockfiles when fetching parents or adding plugins based on preferred source
- Simplify the lock command by deferring to project.plugins listing and unified behavior in lock service

Tests:
- Add tests for SKIP behavior in PluginLockService