### PR TITLE
feat: Remove stale tables used by long-removed UI/API

### DIFF
--- a/src/meltano/migrations/db.lock
+++ b/src/meltano/migrations/db.lock
@@ -1,1 +1,1 @@
-6828cc5b1a4f
+c0efb3c314eb

--- a/src/meltano/migrations/versions/c0efb3c314eb_drop_ui_api_tables.py
+++ b/src/meltano/migrations/versions/c0efb3c314eb_drop_ui_api_tables.py
@@ -1,0 +1,41 @@
+"""Drop UI/API tables that are no longer used.
+
+These tables (user, role, roles_users, role_permissions, oauth, embed_tokens,
+subscriptions) were only used by the Meltano UI/API which has been removed.
+
+Revision ID: c0efb3c314eb
+Revises: 6828cc5b1a4f
+Create Date: 2025-12-15 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c0efb3c314eb"
+down_revision = "6828cc5b1a4f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Drop redundant UI/API tables if they exist."""
+    # Drop tables in correct order (respecting foreign key constraints)
+    # Drop child tables first, then parent tables
+    op.drop_table("roles_users", if_exists=True)
+    op.drop_table("role_permissions", if_exists=True)
+    op.drop_table("oauth", if_exists=True)
+    op.drop_table("embed_tokens", if_exists=True)
+    op.drop_table("subscriptions", if_exists=True)
+    op.drop_table("role", if_exists=True)
+    op.drop_index("ix_user_username", table_name="user", if_exists=True)
+    op.drop_table("user", if_exists=True)
+
+
+def downgrade() -> None:
+    """No-op.
+
+    We're not interested in recreating these tables.
+    """


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* #6529
* #9685

## Summary by Sourcery

Enhancements:
- Add an Alembic migration that drops legacy UI/API-related tables and indexes that are no longer in use.

## Summary by Sourcery

Enhancements:
- Add an Alembic migration that conditionally drops obsolete UI/API-related tables and associated index no longer used by the application.