### PR TITLE
fix: Auto-install plugin if existing virtualenv is broken

### DIFF
--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -437,14 +437,10 @@ class PluginInstallService:
             return False, message
 
         venv = VirtualEnv(
-            self.project.plugin_dir(plugin, "venv", make_dirs=False),  # type: ignore[deprecated]
+            self.project.dirs.plugin(plugin, "venv", make_dirs=False),
             python=plugin.python or self.project.settings.get("python"),
         )
-        message = "Requirements have not changed"
-        return (
-            venv.get_fingerprint(pip_install_args) != venv.read_fingerprint(),
-            message,
-        )
+        return venv.requires_install(pip_install_args), "Requirements have not changed"
 
     def plugin_installation_env(self, plugin: ProjectPlugin) -> dict[str, str]:
         """Environment variables to use during plugin installation.


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Detect and automatically reinstall broken virtual environments by introducing venv health checks and centralizing path resolution in the VirtualEnv class, and update services to leverage these new methods and modern project directory APIs.

New Features:
- Add VirtualEnv.requires_install to determine when a venv is stale or invalid based on missing executables or fingerprint mismatches.
- Add VirtualEnv.exec_path and python_path to resolve venv executables across platforms.

Bug Fixes:
- Ensure Windows executables are correctly resolved by checking for a .exe suffix in exec_path.

Enhancements:
- Delegate VenvService.requires_clean_install and exec_path to the new VirtualEnv methods.
- Simplify PluginInstallService installation checks to use VirtualEnv.requires_install.
- Replace deprecated project.venvs_dir, run_dir, and plugin_dir calls with the new project.dirs API.