### PR TITLE
docs: Fix command syntax in troubleshooting docs

### DIFF
--- a/docs/docs/guide/troubleshooting.md
+++ b/docs/docs/guide/troubleshooting.md
@@ -206,7 +206,7 @@ meltano config <EXTRACTOR_NAME> list
 Alternatively, you can use:
 
 ```bash
-meltano invoke <EXTRACTOR_NAME> --dump=config
+meltano invoke --dump=config <EXTRACTOR_NAME>
 ```
 
 #### Dumping Loader Configuration
@@ -222,7 +222,7 @@ meltano config <LOADER_NAME> list
 Instead of `meltano run ... --dump=catalog`, use:
 
 ```bash
-meltano invoke <EXTRACTOR_NAME> --dump=catalog
+meltano invoke --dump=catalog <EXTRACTOR_NAME>
 ```
 
 ### Meltano UI


### PR DESCRIPTION
Correct the order of arguments for 'meltano invoke --dump' commands. The correct syntax is 'meltano invoke --dump=<type> <EXTRACTOR_NAME>' not 'meltano invoke <EXTRACTOR_NAME> --dump=<type>'.

This fixes both --dump=config and --dump=catalog examples to match the correct syntax used in other documentation files and what actually works in meltano 3.6.0

## Summary by Sourcery

Documentation:
- Correct syntax examples for --dump=config and --dump=catalog in troubleshooting documentation to use the proper flag-first format