### PR TITLE
chore: Use `nox.session(default=...)` to mark default sessions and make `noxfile.py` executable

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = ["nox"]
+# ///
+
 """Nox configuration.
 
 - Run `nox -l` to list the sessions Nox can run.
@@ -29,11 +35,6 @@ import nox
 
 nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv"
-nox.options.sessions = [
-    "typing",
-    "pre-commit",
-    "pytest",
-]
 
 root_path = Path(__file__).parent
 pyproject = nox.project.load_toml()
@@ -121,7 +122,7 @@ def pytest_meltano(session: nox.Session) -> None:
     _run_pytest(session)
 
 
-@nox.session(python=main_python_version)
+@nox.session(python=main_python_version, default=False)
 def coverage(session: nox.Session) -> None:
     """Combine and report previously generated coverage data.
 
@@ -184,3 +185,7 @@ def typing(session: nox.Session) -> None:
     )
     session.run("ty", "check", *session.posargs)
     session.run("mypy", *session.posargs)
+
+
+if __name__ == "__main__":
+    nox.main()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Mark the nox configuration file as an executable uv-powered script and adjust default session handling.

Enhancements:
- Configure noxfile.py to be executable via a uv shebang with nox as a declared script dependency.
- Switch from global default sessions configuration to per-session default flags, explicitly marking the coverage session as non-default.
- Invoke nox.main() when running noxfile.py directly as a script.