### PR TITLE
fix: Handle `python` attribute when present in plugin YAML added with `meltano add <name> --from-ref ...`

### DIFF
--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -309,6 +309,7 @@ def add_plugin(  # noqa: ANN201
 
         plugin_name = plugin_attrs.pop("name")
         variant = plugin_attrs.pop("variant", variant)
+        python = plugin_attrs.pop("python", python)
 
     try:
         plugin, flags = add_service.add_with_flags(

--- a/tests/fixtures/plugins/extractors/tap-custom/has_python.yml
+++ b/tests/fixtures/plugins/extractors/tap-custom/has_python.yml
@@ -1,0 +1,32 @@
+capabilities:
+- catalog
+- discover
+- state
+- about
+- stream-maps
+description: Custom extractor for testing
+domain_url: https://meltano.com/
+keywords:
+- custom
+- test
+label: Custom
+logo_url: /assets/logos/extractors/custom.png
+maintenance_status: development
+name: tap-custom
+namespace: tap_custom
+pip_url: git+https://github.com/MeltanoLabs/tap-custom.git
+python: 3.12
+quality: gold
+repo: https://github.com/MeltanoLabs/tap-custom
+settings:
+- description: Username
+  label: Username
+  name: username
+- description: Password
+  label: Password
+  name: password
+  sensitive: true
+settings_group_validation:
+- - username
+  - password
+variant: test

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -26,6 +26,7 @@ if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
 plugin_ref = plugins_dir / "extractors" / "tap-custom" / "test.yml"
+plugin_ref_with_python = plugins_dir / "extractors" / "tap-custom" / "has_python.yml"
 fails_on_windows = pytest.mark.xfail(
     platform.system() == "Windows",
     reason="Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -692,6 +693,7 @@ class TestCliAdd:
         "ref",
         (
             plugin_ref,
+            plugin_ref_with_python,
             (
                 "https://raw.githubusercontent.com/meltano/hub/main/_data/meltano/"
                 f"{plugin_ref.relative_to(plugins_dir)}"
@@ -699,6 +701,7 @@ class TestCliAdd:
         ),
         ids=(
             "local",
+            "local with python",
             "remote",
         ),
     )

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -199,10 +199,10 @@ class TestCliAdd:
         )
         assert_cli_runner(res)
 
-        with project.root_dir("transform/packages.yml").open() as packages_file:
+        with project.dirs.root_dir("transform/packages.yml").open() as packages_file:
             packages_yaml = yaml.safe_load(packages_file)
 
-        with project.root_dir("transform/dbt_project.yml").open() as project_file:
+        with project.dirs.root_dir("transform/dbt_project.yml").open() as project_file:
             project_yaml = yaml.safe_load(project_file)
 
         assert {
@@ -245,7 +245,7 @@ class TestCliAdd:
         # File has been created
         assert "Created orchestrate/dags/meltano.py" in output
 
-        file_path = project.root_dir("orchestrate/dags/meltano.py")
+        file_path = project.dirs.root_dir("orchestrate/dags/meltano.py")
         assert file_path.is_file()
 
         # File has "managed" header
@@ -270,7 +270,7 @@ class TestCliAdd:
         # File has been created
         assert "Created docker-compose.yml" in output
 
-        file_path = project.root_dir("docker-compose.yml")
+        file_path = project.dirs.root_dir("docker-compose.yml")
         assert file_path.is_file()
 
         # File does not have "managed" header
@@ -279,8 +279,8 @@ class TestCliAdd:
     @fails_on_windows
     def test_add_files_that_already_exists(self, project: Project, cli_runner) -> None:
         # dbt lockfile was created in an upstream test. Need to remove.
-        shutil.rmtree(project.root_dir("plugins/files"), ignore_errors=True)
-        project.root_dir("transform/dbt_project.yml").write_text("Exists!")
+        shutil.rmtree(project.dirs.root_dir("plugins/files"), ignore_errors=True)
+        project.dirs.root_dir("transform/dbt_project.yml").write_text("Exists!")
         result = cli_runner.invoke(cli, ["add", "--plugin-type=files", "dbt"])
         output = result.stdout + result.stderr
         assert_cli_runner(result)
@@ -290,7 +290,7 @@ class TestCliAdd:
             in output
         )
         assert "Created transform/dbt_project (dbt).yml" in output
-        assert project.root_dir("transform/dbt_project (dbt).yml").is_file()
+        assert project.dirs.root_dir("transform/dbt_project (dbt).yml").is_file()
 
     def test_add_missing(self, project: Project, cli_runner) -> None:
         res = cli_runner.invoke(cli, ["add", "--plugin-type=extractor", "tap-unknown"])
@@ -357,7 +357,7 @@ class TestCliAdd:
             project.plugins.remove_from_file(tap)
 
         # Remove all lockfiles
-        shutil.rmtree(project.root_plugins_dir(), ignore_errors=True)
+        shutil.rmtree(project.dirs.root_plugins(), ignore_errors=True)
 
         with mock.patch("meltano.cli.params.install_plugins") as install_plugin_mock:
             install_plugin_mock.return_value = True
@@ -655,7 +655,7 @@ class TestCliAdd:
                 assert plugin.variant == default_variant
 
                 # check plugin lock file is added
-                plugins_dir = project.root_dir("plugins")
+                plugins_dir = project.dirs.root_plugins()
                 assert plugins_dir.joinpath(
                     f"{plugin_type}/{plugin_name}--{default_variant}.lock",
                 ).exists()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

See a failure in

- https://github.com/meltano/hub/actions/runs/21143327346/job/60802694865?pr=2202

## Related Issues

* https://github.com/meltano/meltano/issues/6615
* https://github.com/meltano/meltano/issues/7368
* https://github.com/meltano/meltano/pull/7907
* https://github.com/meltano/meltano/pull/8379

## Summary by Sourcery

Ensure plugin additions correctly handle optional python attribute in plugin references.

Bug Fixes:
- Preserve the python configuration when adding a plugin from a YAML reference that defines a python field.

Tests:
- Extend add-plugin tests to cover plugins whose reference YAML includes a python attribute using a new test fixture.