### PR TITLE
feat(cli): Print installation error in a nice panel when using the console logger

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,7 +29,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1"
-  UV_EXCLUDE_NEWER: "2025-10-01"
+  UV_EXCLUDE_NEWER: "2025-10-14"
 
 jobs:
   validate:

--- a/src/meltano/cli/install.py
+++ b/src/meltano/cli/install.py
@@ -8,10 +8,7 @@ import click
 import structlog
 
 from meltano.cli.params import PluginTypeArg, pass_project
-from meltano.cli.utils import (
-    CliError,
-    PartialInstrumentedCmd,
-)
+from meltano.cli.utils import PartialInstrumentedCmd
 from meltano.core.block.block_parser import BlockParser
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_install_service import install_plugins
@@ -114,7 +111,7 @@ async def install(
     )
     if not success:
         tracker.track_command_event(CliEvent.failed)
-        raise CliError("Failed to install plugin(s)")  # noqa: EM101
+        ctx.exit(1)
     tracker.track_command_event(CliEvent.completed)
 
 

--- a/src/meltano/core/logging/renderers.py
+++ b/src/meltano/core/logging/renderers.py
@@ -243,8 +243,15 @@ class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
             kwargs: Keyword arguments to pass to the parent class.
         """
         super().__init__(*args, **kwargs)
-        self._error_formatter = plugin_error_renderer or PluginErrorFormatter()
-        self._install_formatter = plugin_install_renderer or PluginInstallFormatter()
+        colors = kwargs.get("colors")
+        self._error_formatter = (
+            plugin_error_renderer  # or construct one with the right flags
+            or PluginErrorFormatter(no_color=not colors)
+        )
+        self._install_formatter = (
+            plugin_install_renderer  # or construct one with the right flags
+            or PluginInstallFormatter(no_color=not colors)
+        )
         self._all_keys = all_keys
         self._include_keys = include_keys
 

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -130,6 +130,17 @@ class PluginInstallState:
             case _:
                 return "Installation failed"
 
+    def __structlog__(self) -> dict[str, t.Any]:
+        """Convert the PluginInstallState to a dictionary."""
+        return {
+            "plugin_type": self.plugin.type.value,
+            "plugin_name": self.plugin.name,
+            "reason": self.reason.value,
+            "status": self.status.value,
+            "message": self.message,
+            "details": self.details,
+        }
+
 
 def with_semaphore(func):  # noqa: ANN001, ANN201
     """Gate access to the method using its class's semaphore.
@@ -564,7 +575,7 @@ def install_status_update(install_state: PluginInstallState) -> None:
                 "%s. %s.",
                 install_state.verb,
                 install_state.message,
-                details=install_state.details,
+                install_state=install_state,
             )
         case PluginInstallStatus.WARNING:  # pragma: no cover
             logger.warning(install_state.message)

--- a/tests/meltano/core/logging/test_renderers.py
+++ b/tests/meltano/core/logging/test_renderers.py
@@ -291,6 +291,21 @@ class TestPluginInstallFormatter:
         formatter.format(buffer, install_state)
         assert buffer.getvalue() == expected_install_output
 
+    def test_render_without_details(
+        self,
+        formatter: PluginInstallFormatter,
+        install_state: PluginInstallState,
+    ) -> None:
+        buffer = StringIO()
+        state = PluginInstallState(
+            plugin=install_state.plugin,
+            reason=install_state.reason,
+            status=install_state.status,
+            details=None,
+        )
+        formatter.format(buffer, state)
+        assert buffer.getvalue() == ""
+
 
 class TestMeltanoConsoleRenderer:
     @pytest.fixture

--- a/tests/meltano/core/logging/test_renderers.py
+++ b/tests/meltano/core/logging/test_renderers.py
@@ -273,27 +273,19 @@ class TestStructuredExceptionFormatter:
 
 
 class TestPluginInstallFormatter:
-    @pytest.fixture
-    def formatter(self) -> PluginInstallFormatter:
-        return PluginInstallFormatter(
-            force_terminal=False,
-            width=80,
-            no_color=True,
-        )
-
     def test_render(
         self,
-        formatter: PluginInstallFormatter,
+        install_formatter: PluginInstallFormatter,
         expected_install_output: str,
         install_state: PluginInstallState,
     ) -> None:
         buffer = StringIO()
-        formatter.format(buffer, install_state)
+        install_formatter.format(buffer, install_state)
         assert buffer.getvalue() == expected_install_output
 
     def test_render_without_details(
         self,
-        formatter: PluginInstallFormatter,
+        install_formatter: PluginInstallFormatter,
         install_state: PluginInstallState,
     ) -> None:
         buffer = StringIO()
@@ -303,7 +295,7 @@ class TestPluginInstallFormatter:
             status=install_state.status,
             details=None,
         )
