### PR TITLE
test: Fix flaky `test_add_inherited`

### DIFF
--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -355,6 +355,9 @@ class TestCliAdd:
         with contextlib.suppress(PluginNotFoundError):
             project.plugins.remove_from_file(tap)
 
+        # Remove all lockfiles
+        shutil.rmtree(project.root_plugins_dir(), ignore_errors=True)
+
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->
Previous tests that create lockfiles where interfering with this test.

A more robust solution to the problem is preferred, but this will make
CI more consistent at least.


## Related Issues

* Closes #XXXX

## Summary by Sourcery

Tests:
- Clear the root plugins directory in test_add_inherited to prevent interference from previous lockfiles