### PR TITLE
test: Validate that the order of rules in `metadata` is meaningful

### DIFF
--- a/docs/docs/guide/integration.md
+++ b/docs/docs/guide/integration.md
@@ -163,12 +163,6 @@ meltano config <plugin> set _metadata <stream> replication-method <LOG_BASED|INC
 # For example:
 meltano config tap-postgres set _metadata some_stream_id replication-method INCREMENTAL
 meltano config tap-postgres set _metadata other_stream replication-method FULL_TABLE
-
-# Set replication-method metadata for all streams
-meltano config tap-postgres set _metadata '*' replication-method INCREMENTAL
-
-# Set replication-method metadata for matching streams
-meltano config tap-postgres set _metadata '*_full' replication-method FULL_TABLE
 ```
 
 This will add the [metadata rules](/concepts/plugins#metadata-extra) to your [`meltano.yml` project file](/concepts/project#plugin-configuration):
@@ -177,16 +171,48 @@ This will add the [metadata rules](/concepts/plugins#metadata-extra) to your [`m
         extractors:
           - name: tap-postgres
             metadata:
+              # highlight-start
               some_stream_id:
                 replication-method: INCREMENTAL
                 replication-key: id
               other_stream:
                 replication-method: FULL_TABLE
+              # highlight-end
+```
+
+You can also set the `replication-method` metadata for all streams or matching streams at once using wildcards:
+
+```bash
+# Set replication-method metadata for all streams
+meltano config tap-postgres set _metadata '*' replication-method INCREMENTAL
+
+# Set replication-method metadata for matching streams
+meltano config tap-postgres set _metadata '*_full' replication-method FULL_TABLE
+```
+
+```yaml title="meltano.yml"
+        extractors:
+          - name: tap-postgres
+            metadata:
+              # highlight-start
               "*":
                 replication-method: INCREMENTAL
               "*_full":
                 replication-method: FULL_TABLE
