### PR TITLE
refactor: Enable Ruff `EXE`, `FA`, `FLY`, `FURB` and `SLOT` rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,8 +373,12 @@ select = [
   "E",     # pycodestyle (error)
   "EM",    # flake8-errmsg
   "ERA",   # flake8-eradicate
+  "EXE",   # flake8-executable
   "F",     # pyflakes
+  "FA",    # flake8-future-annotations
   "FBT",   # flake8-boolean-trap
+  "FLY",   # flynt
+  "FURB",  # refurb
   "G",     # flake8-logging-format
   "I",     # isort
   "ICN",   # flake8-import-conventions
@@ -394,6 +398,7 @@ select = [
   "RUF",   # Ruff specific rules
   "S",     # flake8-bandit
   "SIM",   # flake8-simplify
+  "SLOT",  # flake8-slots
   "T10",   # flake8-debugger
   "T20",   # flake8-print
   "TC",    # flake8-type-checking

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -149,7 +149,7 @@ class PluginSettingsService(SettingsService):
             Namespace for setting value records in system database.
         """
         # "default" is included for legacy reasons
-        return ".".join((self.plugin.type, self.plugin.name, "default"))
+        return f"{self.plugin.type}.{self.plugin.name}.default"
 
     @property
     def setting_definitions(self) -> list[SettingDefinition]:

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -302,13 +302,13 @@ class TestCli:
         project = test_cli_project
         with cd(project.root_dir()):
             assert_cli_runner(cli_runner.invoke(cli, ("dragon",)))
-            assert Path().resolve() == project.root_dir()
+            assert Path.cwd() == project.root_dir()
 
         with cd(project.root_dir()):
             assert_cli_runner(
                 cli_runner.invoke(cli, ("--cwd", str(tmp_path), "dragon")),
             )
-            assert Path().resolve() == tmp_path
+            assert Path.cwd() == tmp_path
 
         with cd(project.root_dir()):
             filepath = tmp_path / "file.txt"
@@ -330,7 +330,7 @@ class TestCli:
         with cd(project.root_dir()):
             dirpath.mkdir()
             assert_cli_runner(cli_runner.invoke(cli, ("--cwd", str(dirpath), "dragon")))
-            assert Path().resolve() == dirpath
+            assert Path.cwd() == dirpath
 
     def test_env_file_option(
         self,

--- a/tests/meltano/core/test_setting_definition.py
+++ b/tests/meltano/core/test_setting_definition.py
@@ -84,7 +84,7 @@ class TestSettingDefinition:
             ("3.14159", Decimal("3.14159")),
             ("123.45", Decimal("123.45")),
             ("0.001", Decimal("0.001")),
-            ("0", Decimal("0")),
+            ("0", Decimal(0)),
             ("0.0", Decimal("0.0")),
             ("-42.5", Decimal("-42.5")),
             ("1640995200.123", Decimal("1640995200.123")),
@@ -142,7 +142,7 @@ class TestSettingDefinition:
 
         test_cases = [
             (Decimal("3.14159"), "3.14159"),
-            (Decimal("0"), "0"),
+            (Decimal(0), "0"),
             (Decimal("123.45"), "123.45"),
             (Decimal("1640995200.123"), "1640995200.123"),
             (Decimal("-42.5"), "-42.5"),


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->
SSIA.

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enable additional Ruff linting rule families and adjust decimal-related tests for compatibility with the new checks.

Enhancements:
- Configure Ruff to enforce EXE, FA, FLY, FURB, and SLOT rule sets for static analysis.

Tests:
- Update decimal casting and stringification test cases to use numeric zero for Decimal initialization.