### PR TITLE
refactor: Embed Hub client directly in lock service

### DIFF
--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -87,10 +87,8 @@ def lock(
             )
         else:
             plugin.parent = None
-            with project.plugins.use_preferred_source(DefinitionSource.HUB):
-                plugin = project.plugins.ensure_parent(plugin)
             try:
-                lock_service.save(plugin, exists_ok=update)
+                lock_service.save(plugin, exists_ok=update, fetch_from_hub=True)
             except LockfileAlreadyExistsError as err:
                 relative_path = err.path.relative_to(project.root)
                 click.secho(

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -216,7 +216,11 @@ class Manifest:
             "dict[str, list[Mapping[str, t.Any]]]",
             {
                 plugin_type.value: [
-                    PluginLock(self.project, plugin).load(create=True, loader=json.load)
+                    PluginLock(
+                        self.project,
+                        plugin_definition=plugin.definition,
+                        variant_name=plugin.variant,
+                    ).load(create=True, loader=json.load)
                     for plugin in plugins
                 ]
                 for (plugin_type, plugins) in plugins.items()

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -260,6 +260,8 @@ class PluginRef(Canonical):
 class Variant(NameEq, Canonical):
     """A variant of a plugin."""
 
+    name: str | None
+
     ORIGINAL_NAME = "original"
     DEFAULT_NAME = "default"
 
@@ -422,7 +424,7 @@ class PluginDefinition(PluginRef):
         except NotFound as err:
             raise VariantNotFoundError(self, variant_name) from err
 
-    def find_variant(self, variant_or_name: str | Variant | None = None):  # noqa: ANN201
+    def find_variant(self, variant_or_name: str | Variant | None = None) -> Variant:
         """Find the variant with the given name or variant.
 
         Args:

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -70,6 +70,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
     variant: str | None
     executable: str
     python: str | None
+    definition: PluginDefinition
 
     config_files: dict[str, str]
 

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -13,7 +13,6 @@ from meltano.core.plugin_lock_service import PluginLock
 if t.TYPE_CHECKING:
     from click.testing import CliRunner
 
-    from meltano.core.hub import MeltanoHubService
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
 
@@ -52,9 +51,13 @@ class TestLock:
         cli_runner: CliRunner,
         project: Project,
         tap: ProjectPlugin,
-        hub_endpoints: MeltanoHubService,
+        hub_endpoints: dict[str, dict],
     ) -> None:
-        tap_lock = PluginLock(project, tap)
+        tap_lock = PluginLock(
+            project,
+            plugin_definition=tap.definition,
+            variant_name=tap.variant,
+        )
 
         assert tap_lock.path.exists()
         old_checksum = tap_lock.sha256_checksum

--- a/tests/meltano/core/test_plugin_lock_service.py
+++ b/tests/meltano/core/test_plugin_lock_service.py
@@ -62,7 +62,11 @@ def plugin():
 class TestPluginLock:
     @pytest.fixture
     def subject(self, project: Project, plugin: ProjectPlugin):
-        return PluginLock(project, plugin)
+        return PluginLock(
+            project,
+            plugin_definition=plugin.definition,
+            variant_name=plugin.variant,
+        )
 
     def test_path(self, subject: PluginLock) -> None:
         assert subject.path.parts[-3:] == (
@@ -96,7 +100,11 @@ class TestPluginLockService:
         project: Project,
         plugin: ProjectPlugin,
     ) -> None:
-        plugin_lock = PluginLock(project, plugin)
+        plugin_lock = PluginLock(
+            project,
+            plugin_definition=plugin.definition,
+            variant_name=plugin.variant,
+        )
         assert not plugin_lock.path.exists()
 
         subject.save(plugin)

--- a/tests/meltano/core/test_project_add_service.py
+++ b/tests/meltano/core/test_project_add_service.py
@@ -183,7 +183,7 @@ class TestProjectAddService:
                 f"tap-mock{STATE_ID_COMPONENT_DELIMITER}",
             )
 
-    @mock.patch("meltano.core.plugin_lock_service.PluginLock.save")
+    @mock.patch("meltano.core.plugin_lock_service.PluginLockService.save")
     def test_add_update(
         self,
         lock_save: mock.MagicMock,
@@ -228,7 +228,7 @@ class TestProjectAddService:
         assert updated.canonical().items() >= updated_attrs.items()
         assert updated.config_with_extras
 
-    @mock.patch("meltano.core.plugin_lock_service.PluginLock.save")
+    @mock.patch("meltano.core.plugin_lock_service.PluginLockService.save")
     def test_add_update_custom(
         self,
         lock_save: mock.MagicMock,


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This will help us eventually support auto-locking plugin definitions from the Hub if the lockfile is not present, improving UX a bit.

## Related Issues

NA

## Summary by Sourcery

Embed Hub client directly into the plugin lock service, refine the PluginLock API to operate on PluginDefinition and variant names, and update related callsites and tests accordingly.

Enhancements:
- Refactor PluginLock to accept PluginDefinition and variant_name instead of ProjectPlugin
- Introduce save_definition method on PluginLock to separate JSON lockfile writing
- Add fetch_from_hub flag to PluginLockService.save to fetch definitions via the Hub
- Update CLI lock command to fetch plugin definitions from the Hub by default
- Update manifest merging and other callsites to use the new PluginLock signature

Tests:
- Adjust tests to invoke PluginLock with the new signature and patch PluginLockService.save instead of PluginLock.save