### PR TITLE
refactor: Delay creation of installation log directory

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -303,12 +303,6 @@ class VenvService:
             self.project.venvs_dir(namespace, name, make_dirs=False),
             python=python or project.settings.get("python"),
         )
-        self.install_log_path = self.project.logs_dir(
-            "pip",
-            self.namespace,
-            self.name,
-            "pip.log",
-        ).resolve()
 
     @classmethod
     def from_plugin(cls, project: Project, plugin: ProjectPlugin) -> Self:
@@ -327,6 +321,20 @@ class VenvService:
             namespace=plugin.type,
             name=plugin.plugin_dir_name,
         )
+
+    @property
+    def install_log_path(self) -> Path:
+        """Return the path to the install log file.
+
+        Returns:
+            The path to the install log file.
+        """
+        return self.project.logs_dir(
+            "pip",
+            self.namespace,
+            self.name,
+            "install.log",
+        ).resolve()
 
     async def install(
         self,


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Convert install_log_path from an eagerly initialized attribute to a lazy property and update the log file name

Enhancements:
- Defer creation of the installation log directory by computing install_log_path on demand
- Rename the installation log file from pip.log to install.log for clarity