### PR TITLE
refactor: Refactor schedule objects into dataclasses

### DIFF
--- a/src/meltano/core/behavior/_dataclass.py
+++ b/src/meltano/core/behavior/_dataclass.py
@@ -1,0 +1,308 @@
+"""Dataclass mixin that preserves YAML comments and provides Canonical-like behavior."""
+
+from __future__ import annotations
+
+import copy
+import sys
+import typing as t
+from dataclasses import fields, is_dataclass
+from functools import lru_cache
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
+
+from meltano.core.behavior.canonical import (
+    CANONICAL_PARSE_CACHE_SIZE,
+    Annotations,
+    AnnotationsMeta,
+    IdHashBox,
+)
+
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: ICN003
+else:
+    from typing_extensions import Self
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
+if t.TYPE_CHECKING:
+    import ruamel.yaml.dumper
+    import ruamel.yaml.nodes
+    import ruamel.yaml.representer
+
+
+class CanonicalDataclassMeta(AnnotationsMeta):
+    """Metaclass that combines dataclass with annotation handling."""
+
+    @override
+    def __call__(cls, *args: t.Any, **kwargs: t.Any) -> t.Any:  # noqa: N805
+        """Create and return an instance, handling annotations before __init__.
+
+        Args:
+            *args: Positional arguments for the instance.
+            **kwargs: Keyword arguments for the instance.
+
+        Returns:
+            The newly created instance with annotations stored separately.
+        """
+        # Remove the annotations from the arguments that would be used for `__init__`.
+        extracted_annotations = (
+            Annotations(
+                index=list(kwargs.keys()).index("annotations"),
+                data=kwargs.pop("annotations"),
+            )
+            if "annotations" in kwargs
+            else None
+        )
+
+        # For dataclasses, filter out extra kwargs that aren't fields
+        if is_dataclass(cls):
+            field_names = {f.name for f in fields(cls)}  # type: ignore[unreachable]
+            extra_kwargs = {k: v for k, v in kwargs.items() if k not in field_names}
+            filtered_kwargs = {k: v for k, v in kwargs.items() if k in field_names}
+
+            # Create instance with only valid field kwargs
+            instance = super(AnnotationsMeta, cls).__call__(*args, **filtered_kwargs)
+
+            # Store extra kwargs for later access
+            if extra_kwargs and hasattr(instance, "_dict"):
+                for key, value in extra_kwargs.items():
+                    instance._dict[key] = value
+            if extra_kwargs and hasattr(instance, "_extra_attrs"):
+                instance._extra_attrs.update(extra_kwargs)
+        else:
+            instance = super(AnnotationsMeta, cls).__call__(*args, **kwargs)
+
+        # Store the annotations for later re-insertion during serialization
+        instance._annotations = extracted_annotations
+        return instance
+
+
+class CanonicalDataclassMixin:
+    """Mixin for dataclasses that provides Canonical-like YAML serialization.
+
+    This mixin provides:
+    - YAML comment preservation via CommentedMap storage
+    - Filtering of None/empty values (except False)
+    - parse() and canonical() methods for serialization
+    - Annotations support
+    - Support for extra kwargs not defined in dataclass fields
+    """
+
+    def __post_init__(self, **extra_kwargs: t.Any) -> None:
+        """Initialize the YAML comment storage after dataclass __init__.
+
+        Args:
+            **extra_kwargs: Extra keyword arguments not defined in dataclass fields.
+        """
+        # Store YAML comments and metadata
+        self._dict = CommentedMap()
+        self._annotations: Annotations | None = None
+        self._extra_attrs: dict[str, t.Any] = {}
+
+        # Copy field values to _dict for YAML comment preservation
+        if is_dataclass(self):
+            for field in fields(self):  # type: ignore[unreachable]
+                value = getattr(self, field.name)
+                if value is not None:
+                    self._dict[field.name] = value
+
+        # Store any extra kwargs that weren't part of the dataclass
+        self._extra_attrs = extra_kwargs
+        for key, value in extra_kwargs.items():
+            self._dict[key] = value
+
+    @classmethod
+    def _canonize(cls, val: t.Any) -> t.Any:  # noqa: ANN401
+        """Call `as_canonical` on `val`, respecting dataclass types.
+
+        Args:
+            val: An object on which `as_canonical` should be called.
+
+        Returns:
+            The value obtained from calling `as_canonical`.
+        """
+        return getattr(type(val), "as_canonical", cls.as_canonical)(val)
+
+    @classmethod
+    def as_canonical(
+        cls,
+        target: t.Any,  # noqa: ANN401
+    ) -> dict | list | CommentedMap | CommentedSeq | t.Any:  # noqa: ANN401
+        """Return a canonical representation of the given instance.
+
+        Args:
+            target: An instance to convert.
+
+        Returns:
+            A canonical representation of the given instance.
+        """
+        if isinstance(target, CanonicalDataclassMixin):
+            # Build the canonical dict from dataclass fields
+            result = CommentedMap()
+            if is_dataclass(target):
+                for field in fields(target):  # type: ignore[unreachable]
+                    val = getattr(target, field.name)
+                    # Skip None values and empty values (except False)
+                    if val is None or (not val and val is not False):
+                        continue
+                    # Skip empty dataclass instances
+                    if isinstance(val, CanonicalDataclassMixin) and not dict(
+                        cls.as_canonical(val),
+                    ):
+                        continue
+                    result[field.name] = cls._canonize(val)
+
+            # Re-insert annotations if they exist
+            if hasattr(target, "_annotations") and target._annotations is not None:
+                result.insert(
+                    target._annotations.index,
+                    "annotations",
+                    target._annotations.data,
+                )
+
+            # Copy YAML attributes (comments, etc.) if they exist
+            if hasattr(target, "_dict"):
+                target._dict.copy_attributes(result)
+
+            return result
+
+        if isinstance(target, dict):
+            as_dict = {key: cls._canonize(val) for key, val in target.items()}
+            if isinstance(target, CommentedMap):
+                as_commented_map = CommentedMap(as_dict)
+                target.copy_attributes(as_commented_map)
+                return as_commented_map
+            return as_dict
+
+        if isinstance(target, list | set | CommentedSet):
+            as_list = [cls._canonize(val) for val in target]
+            if isinstance(target, CommentedSet | CommentedSeq):
+                as_commented_seq = CommentedSeq(as_list)
+                target.copy_attributes(as_commented_seq)
+                return as_commented_seq
+            return as_list
+
+        return copy.deepcopy(target)
+
+    def canonical(self) -> dict | list | CommentedMap | CommentedSeq | t.Any:  # noqa: ANN401
+        """Return a canonical representation of the current instance.
+
+        Returns:
+            A canonical representation of the current instance.
+        """
+        return type(self).as_canonical(self)
+
+    @classmethod
+    def parse(cls, obj: t.Any) -> Self | None:  # noqa: ANN401
+        """Parse a dataclass object from a dictionary or return the instance.
+
+        Args:
+            obj: Dictionary or instance to parse.
+
+        Returns:
+            Parsed instance.
+        """
+        return cls._parse(IdHashBox(obj))
+
+    @classmethod
+    @lru_cache(maxsize=CANONICAL_PARSE_CACHE_SIZE)
+    def _parse(cls, boxed_obj: IdHashBox) -> Self | None:
+        """Parse a dataclass object from a dictionary or return the instance.
+
+        Args:
+            boxed_obj: Dictionary or instance to parse wrapped in an `IdHashBox`.
+
+        Returns:
+            Parsed instance.
+        """
+        obj = boxed_obj.content
+
+        if obj is None:
+            return None
+
+        if isinstance(obj, cls):
+            return obj
+
+        # Filter kwargs to only include fields defined on the dataclass
+        if is_dataclass(cls):
+            field_names = {f.name for f in fields(cls)}  # type: ignore[unreachable]
+            filtered_kwargs = {k: v for k, v in obj.items() if k in field_names}
+        else:
+            filtered_kwargs = dict(obj)
+
+        instance = cls(**filtered_kwargs)
+
+        # Copy YAML attributes if the source is a CommentedMap
+        if isinstance(obj, CommentedMap) and hasattr(instance, "_dict"):
+            obj.copy_attributes(instance._dict)
+
+        return instance
+
+    @property
+    def attrs(self) -> CommentedMap:
+        """The attributes storage (for YAML comments)."""
+        return self._dict
+
+    def __getitem__(self, key: str) -> t.Any:  # noqa: ANN401
+        """Support subscript access to fields.
+
+        Args:
+            key: The field name to access.
+
+        Returns:
+            The field value.
+        """
+        return getattr(self, key)
+
+    def __setitem__(self, key: str, value: t.Any) -> None:  # noqa: ANN401
+        """Support subscript assignment to fields.
+
+        Args:
+            key: The field name to set.
+            value: The value to set.
+        """
+        setattr(self, key, value)
+
+    @classmethod
+    def yaml(
+        cls,
+        dumper: ruamel.yaml.dumper.BaseDumper,
+        obj: t.Any,  # noqa: ANN401
+    ) -> ruamel.yaml.nodes.MappingNode:
+        """YAML serializer for dataclass objects.
+
+        Args:
+            dumper: The YAML dumper.
+            obj: The dataclass object to serialize.
+
+        Returns:
+            The serialized YAML representation of the object.
+        """
+        return dumper.represent_mapping(
+            "tag:yaml.org,2002:map",
+            cls.as_canonical(obj),
+            flow_style=False,
+        )
+
+    @classmethod
+    def to_yaml(
+        cls,
+        representer: ruamel.yaml.representer.Representer,
+        obj: t.Any,  # noqa: ANN401
+    ) -> ruamel.yaml.nodes.MappingNode:
+        """YAML serializer for dataclass objects.
+
+        Args:
+            representer: The YAML representer.
+            obj: The dataclass object to serialize.
+
+        Returns:
+            The serialized YAML representation of the object.
+        """
+        return representer.represent_mapping(
+            "tag:yaml.org,2002:map",
+            cls.as_canonical(obj),
+        )

