### PR TITLE
fix: Prioritize labeling added plugin as "deprecated"

### DIFF
--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -461,11 +461,11 @@ class PluginDefinition(PluginRef):
 
         label = variant.name or Variant.ORIGINAL_NAME
 
-        if variant == self.variants[0] and self.is_default_variant is not False:
-            return f"{label} (default)"
-
         if variant.deprecated:
             return f"{label} (deprecated)"
+
+        if variant == self.variants[0] and self.is_default_variant is not False:
+            return f"{label} (default)"
 
         return label
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Bug Fixes:
- Prioritize "(deprecated)" label over "(default)" when a plugin variant is both default and deprecated