### PR TITLE
refactor: Use explicit package names to load resource files (e.g. `initialize.yml`) instead of unreliable `__package__`

### DIFF
--- a/src/meltano/core/bundle/__init__.py
+++ b/src/meltano/core/bundle/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 import importlib.resources
 
-root = importlib.resources.files(__package__)
+root = importlib.resources.files("meltano.core.bundle")

--- a/tests/fixtures/docker/__init__.py
+++ b/tests/fixtures/docker/__init__.py
@@ -24,4 +24,6 @@ def docker_compose_file() -> str:
     Returns:
         The absolute path to the `docker-compose.yml` file used by `pytest-docker`.
     """
-    return str(importlib.resources.files(__package__) / "docker-compose.yml")
+    return str(
+        importlib.resources.files("tests.fixtures.docker") / "docker-compose.yml"
+    )


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Replace implicit __package__ usage with explicit package names when locating bundled resource files.

Enhancements:
- Use explicit package name for loading the docker-compose.yml test fixture resource.
- Set the bundle root using the concrete meltano.core.bundle package instead of relying on __package__.