### PR TITLE
refactor: Remove dependency one `click-didyoumean`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
   "check-jsonschema>=0.33,<0.36",
   "click>=8.1,<8.4,!=8.2.2",
   "click-default-group>=1.2.4,<2",
-  "click-didyoumean>=0.3.1,<0.4",
   "dateparser>=1.2.1",
   "fasteners>=0.19,<0.21",
   "importlib-metadata>=5 ; python_version < '3.12'",

--- a/src/meltano/cli/_didyoumean.py
+++ b/src/meltano/cli/_didyoumean.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import difflib
+import sys
+
+import click
+import click.exceptions
+import click.utils
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
+
+class DYMGroup(click.Group):
+    """Provides *Did you mean ...* suggestions when a command is not found."""
+
+    CUTOFF = 0.5
+    MAX_SUGGESTIONS = 3
+
+    @override
+    def resolve_command(
+        self,
+        ctx: click.Context,
+        args: list[str],
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        """Resolve a command from a list of commands.
+
+        Appends *Did you mean ...* suggestions to the raised exception message.
+        """
+        try:
+            return super().resolve_command(ctx, args)
+        except click.exceptions.UsageError as error:
+            error_msg = str(error)
+
+            if matches := difflib.get_close_matches(
+                click.utils.make_str(args[0]),
+                self.list_commands(ctx),
+                n=self.MAX_SUGGESTIONS,
+                cutoff=self.CUTOFF,
+            ):
+                fmt_matches = "\n    ".join(matches)
+                error_msg += f"\n\nDid you mean one of these?\n    {fmt_matches}"
+
+            raise click.exceptions.UsageError(error_msg, error.ctx) from None

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -12,8 +12,8 @@ from enum import Enum, auto
 import click
 import structlog
 from click_default_group import DefaultGroup
-from click_didyoumean import DYMGroup
 
+from meltano.cli._didyoumean import DYMGroup
 from meltano.core.error import MeltanoConfigurationError
 from meltano.core.logging import setup_logging
 from meltano.core.plugin.base import PluginDefinition, PluginType

--- a/tests/meltano/cli/test_didyoumean.py
+++ b/tests/meltano/cli/test_didyoumean.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+import click
+from click.testing import CliRunner
+
+from meltano.cli._didyoumean import DYMGroup
+
+
+class TestDYMGroup:
+    def test_basic_functionality_with_group(self):
+        @click.group(cls=DYMGroup)
+        def cli(): ...
+
+        @cli.command()
+        def foo(): ...
+
+        @cli.command()
+        def bar(): ...
+
+        @cli.command()
+        def barrr(): ...
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["barr"])
+        assert result.output == dedent(
+            """\
+            Usage: cli [OPTIONS] COMMAND [ARGS]...
+            Try 'cli --help' for help.
+
+            Error: No such command 'barr'.
+
+            Did you mean one of these?
+                barrr
+                bar
+            """
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -584,18 +584,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click-didyoumean"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz", hash = "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463", size = 3089, upload-time = "2024-03-24T08:22:07.499Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl", hash = "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c", size = 3631, upload-time = "2024-03-24T08:22:06.356Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1374,7 +1362,6 @@ dependencies = [
     { name = "check-jsonschema" },
     { name = "click" },
     { name = "click-default-group" },
-    { name = "click-didyoumean" },
     { name = "dateparser" },
     { name = "fasteners" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
@@ -1517,7 +1504,6 @@ requires-dist = [
     { name = "check-jsonschema", specifier = ">=0.33,<0.36" },
     { name = "click", specifier = ">=8.1,!=8.2.2,<8.4" },
     { name = "click-default-group", specifier = ">=1.2.4,<2" },
-    { name = "click-didyoumean", specifier = ">=0.3.1,<0.4" },
     { name = "dateparser", specifier = ">=1.2.1" },
     { name = "fasteners", specifier = ">=0.19,<0.21" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=1.31.0" },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Replace the third-party click-didyoumean dependency with an internal implementation of Click command suggestion behavior.

New Features:
- Introduce an internal DYMGroup Click command group that suggests similar commands when an unknown command is invoked.

Enhancements:
- Add a custom error message enhancement that lists close command name matches when a CLI command is not found.

Build:
- Remove click-didyoumean from runtime dependencies in pyproject.toml.

Tests:
- Add unit tests covering the new DYMGroup suggestion behavior for mistyped CLI commands.