### PR TITLE
chore: Deprecate internally the calling of dirs methods on `Project` object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ filterwarnings = [
   "ignore: Parsing dates involving a day of month without a year specified is:DeprecationWarning:dateparser.*",  # https://github.com/scrapinghub/dateparser/issues/1246
   "ignore::pytest.PytestUnraisableExceptionWarning",
   "ignore::ResourceWarning",
+  "once::meltano.core._compat.MeltanoInternalDeprecationWarning",
 ]
 log_cli = true
 log_cli_format = "%(message)s"
@@ -269,6 +270,7 @@ enable_error_code = [
   "redundant-expr",
   "truthy-bool",
   "exhaustive-match",
+  "deprecated",
 ]
 incremental = false # Disabled until https://github.com/python/mypy/issues/12664 is resolved
 files = [
@@ -297,7 +299,6 @@ module = [
   "meltano.core.behavior.canonical",
   "meltano.core.behavior.hookable",
   "meltano.core.behavior.name_eq",
-  "meltano.core.behavior.versioned",
   "meltano.core.behavior.visitor",
   "meltano.core.block.extract_load",
   "meltano.core.block.plugin_command",

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -36,6 +36,7 @@ from meltano.cli import (
 from meltano.cli import compile as compile_module
 from meltano.cli.cli import cli
 from meltano.cli.utils import CliError
+from meltano.core._compat import MeltanoInternalDeprecationWarning
 from meltano.core.error import MeltanoError, ProjectReadonly
 from meltano.core.logging import setup_logging
 
@@ -125,6 +126,7 @@ def main() -> None:
     # Mark the current process as executed via the CLI
     logging.captureWarnings(capture=True)
     warnings.filterwarnings("once", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=MeltanoInternalDeprecationWarning)
     os.environ["MELTANO_JOB_TRIGGER"] = os.getenv("MELTANO_JOB_TRIGGER", "cli")
     try:
         _run_cli()

--- a/src/meltano/core/_compat.py
+++ b/src/meltano/core/_compat.py
@@ -1,0 +1,18 @@
+"""Compatibility layer for different Python versions."""
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
+
+__all__ = [
+    "deprecated",
+]
+
+
+class MeltanoInternalDeprecationWarning(DeprecationWarning):
+    """Warning for deprecated internal Meltano APIs."""

--- a/src/meltano/core/config_service.py
+++ b/src/meltano/core/config_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import typing as t
 from contextlib import contextmanager
 from functools import cached_property
@@ -105,10 +104,6 @@ class ConfigService:
         """
         with self.update_meltano_yml() as meltano_yml:
             meltano_yml.extras = config
-
-    def make_meltano_secret_dir(self) -> None:
-        """Create the secret directory."""
-        os.makedirs(self.project.meltano_dir(), exist_ok=True)  # noqa: PTH103
 
     @property
     def env(self) -> dict[str, str | None]:

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -160,7 +160,7 @@ class ELTContext(ELContextProtocol):
             The job dir, if a Job is provided, else None.
         """
         if self.job:
-            return self.project.job_dir(self.job.job_name, str(self.job.run_id))
+            return self.project.job_dir(self.job.job_name, str(self.job.run_id))  # type: ignore[deprecated]
 
         return None
 

--- a/src/meltano/core/logging/job_logging_service.py
+++ b/src/meltano/core/logging/job_logging_service.py
@@ -52,7 +52,7 @@ class JobLoggingService:  # noqa: D101
         Returns:
             The logs directory for the given state ID.
         """
-        return self.project.job_logs_dir(state_id, *joinpaths, make_dirs=make_dirs)
+        return self.project.job_logs_dir(state_id, *joinpaths, make_dirs=make_dirs)  # type: ignore[deprecated]
 
     def generate_log_name(
         self,
@@ -162,7 +162,7 @@ class JobLoggingService:  # noqa: D101
             log_path.unlink()
 
     def legacy_logs_dir(self, state_id, *joinpaths):  # noqa: ANN001, ANN002, ANN201, D102
-        job_dir = self.project.run_dir("elt").joinpath(slugify(state_id), *joinpaths)
+        job_dir = self.project.run_dir("elt").joinpath(slugify(state_id), *joinpaths)  # type: ignore[deprecated]
         return job_dir if job_dir.exists() else None
 
     def logs_dirs(self, state_id, *joinpaths):  # noqa: ANN001, ANN002, ANN201, D102

--- a/src/meltano/core/meltano_invoker.py
+++ b/src/meltano/core/meltano_invoker.py
@@ -59,7 +59,7 @@ class MeltanoInvoker:
     def _executable_path(self, command):  # noqa: ANN001, ANN202
         if command == MELTANO_COMMAND:
             # This symlink is created by Project.activate
-            executable_symlink = self.project.run_dir().joinpath("bin")
+            executable_symlink = self.project.run_dir().joinpath("bin")  # type: ignore[deprecated]
             if executable_symlink.exists():
                 return str(executable_symlink)
 

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -67,7 +67,7 @@ class FilePlugin(BasePlugin):
         # This ignores plugin inheritance, but that's fine because the file contents
         # are bundled with the package, so they should be the same for all plugins that
         # share a pip_url.
-        venv = VirtualEnv(project.plugin_dir(self, "venv"))  # type: ignore[arg-type]
+        venv = VirtualEnv(project.plugin_dir(self, "venv"))  # type: ignore[arg-type,deprecated]
         bundle_dir = venv.site_packages_dir / "bundle"
 
         return {
@@ -149,7 +149,7 @@ class FilePlugin(BasePlugin):
         Returns:
             True if the file was written, False otherwise.
         """
-        project_path = project.root_dir(relative_path)
+        project_path = project.root_dir(relative_path)  # type: ignore[deprecated]
         if project_path.exists() and project_path.read_text() == content:
             return False
 
@@ -194,7 +194,7 @@ class FilePlugin(BasePlugin):
         """
 
         def rename_if_exists(relative_path: Path) -> Path:
-            if not project.root_dir(relative_path).exists():
+            if not project.root_dir(relative_path).exists():  # type: ignore[deprecated]
                 return relative_path
 
             logger.info(

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -437,7 +437,7 @@ class PluginInstallService:
             return False, message
 
         venv = VirtualEnv(
-            self.project.plugin_dir(plugin, "venv", make_dirs=False),
+            self.project.plugin_dir(plugin, "venv", make_dirs=False),  # type: ignore[deprecated]
             python=plugin.python or self.project.settings.get("python"),
         )
         message = "Requirements have not changed"

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -198,8 +198,8 @@ class PluginInvoker:
 
         self.plugin_config_service = plugin_config_service or PluginConfigService(
             plugin,
-            config_dir or self.project.plugin_dir(plugin),
-            run_dir or self.project.run_dir(plugin.name),
+            config_dir or self.project.plugin_dir(plugin),  # type: ignore[deprecated]
+            run_dir or self.project.run_dir(plugin.name),  # type: ignore[deprecated]
         )
 
         self.settings_service = plugin_settings_service or PluginSettingsService(
@@ -427,7 +427,7 @@ class PluginInvoker:
         if self.venv_service:
             # Switch to plugin-specific venv
             venv = VirtualEnv(
-                self.project.venvs_dir(
+                self.project.venvs_dir(  # type: ignore[deprecated]
                     self.plugin.type,
                     self.plugin.name,
                     make_dirs=False,

--- a/src/meltano/core/plugin_location_remove.py
+++ b/src/meltano/core/plugin_location_remove.py
@@ -150,7 +150,7 @@ class LockedDefinitionRemoveManager(PluginLocationRemoveManager):
             plugin: The plugin to remove.
             project: The Meltano project.
         """
-        lockfile_dir = project.root_plugins_dir(plugin.type)
+        lockfile_dir = project.root_plugins_dir(plugin.type)  # type: ignore[deprecated]
         glob_expr = f"{plugin.name}*.lock"
         super().__init__(
             plugin,
@@ -186,7 +186,7 @@ class InstallationRemoveManager(PluginLocationRemoveManager):
             plugin: The plugin to remove.
             project: The Meltano project.
         """
-        path = project.plugin_dir(plugin, make_dirs=False)
+        path = project.plugin_dir(plugin, make_dirs=False)  # type: ignore[deprecated]
         super().__init__(plugin, str(path.parent.relative_to(project.root)))
         self.path = path
 

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -62,7 +62,7 @@ class PluginLockService:
         variant_name: str | None = None,
     ) -> Path:
         """Get the path to the plugin lockfile from a type, name, and variant."""
-        return self.project.plugin_lock_path(
+        return self.project.plugin_lock_path(  # type: ignore[deprecated]
             plugin_type,
             plugin_name,
             variant_name=variant_name,

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -16,6 +16,7 @@ import structlog
 from dotenv import dotenv_values
 
 from meltano.core import yaml
+from meltano.core._compat import MeltanoInternalDeprecationWarning, deprecated
 from meltano.core.config_service import ConfigService
 from meltano.core.environment import Environment
 from meltano.core.error import (
@@ -234,7 +235,7 @@ class Project:
                 # Admin privileges are required to create symlinks on Windows
                 if ctypes.windll.shell32.IsUserAnAdmin():  # type: ignore[attr-defined]
                     if executable.is_file():
-                        project.run_dir().joinpath("bin").symlink_to(executable)
+                        project.run_dir().joinpath("bin").symlink_to(executable)  # type: ignore[deprecated]
                     else:
                         logger.warning(
                             "Could not create symlink: meltano.exe not "  # noqa: G004
@@ -248,7 +249,7 @@ class Project:
             else:
                 executable = Path(sys.executable).parent / "meltano"
                 if executable.is_file():
-                    project.run_dir().joinpath("bin").symlink_to(executable)
+                    project.run_dir().joinpath("bin").symlink_to(executable)  # type: ignore[deprecated]
         except FileExistsError:
             pass
         except OSError as error:
@@ -380,6 +381,10 @@ class Project:
 
         self.refresh()
 
+    @deprecated(
+        "Use `dirs.root_dir` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     def root_dir(self, *joinpaths: StrPath) -> Path:
         """Return the root directory of this project, optionally joined with path.
 
@@ -459,6 +464,10 @@ class Project:
         yield self.dotenv
         self.refresh()
 
+    @deprecated(
+        "Use `dirs.meltano` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def meltano_dir(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
         """Path to the project `.meltano` directory.
@@ -472,6 +481,10 @@ class Project:
         """
         return self.dirs.meltano(*joinpaths, make_dirs=make_dirs)
 
+    @deprecated(
+        "Use `dirs.venvs` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def venvs_dir(self, *prefixes: StrPath, make_dirs: bool = True) -> Path:
         """Path to a `venv` directory in `.meltano`.
@@ -485,6 +498,10 @@ class Project:
         """
         return self.dirs.venvs(*prefixes, make_dirs=make_dirs)
 
+    @deprecated(
+        "Use `dirs.run` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def run_dir(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
         """Path to the `run` directory in `.meltano`.
@@ -498,6 +515,10 @@ class Project:
         """
         return self.dirs.run(*joinpaths, make_dirs=make_dirs)
 
+    @deprecated(
+        "Use `dirs.logs` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def logs_dir(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
         """Path to the `logs` directory in `.meltano`.
@@ -511,6 +532,10 @@ class Project:
         """
         return self.dirs.logs(*joinpaths, make_dirs=make_dirs)
 
+    @deprecated(
+        "Use `dirs.job` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def job_dir(
         self,
@@ -530,6 +555,10 @@ class Project:
         """
         return self.dirs.job(state_id, *joinpaths, make_dirs=make_dirs)
 
+    @deprecated(
+        "Use `dirs.job_logs` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def job_logs_dir(
         self,
@@ -549,6 +578,10 @@ class Project:
         """
         return self.dirs.job_logs(state_id, *joinpaths, make_dirs=make_dirs)
 
+    @deprecated(
+        "Use `dirs.plugin` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def plugin_dir(
         self,
@@ -568,6 +601,10 @@ class Project:
         """
         return self.dirs.plugin(plugin, *joinpaths, make_dirs=make_dirs)
 
+    @deprecated(
+        "Use `dirs.root_plugins` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def root_plugins_dir(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
         """Path to the project `plugins` directory.
@@ -581,6 +618,10 @@ class Project:
         """
         return self.dirs.root_plugins(*joinpaths, make_dirs=make_dirs)
 
+    @deprecated(
+        "Use `dirs.plugin_lock_path` instead.",
+        category=MeltanoInternalDeprecationWarning,
+    )
     @makedirs
     def plugin_lock_path(
         self,

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -101,7 +101,7 @@ class ProjectInitService:
         """
         # explicitly create the .meltano directory if it doesn't exist
         click.secho("Creating .meltano folder", fg="blue")
-        project.meltano_dir().mkdir(parents=True, exist_ok=True)
+        project.meltano_dir().mkdir(parents=True, exist_ok=True)  # type: ignore[deprecated]
         click.secho("created", fg="blue", nl=False)
         click.echo(f" .meltano in {project.sys_dir_root}")
 

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -101,7 +101,7 @@ class ProjectSettingsService(SettingsService):
             project_id = None
 
         if project_id is None:
-            analytics_path = self.project.meltano_dir() / "analytics.json"
+            analytics_path = self.project.meltano_dir() / "analytics.json"  # type: ignore[deprecated]
             try:
                 with analytics_path.open() as analytics_json_file:
                     project_id = json.load(analytics_json_file)["project_id"]

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -300,7 +300,7 @@ class VenvService:
         self.namespace = namespace
         self.name = name
         self.venv = VirtualEnv(
-            self.project.venvs_dir(namespace, name, make_dirs=False),
+            self.project.venvs_dir(namespace, name, make_dirs=False),  # type: ignore[deprecated]
             python=python or project.settings.get("python"),
         )
 
@@ -386,7 +386,7 @@ class VenvService:
 
     def clean_run_files(self) -> None:
         """Destroy cached configuration files, if they exist."""
-        run_dir = self.project.run_dir(self.name, make_dirs=False)
+        run_dir = self.project.run_dir(self.name, make_dirs=False)  # type: ignore[deprecated]
 
         try:
             for path in run_dir.iterdir():


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Deprecate legacy directory accessor methods on the Project object in favor of the new `dirs` API, introduce a compatibility layer for the deprecated decorator and a custom internal deprecation warning, and update internal code and configuration to ignore these warnings

New Features:
- Add compatibility module exporting a deprecated decorator and define MeltanoInternalDeprecationWarning

Enhancements:
- Mark Project methods (root_dir, meltano_dir, venvs_dir, run_dir, logs_dir, job_dir, job_logs_dir, plugin_dir, root_plugins_dir, plugin_lock_path) as internally deprecated in favor of `dirs.*` API
- Annotate internal usages of deprecated Project methods with type ignores to suppress warnings

CI:
- Filter MeltanoInternalDeprecationWarning in CLI startup and pytest configuration
- Enable mypy’s deprecated code checks

## Summary by Sourcery

Deprecate legacy directory accessor methods on the Project object in favor of the new dirs API, introduce an internal deprecation decorator and warning, and update code and configuration to suppress these warnings

Enhancements:
- Add a compatibility module exporting a deprecated decorator and define MeltanoInternalDeprecationWarning
- Mark all legacy Project directory methods as internally deprecated and redirect them to the new dirs API
- Annotate internal usages of deprecated Project methods with ignore directives to suppress warnings

CI:
- Filter MeltanoInternalDeprecationWarning in CLI startup and pytest configuration
- Enable mypy’s deprecated-code checks

Chores:
- Remove the unused make_meltano_secret_dir method in config_service