### PR TITLE
docs: Add an admonition for `psycopg2` and link to SQLAlchemy docs

### DIFF
--- a/docs/docs/concepts/project.md
+++ b/docs/docs/concepts/project.md
@@ -402,7 +402,7 @@ Meltano is currently tested with the following databases as backends for state a
 | Database      | Supported Versions                      | Extra Requirement                                                                 | Example URL                                                     |
 | :------------ | :-------------------------------------- | :-------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
 | SQLite        | Version `3.25.0` or higher is required. | None                                                                              | `sqlite:///$MELTANO_SYS_DIR_ROOT/meltano.db` (default)          |
-| PostgreSQL    | Version `13` or higher is required.     | [`postgres` or `psycopg2`](/guide/advanced-topics#installing-optional-components) | `postgresql+psycopg://<user>:<password>@<host>:<port>/<dbname>` |
+| PostgreSQL    | Version `13` or higher is required.     | [`postgres`](/guide/advanced-topics#installing-optional-components) .             | `postgresql+psycopg://<user>:<password>@<host>:<port>/<dbname>` |
 | MS SQL Server | Version `2019` or higher is required.   | [`mssql`](/guide/advanced-topics#installing-optional-components)                  | `mssql+pymssql://<user>:<password@<freetds_name>/?charset=utf8` |
 
 Support for other databases has been requested and is being tracked in the following issues:

--- a/docs/docs/guide/advanced-topics.mdx
+++ b/docs/docs/guide/advanced-topics.mdx
@@ -37,9 +37,12 @@ Most of Meltano's features are available without installing any additional packa
 
 The following extras add support for different [system database](/concepts/project/#system-database) types, which function as the default [state backend](/concepts/state_backends):
 
-- `mssql` - Microsoft SQL Server.
-- `psycopg2` - PostgreSQL. It uses the legacy `psycopg2` driver.
-- `postgres` - PostgreSQL. It uses the modern `psycopg` driver.
+- [`mssql` - Microsoft SQL Server](https://docs.sqlalchemy.org/en/20/dialects/mssql.html#module-sqlalchemy.dialects.mssql.pymssql).
+- [`postgres` - PostgreSQL. It uses the modern `psycopg` driver](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg).
+
+:::warning
+<p>The <code>psycopg2</code> extra is supported, but the package won't receive any new features, so we recommend using the <code>postgres</code> extra instead.</p>
+:::
 
 To use these system databases, Meltano must be installed with the matching [optional component](#installing-optional-components)
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Introduce a warning advising users to prefer the modern ‘postgres’ extra over the legacy ‘psycopg2’ driver, update database extras with links to the corresponding SQLAlchemy docs, and remove ‘psycopg2’ from the supported extras list in the project concepts table.

Enhancements:
- Add warning admonition in the advanced topics guide recommending the ‘postgres’ extra instead of legacy ‘psycopg2'.
- Hyperlink ‘mssql’ and ‘postgres’ extras in the advanced topics guide to their SQLAlchemy documentation.

Documentation:
- Remove ‘psycopg2’ from the PostgreSQL extras list in the project concepts table, leaving only ‘postgres’.