### PR TITLE
test: Handle Google API core "future" warnings

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -49,6 +49,16 @@ UV_SYNC_COMMAND = (
 )
 
 
+def _install_env(session: nox.Session) -> dict[str, str]:
+    env = {
+        "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+    }
+    if isinstance(session.python, str):
+        env["UV_PYTHON"] = session.python
+
+    return env
+
+
 def _run_pytest(session: nox.Session) -> None:
     random_seed = randint(0, 2**32 - 1)  # noqa: S311
     args = session.posargs or ("tests/",)
@@ -106,7 +116,7 @@ def pytest_meltano(session: nox.Session) -> None:
         *UV_SYNC_COMMAND,
         "--group=testing",
         *(f"--extra={extra}" for extra in extras),
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env=_install_env(session),
     )
     _run_pytest(session)
 
@@ -123,7 +133,7 @@ def coverage(session: nox.Session) -> None:
     session.run_install(
         *UV_SYNC_COMMAND,
         "--group=coverage",
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env=_install_env(session),
     )
 
     if not session.posargs and any(Path().glob(".coverage.*")):
@@ -147,7 +157,7 @@ def pre_commit(session: nox.Session) -> None:
     session.run_install(
         *UV_SYNC_COMMAND,
         "--group=pre-commit",
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env=_install_env(session),
     )
     session.run("pre-commit", *args)
 
@@ -170,6 +180,6 @@ def mypy(session: nox.Session) -> None:
         "--extra=gcs",
         "--extra=s3",
         "--extra=containers",
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env=_install_env(session),
     )
     session.run("mypy", *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ filterwarnings = [
   "ignore::pytest.PytestUnraisableExceptionWarning",
   "ignore::ResourceWarning",
   "once::meltano.core._compat.MeltanoInternalDeprecationWarning",
+  "once:You are using a Python version .* which Google will stop supporting in new releases of google.api_core once it reaches its end of life:FutureWarning",
 ]
 log_cli = true
 log_cli_format = "%(message)s"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

DRY up nox session environment configuration with a helper and suppress Google API core FutureWarnings in test runs

Enhancements:
- Extract the duplicated environment setup in noxfile into a reusable _install_env helper and apply it across nox sessions

Tests:
- Add a pytest filter in pyproject.toml to ignore FutureWarning from google.api_core about Python EOL