+              # highlight-end
 ```
+
+:::info
+
+  <p><strong>Order Matters When Declaring Metadata Rules</strong></p>
+  <p>When using the `metadata` extractor extra, the order of the metadata rules matters. The last rule that matches a stream or property will be used.</p>
+
+  <br/>
+  <p>In the example above, if a stream matches both rules, the `replication-method` will be set to `FULL_TABLE`.</p>
+
+  <br/>
+  <p>This might change in the future, when metadata rules are applied in increasing order of specificity. See <a href="https://github.com/meltano/meltano/issues/9629">the GitHub issue tracking this</a> for more details.</p>
+:::
 
 ### Overriding schemas
 

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -121,7 +121,7 @@ class MetadataRule(_CatalogRuleProtocol):
     tap_stream_id: str | list[str]
     breadcrumb: list[str]
     key: str
-    value: bool
+    value: bool | str
     negated: bool = False
 
     @classmethod

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import typing as t
+from copy import deepcopy
 
 import pytest
 
@@ -1528,6 +1529,192 @@ class TestMetadataExecutor:
     @pytest.fixture
     def catalog(self, request):
         return json.loads(globals()[request.param])
+
+    @pytest.mark.parametrize(
+        "catalog",
+        ("CATALOG", "JSON_SCHEMA"),
+        indirect=["catalog"],
+    )
+    def test_metadata_rules_order_matters(self, catalog) -> None:
+        """Test that metadata rules are applied in order and last matching rule wins.
+
+        This test documents the current behavior where metadata rules are processed
+        sequentially and later rules override earlier ones when they match the same
+        stream/property. This is based on the example from:
+        https://docs.meltano.com/guide/integration/#setting-metadata
+
+        In this test we verify that:
+        1. A wildcard rule ("*") applies to all streams
+        2. A more specific pattern ("*_full") overrides the wildcard when it matches
+        3. The order of rules in the list determines the final value
+        """
+        # First test: wildcard rule followed by specific pattern
+        # This mimics the example from the documentation where:
+        # - "*": replication-method: INCREMENTAL (applies to all)
+        # - "*_full": replication-method: FULL_TABLE (overrides for matching streams)
+        executor_wildcard_first = MetadataExecutor(
+            [
+                # First rule: all streams get INCREMENTAL
+                MetadataRule(
+                    "*",
+                    [],
+                    "replication-method",
+                    value="INCREMENTAL",
+                ),
+                # Second rule: streams ending in _full get FULL_TABLE (overrides)
+                MetadataRule(
+                    "*Name",  # Matches UniqueEntitiesName
+                    [],
+                    "replication-method",
+                    value="FULL_TABLE",
+                ),
+            ],
+        )
+
+        catalog_copy = deepcopy(catalog)
+        visit(catalog_copy, executor_wildcard_first)
+
+        stream_node = next(
+            s
+            for s in catalog_copy["streams"]
+            if s["tap_stream_id"] == "UniqueEntitiesName"
+        )
+        stream_metadata_node = next(
+            m for m in stream_node["metadata"] if len(m["breadcrumb"]) == 0
+        )
+
+        # The second rule (*Name -> FULL_TABLE) should win
+        assert stream_metadata_node["metadata"]["replication-method"] == "FULL_TABLE"
+
+        # Second test: reverse the order - specific pattern followed by wildcard
+        # This shows that order matters: the wildcard will override the specific pattern
+        executor_wildcard_last = MetadataExecutor(
+            [
+                # First rule: streams ending in Name get FULL_TABLE
+                MetadataRule(
+                    "*Name",
+                    [],
+                    "replication-method",
+                    value="FULL_TABLE",
+                ),
+                # Second rule: all streams get INCREMENTAL (overrides)
+                MetadataRule(
+                    "*",
+                    [],
+                    "replication-method",
+                    value="INCREMENTAL",
+                ),
+            ],
+        )
+
+        catalog_copy2 = deepcopy(catalog)
+        visit(catalog_copy2, executor_wildcard_last)
+
+        stream_node2 = next(
+            s
+            for s in catalog_copy2["streams"]
+            if s["tap_stream_id"] == "UniqueEntitiesName"
+        )
+        stream_metadata_node2 = next(
+            m for m in stream_node2["metadata"] if len(m["breadcrumb"]) == 0
+        )
+
+        # The second rule (* -> INCREMENTAL) should win
+        assert stream_metadata_node2["metadata"]["replication-method"] == "INCREMENTAL"
+
+    @pytest.mark.parametrize(
+        "catalog",
+        ("CATALOG", "JSON_SCHEMA"),
+        indirect=["catalog"],
+    )
+    def test_metadata_rules_order_matters_property_level(self, catalog) -> None:
+        """Test that metadata rules order matters at the property level too.
+
+        This test verifies that when multiple metadata rules match the same property,
+        the last matching rule wins. This is important for cases where users want to
+        set a default for all properties and then override specific ones.
+        """
+        # Apply rules: first mark all as available, then mark *_at as automatic
+        executor_general_then_specific = MetadataExecutor(
+            [
+                # First: all properties of UniqueEntitiesName are available
+                MetadataRule(
+                    "UniqueEntitiesName",
+                    ["properties", "*"],
+                    "inclusion",
+                    value="available",
+                ),
+                # Second: *_at properties are automatic (should override)
+                MetadataRule(
+                    "UniqueEntitiesName",
+                    ["properties", "*_at"],
+                    "inclusion",
+                    value="automatic",
+                ),
+            ],
+        )
+
+        catalog_copy = deepcopy(catalog)
+        visit(catalog_copy, executor_general_then_specific)
+
+        stream_node = next(
+            s
+            for s in catalog_copy["streams"]
+            if s["tap_stream_id"] == "UniqueEntitiesName"
+        )
+
+        # created_at should be automatic (second rule wins)
+        created_at_metadata = next(
+            m
+            for m in stream_node["metadata"]
+            if m["breadcrumb"] == ["properties", "created_at"]
+        )
+        assert created_at_metadata["metadata"]["inclusion"] == "automatic"
+
+        # code should be available (only first rule matches)
+        code_metadata = next(
+            m
+            for m in stream_node["metadata"]
+            if m["breadcrumb"] == ["properties", "code"]
+        )
+        assert code_metadata["metadata"]["inclusion"] == "available"
+
+        # Now reverse the order: specific pattern first, then general wildcard
+        executor_specific_then_general = MetadataExecutor(
+            [
+                # First: *_at properties are automatic
+                MetadataRule(
+                    "UniqueEntitiesName",
+                    ["properties", "*_at"],
+                    "inclusion",
+                    value="automatic",
+                ),
+                # Second: all properties are available (should override everything)
+                MetadataRule(
+                    "UniqueEntitiesName",
+                    ["properties", "*"],
+                    "inclusion",
+                    value="available",
+                ),
+            ],
+        )
+
+        catalog_copy2 = deepcopy(catalog)
+        visit(catalog_copy2, executor_specific_then_general)
+
+        stream_node2 = next(
+            s
+            for s in catalog_copy2["streams"]
+            if s["tap_stream_id"] == "UniqueEntitiesName"
+        )
+
+        # created_at should now be available (second rule overrides)
+        created_at_metadata2 = next(
+            m
+            for m in stream_node2["metadata"]
+            if m["breadcrumb"] == ["properties", "created_at"]
+        )
+        assert created_at_metadata2["metadata"]["inclusion"] == "available"
 
     @pytest.mark.parametrize(
         "catalog",


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Validate that metadata rules are applied in sequence with the last matching rule taking precedence, and update documentation to highlight this behavior

Enhancements:
- Extend MetadataRule.value type to accept both boolean and string values

Documentation:
- Update integration guide with examples and an info note emphasizing that metadata rule order matters

Tests:
- Add tests for MetadataExecutor to confirm that the last matching metadata rule wins at both stream and property levels