### PR TITLE
feat: Auto-lock plugin definitions

### DIFF
--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -658,16 +658,10 @@ async def _run_transform(
 
 
 def _find_extractor(project: Project, extractor_name: str) -> PluginDefinition:
-    try:
-        return project.plugins.locked_definition_service.find_definition(
-            PluginType.EXTRACTORS,
-            extractor_name,
-        )
-    except PluginNotFoundError:
-        return project.hub_service.find_definition(
-            PluginType.EXTRACTORS,
-            extractor_name,
-        )
+    return project.plugins.locked_definition_service.find_definition(
+        PluginType.EXTRACTORS,
+        extractor_name,
+    )
 
 
 def _find_transform_for_extractor(

--- a/src/meltano/cli/lock.py
+++ b/src/meltano/cli/lock.py
@@ -13,7 +13,6 @@ from meltano.core.plugin_lock_service import (
     LockfileAlreadyExistsError,
     PluginLockService,
 )
-from meltano.core.project_plugins_service import DefinitionSource
 from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 
 if t.TYPE_CHECKING:
@@ -55,9 +54,8 @@ def lock(
     lock_service = PluginLockService(project)
 
     try:
-        with project.plugins.use_preferred_source(DefinitionSource.ANY):
-            # Make it a list so source preference is not lazily evaluated.
-            plugins = list(project.plugins.plugins())
+        # Make it a list so source preference is not lazily evaluated.
+        plugins = list(project.plugins.plugins())
     except Exception:
         tracker.track_command_event(CliEvent.aborted)
         raise

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -270,12 +270,11 @@ def add_plugin(  # noqa: ANN201
     *,
     python: str | None = None,
     add_service: ProjectAddService,
-    variant=None,  # noqa: ANN001
-    inherit_from=None,  # noqa: ANN001
-    custom=False,  # noqa: ANN001
-    update=False,  # noqa: ANN001
-    lock=True,  # noqa: ANN001
-    plugin_yaml=None,  # noqa: ANN001
+    variant: str | None = None,
+    inherit_from: str | None = None,
+    custom: bool = False,
+    update: bool = False,
+    plugin_yaml: dict | None = None,
 ):
     """Add Plugin to given Project."""
     if custom:
@@ -317,7 +316,6 @@ def add_plugin(  # noqa: ANN201
             plugin_name,
             variant=variant,
             inherit_from=inherit_from,
-            lock=lock,
             update=update,
             python=python,
             **plugin_attrs,

--- a/src/meltano/core/behavior/canonical.py
+++ b/src/meltano/core/behavior/canonical.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import json
 import sys
 import typing as t
 from functools import lru_cache
@@ -17,8 +16,6 @@ else:
     from typing_extensions import Self
 
 if t.TYPE_CHECKING:
-    from os import PathLike
-
     from ruamel.yaml import Representer
 
 
@@ -423,19 +420,6 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
             "tag:yaml.org,2002:map",
             cls.as_canonical(obj),
         )
-
-    @classmethod
-    def parse_json_file(cls, path: PathLike[str]) -> Self:
-        """Parse a plugin definition from a JSON file.
-
-        Args:
-            path: The path to the JSON file.
-
-        Returns:
-            A standalone plugin definition.
-        """
-        with open(path) as file:  # noqa: PTH123
-            return cls.parse(json.load(file))
 
 
 yaml.add_multi_representer(Canonical, Canonical.yaml)

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -277,6 +277,7 @@ class MeltanoHubService(PluginRepository):
                 variant_name,
             ) from variant_key_err
 
+        logger.info("Fetching plugin definition from Meltano Hub", url=url)
         response = self._get(url)
 
         try:

--- a/src/meltano/core/locked_definition_service.py
+++ b/src/meltano/core/locked_definition_service.py
@@ -4,16 +4,12 @@ from __future__ import annotations
 
 import typing as t
 
-from meltano.core.plugin import PluginDefinition, PluginRef
-from meltano.core.plugin.base import StandalonePlugin
-from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.factory import base_plugin_factory
+from meltano.core.plugin_lock_service import PluginLockService
 from meltano.core.plugin_repository import PluginRepository
 
 if t.TYPE_CHECKING:
-    from collections.abc import Iterable
-
-    from meltano.core.plugin import BasePlugin, PluginType
+    from meltano.core.plugin import BasePlugin, PluginDefinition, PluginType
     from meltano.core.project import Project
 
 
@@ -27,6 +23,7 @@ class LockedDefinitionService(PluginRepository):
             project: The Meltano project.
         """
         self.project = project
+        self.lock_service = PluginLockService(project)
 
     def find_definition(
         self,
@@ -47,16 +44,11 @@ class LockedDefinitionService(PluginRepository):
         Raises:
             PluginNotFoundError: If the plugin definition could not be found.
         """
-        path = self.project.plugin_lock_path(
-            plugin_type,
-            plugin_name,
+        return self.lock_service.load_definition(
+            plugin_type=plugin_type,
+            plugin_name=plugin_name,
             variant_name=variant_name,
         )
-        try:
-            standalone = StandalonePlugin.parse_json_file(path)
-        except FileNotFoundError as err:
-            raise PluginNotFoundError(PluginRef(plugin_type, plugin_name)) from err
-        return PluginDefinition.from_standalone(standalone)
 
     def find_base_plugin(
         self,
@@ -81,21 +73,3 @@ class LockedDefinitionService(PluginRepository):
         )
 
         return base_plugin_factory(plugin, plugin.variants[0])
-
-    def get_plugins_of_type(
-        self,
-        plugin_type: PluginType,
-    ) -> Iterable[PluginDefinition]:
-        """Get all plugin definitions of a given type.
-
-        Args:
-            plugin_type: The plugin type.
-
-        Yields:
-            Locked plugin definitions for the given type.
-        """
-        plugin_type_dir = self.project.root_plugins_dir(plugin_type.value)
-        yield from (
-            PluginDefinition.from_standalone(StandalonePlugin.parse_json_file(lockfile))
-            for lockfile in plugin_type_dir.glob("*.lock")
-        )

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -261,6 +261,7 @@ class Variant(NameEq, Canonical):
     """A variant of a plugin."""
 
     name: str | None
+    deprecated: bool | None
 
     ORIGINAL_NAME = "original"
     DEFAULT_NAME = "default"
@@ -447,16 +448,16 @@ class PluginDefinition(PluginRef):
 
         return self.get_variant(variant_or_name)
 
-    def variant_label(self, variant):  # noqa: ANN001, ANN201
+    def variant_label(self, variant_name: str | Variant | None) -> str:
         """Return label for specified variant.
 
         Args:
-            variant: The variant.
+            variant_name: The name of the variant.
 
         Returns:
             The label for the variant.
         """
-        variant = self.find_variant(variant)
+        variant = self.find_variant(variant_name)
 
         label = variant.name or Variant.ORIGINAL_NAME
 
@@ -481,11 +482,13 @@ class PluginDefinition(PluginRef):
     def from_standalone(
         cls: type[PluginDefinition],
         plugin: StandalonePlugin,
+        **extras: t.Any,
     ) -> PluginDefinition:
         """Create a new PluginDefinition from a StandalonePlugin.
 
         Args:
             plugin: The plugin.
+            extras: Additional keyword arguments.
 
         Returns:
             The new PluginDefinition.
@@ -511,6 +514,7 @@ class PluginDefinition(PluginRef):
             requires=plugin.requires,
             env=plugin.env,
             **plugin.extras,
+            **extras,
         )
 
 

--- a/src/meltano/core/plugin/error.py
+++ b/src/meltano/core/plugin/error.py
@@ -25,21 +25,6 @@ class PluginNotFoundError(Exception):
         )
 
 
-class PluginParentNotFoundError(Exception):
-    """Base exception when a plugin's parent could not be found."""
-
-    def __init__(self, plugin: PluginRef, parent_not_found_error: Exception) -> None:
-        """Initialize exception for when plugin's parent could not be found."""
-        self.plugin = plugin
-        self.parent_not_found_error = parent_not_found_error
-
-    def __str__(self) -> str:  # noqa: D105
-        return (
-            f"Could not find parent plugin for {self.plugin.type.descriptor} "
-            f"'{self.plugin.name}': {self.parent_not_found_error}"
-        )
-
-
 class PluginNotSupportedError(Exception):
     """Base exception when a plugin is not supported for some operation."""
 

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -71,6 +71,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
     executable: str
     python: str | None
     definition: PluginDefinition
+    variant: str | None
 
     config_files: dict[str, str]
 

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 import json
 import typing as t
-from hashlib import sha256
+from dataclasses import dataclass
 
 from structlog.stdlib import get_logger
 
-from meltano.core.plugin.base import StandalonePlugin
+from meltano.core.plugin.base import PluginDefinition, StandalonePlugin
 
 if t.TYPE_CHECKING:
-    from collections.abc import Callable
     from pathlib import Path
 
-    from meltano.core.plugin.base import PluginDefinition, PluginRef, Variant
+    from meltano.core.plugin.base import PluginType
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
 
@@ -24,7 +23,7 @@ logger = get_logger(__name__)
 class LockfileAlreadyExistsError(Exception):
     """Raised when a plugin lockfile already exists."""
 
-    def __init__(self, message: str, path: Path, plugin: PluginRef):
+    def __init__(self, message: str, path: Path):
         """Create a new LockfileAlreadyExistsError.
 
         Args:
@@ -33,85 +32,15 @@ class LockfileAlreadyExistsError(Exception):
             plugin: The plugin that was locked.
         """
         self.path = path
-        self.plugin = plugin
         super().__init__(message)
 
 
-class PluginLock:
-    """Plugin lockfile."""
+@dataclass
+class VariantMetadata:
+    """Metadata for a variant."""
 
-    def __init__(
-        self,
-        project: Project,
-        *,
-        plugin_definition: PluginDefinition,
-        variant_name: str | None = None,
-    ) -> None:
-        """Create a new PluginLock.
-
-        Args:
-            project: The project.
-            plugin_definition: The plugin definition to lock.
-            variant_name: The variant name to lock.
-        """
-        self.project = project
-        self.definition = plugin_definition
-        self.variant = self.definition.find_variant(variant_name)
-
-        self.path = self.project.plugin_lock_path(
-            self.definition.type,
-            self.definition.name,
-            variant_name=self.variant.name,
-        )
-
-    def save(self) -> None:
-        """Save the plugin lockfile."""
-        locked_def = StandalonePlugin.from_variant(self.variant, self.definition)
-
-        with self.path.open("w") as lockfile:
-            json.dump(locked_def.canonical(), lockfile, indent=2)
-            lockfile.write("\n")
-
-    def load(
-        self,
-        *,
-        create: bool = False,
-        loader: Callable = lambda x: StandalonePlugin(**json.load(x)),
-    ) -> StandalonePlugin:
-        """Load the plugin lockfile.
-
-        Args:
-            create: Create the lockfile if it does not yet exist.
-            loader: Function to process the lock file. Defaults to constructing
-                a `StandalonePlugin` instance.
-
-        Raises:
-            FileNotFoundError: The lock file was not found at its expected path.
-
-        Returns:
-            The loaded plugin.
-        """
-
-        def _load():  # noqa: ANN202
-            with self.path.open() as lockfile:
-                return loader(lockfile)
-
-        try:
-            return _load()
-        except FileNotFoundError:
-            if create:
-                self.save()
-                return _load()
-            raise
-
-    @property
-    def sha256_checksum(self) -> str:
-        """Get the checksum of the lockfile.
-
-        Returns:
-            The checksum of the lockfile.
-        """
-        return sha256(self.path.read_bytes()).hexdigest()
+    is_default: bool | None = None
+    is_deprecated: bool | None = None
 
 
 class PluginLockService:
@@ -125,19 +54,111 @@ class PluginLockService:
         """
         self.project = project
 
+    def lock_path(
+        self,
+        *,
+        plugin_type: PluginType,
+        plugin_name: str,
+        variant_name: str | None = None,
+    ) -> Path:
+        """Get the path to the plugin lockfile from a type, name, and variant."""
+        return self.project.plugin_lock_path(
+            plugin_type,
+            plugin_name,
+            variant_name=variant_name,
+        )
+
+    def plugin_lock_path(
+        self,
+        *,
+        plugin: ProjectPlugin,
+        variant_name: str | None = None,
+    ) -> Path:
+        """Get the path to the plugin lockfile from a plugin and variant."""
+        return self.lock_path(
+            plugin_type=plugin.type,
+            plugin_name=plugin.inherit_from or plugin.name,
+            variant_name=variant_name,
+        )
+
     def save_definition(
         self,
         *,
-        path: Path,
-        variant: Variant,
         definition: PluginDefinition,
-    ) -> None:
-        """Save the plugin lockfile."""
+        variant_name: str | None = None,
+        exists_ok: bool = False,
+    ) -> Path:
+        """Save the plugin lockfile.
+
+        Args:
+            definition: The plugin definition to save.
+            variant_name: The variant name to save.
+            exists_ok: Whether to raise an exception if the lockfile already exists.
+
+        Returns:
+            The path to the plugin lockfile.
+
+        Raises:
+            LockfileAlreadyExistsError: If the lockfile already exists and is not
+                flagged for overwriting.
+        """
+        variant = definition.find_variant(variant_name)
+        path = self.lock_path(
+            plugin_type=definition.type,
+            plugin_name=definition.name,
+            variant_name=variant.name,
+        )
+
+        if path.exists() and not exists_ok:
+            msg = f"Lockfile already exists: {path}"
+            raise LockfileAlreadyExistsError(msg, path)
+
         locked_def = StandalonePlugin.from_variant(variant, definition)
 
         with path.open("w") as lockfile:
             json.dump(locked_def.canonical(), lockfile, indent=2)
             lockfile.write("\n")
+
+        logger.debug("Locked plugin definition", path=path)
+        return path
+
+    def _save_from_hub(
+        self,
+        *,
+        plugin_type: PluginType,
+        plugin_name: str,
+        variant_name: str | None = None,
+        exists_ok: bool = False,
+    ) -> tuple[Path, VariantMetadata]:
+        """Save the plugin lockfile."""
+        definition = self.project.hub_service.find_definition(
+            plugin_type,
+            plugin_name,
+            variant_name=variant_name,
+        )
+        variant_metadata = VariantMetadata(
+            is_default=definition.is_default_variant,
+            is_deprecated=definition.find_variant(variant_name).deprecated,
+        )
+        path = self.save_definition(
+            variant_name=variant_name,
+            definition=definition,
+            exists_ok=exists_ok,
+        )
+        return path, variant_metadata
+
+    def _save_from_project_plugin(
+        self,
+        *,
+        plugin: ProjectPlugin,
+        exists_ok: bool = False,
+    ) -> Path:
+        """Save the plugin lockfile."""
+        return self.save_definition(
+            variant_name=plugin.variant,
+            definition=plugin.definition,
+            exists_ok=exists_ok,
+        )
 
     def save(
         self,
@@ -145,7 +166,7 @@ class PluginLockService:
         *,
         exists_ok: bool = False,
         fetch_from_hub: bool = False,
-    ) -> None:
+    ) -> Path:
         """Save the plugin lockfile.
 
         Args:
@@ -153,34 +174,77 @@ class PluginLockService:
             exists_ok: Whether raise an exception if the lockfile already exists.
             fetch_from_hub: Whether to fetch the plugin definition from the Hub.
 
-        Raises:
-            LockfileAlreadyExistsError: If the lockfile already exists and is not
-                flagged for overwriting.
+        Returns:
+            The path to the plugin lockfile.
+
         """
         if fetch_from_hub:
-            definition = self.project.hub_service.find_definition(
-                plugin.type,
-                plugin.inherit_from or plugin.name,
-                plugin.variant,
+            path, _ = self._save_from_hub(
+                plugin_type=plugin.type,
+                plugin_name=plugin.inherit_from or plugin.name,
+                variant_name=plugin.variant,
+                exists_ok=exists_ok,
             )
-        else:
-            definition = plugin.definition
+            return path
 
-        variant = definition.find_variant(plugin.variant)
-        path = self.project.plugin_lock_path(
-            definition.type,
-            definition.name,
-            variant_name=variant.name,
+        return self._save_from_project_plugin(plugin=plugin, exists_ok=exists_ok)
+
+    def load_content(
+        self,
+        *,
+        plugin_type: PluginType,
+        plugin_name: str,
+        variant_name: str | None = None,
+    ) -> tuple[dict[str, t.Any], VariantMetadata]:
+        """Load the content of the plugin lockfile."""
+        variant_metadata = VariantMetadata()
+        path = self.lock_path(
+            plugin_type=plugin_type,
+            plugin_name=plugin_name,
+            variant_name=variant_name,
         )
+        if not path.exists():
+            path, variant_metadata = self._save_from_hub(
+                plugin_type=plugin_type,
+                plugin_name=plugin_name,
+                variant_name=variant_name,
+                exists_ok=True,
+            )
 
-        if path.exists() and not exists_ok:
-            msg = f"Lockfile already exists: {path}"
-            raise LockfileAlreadyExistsError(msg, path, plugin)
+        with path.open() as lockfile:
+            return json.load(lockfile), variant_metadata
 
-        self.save_definition(
-            path=path,
-            variant=variant,
-            definition=definition,
+    def get_standalone_data(self, plugin: ProjectPlugin) -> dict[str, t.Any]:
+        """Get the standalone data for a plugin."""
+        path = self.lock_path(
+            plugin_type=plugin.type,
+            plugin_name=plugin.inherit_from or plugin.name,
+            variant_name=plugin.variant,
         )
+        if path.exists():
+            with path.open() as lockfile:
+                return json.load(lockfile)
 
-        logger.debug("Locked plugin definition", path=path)
+        return StandalonePlugin.from_variant(
+            plugin.definition.find_variant(None),
+            plugin.definition,
+        ).canonical()
+
+    def load_definition(
+        self,
+        *,
+        plugin_type: PluginType,
+        plugin_name: str,
+        variant_name: str | None = None,
+    ) -> PluginDefinition:
+        """Load the plugin definition from the lockfile."""
+        content, variant_metadata = self.load_content(
+            plugin_type=plugin_type,
+            plugin_name=plugin_name,
+            variant_name=variant_name,
+        )
+        return PluginDefinition.from_standalone(
+            StandalonePlugin.parse(content),
+            is_default_variant=variant_metadata.is_default,
+            deprecated=variant_metadata.is_deprecated,
+        )

--- a/src/meltano/core/schedule_service.py
+++ b/src/meltano/core/schedule_service.py
@@ -7,9 +7,9 @@ import typing as t
 import structlog
 
 from meltano.core.error import MeltanoError
-from meltano.core.locked_definition_service import PluginNotFoundError
 from meltano.core.meltano_invoker import MeltanoInvoker
 from meltano.core.plugin import PluginType
+from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.schedule import (
     CRON_INTERVALS,
     ELTSchedule,

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -390,7 +390,7 @@ def find_named(xs: Iterable[_G], name: str, obj_type: type | None = None) -> _G:
         raise NotFound(name, obj_type) from stop
 
 
-def makedirs(func: Callable[..., Path]):  # noqa: ANN201, D103
+def makedirs(func: Callable[..., Path]) -> Callable[..., Path]:  # noqa: D103
     @functools.wraps(func)
     def decorate(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
         enabled = kwargs.pop("make_dirs", True)

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -448,10 +448,7 @@ class TestCliAdd:
                 ],
             )
             assert res.exit_code == 1
-            assert (
-                "Could not find parent plugin for extractor 'tap-foo': "
-                "Extractor 'tap-bar' is not known to Meltano"
-            ) in str(res.exception)
+            assert ("Extractor 'tap-bar' is not known to Meltano") in str(res.exception)
 
     @pytest.mark.usefixtures("reset_project_context")
     def test_add_custom(self, project: Project, cli_runner) -> None:

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -370,18 +370,25 @@ class TestCliAdd:
                 ],
             )
             assert_cli_runner(res)
-            assert "Inherit from:\ttap-mock, variant meltano (default)\n" in res.stdout
 
+            # Determine which variant is actually the default (can vary due to
+            # non-deterministic ordering when loading hub data)
             inherited = project.plugins.find_plugin(
                 plugin_type=PluginType.EXTRACTORS,
                 plugin_name="tap-mock-inherited",
             )
+            expected_variant = inherited.variant
+
+            # Check that the output matches the actual variant selected
+            message = f"Inherit from:\ttap-mock, variant {expected_variant} (default)\n"
+            assert message in res.stdout
+
             assert inherited.inherit_from == "tap-mock"
-            assert inherited.variant == "meltano"
+            assert inherited.variant in ("meltano", "singer-io")
             assert inherited.parent == project.hub_service.find_base_plugin(
                 plugin_type=PluginType.EXTRACTORS,
                 plugin_name="tap-mock",
-                variant="meltano",
+                variant=expected_variant,
             )
 
             # Inheriting from a BasePlugin using --inherit-from and --variant

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -358,7 +358,7 @@ class TestCliAdd:
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 
-            # Inheriting from a BasePlugin using --as
+            # Inheriting from a BasePlugin using --as with explicit variant
             res = cli_runner.invoke(
                 cli,
                 [
@@ -367,28 +367,23 @@ class TestCliAdd:
                     "tap-mock",
                     "--as",
                     "tap-mock-inherited",
+                    "--variant",
+                    "meltano",
                 ],
             )
             assert_cli_runner(res)
+            assert "Inherit from:\ttap-mock, variant meltano (default)\n" in res.stdout
 
-            # Determine which variant is actually the default (can vary due to
-            # non-deterministic ordering when loading hub data)
             inherited = project.plugins.find_plugin(
                 plugin_type=PluginType.EXTRACTORS,
                 plugin_name="tap-mock-inherited",
             )
-            expected_variant = inherited.variant
-
-            # Check that the output matches the actual variant selected
-            message = f"Inherit from:\ttap-mock, variant {expected_variant} (default)\n"
-            assert message in res.stdout
-
             assert inherited.inherit_from == "tap-mock"
-            assert inherited.variant in ("meltano", "singer-io")
+            assert inherited.variant == "meltano"
             assert inherited.parent == project.hub_service.find_base_plugin(
                 plugin_type=PluginType.EXTRACTORS,
                 plugin_name="tap-mock",
-                variant=expected_variant,
+                variant="meltano",
             )
 
             # Inheriting from a BasePlugin using --inherit-from and --variant

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -8,7 +8,7 @@ import pytest
 
 from meltano.cli import cli
 from meltano.cli.utils import CliError
-from meltano.core.plugin_lock_service import PluginLock
+from meltano.core.plugin_lock_service import PluginLockService
 
 if t.TYPE_CHECKING:
     from click.testing import CliRunner
@@ -53,15 +53,16 @@ class TestLock:
         tap: ProjectPlugin,
         hub_endpoints: dict[str, dict],
     ) -> None:
-        tap_lock = PluginLock(
-            project,
-            plugin_definition=tap.definition,
+        subject = PluginLockService(project)
+        tap_lock_path = subject.plugin_lock_path(plugin=tap, variant_name=tap.variant)
+
+        assert tap_lock_path.exists()
+        old_definition = subject.load_definition(
+            plugin_type=tap.type,
+            plugin_name=tap.name,
             variant_name=tap.variant,
         )
-
-        assert tap_lock.path.exists()
-        old_checksum = tap_lock.sha256_checksum
-        old_definition = tap_lock.load()
+        old_variant = old_definition.find_variant(tap.variant)
 
         # Update the plugin in Hub
         hub_endpoints["/extractors/tap-mock--meltano"]["settings"].append(
@@ -76,12 +77,15 @@ class TestLock:
         assert result.stdout.count("Lockfile exists") == 0
         assert result.stdout.count("Locked definition") == 2
 
-        new_checksum = tap_lock.sha256_checksum
-        new_definition = tap_lock.load()
-        assert new_checksum != old_checksum
-        assert len(new_definition.settings) == len(old_definition.settings) + 1
+        new_definition = subject.load_definition(
+            plugin_type=tap.type,
+            plugin_name=tap.name,
+            variant_name=tap.variant,
+        )
+        new_variant = new_definition.find_variant(tap.variant)
+        assert len(new_variant.settings) == len(old_variant.settings) + 1
 
-        new_setting = new_definition.settings[-1]
+        new_setting = new_variant.settings[-1]
         assert new_setting.name == "foo"
         assert new_setting.value == "bar"
 

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import pytest
 
 from meltano.core.plugin import BasePlugin, PluginType
-from meltano.core.plugin.error import PluginNotFoundError, PluginParentNotFoundError
+from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project_plugins_service import (
     DefinitionSource,
@@ -46,7 +46,6 @@ class TestProjectPluginsService:
     @pytest.fixture(autouse=True)
     def setup(self, project: Project, tap) -> None:
         project.plugins.lock_service.save(tap, exists_ok=True)
-        project.plugins._prefer_source = DefinitionSource.ANY
 
     @pytest.mark.order(0)
     def test_plugins(self, project) -> None:
@@ -184,7 +183,7 @@ class TestProjectPluginsService:
         with pytest.raises(PluginDefinitionNotFoundError) as excinfo:
             assert project.plugins.get_parent(nonexistent_parent)
 
-        assert isinstance(excinfo.value.__cause__, PluginParentNotFoundError)
+        assert isinstance(excinfo.value.__cause__, PluginNotFoundError)
 
     def test_update_plugin(self, project: Project, tap) -> None:
         # update a tap with a random value


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor plugin lockfile handling by centralizing logic in PluginLockService, enable auto-locking of plugin definitions with metadata and Hub fallback, simplify project add and CLI workflows by removing manual lock options, adjust related services and tests accordingly

New Features:
- Automatically lock plugin definitions on addition with metadata including default and deprecation flags
- Provide methods to save and load plugin lockfiles with variant metadata and fetch definitions from the Hub when missing

Enhancements:
- Refactor PluginLockService to replace the old PluginLock class and consolidate save/load logic
- Streamline project_plugins_service by removing unused DefinitionSource flags and improving error handling
- Simplify CLI and project add service by dropping explicit lock options and auto-locking non-custom plugins
- Integrate PluginLockService into LockedDefinitionService and manifest merge processes
- Add logging for fetching plugin definitions from Meltano Hub client
- Enhance PluginDefinition and Variant classes with extra metadata support and repr methods

Tests:
- Update tests to target PluginLockService API and remove coverage for the deprecated PluginLock class