### PR TITLE
fix(cli): Allow `meltano upgrade package` to run outside of a project directory

### DIFF
--- a/docs/docs/reference/command-line-interface.mdx
+++ b/docs/docs/reference/command-line-interface.mdx
@@ -1890,10 +1890,14 @@ When called without arguments, this will:
 meltano upgrade
 meltano upgrade --skip-package # Skip upgrading the Meltano package
 
-meltano upgrade package # Only upgrade Meltano package
+meltano upgrade package # Only upgrade Meltano package (can run outside project directory)
 meltano upgrade files # Only update files managed by file bundles
 meltano upgrade database # Only apply migrations to system database
 ```
+
+### Project Directory Requirements
+
+The `upgrade` command and its subcommands require you to run them from within a Meltano project directory, with the exception of `meltano upgrade package`, which can be run from anywhere since it only upgrades the Meltano package itself.
 
 ### Using `upgrade` with Environments
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor the core upgrade service to defer project and engine injection to method calls and update CLI commands to instantiate UpgradeService without project context, enabling package upgrades to execute outside of a project directory.

Enhancements:
- Refactor UpgradeService to remove engine and project parameters from its constructor and accept Project instances in upgrade methods
- Modify update_files, migrate_database, migrate_state, and upgrade methods to take a project argument and use project_engine for database migrations
- Update CLI upgrade commands to instantiate UpgradeService without project context and apply pass_project only to subcommands that require a project
- Allow ‘meltano upgrade package’ (and other package-only operations) to run outside of a project directory by removing its project dependency