### PR TITLE
feat: Lower log level for symlink creation failure on Windows when not run as administrator

### DIFF
--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -229,7 +229,7 @@ class Project(Versioned):
                             f"present in {Path(sys.executable).parent!s}",
                         )
                 else:
-                    logger.warning(
+                    logger.debug(
                         "Failed to create symlink to 'meltano.exe': "
                         "administrator privilege required",
                     )


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

This PR lowers the log level from `WARNING` to `DEBUG` when the symlink to 'meltano.exe' fails on Windows due to the process not being run as administrator.

## Related Issues

* Closes #9039

## Summary by Sourcery

Enhancements:
- Lower the log level from warning to debug for symlink creation failures on Windows due to lack of admin rights