-        formatter.format(buffer, state)
+        install_formatter.format(buffer, state)
         assert buffer.getvalue() == ""
 
 

--- a/tests/meltano/core/logging/test_renderers.py
+++ b/tests/meltano/core/logging/test_renderers.py
@@ -13,7 +13,15 @@ import structlog.processors
 from meltano.core.logging.models import PluginException, TracebackFrame
 from meltano.core.logging.renderers import (
     MeltanoConsoleRenderer,
-    StructuredExceptionFormatter,
+    PluginErrorFormatter,
+    PluginInstallFormatter,
+)
+from meltano.core.plugin import PluginType
+from meltano.core.plugin.project_plugin import ProjectPlugin
+from meltano.core.plugin_install_service import (
+    PluginInstallReason,
+    PluginInstallState,
+    PluginInstallStatus,
 )
 
 if t.TYPE_CHECKING:
@@ -62,8 +70,22 @@ def exception() -> PluginException:
 
 
 @pytest.fixture
-def formatter() -> StructuredExceptionFormatter:
-    return StructuredExceptionFormatter(
+def install_state() -> PluginInstallState:
+    return PluginInstallState(
+        plugin=ProjectPlugin(name="tap-mock", plugin_type=PluginType.EXTRACTORS),
+        reason=PluginInstallReason.INSTALL,
+        status=PluginInstallStatus.ERROR,
+        message="Custom exception message",
+        details=(
+            "This is multi-line error message.\n\nDetails of the error are "
+            "contained here."
+        ),
+    )
+
+
+@pytest.fixture
+def error_formatter() -> PluginErrorFormatter:
+    return PluginErrorFormatter(
         force_terminal=False,
         width=80,
         no_color=True,
@@ -73,7 +95,18 @@ def formatter() -> StructuredExceptionFormatter:
 
 
 @pytest.fixture
-def expected_output() -> str:
+def install_formatter() -> PluginInstallFormatter:
+    return PluginInstallFormatter(
+        force_terminal=False,
+        width=80,
+        no_color=True,
+        color_system="auto",
+        legacy_windows=False,
+    )
+
+
+@pytest.fixture
+def expected_exception_output() -> str:
     return dedent("""\
         ╭─────────────────────────────── Error details ────────────────────────────────╮
         │                                                                              │
@@ -98,6 +131,17 @@ def expected_output() -> str:
         During handling of the above exception, another exception occurred:
 
         ValueError: An invalid value was provided
+    """)
+
+
+@pytest.fixture
+def expected_install_output() -> str:
+    return dedent("""\
+        ╭───────────────────────────── Installation error ─────────────────────────────╮
+        │ This is multi-line error message.                                            │
+        │                                                                              │
+        │ Details of the error are contained here.                                     │
+        ╰────────────────────────── Custom exception message ──────────────────────────╯
     """)
 
 
@@ -150,17 +194,17 @@ class TestPluginException:
 
 
 class TestStructuredExceptionFormatter:
-    def test_simple_exception(self, formatter: StructuredExceptionFormatter) -> None:
+    def test_simple_exception(self, error_formatter: PluginErrorFormatter) -> None:
         exception = PluginException(
             type="CustomException",
             module="my_package.my_module",
             message="Custom exception message",
         )
         buffer = StringIO()
-        formatter.format(buffer, exception)
+        error_formatter.format(buffer, exception)
         assert buffer.getvalue() == "CustomException: Custom exception message\n"
 
-    def test_no_tracebacks(self, formatter: StructuredExceptionFormatter) -> None:
+    def test_no_tracebacks(self, error_formatter: PluginErrorFormatter) -> None:
         exception = PluginException(
             type="CustomException",
             module="my_package.my_module",
@@ -172,14 +216,14 @@ class TestStructuredExceptionFormatter:
             ),
         )
         buffer = StringIO()
-        formatter.format(buffer, exception)
+        error_formatter.format(buffer, exception)
         assert buffer.getvalue() == (
             "CustomException: Custom exception message\n\n"
             "The above exception was the direct cause of the following exception:\n\n"
             "ValueError: Invalid value provided\n"
         )
 
-    def test_hidden_tracebacks(self, formatter: StructuredExceptionFormatter) -> None:
+    def test_hidden_tracebacks(self, error_formatter: PluginErrorFormatter) -> None:
         expected_output = dedent("""\
         ╭─────────────────────────────── Error details ────────────────────────────────╮
         │                                                                              │
@@ -214,41 +258,63 @@ class TestStructuredExceptionFormatter:
             ],
         )
         buffer = StringIO()
-        formatter.format(buffer, exception)
+        error_formatter.format(buffer, exception)
         assert buffer.getvalue() == expected_output
 
     def test_render(
         self,
-        formatter: StructuredExceptionFormatter,
+        error_formatter: PluginErrorFormatter,
         exception: PluginException,
-        expected_output: str,
+        expected_exception_output: str,
     ) -> None:
         buffer = StringIO()
-        formatter.format(buffer, exception)
-        assert buffer.getvalue() == expected_output
+        error_formatter.format(buffer, exception)
+        assert buffer.getvalue() == expected_exception_output
+
+
+class TestPluginInstallFormatter:
+    @pytest.fixture
+    def formatter(self) -> PluginInstallFormatter:
+        return PluginInstallFormatter(
+            force_terminal=False,
+            width=80,
+            no_color=True,
+        )
+
+    def test_render(
+        self,
+        formatter: PluginInstallFormatter,
+        expected_install_output: str,
+        install_state: PluginInstallState,
+    ) -> None:
+        buffer = StringIO()
+        formatter.format(buffer, install_state)
+        assert buffer.getvalue() == expected_install_output
 
 
 class TestMeltanoConsoleRenderer:
     @pytest.fixture
     def subject(
         self,
-        formatter: StructuredExceptionFormatter,
+        error_formatter: PluginErrorFormatter,
+        install_formatter: PluginInstallFormatter,
     ) -> MeltanoConsoleRenderer:
         return MeltanoConsoleRenderer(
-            plugin_exception_renderer=formatter,
+            plugin_error_renderer=error_formatter,
+            plugin_install_renderer=install_formatter,
             colors=False,
             all_keys=True,
         )
 
     def test_included_keys(
         self,
-        formatter: StructuredExceptionFormatter,
+        error_formatter: PluginErrorFormatter,
         exception: PluginException,
         subtests: SubTests,
     ) -> None:
         make_renderer = functools.partial(
             MeltanoConsoleRenderer,
-            plugin_exception_renderer=formatter,
+            plugin_error_renderer=error_formatter,
             colors=False,
         )
 
@@ -313,25 +379,25 @@ class TestMeltanoConsoleRenderer:
             # Extra keys (included)
             assert "foo=bar" in result
 
-    def test_console_output(
+    def test_console_output_from_plugin_error(
         self,
         subtests: SubTests,
-        formatter: StructuredExceptionFormatter,
+        error_formatter: PluginErrorFormatter,
         exception: PluginException,
-        expected_output: str,
+        expected_exception_output: str,
     ) -> None:
         def key_val(**kwargs) -> str:
             return " ".join(f"{k}={v}" for k, v in kwargs.items())
 
         renderer = MeltanoConsoleRenderer(
-            plugin_exception_renderer=formatter,
+            plugin_error_renderer=error_formatter,
             colors=False,
             include_keys={"key"},
         )
 
         with subtests.test(msg="error"):
             out = renderer(None, "error", {"plugin_exception": exception})
-            assert out == expected_output + "\n" + key_val(
+            assert out == expected_exception_output + "\n" + key_val(
                 plugin_exc_message="'Custom exception message'",
                 plugin_exc_type="CustomException",
             )
@@ -346,3 +412,17 @@ class TestMeltanoConsoleRenderer:
         with subtests.test(msg="no exception"):
             out = renderer(None, "warning", {"key": "value"})
             assert out == key_val(key="value")
+
+    def test_console_output_from_plugin_install(
+        self,
+        install_formatter: PluginInstallFormatter,
+        expected_install_output: str,
+        install_state: PluginInstallState,
+    ) -> None:
+        renderer = MeltanoConsoleRenderer(
+            plugin_install_renderer=install_formatter,
+            colors=False,
+        )
+
+        out = renderer(None, "install", {"install_state": install_state})
+        assert out == expected_install_output + "\n"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Instead of directing the user to look at a log file somewhere, we print a nice panel with installation error details when using the console logger.

## Related Issues

* https://github.com/meltano/meltano/pull/9400

## Summary by Sourcery

Display installation errors in a rich console panel and unify plugin error rendering with new formatters, refactoring VenvService logging and adjusting CLI exit behavior.

New Features:
- Print plugin installation errors in a styled console panel using a new PluginInstallFormatter
- Replace StructuredExceptionFormatter with PluginErrorFormatter for consistent plugin exception rendering

Bug Fixes:
- Have the CLI install command exit with code 1 instead of raising CliError on failure

Enhancements:
- Integrate plugin error and installation formatters into MeltanoConsoleRenderer for improved console logging
- Add __structlog__ support to PluginInstallState to include installation context in structured logs
- Refactor VenvService to use install_log_path and remove legacy file-based error handling

CI:
- Bump UV_EXCLUDE_NEWER date in integration_tests GitHub workflow

Tests:
- Revise tests to cover new console formatters and remove obsolete VenvService error-logging tests