### PR TITLE
perf: Revert to sync APIs for writing the tap catalog file following discovery

### DIFF
--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import asyncio.subprocess
-import inspect
 import json
 import logging
 import shutil
@@ -52,7 +51,7 @@ logger = structlog.stdlib.get_logger(__name__)
 
 async def _stream_redirect(
     stream: asyncio.StreamReader | None,
-    *file_like_objs,  # noqa: ANN002
+    *file_like_objs: t.IO,
     write_str: bool = False,
 ) -> None:
     """Redirect stream to a file like obj.
@@ -66,10 +65,7 @@ async def _stream_redirect(
     while stream and not stream.at_eof():
         data = await stream.readline()
         for file_like_obj in file_like_objs:
-            if inspect.iscoroutinefunction(file_like_obj.write):
-                await file_like_obj.write(data.decode(encoding) if write_str else data)
-            else:
-                file_like_obj.write(data.decode(encoding) if write_str else data)
+            file_like_obj.write(data.decode(encoding) if write_str else data)
 
 
 def config_metadata_rules(config: dict[str, t.Any]) -> list[MetadataRule]:

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -438,6 +438,7 @@ class SingerTap(SingerPlugin):
                 f"Extractor '{self.name}' does not support catalog discovery "  # noqa: EM102
                 "(the `discover` capability is not advertised)",
             )
+        logger.info("Running catalog discovery")
         with StringIO("") as stderr_buff:
             try:
                 with catalog_path.open(mode="wb") as catalog:


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

A performance regression was noticed in 3.6.0 -> 3.7.9, ~most likely caused by https://github.com/meltano/meltano/commit/f3fa5b45075261ec32e770bc9e4454d23dbb932c~. CONFIRMED:

<details><summary>Details</summary>
<p>

43bba8c9859a9f679d61716e98a3d5b753815f9d:

![profile-43bba8c9859a9f679d61716e98a3d5b753815f9d](https://github.com/user-attachments/assets/efa5cfbb-66ef-4f10-ada1-6eb183d4b7c5)

f3fa5b45075261ec32e770bc9e4454d23dbb932c (see the node for `_stream_redirect`):

![profile-f3fa5b45075261ec32e770bc9e4454d23dbb932c](https://github.com/user-attachments/assets/a6b1652e-0468-48f7-a099-ea7709c86d39)

</p>
</details> 

## Related Issues

* Partially reverts https://github.com/meltano/meltano/pull/8972
* https://github.com/meltano/meltano/pull/9774

## Summary by Sourcery

Enhancements:
- Use standard synchronous file I/O for reading and writing Singer tap state and catalog files instead of async anyio-based operations.
