### PR TITLE
refactor: Filter out `urllib3` logs below the error level

### DIFF
--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -200,9 +200,6 @@ def default_config(
                 "level": logging.ERROR,
             },
             "urllib3": {
-                "level": logging.INFO,
-            },
-            "urllib3.connection": {
                 "level": logging.ERROR,
             },
             "asyncio": {


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enhancements:
- Raise the default level for the urllib3 logger to ERROR and remove its INFO-level and connection-specific overrides