### PR TITLE
fix: Expand environment variables in mapping configuration

### DIFF
--- a/src/meltano/core/plugin/singer/mapper.py
+++ b/src/meltano/core/plugin/singer/mapper.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 import typing as t
 
+import anyio
 import structlog
 
 from meltano.core.behavior.hookable import hook
 from meltano.core.setting_definition import SettingDefinition, SettingKind
+from meltano.core.utils import expand_env_vars
 
 from . import PluginType, SingerPlugin
 
@@ -65,12 +67,16 @@ class SingerMapper(SingerPlugin):
         config_path = invoker.files["config"]
 
         config_payload: dict = {}
-        with config_path.open("w") as config_file:
+        expandable_env = {**invoker.project.dotenv_env, **invoker.project.settings.env}
+        async with await anyio.open_file(config_path, "w") as config_file:
             config_payload = {
                 **invoker.plugin_config_processed,
-                **self._get_mapping_config(invoker.plugin.extra_config),
+                **expand_env_vars(
+                    self._get_mapping_config(invoker.plugin.extra_config),
+                    expandable_env,
+                ),
             }
-            json.dump(config_payload, config_file, indent=2)
+            await config_file.write(json.dumps(config_payload, indent=2))
 
         logger.debug(
             "Created configuration",

--- a/tests/meltano/core/plugin/singer/test_mapper.py
+++ b/tests/meltano/core/plugin/singer/test_mapper.py
@@ -33,6 +33,7 @@ class TestSingerMapper:
                                 "field_id": "author_email",
                                 "tap_stream_name": "commits",
                                 "type": "MASK-HIDDEN",
+                                "foo": "$ENV_FOO",
                             },
                         ],
                     },
@@ -45,6 +46,7 @@ class TestSingerMapper:
                                 "field_id": "given_name",
                                 "tap_stream_name": "users",
                                 "type": "lowercase",
+                                "foo": "$ENV_FOO",
                             },
                         ],
                     },
@@ -80,9 +82,11 @@ class TestSingerMapper:
         subject: ProjectPlugin,
         session: Session,
         plugin_invoker_factory: Callable[[ProjectPlugin], PluginInvoker],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         invoker = plugin_invoker_factory(subject)
 
+        monkeypatch.setenv("ENV_FOO", "env_foo")
         async with invoker.prepared(session):
             config_path = invoker.files["config"]
 
@@ -95,6 +99,7 @@ class TestSingerMapper:
                         "field_id": "author_email",
                         "tap_stream_name": "commits",
                         "type": "MASK-HIDDEN",
+                        "foo": "env_foo",
                     },
                 ],
                 "parent_mapper_setting": "parent_mapper_setting_value",


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Related Issues

* Closes https://github.com/meltano/meltano/issues/7151
* https://github.com/MeltanoLabs/meltano-map-transform/pull/421

## Summary by Sourcery

Fix mapping configuration handling by reordering merge to apply processed values and migrating file writes to async for consistency

Bug Fixes:
- Process environment variables in mapping configuration

Enhancements:
- Switch to asynchronous file operations when writing the mapping config

## Summary by Sourcery

Fix Singer mapper to process environment variables in mapping configuration and switch to asynchronous file writes

Bug Fixes:
- Process environment variables in mapping configuration when merging plugin and mapping settings

Enhancements:
- Use asynchronous file operations for writing the mapping configuration file

Tests:
- Add test for environment variable expansion in mapping configuration