### PR TITLE
chore: Add type checking with ty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
 
-  mypy:
+  typing:
     name: "Static type checking"
     runs-on: ubuntu-latest
 
@@ -226,6 +226,6 @@ jobs:
       run: |
         uv tool install nox
 
-    - name: Run mypy
+    - name: Run typing
       run: |
-        nox -rs mypy
+        nox -rs typing

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ import nox
 nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv"
 nox.options.sessions = [
-    "mypy",
+    "typing",
     "pre-commit",
     "pytest",
 ]
@@ -166,8 +166,8 @@ def pre_commit(session: nox.Session) -> None:
     python=main_python_version,
     tags=("lint",),
 )
-def mypy(session: nox.Session) -> None:
-    """Run mypy type checking.
+def typing(session: nox.Session) -> None:
+    """Run mypy and ty type checking.
 
     Args:
         session: Nox session.
@@ -182,4 +182,5 @@ def mypy(session: nox.Session) -> None:
         "--extra=containers",
         env=_install_env(session),
     )
+    session.run("ty", "check", *session.posargs)
     session.run("mypy", *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ typing = [
   "boto3-stubs[essential]>=1.35",
   "importlib-metadata",  # TODO: Drop once the runtime dependency is dropped
   "mypy>=1.16.0,<2",
+  "ty>=0.0.4",
   "types-dateparser>=1.2.0.20250208",
   "types-jsonschema>=4.23.0.20240813,<5",
   "types-psutil>=7.0.0.20250218,<8",
@@ -290,7 +291,6 @@ warn_unused_ignores = true
 ignore_errors = true
 module = [
   # Way too many modules at the root of meltano.core to tackle them all at once  # so listing them individually here.
-  "meltano.core.task_sets_service",
   "meltano.core.transform_add_service",
   # Meltano Core submodules
   "meltano.core.behavior.canonical",
@@ -299,7 +299,6 @@ module = [
   "meltano.core.behavior.visitor",
   "meltano.core.block.extract_load",
   "meltano.core.block.plugin_command",
-  "meltano.core.block.singer",
   "meltano.core.plugin.base",
   "meltano.core.plugin.dbt.*",
   "meltano.core.plugin.meltano_file",
@@ -308,6 +307,39 @@ module = [
   "meltano.core.runner.*",
   "meltano.core.tracking.*",
   "meltano.core.utils.*",
+]
+
+[tool.ty.src]
+include = [
+  "src/",
+]
+exclude = [
+  "src/meltano/cli/elt.py",
+  "src/meltano/cli/utils.py",
+  "src/meltano/core/behavior/canonical.py",
+  "src/meltano/core/behavior/hookable.py",
+  "src/meltano/core/behavior/name_eq.py",
+  "src/meltano/core/block/extract_load.py",
+  "src/meltano/core/block/plugin_command.py",
+  "src/meltano/core/environment_service.py",
+  "src/meltano/core/job/job.py",
+  "src/meltano/core/manifest/manifest.py",
+  "src/meltano/core/plugin/airflow.py",
+  "src/meltano/core/plugin/base.py",
+  "src/meltano/core/plugin/singer/base.py",
+  "src/meltano/core/plugin/singer/catalog.py",
+  "src/meltano/core/plugin/meltano_file.py",
+  "src/meltano/core/plugin/project_plugin.py",
+  "src/meltano/core/project_plugins_service.py",
+  "src/meltano/core/runner/dbt.py",
+  "src/meltano/core/runner/singer.py",
+  "src/meltano/core/schedule.py",
+  "src/meltano/core/schedule_service.py",
+  "src/meltano/core/settings_store.py",
+  "src/meltano/core/sqlalchemy.py",
+  "src/meltano/core/tracking/**",
+  "src/meltano/core/utils/**",
+  "src/meltano/migrations/**",
 ]
 
 [build-system]

--- a/src/meltano/cli/job.py
+++ b/src/meltano/cli/job.py
@@ -81,14 +81,14 @@ def _list_all_jobs(  # noqa: D417
                 {
                     "jobs": [
                         {"job_name": tset.name, "tasks": tset.tasks}
-                        for tset in task_sets_service.list()
+                        for tset in task_sets_service.list_task_sets()
                     ],
                 },
                 indent=2,
             ),
         )
     elif list_format == "text":
-        for task_set in task_sets_service.list():
+        for task_set in task_sets_service.list_task_sets():
             click.echo(f"{task_set.name}: {task_set.tasks}")
     tracker: Tracker = ctx.obj["tracker"]
     tracker.track_command_event(CliEvent.completed)

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -81,7 +81,7 @@ class EnvironmentPluginConfig(PluginRef):
         return {f"_{key}": value for key, value in self.extras.items()}
 
     @property
-    def config_with_extras(self):  # noqa: ANN201
+    def config_with_extras(self) -> dict[str, t.Any]:
         """Get plugin configuration values from the Meltano environment.
 
         Returns:

--- a/src/meltano/core/task_sets_service.py
+++ b/src/meltano/core/task_sets_service.py
@@ -77,7 +77,7 @@ class TaskSetsService:
         Raises:
             JobNotFoundError: If the TaskSet with the given name does not exist.
         """
-        for job in self.list():
+        for job in self.list_task_sets():
             if job.name == name:
                 with self.project.meltano_update() as meltano:
                     logger.debug("removing job", name=job.name)
@@ -94,7 +94,7 @@ class TaskSetsService:
         Raises:
             JobNotFoundError: If the TaskSet with the given name does not exist.
         """
-        for idx, job in enumerate(self.list()):
+        for idx, job in enumerate(self.list_task_sets()):
             if job.name == task_sets.name:
                 with self.project.meltano_update() as meltano:
                     logger.debug("updating job", name=job.name)
@@ -119,7 +119,7 @@ class TaskSetsService:
                 return job
         raise JobNotFoundError(name)
 
-    def list(self) -> list[TaskSets]:
+    def list_task_sets(self) -> list[TaskSets]:
         """List all TaskSets in the project.
 
         Returns:

--- a/tests/meltano/core/test_task_sets_service.py
+++ b/tests/meltano/core/test_task_sets_service.py
@@ -32,14 +32,14 @@ class TestTaskSetsService:
         for job in jobs:
             subject.add(job)
 
-        assert subject.list() == jobs
+        assert subject.list_task_sets() == jobs
 
         # verify that we can not add a job with the same name
         with pytest.raises(JobAlreadyExistsError):
             subject.add(jobs[0])
 
     def test_update(self, subject: TaskSetsService, create_task_set) -> None:
-        job = subject.list()[0]
+        job = subject.list_task_sets()[0]
         job.tasks = ["tap-mock target-mock updated:addition"]
         subject.update(job)
 
@@ -51,9 +51,9 @@ class TestTaskSetsService:
 
     @pytest.mark.usefixtures("create_task_set")
     def test_remove(self, subject: TaskSetsService) -> None:
-        jobs = subject.list()
+        jobs = subject.list_task_sets()
         subject.remove(jobs[0].name)
-        assert subject.list() == jobs[1:]
+        assert subject.list_task_sets() == jobs[1:]
         assert subject.exists(jobs[0].name) is False
 
         # verify that we can not remove a job that does not exist
@@ -62,7 +62,7 @@ class TestTaskSetsService:
 
     @pytest.mark.usefixtures("create_task_set")
     def test_get(self, subject: TaskSetsService) -> None:
-        jobs = subject.list()
+        jobs = subject.list_task_sets()
 
         assert subject.get(jobs[0].name) == jobs[0]
 
@@ -72,7 +72,7 @@ class TestTaskSetsService:
 
     @pytest.mark.usefixtures("create_task_set")
     def test_exists(self, subject: TaskSetsService) -> None:
-        job = subject.list()[0]
+        job = subject.list_task_sets()[0]
         assert subject.exists(job.name)
         assert not subject.exists("non-existent")
 
@@ -82,7 +82,7 @@ class TestTaskSetsService:
         for job in expected_jobs:
             subject.add(job)
 
-        result = subject.list()
+        result = subject.list_task_sets()
 
         for job in expected_jobs:
             assert job in result

--- a/uv.lock
+++ b/uv.lock
@@ -1503,6 +1503,7 @@ dev = [
     { name = "requests-mock" },
     { name = "setproctitle" },
     { name = "time-machine" },
+    { name = "ty" },
     { name = "types-dateparser" },
     { name = "types-jsonschema" },
     { name = "types-psutil" },
@@ -1549,6 +1550,7 @@ typing = [
     { name = "requests-mock" },
     { name = "setproctitle" },
     { name = "time-machine" },
+    { name = "ty" },
     { name = "types-dateparser" },
     { name = "types-jsonschema" },
     { name = "types-psutil" },
@@ -1622,6 +1624,7 @@ dev = [
     { name = "requests-mock", specifier = ">=1.12.1,<2" },
     { name = "setproctitle", specifier = "~=1.3" },
     { name = "time-machine", specifier = ">=3" },
+    { name = "ty", specifier = ">=0.0.4" },
     { name = "types-dateparser", specifier = ">=1.2.0.20250208" },
     { name = "types-jsonschema", specifier = ">=4.23.0.20240813,<5" },
     { name = "types-psutil", specifier = ">=7.0.0.20250218,<8" },
@@ -1666,6 +1669,7 @@ typing = [
     { name = "requests-mock", specifier = ">=1.12.1,<2" },
     { name = "setproctitle", specifier = "~=1.3" },
     { name = "time-machine", specifier = ">=3" },
+    { name = "ty", specifier = ">=0.0.4" },
     { name = "types-dateparser", specifier = ">=1.2.0.20250208" },
     { name = "types-jsonschema", specifier = ">=4.23.0.20240813,<5" },
     { name = "types-psutil", specifier = ">=7.0.0.20250218,<8" },
@@ -3506,6 +3510,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/9d/59e955cc39206a0d58df5374808785c45ec2a8a2a230eb1638fbb4fe5c5d/ty-0.0.8.tar.gz", hash = "sha256:352ac93d6e0050763be57ad1e02087f454a842887e618ec14ac2103feac48676", size = 4828477, upload-time = "2025-12-29T13:50:07.193Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/2b/dd61f7e50a69c72f72c625d026e9ab64a0db62b2dd32e7426b520e2429c6/ty-0.0.8-py3-none-linux_armv6l.whl", hash = "sha256:a289d033c5576fa3b4a582b37d63395edf971cdbf70d2d2e6b8c95638d1a4fcd", size = 9853417, upload-time = "2025-12-29T13:50:08.979Z" },
+    { url = "https://files.pythonhosted.org/packages/90/72/3f1d3c64a049a388e199de4493689a51fc6aa5ff9884c03dea52b4966657/ty-0.0.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:788ea97dc8153a94e476c4d57b2551a9458f79c187c4aba48fcb81f05372924a", size = 9657890, upload-time = "2025-12-29T13:50:27.867Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d1/08ac676bd536de3c2baba0deb60e67b3196683a2fabebfd35659d794b5e9/ty-0.0.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1b5f1f3d3e230f35a29e520be7c3d90194a5229f755b721e9092879c00842d31", size = 9180129, upload-time = "2025-12-29T13:50:22.842Z" },
+    { url = "https://files.pythonhosted.org/packages/af/93/610000e2cfeea1875900f73a375ba917624b0a008d4b8a6c18c894c8dbbc/ty-0.0.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6da9ed377fbbcec0a3b60b2ca5fd30496e15068f47cef2344ba87923e78ba996", size = 9683517, upload-time = "2025-12-29T13:50:18.658Z" },
+    { url = "https://files.pythonhosted.org/packages/05/04/bef50ba7d8580b0140be597de5cc0ba9a63abe50d3f65560235f23658762/ty-0.0.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7d0a2bdce5e701d19eb8d46d9da0fe31340f079cecb7c438f5ac6897c73fc5ba", size = 9676279, upload-time = "2025-12-29T13:50:25.207Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b9/2aff1ef1f41b25898bc963173ae67fc8f04ca666ac9439a9c4e78d5cc0ff/ty-0.0.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef9078799d26d3cc65366e02392e2b78f64f72911b599e80a8497d2ec3117ddb", size = 10073015, upload-time = "2025-12-29T13:50:35.422Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0e/9feb6794b6ff0a157c3e6a8eb6365cbfa3adb9c0f7976e2abdc48615dd72/ty-0.0.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:54814ac39b4ab67cf111fc0a236818155cf49828976152378347a7678d30ee89", size = 10961649, upload-time = "2025-12-29T13:49:58.717Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/3b/faf7328b14f00408f4f65c9d01efe52e11b9bcc4a79e06187b370457b004/ty-0.0.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4baf0a80398e8b6c68fa36ff85045a50ede1906cd4edb41fb4fab46d471f1d4", size = 10676190, upload-time = "2025-12-29T13:50:01.11Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a5/cfeca780de7eeab7852c911c06a84615a174d23e9ae08aae42a645771094/ty-0.0.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ac8e23c3faefc579686799ef1649af8d158653169ad5c3a7df56b152781eeb67", size = 10438641, upload-time = "2025-12-29T13:50:29.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8d/8667c7e0ac9f13c461ded487c8d7350f440cd39ba866d0160a8e1b1efd6c/ty-0.0.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b558a647a073d0c25540aaa10f8947de826cb8757d034dd61ecf50ab8dbd77bf", size = 10214082, upload-time = "2025-12-29T13:50:31.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/11/e563229870e2c1d089e7e715c6c3b7605a34436dddf6f58e9205823020c2/ty-0.0.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8c0104327bf480508bd81f320e22074477df159d9eff85207df39e9c62ad5e96", size = 9664364, upload-time = "2025-12-29T13:50:05.443Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ad/05b79b778bf5237bcd7ee08763b226130aa8da872cbb151c8cfa2e886203/ty-0.0.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:496f1cb87261dd1a036a5609da80ee13de2e6ee4718a661bfa2afb91352fe528", size = 9679440, upload-time = "2025-12-29T13:50:11.289Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b5/23ba887769c4a7b8abfd1b6395947dc3dcc87533fbf86379d3a57f87ae8f/ty-0.0.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2c488031f92a075ae39d13ac6295fdce2141164ec38c5d47aa8dc24ee3afa37e", size = 9808201, upload-time = "2025-12-29T13:50:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/90/5a82ac0a0707db55376922aed80cd5fca6b2e6d6e9bcd8c286e6b43b4084/ty-0.0.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:90d6f08c5982fa3e802b8918a32e326153519077b827f91c66eea4913a86756a", size = 10313262, upload-time = "2025-12-29T13:50:03.306Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f7/ff97f37f0a75db9495ddbc47738ec4339837867c4bfa145bdcfbd0d1eb2f/ty-0.0.8-py3-none-win32.whl", hash = "sha256:d7f460ad6fc9325e9cc8ea898949bbd88141b4609d1088d7ede02ce2ef06e776", size = 9254675, upload-time = "2025-12-29T13:50:33.35Z" },
+    { url = "https://files.pythonhosted.org/packages/af/51/eba5d83015e04630002209e3590c310a0ff1d26e1815af204a322617a42e/ty-0.0.8-py3-none-win_amd64.whl", hash = "sha256:1641fb8dedc3d2da43279d21c3c7c1f80d84eae5c264a1e8daa544458e433c19", size = 10131382, upload-time = "2025-12-29T13:50:13.719Z" },
+    { url = "https://files.pythonhosted.org/packages/38/1c/0d8454ff0f0f258737ecfe84f6e508729191d29663b404832f98fa5626b7/ty-0.0.8-py3-none-win_arm64.whl", hash = "sha256:ec74f022f315bede478ecae1277a01ab618e6500c1d68450d7883f5cd6ed554a", size = 9636374, upload-time = "2025-12-29T13:50:16.344Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Introduce ty-based type checking alongside mypy and perform type-hinting and API cleanups to satisfy the stricter checks.

Enhancements:
- Add ty as a typing dependency and configure its source and exclusion paths in pyproject.toml.
- Run ty in the existing mypy nox session to integrate the new type checker into the local typing workflow.
- Rename TaskSetsService.list to list_task_sets and update call sites to use a more descriptive API name.
- Tighten type annotations and attribute initialization in plugin environment configuration handling, including config_with_extras and settings updates.
- Refine filesystem state store deletion signatures and bundle root resource resolution for clearer, more precise typing semantics.

Tests:
- Update TaskSetsService tests to use the new list_task_sets API to keep coverage aligned with the refactored service.