### PR TITLE
docs: Fix `meltano config <plugin>` examples to use the correct syntax `meltano config print <plugin>`

### DIFF
--- a/docs/docs/getting-started/index.mdx
+++ b/docs/docs/getting-started/index.mdx
@@ -392,13 +392,13 @@ Sensitive configuration (like `private_token`) will instead be stored in your pr
 export TAP_GITLAB_PRIVATE_TOKEN=my_private_token
 ```
 
-1. Optionally, verify that the configuration looks like what the Singer tap expects according to its documentation using [`meltano config <plugin>`](/reference/command-line-interface#config):
+1. Optionally, verify that the configuration looks like what the Singer tap expects according to its documentation using [`meltano config print <plugin>`](/reference/command-line-interface#config):
 
    ```bash
-   meltano config <plugin>
+   meltano config print <plugin>
 
    # For example:
-   meltano config tap-gitlab
+   meltano config print tap-gitlab
    ```
 
    This will show the current configuration:
@@ -783,13 +783,13 @@ Sensitive configuration information (such as `password`) will instead be stored 
 export TARGET_POSTGRES_PASSWORD=meltano
 ```
 
-1. Optionally, verify that the configuration looks like what the Singer target expects according to its documentation using [`meltano config <plugin>`](/reference/command-line-interface#config):
+1. Optionally, verify that the configuration looks like what the Singer target expects according to its documentation using [`meltano config print <plugin>`](/reference/command-line-interface#config):
 
    ```bash
-   meltano config <plugin>
+   meltano config print <plugin>
 
    # For example:
-   meltano config target-postgres
+   meltano config print target-postgres
    ```
 
    This will show the current configuration:

--- a/docs/docs/getting-started/part1.mdx
+++ b/docs/docs/getting-started/part1.mdx
@@ -255,7 +255,7 @@ It will also add your secret auth token to the file `.env`:
 TAP_GITHUB_AUTH_TOKEN='ghp_XXX' # your token!
 ```
 
-3. Double check the config by running [`meltano config tap-github`](/reference/command-line-interface#config):
+3. Double check the config by running [`meltano config list tap-github`](/reference/command-line-interface#config):
 
 ```bash
 meltano config list tap-github

--- a/docs/docs/getting-started/part2.mdx
+++ b/docs/docs/getting-started/part2.mdx
@@ -163,12 +163,12 @@ plugins:
 
 Sensitive configuration information (such as `password`) will instead be stored in your project's [`.env` file](/concepts/project#env) so that it will not be checked into version control.
 
-You can use `meltano config target-postgres` to check the configuration, including the default settings not visible in the project file.
+You can use `meltano config print target-postgres` to check the configuration, including the default settings not visible in the project file.
 
 <Termy>
 
 ```console
-$ meltano config target-postgres
+$ meltano config print target-postgres
 {
 &ensp;&ensp;&ensp;&ensp;"add_record_metadata": true,
 &ensp;&ensp;&ensp;&ensp;"database": "postgres",

--- a/docs/docs/guide/complete_tutorial.md
+++ b/docs/docs/guide/complete_tutorial.md
@@ -428,13 +428,13 @@ Sensitive configuration (like `private_token`) will instead be stored in your pr
 export TAP_GITLAB_PRIVATE_TOKEN=my_private_token
 ```
 
-1. Optionally, verify that the configuration looks like what the Singer tap expects according to its documentation using [`meltano config <plugin>`](/reference/command-line-interface#config):
+1. Optionally, verify that the configuration looks like what the Singer tap expects according to its documentation using [`meltano config print <plugin>`](/reference/command-line-interface#config):
 
    ```bash
-   meltano config <plugin>
+   meltano config print <plugin>
 
    # For example:
-   meltano config tap-gitlab
+   meltano config print tap-gitlab
    ```
 
    This will show the current configuration:
@@ -890,13 +890,13 @@ Sensitive configuration information (such as `password`) will instead be stored 
 export TARGET_POSTGRES_PASSWORD=meltano
 ```
 
-1. Optionally, verify that the configuration looks like what the Singer target expects according to its documentation using [`meltano config <plugin>`](/reference/command-line-interface#config):
+1. Optionally, verify that the configuration looks like what the Singer target expects according to its documentation using [`meltano config print <plugin>`](/reference/command-line-interface#config):
 
    ```bash
-   meltano config <plugin>
+   meltano config print <plugin>
 
    # For example:
-   meltano config target-postgres
+   meltano config print target-postgres
    ```
 
    This will show the current configuration:

--- a/docs/docs/guide/integration.md
+++ b/docs/docs/guide/integration.md
@@ -22,9 +22,9 @@ If you encounter some trouble running a pipeline, read our [troubleshooting tips
 
 As described in the [Configuration guide](/guide/configuration#configuration-layers), [`meltano run`](/reference/command-line-interface#run) will determine the configuration of your extractor + loader pairs and any optional utilities (e.g. dbt) by looking in [**the environment**](/guide/configuration#configuring-settings), your project's [**`.env` file**](/concepts/project#env), the [system database](/concepts/project#system-database), and finally your [**`meltano.yml` project file**](/concepts/project#meltano-yml-project-file), falling back to a default value if nothing was found.
 
-You can use [`meltano config list <plugin>`](/reference/command-line-interface#config) to list all available settings with their names, environment variables, and current values. [`meltano config <plugin>`](/reference/command-line-interface#config) will print the current configuration in JSON format.
+You can use [`meltano config list <plugin>`](/reference/command-line-interface#config) to list all available settings with their names, environment variables, and current values. [`meltano config print <plugin>`](/reference/command-line-interface#config) will print the current configuration in JSON format.
 
-If supported by the plugin type, its configuration can be tested using [`meltano config <plugin> test`](/reference/command-line-interface#config).
+If supported by the plugin type, its configuration can be tested using [`meltano config test <plugin>`](/reference/command-line-interface#config).
 
 ## Extractor catalog generation
 
@@ -333,7 +333,7 @@ meltano run ...
 TAP_FOO_BAR=bar TAP_FOO_BAZ=baz meltano run ...
 ```
 
-To verify that these environment variables will be picked up by Meltano as you intended, you can test them with [`meltano config <plugin>`](/reference/command-line-interface#config) before running `meltano run`.
+To verify that these environment variables will be picked up by Meltano as you intended, you can test them with [`meltano config print <plugin>`](/reference/command-line-interface#config) before running `meltano run`.
 
 ## Running pipelines with `elt`
 

--- a/docs/docs/reference/command-line-interface.mdx
+++ b/docs/docs/reference/command-line-interface.mdx
@@ -511,10 +511,10 @@ The `config` command can accept the `--environment` flag to target a specific [M
 
 In the context of `meltano config`, [plugin extras](/guide/configuration#plugin-extras) are distinguished from regular plugin-specific settings using an underscore (`_`) prefix, e.g. `_example_extra`. This also applies in the [environment variables](/guide/configuration#configuring-settings) that can be used to override them at runtime: since setting names for extras are prefixed with underscores (`_`), they get an extra underscore to separate them from the plugin name, e.g. `TAP_EXAMPLE__EXAMPLE_EXTRA`.
 
-By default, `meltano config <plugin>` and `meltano config list <plugin>` only take into account regular plugin settings.
+By default, `meltano config print <plugin>` and `meltano config list <plugin>` only take into account regular plugin settings.
 An `--extras` flag can be passed to view or list only extras instead.
 
-Be aware that `meltano config <plugin> reset` resets both regular settings _and_ extras.
+Be aware that `meltano config reset <plugin>` resets both regular settings _and_ extras.
 
 ```bash
 # List all extras for the specified plugin with their names,
@@ -522,7 +522,7 @@ Be aware that `meltano config <plugin> reset` resets both regular settings _and_
 meltano config list <plugin> --extras
 
 # View the plugin's current extras
-meltano config --extras <plugin>
+meltano config print <plugin> --extras
 
 # Set value of extra `<extra>` to `<value>` through the `_<extra>` setting
 meltano config set <plugin> _<extra> <value>
@@ -531,7 +531,7 @@ meltano config set <plugin> _<extra> <value>
 meltano config unset <plugin> _<extra>
 
 # Reset regular settings _and_ extras
-meltano config <plugin> reset
+meltano config reset <plugin>
 ```
 
 ### How to use: Interactive config


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Related Issues

* https://github.com/meltano/meltano/pull/9477
* https://github.com/meltano/meltano/pull/9675
* Slack: https://meltano.slack.com/archives/C069CQNHDNF/p1767021970936479

## Summary by Sourcery

Update documentation to reflect the correct Meltano configuration CLI syntax.

Documentation:
- Correct configuration verification examples to use `meltano config print <plugin>` instead of the outdated `meltano config <plugin>` syntax across the guides.
- Clarify usage of `meltano config test <plugin>` for testing plugin configuration in the integration guide.