--- a/src/meltano/core/behavior/_dataclass.py
+++ b/src/meltano/core/behavior/_dataclass.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import sys
 import typing as t
-from dataclasses import fields, is_dataclass
+from dataclasses import fields
 from functools import lru_cache
 
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet
@@ -58,22 +58,19 @@ class CanonicalDataclassMeta(AnnotationsMeta):
         )
 
         # For dataclasses, filter out extra kwargs that aren't fields
-        if is_dataclass(cls):
-            field_names = {f.name for f in fields(cls)}  # type: ignore[unreachable]
-            extra_kwargs = {k: v for k, v in kwargs.items() if k not in field_names}
-            filtered_kwargs = {k: v for k, v in kwargs.items() if k in field_names}
+        field_names = {f.name for f in fields(cls)}  # type:ignore[arg-type] # ty:ignore[invalid-argument-type]
+        extra_kwargs = {k: v for k, v in kwargs.items() if k not in field_names}
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k in field_names}
 
-            # Create instance with only valid field kwargs
-            instance = super(AnnotationsMeta, cls).__call__(*args, **filtered_kwargs)
+        # Create instance with only valid field kwargs
+        instance = super(AnnotationsMeta, cls).__call__(*args, **filtered_kwargs)
 
-            # Store extra kwargs for later access
-            if extra_kwargs and hasattr(instance, "_dict"):
-                for key, value in extra_kwargs.items():
-                    instance._dict[key] = value
-            if extra_kwargs and hasattr(instance, "_extra_attrs"):
-                instance._extra_attrs.update(extra_kwargs)
-        else:
-            instance = super(AnnotationsMeta, cls).__call__(*args, **kwargs)
+        # Store extra kwargs for later access
+        if extra_kwargs and hasattr(instance, "_dict"):
+            for key, value in extra_kwargs.items():
+                instance._dict[key] = value
+        if extra_kwargs and hasattr(instance, "_extra_attrs"):
+            instance._extra_attrs.update(extra_kwargs)
 
         # Store the annotations for later re-insertion during serialization
         instance._annotations = extracted_annotations
