### PR TITLE
docs: Document usage of uv environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - [#9385](https://github.com/meltano/meltano/issues/9385) Use tabs to exemplify new and legacy syntax for `meltano add`
 - [#9381](https://github.com/meltano/meltano/issues/9381) Document that Snowflake is a supported state backend
 - [#9370](https://github.com/meltano/meltano/issues/9370) The "most straightforward" way to install Meltano now is uv
+- [#9597](https://github.com/meltano/meltano/issues/9597) docs: Document usage of uv environment variables
 
 ### 📦 Packaging changes
 

--- a/docs/docs/guide/plugin-management.md
+++ b/docs/docs/guide/plugin-management.md
@@ -710,6 +710,97 @@ ARG PIP_INDEX_URL=<your_custom_pypi_url>
 RUN meltano install
 ```
 
+## Configuring _uv_ virtual environment options
+
+Starting with Meltano 3.8, the default virtual environment backend is [`uv`](/reference/settings#venvbackend), which creates virtual environments significantly faster than the traditional `virtualenv` backend.
+
+By default, `uv` creates lightweight virtual environments without bundling `pip`, `setuptools`, or `wheel` to optimize installation speed. However, some plugins or workflows may require these tools to be available within the virtual environment (e.g., notebooks that run `pip install` commands).
+
+### Using _uv_ environment variables
+
+You can configure `uv`'s virtual environment behavior using environment variables. These can be set in your project's [`.env` file](/concepts/project#env), in your shell environment, or in the top-level `env` key in your [`meltano.yml` project file](/concepts/project#meltano-yml-project-file).
+
+```mdx-code-block
+<Tabs className="meltano-tabs" queryString="meltano-tabs">
+  <TabItem className="meltano-tab-content" value="meltano.yml" label="meltano.yml" default>
+```
+
+```yaml
+version: 1
+env:
+  UV_VENV_SEED: "1"
+  UV_EXCLUDE_NEWER: "2025-01-01T00:00:00Z"
+
+plugins:
+  extractors:
+    - name: tap-gitlab
+      # ...
+```
+
+```mdx-code-block
+  </TabItem>
+  <TabItem className="meltano-tab-content" value=".env" label=".env">
+```
+
+```bash
+UV_VENV_SEED=1
+UV_EXCLUDE_NEWER=2025-01-01T00:00:00Z
+```
+
+```mdx-code-block
+  </TabItem>
+  <TabItem className="meltano-tab-content" value="shell" label="Shell">
+```
+
+```bash
+export UV_VENV_SEED=1
+export UV_EXCLUDE_NEWER=2025-01-01T00:00:00Z
+```
+
+```mdx-code-block
+  </TabItem>
+</Tabs>
+```
+
+#### `UV_VENV_SEED`
+
+The `UV_VENV_SEED` environment variable controls whether seed packages (`pip`, `setuptools`, and `wheel`) are installed into virtual environments created by `uv venv`.
+
+**When to use it:**
+- Your plugin or utility needs to run `pip install` commands within its virtual environment
+- You're using Jupyter notebooks that install dependencies dynamically
+- You need backwards compatibility with workflows that assume `pip` is available
+
+:::info
+Note that `setuptools` and `wheel` are excluded from Python 3.12+ environments by default, even when seeding is enabled.
+:::
+
+#### `UV_EXCLUDE_NEWER`
+
+The `UV_EXCLUDE_NEWER` environment variable limits package resolution to versions published before a specific date. This is useful for ensuring reproducible builds by preventing newer package versions from being considered during installation.
+
+**When to use it:**
+- You want to ensure consistent builds across different environments
+- You need to avoid issues caused by recently published package versions
+- You're troubleshooting dependency resolution problems
+
+:::info
+The date should be in ISO 8601 format (e.g., `2025-01-01T00:00:00Z`).
+:::
+
+:::tip Alternative approach
+If you only need `pip` available and don't want to enable full seeding, you can add `pip` to your plugin's `pip_url` configuration:
+
+```yaml
+plugins:
+  utilities:
+  - name: notebook
+    pip_url: jupyter pip
+```
+
+This installs `pip` as a dependency of the plugin without requiring `UV_VENV_SEED`.
+:::
+
 ## Removing a plugin from your project
 
 You can remove a [plugin](/concepts/project#plugins) from your Meltano [project](/concepts/project) by using [`meltano remove`](/reference/command-line-interface#remove). The plugin type is automatically inferred from the plugin name, so you no longer need to specify the type explicitly.


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Document the usage and configuration of uv virtual environment environment variables in the plugin management guide

Documentation:
- Add a new section detailing uv virtual environment options including UV_VENV_SEED and UV_EXCLUDE_NEWER variables
- Provide code examples for setting uv env vars via meltano.yml, .env file, or shell
- Explain the purpose and use cases for UV_VENV_SEED and UV_EXCLUDE_NEWER
- Include an alternative approach tip for installing pip via plugin pip_url
- Add a CHANGELOG entry for documenting uv environment variables