### PR TITLE
feat(core): Auto-select a supported Python version if the plugin is not compatible with Meltano's own Python version

### DIFF
--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -112,6 +112,9 @@ def print_added_plugin(
     if docs_url := plugin.docs:
         click.echo(f"Documentation:\t{docs_url}")
 
+    if plugin.python:
+        click.echo(f"Python Version:\t{plugin.python}")
+
 
 def _prompt_plugin_namespace(plugin_type, plugin_name):  # noqa: ANN001, ANN202
     click.secho(

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -262,6 +262,7 @@ class Variant(NameEq, Canonical):
 
     name: str | None
     deprecated: bool | None
+    supported_python_versions: list[str] | None
 
     ORIGINAL_NAME = "original"
     DEFAULT_NAME = "default"
@@ -286,6 +287,7 @@ class Variant(NameEq, Canonical):
         requires: dict[PluginType, list] | None = None,
         requires_meltano: str | None = None,
         env: dict[str, str] | None = None,
+        supported_python_versions: list[str] | None = None,
         **extras,  # noqa: ANN003
     ):
         """Create a new Variant.
@@ -310,6 +312,8 @@ class Variant(NameEq, Canonical):
             requires_meltano: A version specifier for the Meltano version required by
                 this plugin.
             env: Environment variables to inject into plugins runtime context.
+            supported_python_versions: List of supported Python versions (e.g.,
+                ['3.10', '3.11', '3.12']).
             extras: Additional keyword arguments.
         """
         super().__init__(
@@ -330,6 +334,7 @@ class Variant(NameEq, Canonical):
             requires=PluginRequirement.parse_all(requires),
             requires_meltano=requires_meltano,
             env=env or {},
+            supported_python_versions=supported_python_versions,
             extras=extras,
         )
 
@@ -517,6 +522,7 @@ class PluginDefinition(PluginRef):
             commands=plugin.commands,
             requires=plugin.requires,
             requires_meltano=plugin.requires_meltano,
+            supported_python_versions=plugin.supported_python_versions,
             env=plugin.env,
             **plugin.extras,
             **extras,
@@ -816,6 +822,7 @@ class StandalonePlugin(Canonical):
         requires: dict[PluginType, list] | None = None,
         requires_meltano: str | None = None,
         env: dict[str, str] | None = None,
+        supported_python_versions: list[str] | None = None,
         **extras,  # noqa: ANN003
     ):
         """Create a locked plugin.
@@ -842,6 +849,8 @@ class StandalonePlugin(Canonical):
             requires_meltano: A version specifier for the Meltano version required by
                 this plugin.
             env: Environment variables to inject into plugins runtime context.
+            supported_python_versions: List of supported Python versions (e.g.,
+                ['3.10', '3.11', '3.12']).
             extras: Additional attributes to set on the plugin.
         """
         super().__init__(
@@ -864,6 +873,7 @@ class StandalonePlugin(Canonical):
             requires=PluginRequirement.parse_all(requires),
             requires_meltano=requires_meltano,
             env=env or {},
+            supported_python_versions=supported_python_versions,
             extras=extras,
         )
 
@@ -930,6 +940,7 @@ class StandalonePlugin(Canonical):
             commands=variant.commands,
             requires=variant.requires,
             requires_meltano=variant.requires_meltano,
+            supported_python_versions=variant.supported_python_versions,
             env=variant.env,
             **{**plugin_def.extras, **variant.extras},
         )

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -67,7 +67,7 @@ class FilePlugin(BasePlugin):
         # This ignores plugin inheritance, but that's fine because the file contents
         # are bundled with the package, so they should be the same for all plugins that
         # share a pip_url.