@@ -103,11 +100,10 @@ class CanonicalDataclassMixin:
         self._extra_attrs: dict[str, t.Any] = {}
 
         # Copy field values to _dict for YAML comment preservation
-        if is_dataclass(self):
-            for field in fields(self):  # type: ignore[unreachable]
-                value = getattr(self, field.name)
-                if value is not None:
-                    self._dict[field.name] = value
+        for field in fields(self):  # type:ignore[arg-type] # ty:ignore[invalid-argument-type]
+            value = getattr(self, field.name)
+            if value is not None:
+                self._dict[field.name] = value
 
         # Store any extra kwargs that weren't part of the dataclass
         self._extra_attrs = extra_kwargs
@@ -142,18 +138,17 @@ class CanonicalDataclassMixin:
         if isinstance(target, CanonicalDataclassMixin):
             # Build the canonical dict from dataclass fields
             result = CommentedMap()
-            if is_dataclass(target):
-                for field in fields(target):  # type: ignore[unreachable]
-                    val = getattr(target, field.name)
-                    # Skip None values and empty values (except False)
-                    if val is None or (not val and val is not False):
-                        continue
-                    # Skip empty dataclass instances
-                    if isinstance(val, CanonicalDataclassMixin) and not dict(
-                        cls.as_canonical(val),
-                    ):
-                        continue
-                    result[field.name] = cls._canonize(val)
+            for field in fields(target):  # type:ignore[arg-type]
+                val = getattr(target, field.name)
+                # Skip None values and empty values (except False)
+                if val is None or (not val and val is not False):
+                    continue
+                # Skip empty dataclass instances
+                if isinstance(val, CanonicalDataclassMixin) and not dict(
+                    cls.as_canonical(val),
+                ):
+                    continue
+                result[field.name] = cls._canonize(val)
 
             # Re-insert annotations if they exist
             if hasattr(target, "_annotations") and target._annotations is not None:
