### PR TITLE
test: Use `psycopg2` driver name explicitly

### DIFF
--- a/.github/workflows/resources/docker-compose.postgres.yaml
+++ b/.github/workflows/resources/docker-compose.postgres.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    # NOTE: Support for PostgreSQL 14 ends on Nov 2026, bump to 14 after that
+    # NOTE: Support for PostgreSQL 14 ends on Nov 2026
     # https://endoflife.date/postgresql
     image: postgres:14
     container_name: postgres

--- a/tests/fixtures/db/postgresql_psycopg2.py
+++ b/tests/fixtures/db/postgresql_psycopg2.py
@@ -28,7 +28,7 @@ def engine_uri(worker_id: str) -> str:
     database = f"{os.getenv('POSTGRES_DB', 'pytest_meltano')}_{worker_id}"
 
     # create the database
-    engine_uri = f"postgresql://{user}:{password}@{host}:{port}/postgres"
+    engine_uri = f"postgresql+psycopg2://{user}:{password}@{host}:{port}/postgres"
     engine = create_engine(
         engine_uri,
         isolation_level="AUTOCOMMIT",
@@ -37,4 +37,4 @@ def engine_uri(worker_id: str) -> str:
     )
     recreate_database(engine, database)
 
-    return f"postgresql://{user}:{password}@{host}:{port}/{database}"
+    return f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}"


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.


## Related Issues

* https://github.com/sqlalchemy/sqlalchemy/issues/13010
* https://github.com/sqlalchemy/sqlalchemy/commit/3988071d0d158081dca0a683a1233959c8203439

## Summary by Sourcery

Explicitly configure PostgreSQL test fixtures to use the psycopg2 SQLAlchemy driver and clean up a stale comment in the Postgres CI docker-compose configuration.

CI:
- Tidy the Postgres docker-compose workflow comment by removing outdated guidance about future version bumping.

Tests:
- Update PostgreSQL SQLAlchemy engine URIs in test fixtures to explicitly use the psycopg2 driver.