### PR TITLE
refactor: Add more type-safety to settings management

### DIFF
--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -204,9 +204,6 @@ class PluginSettingsService(SettingsService):
 
         Args:
             config_with_extras: Configuration to update.
-
-        Raises:
-            NoActiveEnvironment: If called when no environment is active.
         """
         assert self.environment_plugin_config is not None  # noqa: S101
         self.environment_plugin_config.config_with_extras = config_with_extras

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -10,6 +10,7 @@ from meltano.core.settings_service import FeatureFlags, SettingsService
 from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars
 
 if t.TYPE_CHECKING:
+    from meltano.core.environment import EnvironmentPluginConfig
     from meltano.core.project import Project
     from meltano.core.setting_definition import EnvVar, SettingDefinition
 
@@ -35,14 +36,13 @@ class PluginSettingsService(SettingsService):
         super().__init__(project, *args, **kwargs)
         self.plugin = plugin
 
+        self.environment_plugin_config: EnvironmentPluginConfig | None = None
         if self.project.environment:
             environment = self.project.environment
             self.environment_plugin_config = environment.get_plugin_config(
                 self.plugin.type,
                 self.plugin.name,
             )
-        else:
-            self.environment_plugin_config = None
 
         self.env_override = {
             # project level environment variables:
@@ -187,13 +187,13 @@ class PluginSettingsService(SettingsService):
             return self.environment_plugin_config.config_with_extras
         return {}
 
-    def update_meltano_yml_config(self, config_with_extras) -> None:  # noqa: ANN001
+    def update_meltano_yml_config(self, config: dict) -> None:
         """Update configuration in `meltano.yml`.
 
         Args:
-            config_with_extras: Configuration to update.
+            config: Configuration to update.
         """
-        self.plugin.config_with_extras = config_with_extras
+        self.plugin.config_with_extras = config
         self.project.plugins.update_plugin(self.plugin)
 
     def update_meltano_environment_config(
@@ -204,7 +204,11 @@ class PluginSettingsService(SettingsService):
 
         Args:
             config_with_extras: Configuration to update.
+
+        Raises:
+            NoActiveEnvironment: If called when no environment is active.
         """
+        assert self.environment_plugin_config is not None  # noqa: S101
         self.environment_plugin_config.config_with_extras = config_with_extras
         self.project.plugins.update_environment_plugin(self.environment_plugin_config)
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Improve type-safety and type annotations in settings management and plugin settings service.

Enhancements:
- Use `Self` and explicit enum members in `SettingValueStore` to tighten classmethod and property return types.
- Add explicit typing for `settings_service`, internal kwargs dicts, and environment plugin configuration in settings store managers and plugin settings service.
- Refine configuration update methods in `PluginSettingsService` with stricter parameter types and an assertion for required environment configuration.