### PR TITLE
fix: Parse plugin logs coming out during `meltano invoke`

### DIFF
--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -198,8 +198,8 @@ class PluginInvoker:
 
         self.plugin_config_service = plugin_config_service or PluginConfigService(
             plugin,
-            config_dir or self.project.plugin_dir(plugin),  # type: ignore[deprecated]
-            run_dir or self.project.run_dir(plugin.name),  # type: ignore[deprecated]
+            config_dir or self.project.dirs.plugin(plugin),  # type: ignore[deprecated]
+            run_dir or self.project.dirs.run(plugin.name),  # type: ignore[deprecated]
         )
 
         self.settings_service = plugin_settings_service or PluginSettingsService(
@@ -427,7 +427,7 @@ class PluginInvoker:
         if self.venv_service:
             # Switch to plugin-specific venv
             venv = VirtualEnv(
-                self.project.venvs_dir(  # type: ignore[deprecated]
+                self.project.dirs.venvs(  # type: ignore[deprecated]
                     self.plugin.type,
                     self.plugin.name,
                     make_dirs=False,

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -198,8 +198,8 @@ class PluginInvoker:
 
         self.plugin_config_service = plugin_config_service or PluginConfigService(
             plugin,
-            config_dir or self.project.dirs.plugin(plugin),  # type: ignore[deprecated]
-            run_dir or self.project.dirs.run(plugin.name),  # type: ignore[deprecated]
+            config_dir or self.project.dirs.plugin(plugin),
+            run_dir or self.project.dirs.run(plugin.name),
         )
 
         self.settings_service = plugin_settings_service or PluginSettingsService(
@@ -427,7 +427,7 @@ class PluginInvoker:
         if self.venv_service:
             # Switch to plugin-specific venv
             venv = VirtualEnv(
-                self.project.dirs.venvs(  # type: ignore[deprecated]
+                self.project.dirs.venvs(
                     self.plugin.type,
                     self.plugin.name,
                     make_dirs=False,

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -395,9 +395,23 @@ class TestLogOutputHandler:
             handler.writeline(warning_log)
 
         # Check that both error and warning were logged
-        messages = [record.message for record in caplog.records]
-        assert any("Error occurred" in msg for msg in messages)
-        assert any("Warning message" in msg for msg in messages)
+        error_record = next(
+            (record for record in caplog.records if "Error occurred" in record.message),
+            None,
+        )
+        assert error_record is not None
+        assert error_record.levelname == "ERROR"
+
+        warning_record = next(
+            (
+                record
+                for record in caplog.records
+                if "Warning message" in record.message
+            ),
+            None,
+        )
+        assert warning_record is not None
+        assert warning_record.levelname == "WARNING"
 
     def test_writeline_preserves_extra_fields(self, caplog: pytest.LogCaptureFixture):
         """Test that extra fields from parsed logs are preserved."""

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -281,10 +281,18 @@ class TestLogOutputHandler:
         logger = structlog.stdlib.get_logger("test")
         handler = _LogOutputHandler(logger, log_parser="singer-sdk")
 
-        singer_log = (
-            '{"level":"info","pid":123,"logger_name":"tap-test","ts":1234567890.0,'
-            '"thread_name":"MainThread","app_name":"singer-sdk","stream_name":null,'
-            '"message":"Test message","extra":{"custom":"value"}}'
+        singer_log = json.dumps(
+            {
+                "level": "info",
+                "pid": 123,
+                "logger_name": "tap-test",
+                "ts": 1234567890.0,
+                "thread_name": "MainThread",
+                "app_name": "singer-sdk",
+                "stream_name": None,
+                "message": "Test message",
+                "extra": {"custom": "value"},
+            },
         )
 
         with caplog.at_level(logging.INFO):
@@ -339,15 +347,31 @@ class TestLogOutputHandler:
         logger = structlog.stdlib.get_logger("test")
         handler = _LogOutputHandler(logger, log_parser="singer-sdk")
 
-        error_log = (
-            '{"level":"error","pid":123,"logger_name":"tap-test","ts":1234567890.0,'
-            '"thread_name":"MainThread","app_name":"singer-sdk","stream_name":null,'
-            '"message":"Error occurred","extra":{}}'
+        error_log = json.dumps(
+            {
+                "level": "error",
+                "pid": 123,
+                "logger_name": "tap-test",
+                "ts": 1234567890.0,
+                "thread_name": "MainThread",
+                "app_name": "singer-sdk",
+                "stream_name": None,
+                "message": "Error occurred",
+                "extra": {},
+            },
         )
-        warning_log = (
-            '{"level":"warning","pid":123,"logger_name":"tap-test","ts":1234567890.0,'
-            '"thread_name":"MainThread","app_name":"singer-sdk","stream_name":null,'
-            '"message":"Warning message","extra":{}}'
+        warning_log = json.dumps(
+            {
+                "level": "warning",
+                "pid": 123,
+                "logger_name": "tap-test",
+                "ts": 1234567890.0,
+                "thread_name": "MainThread",
+                "app_name": "singer-sdk",
+                "stream_name": None,
+                "message": "Warning message",
+                "extra": {},
+            },
         )
 
         with caplog.at_level(logging.WARNING):
@@ -364,10 +388,18 @@ class TestLogOutputHandler:
         logger = structlog.stdlib.get_logger("test")
         handler = _LogOutputHandler(logger, log_parser="singer-sdk")
 
-        log_with_extras = (
-            '{"level":"info","pid":123,"logger_name":"tap-test","ts":1234567890.0,'
-            '"thread_name":"MainThread","app_name":"singer-sdk","stream_name":"users",'
-            '"message":"Processing stream","extra":{"record_count":100}}'
+        log_with_extras = json.dumps(
+            {
+                "level": "info",
+                "pid": 123,
+                "logger_name": "tap-test",
+                "ts": 1234567890.0,
+                "thread_name": "MainThread",
+                "app_name": "singer-sdk",
+                "stream_name": "users",
+                "message": "Processing stream",
+                "extra": {"record_count": 100},
+            },
         )
 
         with caplog.at_level(logging.INFO):

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -406,4 +406,14 @@ class TestLogOutputHandler:
             handler.writeline(log_with_extras)
 
         # Verify the message was logged
-        assert any("Processing stream" in record.message for record in caplog.records)
+        record = next(
+            (
+                record
+                for record in caplog.records
+                if "Processing stream" in record.message
+            ),
+            None,
+        )
+        assert record is not None
+        assert "Processing stream" in record.message
+        assert record.__dict__["msg"]["record_count"] == 100

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -416,4 +416,4 @@ class TestLogOutputHandler:
         )
         assert record is not None
         assert "Processing stream" in record.message
-        assert record.__dict__["msg"]["record_count"] == 100
+        assert "record_count" in str(record.msg)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Improve `meltano invoke` plugin log handling by parsing structured stderr output and aligning plugin directory resolution with the new project directory API.

Enhancements:
- Add a log output handler to parse plugin stderr using configured log parsers during `meltano invoke`, falling back gracefully to plain logging when parsing fails.
- Capture plugin stderr asynchronously in `meltano invoke` and route it through structured logging with proper log levels and extra fields preserved.
- Update plugin configuration, run, and virtualenv directory resolution to use the newer `project.dirs` helpers instead of deprecated path accessors.

Tests:
- Add unit tests for the log output handler covering structured Singer SDK logs, plain text logs, empty lines, multiple severity levels, and preservation of extra fields.