### PR TITLE
packaging: Remove unmaintained dependency `flatten-dict`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "click-didyoumean>=0.3.1,<0.4",
   "dateparser>=1.2.1",
   "fasteners>=0.19,<0.20",
-  "flatten-dict>=0,<1",
   "importlib-metadata>=5 ; python_version < '3.12'",
   "jinja2>=3.1.4,<4",
   "jsonschema>=4.23,<5",

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -197,7 +197,6 @@ class Manifest:
                     for x in self.project.project_files.include_paths
                 ),
             ),
-            "dot",
         )
         if self.check_schema:
             self._validate_against_manifest_schema(

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -14,7 +14,6 @@ from importlib import resources
 from operator import getitem
 from tempfile import NamedTemporaryFile
 
-import flatten_dict
 import structlog
 import yaml
 
@@ -30,6 +29,7 @@ from meltano.core.utils import (
     default_deep_merge_strategies,
     expand_env_vars,
     get_no_color_flag,
+    unflatten,
 )
 
 if t.TYPE_CHECKING:
@@ -183,7 +183,7 @@ class Manifest:
 
     @cached_property
     def _project_files(self) -> dict[str, t.Any]:
-        project_files = flatten_dict.unflatten(
+        project_files = unflatten(
             deep_merge(
                 yaml.load(
                     self._meltano_file,

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -31,6 +31,7 @@ if t.TYPE_CHECKING:
 
     from sqlalchemy.orm import Session
 
+    from meltano.core.plugin.settings_service import PluginSettingsService
     from meltano.core.setting_definition import EnvVar, SettingDefinition
     from meltano.core.settings_service import SettingsService
 
@@ -877,8 +878,12 @@ class MeltanoEnvStoreManager(MeltanoYmlStoreManager):
         Returns:
             A dictionary of flattened configuration.
         """
+        # TODO: Remove this cast when we have a better way to get the settings service
+        # type or when we figure how the settings service type should be narrowed
+        # per-manager.
+        settings_service = t.cast("PluginSettingsService", self.settings_service)
         if self._flat_config is None:
-            self._flat_config = flatten(self.settings_service.environment_config, "dot")  # type: ignore[attr-defined]
+            self._flat_config = flatten(settings_service.environment_config, "dot")
         return self._flat_config
 
     def ensure_supported(self, method: str = "get") -> None:

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -327,7 +327,22 @@ def to_env_var(*xs: str) -> str:
     return "_".join(re.sub(r"[^A-Za-z0-9]", "_", x).upper() for x in xs if x)
 
 
-def flatten(d: dict, reducer: str | Callable = "tuple"):  # noqa: ANN201
+@t.overload
+def flatten(d: dict, reducer: t.Literal["dot"]) -> dict[str, t.Any]: ...
+
+
+@t.overload
+def flatten(d: dict, reducer: t.Literal["env_var"]) -> dict[str, str]: ...
+
+
+@t.overload
+def flatten(d: dict, reducer: t.Literal["tuple"]) -> dict[tuple[str, ...], str]: ...
+
+
+def flatten(
+    d: dict,
+    reducer: t.Literal["dot", "env_var", "tuple"] | Callable = "tuple",
+) -> dict[str, t.Any]:
     """Flatten a dictionary with `dot` and `env_var` reducers.
 
     Args:
@@ -369,7 +384,10 @@ def flatten(d: dict, reducer: str | Callable = "tuple"):  # noqa: ANN201
     return {reducer(*key): value for key, value in flattened.items()}
 
 
-def unflatten(d: dict, splitter: str | Callable = "tuple") -> dict:
+def unflatten(
+    d: dict,
+    splitter: t.Literal["tuple", "dot"] | Callable[[str], tuple[str, ...]] = "dot",
+) -> dict[str, t.Any]:
     """Unflatten a dictionary with dot-separated keys into a nested dictionary.
 
     Args:

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -26,7 +26,6 @@ from operator import setitem
 from pathlib import Path
 
 import dateparser
-import flatten_dict
 import structlog
 from packaging.specifiers import SpecifierSet
 from requests.auth import HTTPBasicAuth
@@ -328,15 +327,12 @@ def to_env_var(*xs: str) -> str:
     return "_".join(re.sub(r"[^A-Za-z0-9]", "_", x).upper() for x in xs if x)
 
 
-def flatten(d: dict, reducer: str | Callable = "tuple", **kwargs):  # noqa: ANN003, ANN201
+def flatten(d: dict, reducer: str | Callable = "tuple"):  # noqa: ANN201
     """Flatten a dictionary with `dot` and `env_var` reducers.
-
-    Wrapper around `flatten_dict.flatten`.
 
     Args:
         d: the dict to flatten
         reducer: the reducer to flatten with
-        **kwargs: additional kwargs to pass to flatten_dict.flatten
 
     Returns:
         the flattened dict
@@ -346,7 +342,60 @@ def flatten(d: dict, reducer: str | Callable = "tuple", **kwargs):  # noqa: ANN0
     if reducer == "env_var":
         reducer = to_env_var
 
-    return flatten_dict.flatten(d, reducer, **kwargs)
+    def _flatten(obj: dict, parent_key: tuple = ()) -> dict:
+        """Recursively flatten a nested dictionary.
+
+        Args:
+            obj: the dictionary to flatten
+            parent_key: tuple of parent keys for nested recursion
+
+        Returns:
+            the flattened dictionary
+        """
+        items = []
+        for key, value in obj.items():
+            new_key = (*parent_key, key)
+            if isinstance(value, dict) and value:
+                items.extend(_flatten(value, new_key).items())
+            else:
+                items.append((new_key, value))
+        return dict(items)
+
+    flattened = _flatten(d)
+
+    # Apply the reducer to convert tuples to the desired key format
+    if reducer == "tuple":
+        return flattened
+    return {reducer(*key): value for key, value in flattened.items()}
+
+
+def unflatten(d: dict, splitter: str | Callable = "tuple") -> dict:
+    """Unflatten a dictionary with dot-separated keys into a nested dictionary.
+
+    Args:
+        d: the flattened dict to unflatten
+        splitter: the splitter to use for key separation. Can be "tuple", "dot",
+            or a callable that takes a key and returns a tuple of key parts.
+
+    Returns:
+        the nested dict
+    """
+    if splitter == "tuple":
+        splitter = lambda x: x if isinstance(x, tuple) else (x,)  # noqa: E731
+    elif splitter == "dot":
+        splitter = lambda x: tuple(x.split(".")) if isinstance(x, str) else (x,)  # noqa: E731
+
+    result = {}
+    for key, value in d.items():
+        key_parts = splitter(key)
+        current = result
+        for part in key_parts[:-1]:
+            if part not in current:
+                current[part] = {}
+            current = current[part]
+        current[key_parts[-1]] = value
+
+    return result
 
 
 def compact(xs: Iterable) -> Iterable:

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -106,6 +106,29 @@ def test_flatten() -> None:
     assert result == expected_flat
 
 
+def test_unflatten() -> None:
+    from meltano.core.utils import unflatten
+
+    # Test basic dot notation unflatten (matches original flatten_dict behavior)
+    flat_config = {"_update.orchestrate/dags/meltano.py": False}
+    # Note: The dot in ".py" is also split, matching original flatten_dict behavior
+    expected_nested = {"_update": {"orchestrate/dags/meltano": {"py": False}}}
+    result = unflatten(flat_config, "dot")
+    assert result == expected_nested
+
+    # Test multiple levels
+    flat_config = {"a.b.c": 1, "a.b.d": 2, "a.e": 3}
+    expected_nested = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+    result = unflatten(flat_config, "dot")
+    assert result == expected_nested
+
+    # Test that flatten and unflatten are inverses
+    original = {"foo": {"bar": {"baz": "value"}}}
+    flattened = flatten(original, "dot")
+    unflattened = unflatten(flattened, "dot")
+    assert unflattened == original
+
+
 @pytest.mark.parametrize(
     ("input_value", "env", "kwargs", "expected_output"),
     (

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -100,9 +100,20 @@ def test_set_at_path() -> None:
 
 
 def test_flatten() -> None:
+    # Test dot flatten
     example_config = {"_update": {"orchestrate/dags/meltano.py": False}}
     expected_flat = {"_update.orchestrate/dags/meltano.py": False}
     result = flatten(example_config, "dot")
+
+    # Test env var flatten
+    example_config = {"_update": {"orchestrate/dags/meltano.py": False}}
+    expected_flat = {"_UPDATE_ORCHESTRATE_DAGS_MELTANO_PY": False}
+    result = flatten(example_config, "env_var")
+
+    # Test tuple flatten
+    example_config = {"_update": {"orchestrate/dags/meltano.py": False}}
+    expected_flat = {("_update", "orchestrate/dags/meltano.py"): False}
+    result = flatten(example_config, "tuple")
     assert result == expected_flat
 
 
@@ -127,6 +138,21 @@ def test_unflatten() -> None:
     flattened = flatten(original, "dot")
     unflattened = unflatten(flattened, "dot")
     assert unflattened == original
+
+    # Test tuple unflatten
+    flat_config = {("_update", "orchestrate/dags/meltano.py"): False}
+    expected_nested = {"_update": {"orchestrate/dags/meltano.py": False}}
+    result = unflatten(flat_config, "tuple")
+    assert result == expected_nested
+
+    # Test custom reducer
+    def custom_reducer(key: str) -> tuple[str, ...]:
+        return tuple(key.split("_")) if isinstance(key, str) else (key,)
+
+    flat_config = {"a_b_c": 1, "a_b_d": 2, "a_e": 3}
+    expected_nested = {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+    result = unflatten(flat_config, custom_reducer)
+    assert result == expected_nested
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -849,18 +849,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flatten-dict"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/89/c6/5fe21639369f2ea609c964e20870b5c6c98a134ef12af848a7776ddbabe3/flatten-dict-0.4.2.tar.gz", hash = "sha256:506a96b6e6f805b81ae46a0f9f31290beb5fa79ded9d80dbe1b7fa236ab43076", size = 10362, upload-time = "2021-08-08T09:56:51.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl", hash = "sha256:7e245b20c4c718981212210eec4284a330c9f713e632e98765560e05421e48ad", size = 9656, upload-time = "2021-08-08T09:56:54.313Z" },
-]
-
-[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1379,7 +1367,6 @@ dependencies = [
     { name = "click-didyoumean" },
     { name = "dateparser" },
     { name = "fasteners" },
-    { name = "flatten-dict" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "jinja2" },
     { name = "jsonschema" },
@@ -1526,7 +1513,6 @@ requires-dist = [
     { name = "click-didyoumean", specifier = ">=0.3.1,<0.4" },
     { name = "dateparser", specifier = ">=1.2.1" },
     { name = "fasteners", specifier = ">=0.19,<0.20" },
-    { name = "flatten-dict", specifier = ">=0,<1" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=1.31.0" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'", specifier = ">=5" },
     { name = "jinja2", specifier = ">=3.1.4,<4" },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Remove the unmaintained flatten-dict dependency by providing in-house flatten and unflatten utility functions, updating all usages and tests accordingly.

Enhancements:
- Implement a custom flatten function with "dot", "env_var", and "tuple" reducers and type overloads
- Add an unflatten function to reconstruct nested dictionaries from flat key mappings
- Replace all external flatten_dict calls in settings_store and manifest with the new implementations

Build:
- Remove flatten-dict from dependencies and update lock files

Tests:
- Extend flatten tests to cover dot, env_var, and tuple reducers
- Add comprehensive unflatten tests, including round-trip and custom splitter scenarios