-        venv = VirtualEnv(project.plugin_dir(self, "venv"))  # type: ignore[arg-type,deprecated]
+        venv = VirtualEnv(project.dirs.plugin(self, "venv"))  # type: ignore[arg-type]
         bundle_dir = venv.site_packages_dir / "bundle"
 
         return {
@@ -149,7 +149,7 @@ class FilePlugin(BasePlugin):
         Returns:
             True if the file was written, False otherwise.
         """
-        project_path = project.root_dir(relative_path)  # type: ignore[deprecated]
+        project_path = project.dirs.root_dir(relative_path)
         if project_path.exists() and project_path.read_text() == content:
             return False
 
@@ -194,7 +194,7 @@ class FilePlugin(BasePlugin):
         """
 
         def rename_if_exists(relative_path: Path) -> Path:
-            if not project.root_dir(relative_path).exists():  # type: ignore[deprecated]
+            if not project.dirs.root_dir(relative_path).exists():
                 return relative_path
 
             logger.info(

--- a/src/meltano/core/project_add_service.py
+++ b/src/meltano/core/project_add_service.py
@@ -6,9 +6,12 @@ import enum
 import sys
 import typing as t
 
+import structlog
+
 from meltano.core.plugin import BasePlugin, Variant
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
+from meltano.core.utils.python_compatibility import determine_plugin_python_version
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -19,6 +22,8 @@ if t.TYPE_CHECKING:
     from meltano.core.plugin import PluginType
     from meltano.core.project import Project
     from meltano.core.project_plugins_service import AddedPluginFlags
+
+logger = structlog.stdlib.get_logger(__name__)
 
 
 class PluginAddedReason(StrEnum):
@@ -82,6 +87,19 @@ class ProjectAddService:
         if isinstance(parent, BasePlugin):
             plugin.variant = parent.variant
             plugin.pip_url = parent.pip_url
+
+            # Auto-configure Python version if current version is not supported
+            # Only auto-set if user didn't explicitly provide --python flag
+            if (attrs.get("python") is None) and (
+                python_version := determine_plugin_python_version(parent._variant)
+            ):
+                plugin.python = python_version
+                logger.warning(
+                    "The current Python version is not supported by this plugin. "
+                    "Automatically configured to use %s instead.",
+                    python_version,
+                    name=plugin.name,
+                )
 
         plugin, flags = self.project.plugins.add_to_file_with_flags(
             plugin,

--- a/src/meltano/core/project_add_service.py
+++ b/src/meltano/core/project_add_service.py
@@ -90,8 +90,10 @@ class ProjectAddService:
 
             # Auto-configure Python version if current version is not supported
             # Only auto-set if user didn't explicitly provide --python flag
-            if (attrs.get("python") is None) and (
-                python_version := determine_plugin_python_version(parent._variant)
+            if (
+                (attrs.get("python") is None)
+                and parent._variant is not None
+                and (python_version := determine_plugin_python_version(parent._variant))
             ):
                 plugin.python = python_version
                 logger.warning(

--- a/src/meltano/core/project_add_service.py
+++ b/src/meltano/core/project_add_service.py
@@ -91,8 +91,7 @@ class ProjectAddService:
             # Auto-configure Python version if current version is not supported
             # Only auto-set if user didn't explicitly provide --python flag
             if (
-                (attrs.get("python") is None)
-                and parent._variant is not None
+                (attrs.get("python") is None)  # User didn't explicitly provide --python
                 and (python_version := determine_plugin_python_version(parent._variant))
             ):
                 plugin.python = python_version

--- a/src/meltano/core/utils/python_compatibility.py
+++ b/src/meltano/core/utils/python_compatibility.py
@@ -1,0 +1,74 @@
+"""Python version compatibility utilities."""
+
+from __future__ import annotations
+
+import sys
+import typing as t
+
+if t.TYPE_CHECKING:
+    from meltano.core.plugin.base import Variant
+
+
+def get_current_python_version() -> str:
+    """Get the current Python version as a string (e.g., '3.11').
+
+    Returns:
+        Python version in format 'major.minor'
+    """
+    return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+def is_python_version_supported(
+    supported_versions: list[str] | None,
+    current_version: str | None = None,
+) -> bool:
+    """Check if current Python version is in the supported list.
+
+    Args:
+        supported_versions: List of supported Python versions (e.g., ['3.10', '3.11'])
+        current_version: Python version to check (defaults to current runtime)
+
+    Returns:
+        True if current version is supported or no restrictions exist, False otherwise
+    """
+    if not supported_versions:
+        # No restrictions means all versions supported
+        return True
+
+    version = current_version or get_current_python_version()
+    return version in supported_versions
+
+
+def _parse_python_version(version: str) -> tuple[int, int]:
+    major, minor = version.split(".", maxsplit=1)
+    return int(major), int(minor)
+
+
+def determine_plugin_python_version(
+    variant: Variant,
+    *,
+    current_version: str | None = None,
+) -> str | None:
+    """Determine the Python version to use for a plugin.
+
+    Args:
+        variant: The plugin variant
+        current_version: Current Python version (defaults to runtime version)
+
+    Returns:
+        Version string like 'python3.11' or None
+    """
+    supported_versions = variant.supported_python_versions
+
+    if not supported_versions:
+        # No restrictions
+        return None
+
+    current = current_version or get_current_python_version()
+
+    if is_python_version_supported(supported_versions, current):
+        # Current version is supported
+        return None
+
+    # Auto-select highest supported version
+    return f"python{max(supported_versions, key=lambda x: _parse_python_version(x))}"

--- a/tests/meltano/core/plugin/test_plugin_compatibility.py
+++ b/tests/meltano/core/plugin/test_plugin_compatibility.py
@@ -165,6 +165,36 @@ class TestPluginCompatibility:
         # The requires_meltano should be in the first variant
         assert plugin_def.variants[0].requires_meltano == ">=3.5.0"
 
+    def test_standalone_from_variant_preserves_supported_python_versions(self):
+        """Test that StandalonePlugin.from_variant preserves supported_python_versions."""  # noqa: E501
+        variant = Variant(
+            name="test-variant",
+            supported_python_versions=["3.11", "3.12"],
+        )
+        plugin_def = PluginDefinition(
+            PluginType.EXTRACTORS,
+            "tap-test",
+            "tap_test",
+        )
+        standalone = StandalonePlugin.from_variant(variant, plugin_def)
+        assert standalone.supported_python_versions == ["3.11", "3.12"]
+
+    def test_definition_from_standalone_preserves_supported_python_versions(self):
+        """Test that PluginDefinition.from_standalone preserves supported_python_versions."""  # noqa: E501
+        standalone = StandalonePlugin(
+            plugin_type="extractors",
+            name="tap-test",
+            namespace="tap_test",
+            supported_python_versions=["3.10", "3.11", "3.12"],
+        )
+        plugin_def = PluginDefinition.from_standalone(standalone)
+        # The supported_python_versions should be in the first variant
+        assert plugin_def.variants[0].supported_python_versions == [
+            "3.10",
+            "3.11",
+            "3.12",
+        ]
+
     def test_lockfile_serialization_includes_requires_meltano(self, project):
         """Test that plugin lockfiles include requires_meltano field."""
         # Create a plugin with requires_meltano
@@ -285,6 +315,7 @@ class TestPluginCompatibility:
         )
 
         canonical_data = plugin.canonical()
+        assert isinstance(canonical_data, dict)
         assert canonical_data["requires_meltano"] == ">=1.0.0"
 
     def test_json_schema_validates_plugin_requires_meltano(self):

--- a/tests/meltano/core/utils/test_python_compatibility.py
+++ b/tests/meltano/core/utils/test_python_compatibility.py
@@ -1,0 +1,141 @@
+"""Tests for Python version compatibility utilities."""
+
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from meltano.core.utils.python_compatibility import (
+    determine_plugin_python_version,
+    get_current_python_version,
+    is_python_version_supported,
+)
+
+
+class TestPythonCompatibility:
+    """Test Python compatibility utility functions."""
+
+    def test_get_current_python_version(self):
+        """Test that current version is in correct format."""
+        version = get_current_python_version()
+        assert version.count(".") == 1
+        parts = version.split(".")
+        assert len(parts) == 2
+        assert all(part.isdigit() for part in parts)
+
+    def test_is_python_version_supported_no_restrictions(self):
+        """Test that None/empty list means all versions supported."""
+        assert is_python_version_supported(None, "3.11") is True
+        assert is_python_version_supported([], "3.11") is True
+
+    def test_is_python_version_supported_matches(self):
+        """Test version matching."""
+        assert is_python_version_supported(["3.10", "3.11"], "3.11") is True
+        assert is_python_version_supported(["3.10", "3.11"], "3.12") is False
+
+    def test_is_python_version_supported_default_current(self):
+        """Test default current version detection."""
+        current = get_current_python_version()
+        assert is_python_version_supported([current]) is True
+
+    @pytest.fixture
+    def mock_variant_supported(self):
+        """Mock variant with supported versions."""
+
+        class MockVariant:
+            supported_python_versions: t.ClassVar = ["3.10", "3.11", "3.12"]
+
+        return MockVariant()
+
+    @pytest.fixture
+    def mock_variant_no_restrictions(self):
+        """Mock variant without restrictions."""
+
+        class MockVariant:
+            supported_python_versions = None
+
+        return MockVariant()
+
+    @pytest.fixture
+    def mock_variant_empty_list(self):
+        """Mock variant with empty supported versions list."""
+
+        class MockVariant:
+            supported_python_versions: t.ClassVar = []
+
+        return MockVariant()
+
+    def test_determine_plugin_python_version_supported(
+        self,
+        mock_variant_supported,
+    ):
+        """Test when current version is supported."""
+        version = determine_plugin_python_version(
+            mock_variant_supported,
+            current_version="3.11",
+        )
+        assert version is None
+
+    def test_determine_plugin_python_version_not_supported(
+        self,
+        mock_variant_supported,
+    ):
+        """Test when current version is not supported."""
+        version = determine_plugin_python_version(
+            mock_variant_supported,
+            current_version="3.9",
+        )
+        assert version == "python3.12"
+
+    def test_determine_plugin_python_version_future_version(
+        self,
+        mock_variant_supported,
+    ):
+        """Test when current version is newer than supported."""
+        version = determine_plugin_python_version(
+            mock_variant_supported,
+            current_version="3.13",
+        )
+        assert version == "python3.12"
+
+    def test_determine_plugin_python_version_no_restrictions(
+        self,
+        mock_variant_no_restrictions,
+    ):
+        """Test when no restrictions exist."""
+        version = determine_plugin_python_version(
+            mock_variant_no_restrictions,
+            current_version="3.8",
+        )
+        assert version is None
+
+    def test_determine_plugin_python_version_empty_list(
+        self,
+        mock_variant_empty_list,
+    ):
+        """Test when supported versions is empty list."""
+        version = determine_plugin_python_version(
+            mock_variant_empty_list,
+            current_version="3.11",
+        )
+        assert version is None
+
+    def test_determine_plugin_python_version_default_current(
+        self,
+        mock_variant_supported,
+    ):
+        """Test that default current version is used when not specified."""
+        current = get_current_python_version()
+        # If running on supported version, should not auto-select
+        if current in mock_variant_supported.supported_python_versions:
+            version = determine_plugin_python_version(
+                mock_variant_supported,
+            )
+            assert version is None
+        else:
+            # If running on unsupported version, should auto-select
+            version = determine_plugin_python_version(
+                mock_variant_supported,
+            )
+            assert version == "python3.12"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

### Usage example

```shell
# Run Meltano under Python 3.14 and add a plugin that supports 3.8-3.11
uv run meltano init my_project
cd my_project
uv run -p 3.14 meltano add tap-theme-parks --from-ref https://raw.githubusercontent.com/meltano/hub/42674a768cf7ab9f50cc6289c0bc4175c54d0506/_data/meltano/extractors/tap-theme-parks/danielpdwalker.yml
meltano invoke tap-theme-parks --help
```

## Related Issues

* https://github.com/meltano/hub/pull/2174

## Summary by Sourcery

Add Python version compatibility handling for plugins and surface auto-selected versions in the CLI when the current Python is unsupported.

New Features:
- Automatically determine and configure a compatible Python interpreter for plugins when the current runtime version is not supported.
- Allow plugin variants to declare supported Python versions and use this metadata when adding plugins.

Enhancements:
- Show a CLI note when a plugin is configured to use an auto-selected Python version instead of the current interpreter.

Tests:
- Add unit tests for Python compatibility helper functions and for plugin addition flows covering auto-selection, explicit overrides, and no-restriction scenarios.

## Summary by Sourcery

Auto-select a supported Python interpreter for newly added plugins when their variants restrict the current runtime version, persisting the chosen version and surfacing it in CLI output.

New Features:
- Allow plugin variants to carry supported Python version metadata and use it to auto-configure the plugin’s interpreter during addition.

Enhancements:
- Log and display the auto-selected interpreter when the current Python version is unsupported.

Tests:
- Add CLI add-flow tests covering auto-selection, explicit overrides, supported-current-version, and unrestricted scenarios.
- Add python_compatibility utility tests to validate version detection, support checks, and selection logic.
- Ensure PluginDefinition/Standalone conversions preserve supported_python_versions metadata.