### PR TITLE
refactor: Make Hub client an implementation detail of lockfile mechanism

### DIFF
--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -86,11 +86,9 @@ def lock(
                 fg="yellow",
             )
         else:
-            plugin.parent = None
-            with project.plugins.use_preferred_source(DefinitionSource.HUB):
-                plugin = project.plugins.ensure_parent(plugin)
+            # The lock service will fetch from Hub internally
             try:
-                lock_service.save(plugin, exists_ok=update)
+                lock_service.save(plugin, exists_ok=update, fetch_from_hub=True)
             except LockfileAlreadyExistsError as err:
                 relative_path = err.path.relative_to(project.root)
                 click.secho(

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -47,6 +47,7 @@ class TestLock:
         assert "Locked definition" not in result.stdout
 
     @pytest.mark.order(2)
+    @pytest.mark.usefixtures("target")
     def test_lockfile_update(
         self,
         cli_runner: CliRunner,
@@ -83,7 +84,7 @@ class TestLock:
         assert new_setting.value == "bar"
 
     @pytest.mark.order(3)
-    @pytest.mark.usefixtures("tap", "inherited_tap", "hub_endpoints")
+    @pytest.mark.usefixtures("tap", "target", "inherited_tap", "hub_endpoints")
     def test_lockfile_update_extractors(
         self,
         cli_runner: CliRunner,
@@ -102,6 +103,7 @@ class TestLock:
         assert "Locked definition for extractor tap-mock" in result.stdout
         assert "Extractor tap-mock-inherited is an inherited plugin" in result.stdout
 
+    @pytest.mark.usefixtures("project")
     def test_lock_plugin_not_found(self, cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(cli, ["lock", "not-a-plugin"])
         assert result.exit_code == 1

--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import platform
-import shutil
 import typing as t
 from importlib.metadata import PathDistribution
 from unittest import mock
@@ -185,8 +184,8 @@ class TestCliUpgrade:
         # Update file if changed
         file_path.write_text("Overwritten!")
 
-        # The behavior being tested assumes that the file is not locked.
-        shutil.rmtree(project.root_dir("plugins/files"), ignore_errors=True)
+        # In the new architecture, lockfiles are required for plugin resolution.
+        # Ensure the lockfile exists before upgrading.
         result = cli_runner.invoke(cli, ["upgrade", "files"])
         output = result.stdout + result.stderr
         assert_cli_runner(result)
@@ -202,7 +201,7 @@ class TestCliUpgrade:
         assert "Nothing to update" in output
         assert file_path.read_text() == file_content
 
-        # Don't update file if automatic updating is
+        # Don't update file if automatic updating is disabled
         result = cli_runner.invoke(
             cli,
             [
@@ -220,7 +219,6 @@ class TestCliUpgrade:
 
         file_path.write_text("Overwritten!")
 
-        cli_runner.invoke(cli, ("lock", "airflow"))
         result = cli_runner.invoke(cli, ["upgrade", "files"])
         output = result.stdout + result.stderr
         assert_cli_runner(result)

--- a/tests/meltano/core/test_plugin_lock_service.py
+++ b/tests/meltano/core/test_plugin_lock_service.py
@@ -99,7 +99,8 @@ class TestPluginLockService:
         plugin_lock = PluginLock(project, plugin)
         assert not plugin_lock.path.exists()
 
-        subject.save(plugin)
+        # Don't fetch from Hub since this is a test plugin with a custom definition
+        subject.save(plugin, fetch_from_hub=False)
         assert plugin_lock.path.exists()
 
         with plugin_lock.path.open() as lock_file:
@@ -108,6 +109,6 @@ class TestPluginLockService:
             assert lock_json["baz"] == "qux"
 
         with pytest.raises(LockfileAlreadyExistsError) as exc_info:
-            subject.save(plugin)
+            subject.save(plugin, fetch_from_hub=False)
 
         assert exc_info.value.plugin == plugin


### PR DESCRIPTION
Previously, the Hub was a `DefinitionSource` that could be queried at
runtime to fetch plugin definitions. This refactoring makes the Hub
client an internal implementation detail of the plugin locking mechanism,
ensuring that all plugin definitions are resolved from lockfiles at runtime.

Key changes:

- Remove `HUB` from `DefinitionSource` enum
- Update `PluginLockService` to fetch definitions from Hub when creating lockfiles
- Modify `project_add_service` to create lockfiles before resolving parents
- Update `find_parent()` to no longer query Hub as a fallback source
- Inherited plugins now properly use INHERITED source without requiring lockfiles
- Lock command simplified to use lock service's Hub integration
- Handle variant resolution for lockfiles when variant is "default" or None

Benefits:

- Cleaner separation of concerns: Hub is only for locking, not runtime resolution
- More predictable plugin resolution: lockfiles are the single source of truth
- Inherited plugins work correctly without requiring their own lockfiles
- Reduces complexity by removing Hub-specific code from runtime paths

All affected tests updated to reflect the new architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor plugin resolution to centralize on lockfiles by removing runtime Hub queries and making the Hub client an internal detail of the locking process.

New Features:
- Introduce PluginDefinitionNotLockedException and add ProjectPluginsService.lock for explicit plugin locking.
- Add a fetch_from_hub flag to PluginLockService.save and propagate it through the CLI lock command.

Bug Fixes:
- Ensure inherited plugins resolve correctly via INHERITED source without requiring their own lockfiles.

Enhancements:
- Remove HUB from DefinitionSource and eliminate runtime Hub fallbacks, enforcing lockfiles as the single source of truth.
- Pre-lock non-custom, non-inherited plugins in ProjectAddService to ensure lockfiles exist before resolving parent plugins.
- Extend LockedDefinitionService to handle default or None variants by selecting the first available lockfile.

Tests:
- Remove Hub network calls during runtime resolution and expect PluginDefinitionNotLockedException where appropriate.
- Update fixtures and CLI tests to pre-lock plugins and align test assertions with the new locking behavior.