### PR TITLE
chore: Skipping `uv-lock` pre-commit hook in CI is no longer necessary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,11 @@
 ci:
   autofix_commit_msg: |
-    [pre-commit.ci] auto fixes from pre-commit.ci hooks
+    chore: auto fixes from pre-commit.ci hooks
 
     for more information, see https://pre-commit.ci
   autofix_prs: true
   autoupdate_commit_msg: "chore: pre-commit autoupdate"
   autoupdate_schedule: monthly
-  skip:
-    - uv-lock
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update pre-commit CI configuration to use a semantic autofix commit message and stop skipping the uv-lock hook during CI runs.

Chores:
- Adjust pre-commit.ci autofix commit message to follow semantic commit conventions.
- Remove the uv-lock hook from the list of hooks skipped in pre-commit CI.