### PR TITLE
refactor: Use the `Project.dirs` API in more places

### DIFF
--- a/src/meltano/core/meltano_invoker.py
+++ b/src/meltano/core/meltano_invoker.py
@@ -59,7 +59,7 @@ class MeltanoInvoker:
     def _executable_path(self, command):  # noqa: ANN001, ANN202
         if command == MELTANO_COMMAND:
             # This symlink is created by Project.activate
-            executable_symlink = self.project.run_dir().joinpath("bin")  # type: ignore[deprecated]
+            executable_symlink = self.project.dirs.run().joinpath("bin")
             if executable_symlink.exists():
                 return str(executable_symlink)
 

--- a/src/meltano/core/plugin/meltano_file.py
+++ b/src/meltano/core/plugin/meltano_file.py
@@ -90,7 +90,7 @@ class MeltanoFilePlugin(FilePlugin):  # noqa: D101
         Returns:
             True if the file was written, False otherwise.
         """
-        project_path = project.root_dir(relative_path)
+        project_path = project.dirs.root_dir(relative_path)
         if project_path.exists() and not any(
             project_path.match(path) for path in self.overwrite
         ):

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -62,7 +62,7 @@ class PluginLockService:
         variant_name: str | None = None,
     ) -> Path:
         """Get the path to the plugin lockfile from a type, name, and variant."""
-        return self.project.plugin_lock_path(  # type: ignore[deprecated]
+        return self.project.dirs.plugin_lock_path(
             plugin_type,
             plugin_name,
             variant_name=variant_name,

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -186,7 +186,7 @@ class Project:
 
     @cached_property
     def _meltano_interprocess_lock(self) -> fasteners.InterProcessLock:
-        return fasteners.InterProcessLock(self.run_dir("meltano.yml.lock"))
+        return fasteners.InterProcessLock(self.dirs.run().joinpath("meltano.yml.lock"))
 
     @property
     def user_agent(self) -> str:
@@ -235,7 +235,7 @@ class Project:
                 # Admin privileges are required to create symlinks on Windows
                 if ctypes.windll.shell32.IsUserAnAdmin():  # type: ignore[attr-defined]
                     if executable.is_file():
-                        project.run_dir().joinpath("bin").symlink_to(executable)  # type: ignore[deprecated]
+                        project.dirs.run().joinpath("bin").symlink_to(executable)
                     else:
                         logger.warning(
                             "Could not create symlink: meltano.exe not "  # noqa: G004
@@ -249,7 +249,7 @@ class Project:
             else:
                 executable = Path(sys.executable).parent / "meltano"
                 if executable.is_file():
-                    project.run_dir().joinpath("bin").symlink_to(executable)  # type: ignore[deprecated]
+                    project.dirs.run().joinpath("bin").symlink_to(executable)
         except FileExistsError:
             pass
         except OSError as error:

--- a/src/meltano/core/project_init_service.py
+++ b/src/meltano/core/project_init_service.py
@@ -101,7 +101,7 @@ class ProjectInitService:
         """
         # explicitly create the .meltano directory if it doesn't exist
         click.secho("Creating .meltano folder", fg="blue")
-        project.meltano_dir().mkdir(parents=True, exist_ok=True)  # type: ignore[deprecated]
+        project.dirs.meltano().mkdir(parents=True, exist_ok=True)
         click.secho("created", fg="blue", nl=False)
         click.echo(f" .meltano in {project.sys_dir_root}")
 

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -437,7 +437,7 @@ class Tracker:  # - too many (public) methods
         Returns:
             Path to 'analytics.json' file.
         """
-        return self.project.meltano_dir() / "analytics.json"
+        return self.project.dirs.meltano().joinpath("analytics.json")
 
     def load_saved_telemetry_settings(self) -> TelemetrySettings:
         """Get settings from the 'analytics.json' file.

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -17,7 +17,6 @@ import typing as t
 import unicodedata
 import uuid
 from collections.abc import Mapping, Sequence
-from contextlib import suppress
 from copy import copy, deepcopy
 from datetime import date, datetime, time, timezone
 from enum import IntEnum

--- a/tests/meltano/core/test_meltano_invoker.py
+++ b/tests/meltano/core/test_meltano_invoker.py
@@ -62,7 +62,7 @@ class TestMeltanoInvoker:
             subject.invoke(["--version"])
 
             # Preferally, we use the symlink created by Project.activate
-            symlink_path = project.run_dir().joinpath("bin")
+            symlink_path = project.dirs.run().joinpath("bin")
             assert run_mock.call_args[0][0][0] == str(symlink_path)
 
             # If a different command is used...

--- a/tests/meltano/core/test_project_add_service.py
+++ b/tests/meltano/core/test_project_add_service.py
@@ -7,7 +7,10 @@ import pytest
 
 from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.plugin import PluginType, Variant
-from meltano.core.plugin.base import PluginRefNameContainsStateIdDelimiterError
+from meltano.core.plugin.base import (
+    BasePlugin,
+    PluginRefNameContainsStateIdDelimiterError,
+)
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.plugin.singer import SingerTap
 from meltano.core.project_plugins_service import PluginDefinitionNotFoundError
@@ -53,7 +56,7 @@ class TestProjectAddService:
         hub_request_counter: Counter,
     ) -> None:
         used_variant = variant or default_variant