@@ -227,11 +222,8 @@ class CanonicalDataclassMixin:
             return obj
 
         # Filter kwargs to only include fields defined on the dataclass
-        if is_dataclass(cls):
-            field_names = {f.name for f in fields(cls)}  # type: ignore[unreachable]
-            filtered_kwargs = {k: v for k, v in obj.items() if k in field_names}
-        else:
-            filtered_kwargs = dict(obj)
+        field_names = {f.name for f in fields(cls)}  # type:ignore[arg-type] # ty:ignore[invalid-argument-type]
+        filtered_kwargs = {k: v for k, v in obj.items() if k in field_names}
 
         instance = cls(**filtered_kwargs)
 

--- a/src/meltano/core/behavior/_dataclass.py
+++ b/src/meltano/core/behavior/_dataclass.py
@@ -88,15 +88,13 @@ class CanonicalDataclassMixin:
     - Support for extra kwargs not defined in dataclass fields
     """
 
-    def __post_init__(self, **extra_kwargs: t.Any) -> None:
-        """Initialize the YAML comment storage after dataclass __init__.
-
-        Args:
-            **extra_kwargs: Extra keyword arguments not defined in dataclass fields.
-        """
+    def __post_init__(self) -> None:
+        """Initialize the YAML comment storage after dataclass __init__."""
         # Store YAML comments and metadata
         self._dict = CommentedMap()
         self._annotations: Annotations | None = None
+        # Extra kwargs (not part of the dataclass fields) are populated by
+        # `CanonicalDataclassMeta.__call__` after `__init__` returns.
         self._extra_attrs: dict[str, t.Any] = {}
 
         # Copy field values to _dict for YAML comment preservation
@@ -104,11 +102,6 @@ class CanonicalDataclassMixin:
             value = getattr(self, field.name)
             if value is not None:
                 self._dict[field.name] = value
-
-        # Store any extra kwargs that weren't part of the dataclass
-        self._extra_attrs = extra_kwargs
-        for key, value in extra_kwargs.items():
-            self._dict[key] = value
 
     @classmethod
     def _canonize(cls, val: t.Any) -> t.Any:  # noqa: ANN401
@@ -158,9 +151,8 @@ class CanonicalDataclassMixin:
                     target._annotations.data,
                 )
 
-            # Copy YAML attributes (comments, etc.) if they exist
-            if hasattr(target, "_dict"):
-                target._dict.copy_attributes(result)
+            # Copy YAML attributes (comments, etc.)
+            target._dict.copy_attributes(result)
 
             return result
 
@@ -221,9 +213,12 @@ class CanonicalDataclassMixin:
         if isinstance(obj, cls):
             return obj
 
-        # Filter kwargs to only include fields defined on the dataclass
+        # Filter kwargs to only include fields defined on the dataclass, plus
+        # "annotations", which `CanonicalDataclassMeta` handles separately.
         field_names = {f.name for f in fields(cls)}  # type:ignore[arg-type] # ty:ignore[invalid-argument-type]
-        filtered_kwargs = {k: v for k, v in obj.items() if k in field_names}
+        filtered_kwargs = {
+            k: v for k, v in obj.items() if k in field_names or k == "annotations"
+        }
 
         instance = cls(**filtered_kwargs)
 

--- a/src/meltano/core/schedule.py
+++ b/src/meltano/core/schedule.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import typing as t
+from dataclasses import KW_ONLY, dataclass, field
+
+import ruamel.yaml as yaml
 
 from meltano.core.behavior import NameEq
-from meltano.core.behavior.canonical import Canonical
+from meltano.core.behavior._dataclass import (
+    CanonicalDataclassMeta,
+    CanonicalDataclassMixin,
+)
 from meltano.core.job import JobFinder as StateJobFinder
 
 if t.TYPE_CHECKING:
@@ -201,35 +207,15 @@ def _parse_value(value: str, field_index: int, /) -> int | None:
     return None
 
 
-class Schedule(NameEq, Canonical):
+@dataclass(eq=False)
+class Schedule(NameEq, CanonicalDataclassMixin, metaclass=CanonicalDataclassMeta):
     """A base schedule class."""
 
+    _: KW_ONLY
+
     name: str
-    interval: str | None
-    env: dict[str, str]
-
-    def __init__(
-        self,
-        *,
-        name: str,
-        interval: str | None,
-        env: dict[str, str] | None = None,
-        **kwargs: t.Any,
-    ):
-        """Initialize a Schedule.
-
-        Args:
-            name: The name of the schedule.
-            interval: The interval of the schedule.
-            env: The env for this schedule.
-            kwargs: The keyword arguments to initialize the schedule with.
-        """
-        super().__init__(**kwargs)
-
-        # Attributes will be listed in meltano.yml in this order:
-        self.name = name
-        self.interval = interval
-        self.env = env or {}
+    interval: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
 
     @property
     def cron_interval(self) -> str | None:
@@ -239,33 +225,13 @@ class Schedule(NameEq, Canonical):
         )
 
 
+@dataclass(eq=False)
 class ELTSchedule(Schedule):
     """A schedule is an elt command or a job configured to run at a certain interval."""
 
     extractor: str
     loader: str
     transform: t.Literal["skip", "only", "run"]
-
-    def __init__(
-        self,
-        *,
-        extractor: str,
-        loader: str,
-        transform: t.Literal["skip", "only", "run"],
-        **kwargs: t.Any,
-    ):
-        """Initialize a Schedule.
-
-        Args:
-            extractor: The name of the extractor.
-            loader: The name of the loader.
-            transform: The transform statement (eg: skip, only, run)
-            kwargs: The keyword arguments to initialize the schedule with.
-        """
-        super().__init__(**kwargs)
-        self.extractor = extractor
-        self.loader = loader
-        self.transform = transform
 
     @property
     def elt_args(self) -> list[str]:
@@ -298,17 +264,14 @@ class ELTSchedule(Schedule):
         return StateJobFinder(self.name).latest_success(session)
 
 
+@dataclass(eq=False)
 class JobSchedule(Schedule):
     """A schedule is a job configured to run at a certain interval."""
 
     job: str
 
-    def __init__(self, *, job: str, **kwargs: t.Any) -> None:
-        """Initialize a Schedule.
 
