### PR TITLE
fix: Fix plugin definition only once when locking plugins with `meltano lock`

### DIFF
--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -39,11 +39,18 @@ class TestLock:
         lockfiles = list(project.root_plugins_dir().glob("./*/*.lock"))
         assert len(lockfiles) == 2
 
-        result = cli_runner.invoke(cli, ["lock"])
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--log-level=debug",
+                "--log-format=uncolored",
+                "lock",
+            ],
+        )
         assert result.exit_code == 0
-        assert "Lockfile exists for extractor tap-mock" in result.stdout
-        assert "Lockfile exists for loader target-mock" in result.stdout
-        assert "Locked definition" not in result.stdout
+        assert "Lockfile exists for extractor tap-mock" in result.stderr
+        assert "Lockfile exists for loader target-mock" in result.stderr
+        assert "Locked definition" not in result.stderr
 
     @pytest.mark.order(2)
     def test_lockfile_update(
@@ -72,11 +79,18 @@ class TestLock:
             },
         )
 
-        result = cli_runner.invoke(cli, ["lock", "--update"])
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--log-level=debug",
+                "--log-format=uncolored",
+                "lock",
+                "--update",
+            ],
+        )
         assert result.exit_code == 0
-        assert result.stdout.count("Lockfile exists") == 0
-        assert result.stdout.count("Locked definition") == 2
-
+        assert result.stderr.count("Lockfile exists") == 0
+        assert result.stderr.count("Locked definition") == 2
         new_definition = subject.load_definition(
             plugin_type=tap.type,
             plugin_name=tap.name,
@@ -102,12 +116,19 @@ class TestLock:
 
         result = cli_runner.invoke(
             cli,
-            ["lock", "--update", "--plugin-type", "extractor"],
+            [
+                "--log-level=debug",
+                "--log-format=uncolored",
+                "lock",
+                "--update",
+                "--plugin-type",
+                "extractor",
+            ],
         )
         assert result.exit_code == 0
-        assert "Lockfile exists" not in result.stdout
-        assert "Locked definition for extractor tap-mock" in result.stdout
-        assert "Extractor tap-mock-inherited is an inherited plugin" in result.stdout
+        assert "Lockfile exists" not in result.stderr
+        assert "Locked definition for extractor tap-mock" in result.stderr
+        assert "Extractor tap-mock-inherited is an inherited plugin" in result.stderr
 
     def test_lock_plugin_not_found(self, cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(cli, ["lock", "not-a-plugin"])


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Prevent redundant plugin fetch in meltano lock by using ensure_parent=False, migrate lock command messaging to use logger, and adjust tests to capture logs via stderr

Bug Fixes:
- Prevent unnecessary plugin definition fetches when locking plugins by passing ensure_parent=False

Enhancements:
- Replace click output in the lock command with structured logger calls
- Log lock command messages (info, warning, error) instead of using click.secho/echo

Tests:
- Update lock command tests to include debug log flags and assert log messages on stderr