-        lockfile_path = project.plugin_lock_path(
+        lockfile_path = project.dirs.plugin_lock_path(
             plugin_type,
             plugin_name,
             variant_name=used_variant,
@@ -67,6 +70,7 @@ class TestProjectAddService:
         # Variant and pip_url are repeated in
         # canonical representation for `meltano.yml`
         canonical = added.canonical()
+        assert isinstance(canonical, dict)
 
         if default_variant:
             assert added.variant == default_variant
@@ -133,17 +137,17 @@ class TestProjectAddService:
         assert isinstance(child.parent, SingerTap)
         assert child.parent.name == "tap-mock"
 
-        parent_path = subject.project.plugin_lock_path(
-            PluginType.EXTRACTORS,
-            "tap-mock",
+        parent_path = subject.project.dirs.plugin_lock_path(
+            plugin_type=PluginType.EXTRACTORS,
+            plugin_name="tap-mock",
             variant_name="meltano",
         )
         assert parent_path.stem == "tap-mock--meltano"
         assert parent_path.exists()
 
-        child_path = subject.project.plugin_lock_path(
-            child.type,
-            child.name,
+        child_path = subject.project.dirs.plugin_lock_path(
+            plugin_type=child.type,
+            plugin_name=child.name,
             variant_name=child.variant,
         )
         assert child_path.stem == "tap-mock-inherited-new--meltano"
@@ -156,11 +160,13 @@ class TestProjectAddService:
         )
         assert isinstance(grandchild.parent, ProjectPlugin)
         assert grandchild.parent.name == "tap-mock-inherited-new"
+
+        assert isinstance(grandchild.parent.parent, BasePlugin)
         assert grandchild.parent.parent.name == "tap-mock"
 
-        grandchild_path = subject.project.plugin_lock_path(
-            grandchild.type,
-            grandchild.name,
+        grandchild_path = subject.project.dirs.plugin_lock_path(
+            plugin_type=grandchild.type,
+            plugin_name=grandchild.name,
             variant_name=grandchild.variant,
         )
         assert grandchild_path.stem == "tap-mock-inherited-new-2--meltano"
@@ -225,7 +231,10 @@ class TestProjectAddService:
         assert lock_save.call_count == 1
 
         assert updated in project.meltano["plugins"][target.type]
-        assert updated.canonical().items() >= updated_attrs.items()
+
+        plugin_dict = updated.canonical()
+        assert isinstance(plugin_dict, dict)
+        assert plugin_dict.items() >= updated_attrs.items()
         assert updated.config_with_extras
 
     @mock.patch("meltano.core.plugin_lock_service.PluginLockService.save")
@@ -270,5 +279,8 @@ class TestProjectAddService:
         assert lock_save.call_count == 0
 
         assert updated in project.meltano["plugins"][custom_plugin.type]
-        assert updated.canonical().items() >= updated_attrs.items()
+
+        plugin_dict = updated.canonical()
+        assert isinstance(plugin_dict, dict)
+        assert plugin_dict.items() >= updated_attrs.items()
         assert updated.config_with_extras

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -22,7 +22,7 @@ if t.TYPE_CHECKING:
 
 @pytest.fixture
 def modified_lockfile(project: Project):
-    lockfile_path = project.plugin_lock_path(
+    lockfile_path = project.dirs.plugin_lock_path(
         PluginType.EXTRACTORS,
         "tap-mock",
         variant_name="meltano",
@@ -138,7 +138,10 @@ class TestProjectPluginsService:
         alternative_target,
     ) -> None:
         # The behavior being tested here assumes that no lockfiles exist.
-        shutil.rmtree(project.plugins.project.root_dir("plugins"), ignore_errors=True)
+        shutil.rmtree(
+            project.plugins.project.dirs.root_dir("plugins"),
+            ignore_errors=True,
+        )
         # name="tap-mock", variant="meltano"
         # Shadows base plugin with correct variant
         parent = project.plugins.get_parent(tap)


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* #9580

## Summary by Sourcery

Refactor path handling to consistently use the Project.dirs API and tighten related tests, particularly around plugin lockfiles, run and meltano directories, and Hub connectivity error handling.

Enhancements:
- Replace direct project path helper usages with Project.dirs methods for plugin lockfiles, run directory symlinks, and meltano directory paths.
- Adjust Hub CLI tests to use a session-bound requests-mock context manager for connection failure scenarios.
- Add explicit type assertions around plugin canonical representations and plugin parent relationships in tests to clarify expectations.

Tests:
- Update plugin and project service tests to rely on Project.dirs-based lockfile paths and directory roots, and to assert dictionary structure for canonical plugin data.

## Summary by Sourcery

Refactor project path handling to rely on the Project.dirs service and tighten related tests and Hub connectivity handling.

Enhancements:
- Replace direct project path helpers with Project.dirs-based methods for plugin lockfiles, run directory symlinks, meltano directory paths, and telemetry analytics file.
- Update Hub CLI ping failure handling to use a session-bound requests-mock context manager for connection errors.
- Clarify plugin canonical representations and parent relationships in tests with explicit type assertions.

Tests:
- Adjust plugin and project service tests to use Project.dirs-derived lockfile and plugin directory paths and to validate canonical plugin dictionaries.