-        Args:
-            job: The name of the job.
-            kwargs: The keyword arguments to initialize the schedule with.
-        """
-        super().__init__(**kwargs)
-        self.job = job
+# Register YAML representers for Schedule classes
+yaml.add_multi_representer(Schedule, Schedule.yaml)
+yaml.add_multi_representer(ELTSchedule, ELTSchedule.yaml)
+yaml.add_multi_representer(JobSchedule, JobSchedule.yaml)

--- a/tests/meltano/core/behavior/test_dataclass.py
+++ b/tests/meltano/core/behavior/test_dataclass.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass, field
+from textwrap import dedent
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+from meltano.core.behavior._dataclass import (
+    CanonicalDataclassMeta,
+    CanonicalDataclassMixin,
+)
+
+
+@dataclass(eq=False)
+class _Nested(CanonicalDataclassMixin, metaclass=CanonicalDataclassMeta):
+    value: str | None = None
+
+
+@dataclass(eq=False)
+class _Subject(CanonicalDataclassMixin, metaclass=CanonicalDataclassMeta):
+    name: str = "test"
+    optional: str | None = None
+    flag: bool = False
+    items: list[str] = field(default_factory=list)
+    mapping: dict[str, str] = field(default_factory=dict)
+    nested: _Nested | None = None
+
+
+class TestCanonicalDataclassMixin:
+    def test_none_and_empty_values_excluded(self) -> None:
+        subject = _Subject(name="hello")
+        assert subject.canonical() == {"name": "hello", "flag": False}
+
+    def test_false_value_included(self) -> None:
+        subject = _Subject(name="hello", flag=True)
+        assert subject.canonical()["flag"] is True
+
+    def test_list_values_canonicalized(self) -> None:
+        subject = _Subject(name="hello", items=["a", "b"])
+        assert subject.canonical()["items"] == ["a", "b"]
+
+    def test_dict_values_canonicalized(self) -> None:
+        subject = _Subject(name="hello", mapping={"a": "1"})
+        assert subject.canonical()["mapping"] == {"a": "1"}
+
+    def test_commented_map_values_preserve_comments(self) -> None:
+        contents = dedent(
+            """\
+            name: hello
+            mapping:
+              # comment on a mapping entry
+              a: '1'
+            """,
+        )
+        yaml = YAML()
+        parsed_mapping = yaml.load(io.StringIO(contents))
+        subject = _Subject.parse(parsed_mapping)
+        assert subject is not None
+
+        out = io.StringIO()
+        yaml.dump(subject.canonical(), out)
+        assert out.getvalue() == dedent(
+            """\
+            name: hello
+            flag: false
+            mapping:
+              # comment on a mapping entry
+              a: '1'
+            """,
+        )
+
+    def test_set_values_canonicalized(self) -> None:
+        # `_canonize` is exercised directly since dataclass fields are typed,
+        # but the underlying `as_canonical` also supports arbitrary sets.
+        assert sorted(_Subject.as_canonical({"a", "b"})) == ["a", "b"]
+
+    def test_nested_dataclass_included(self) -> None:
+        subject = _Subject(name="hello", nested=_Nested(value="x"))
+        assert subject.canonical()["nested"] == {"value": "x"}
+
+    def test_nested_empty_dataclass_excluded(self) -> None:
+        subject = _Subject(name="hello", nested=_Nested())
+        assert "nested" not in subject.canonical()
+
+    def test_extra_kwargs_stored(self) -> None:
+        subject = _Subject(name="hello", unknown="value")
+        assert subject._extra_attrs == {"unknown": "value"}
+        assert subject._dict["unknown"] == "value"
+
+    def test_getitem_setitem(self) -> None:
+        subject = _Subject(name="hello")
+        assert subject["name"] == "hello"
+        subject["name"] = "changed"
+        assert subject.name == "changed"
+
+    def test_attrs_property(self) -> None:
+        subject = _Subject(name="hello")
+        assert subject.attrs is subject._dict
+
+    def test_parse_returns_instance_as_is(self) -> None:
+        subject = _Subject(name="hello")
+        assert _Subject.parse(subject) is subject
+
+    def test_parse_none(self) -> None:
+        assert _Subject.parse(None) is None
+
+    def test_parse_dict_filters_unknown_fields(self) -> None:
+        parsed = _Subject.parse({"name": "hello", "unknown": "ignored"})
+        assert parsed is not None
+        assert parsed.name == "hello"
+        assert "unknown" not in parsed._extra_attrs
+
+    def test_parse_preserves_comments(self) -> None:
+        contents = dedent(
+            """\
+            # top-level comment
+            name: hello
+            items:
+            # comment in list
+            - a # trailing comment
+            """,
+        )
+        yaml = YAML()
+        mapping = yaml.load(io.StringIO(contents))
+        subject = _Subject.parse(mapping)
+        assert subject is not None
+        assert subject.name == "hello"
+        assert subject.items[0] == "a"
+
+        out = io.StringIO()
+        yaml.dump(subject.canonical(), out)
+        assert out.getvalue() == dedent(
+            """\
+            # top-level comment
+            name: hello
+            flag: false
+            items:
+            # comment in list
+            - a # trailing comment
+            """,
+        )
+
+    def test_annotations_round_trip(self) -> None:
+        original = CommentedMap(
+            {"name": "hello", "annotations": {"cloud": {"data": 1}}},
+        )
+        subject = _Subject.parse(original)
+        assert subject is not None
+        assert subject.name == "hello"
+        canonical = dict(subject.canonical())
+        assert canonical["annotations"] == original["annotations"]
+        assert canonical["flag"] is False
+
+    def test_yaml_classmethod(self) -> None:
+        yaml = YAML()
+        yaml.default_flow_style = False
+        yaml.representer.add_representer(_Subject, _Subject.yaml)
+
+        buf = io.StringIO()
+        yaml.dump(_Subject(name="hello"), buf)
+        assert buf.getvalue() == "name: hello\nflag: false\n"
+
+    def test_to_yaml_classmethod(self) -> None:
+        yaml = YAML(typ="safe")
+        yaml.representer.add_representer(_Subject, _Subject.to_yaml)
+
+        buf = io.StringIO()
+        yaml.dump(_Subject(name="hello"), buf)
+        assert buf.getvalue() == "{flag: false, name: hello}\n"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor schedule objects into dataclasses with a shared mixin for YAML serialization, streamline the CLI update logic using pattern matching, tighten transform type hints, and update tests to align with the new implementations.

Bug Fixes:
- Use click.UsageError for invalid option combinations resulting in consistent exit codes

Enhancements:
- Convert Schedule, ELTSchedule, and JobSchedule models to dataclasses with built-in YAML comment preservation
- Introduce CanonicalDataclassMixin and CanonicalDataclassMeta to provide canonical YAML serialization for dataclasses
- Simplify the schedule set command using structural pattern matching and inline field updates
- Tighten type hints for the transform field to Literal["skip","only","run"]
- Register YAML representers for the new dataclass schedule classes

Tests:
- Update CLI schedule tests to assert on new dataclass types and adjust expected exit codes