### PR TITLE
chore: Configure Dependabot `cooldown`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
         - "patch"
     commit-message:
       prefix: "ci: "
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -30,6 +32,8 @@ updates:
           - "*"
     commit-message:
       prefix: "ci: "
+    cooldown:
+      default-days: 7
   - package-ecosystem: uv
     versioning-strategy: increase-if-necessary
     directory: "/"
@@ -50,6 +54,8 @@ updates:
     commit-message:
       prefix: "chore(deps): "
       prefix-development: "chore(deps-dev): "
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     versioning-strategy: increase
     directory: "docs"
@@ -70,9 +76,13 @@ updates:
     commit-message:
       prefix: "chore(deps): "
       prefix-development: "chore(deps-dev): "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker-compose"
     directory: "tests/fixtures/docker/"
     schedule:
       interval: "monthly"
       time: "12:00"
       timezone: "Etc/UTC"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Configure Dependabot to only open update PRs once every 7 days across all configured ecosystems.

CI:
- Add a default 7-day cooldown to the pip update schedule.
- Add a default 7-day cooldown to the GitHub Actions update schedule.
- Add a default 7-day cooldown to the Python UV update schedule.
- Add a default 7-day cooldown to the npm docs update schedule.
- Add a default 7-day cooldown to the Docker Compose update schedule.