### PR TITLE
fix(cli): `meltano el/elt` now also supports log parsing

### DIFF
--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -106,6 +106,14 @@ class LineWriter:
         """
         self.__out.writeline(line.rstrip())
 
+    def set_log_parser(self, *, log_parser: str | None) -> None:
+        """Set the log parser.
+
+        Args:
+            log_parser: The log parser to use.
+        """
+        self.__out.log_parser = log_parser
+
 
 class FileDescriptorWriter:
     """File Descriptor Writer."""

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -15,6 +15,7 @@ from meltano.core.utils import human_size
 
 if t.TYPE_CHECKING:
     from meltano.core.elt_context import ELTContext
+    from meltano.core.logging.output_logger import LineWriter
     from meltano.core.plugin_invoker import PluginInvoker
 
 
@@ -212,10 +213,10 @@ class SingerRunner(Runner):  # noqa: D101
 
     async def run(  # noqa: D102
         self,
-        extractor_log=None,  # noqa: ANN001
-        loader_log=None,  # noqa: ANN001
-        extractor_out=None,  # noqa: ANN001
-        loader_out=None,  # noqa: ANN001
+        extractor_log: LineWriter | None = None,
+        loader_log: LineWriter | None = None,
+        extractor_out: LineWriter | None = None,
+        loader_out: LineWriter | None = None,
     ) -> None:
         tap = self.context.extractor_invoker()
         target = self.context.loader_invoker()
@@ -228,6 +229,11 @@ class SingerRunner(Runner):  # noqa: D101
             tap.prepared(self.context.session),
             target.prepared(self.context.session),
         ):
+            if extractor_log:
+                extractor_log.set_log_parser(log_parser=tap.get_log_parser())
+            if loader_log:
+                loader_log.set_log_parser(log_parser=target.get_log_parser())
+
             await self.invoke(
                 tap,
                 target,


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enable log parsing support in meltano el/elt by extending output loggers to accept parsers and configuring the Singer runner to set the appropriate log parser on extractor and loader logs.

Enhancements:
- Add set_log_parser to OutputLogger to allow configuring a log parser
- Update Singer runner to apply plugin-provided log parsers to extractor and loader log writers