### PR TITLE
feat(cli): Add plugin name or `meltano` as another column in the console-formatted output

### DIFF
--- a/integration/meltano-run/validate.sh
+++ b/integration/meltano-run/validate.sh
@@ -8,8 +8,7 @@ LOG_FILE="./integration/example-library/meltano-run/integration-test.log"
 
 # test that meltano run saw dbt:test (set=1) as successfully completed
 grep "Block run completed" $LOG_FILE
-# test that we see dbt:run output
-grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1 .*name=dbt-postgres" $LOG_FILE
+grep "\[info     \] dbt-postgres .* Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1" $LOG_FILE
 
 # we could also run psql statements
 # check for the existance of files

--- a/src/meltano/core/logging/renderers.py
+++ b/src/meltano/core/logging/renderers.py
@@ -295,7 +295,7 @@ class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
                     key_style=None,  # No key label, just the value
                     value_style=styles.kv_key,  # Cyan color
                     reset_style=styles.reset,
-                    value_repr=str,
+                    value_repr=self._repr_name,
                     width=self.DEFAULT_NAME_COLUMN_WIDTH,
                 ),
             ),
@@ -336,6 +336,10 @@ class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
         )
         self._all_keys = all_keys
         self._include_keys = include_keys
+
+    def _repr_name(self, name: t.Any) -> str:  # noqa: ANN401
+        """Render the name to a string."""
+        return name or self.DEFAULT_PLUGIN_NAME
 
     def __call__(
         self,

--- a/src/meltano/core/logging/renderers.py
+++ b/src/meltano/core/logging/renderers.py
@@ -204,6 +204,10 @@ class PluginInstallFormatter:
 class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
     """Custom console renderer that handles our own data structures."""
 
+    DEFAULT_NAME_COLUMN_WIDTH: t.ClassVar[int] = 12
+    DEFAULT_EVENT_COLUMN_WIDTH: t.ClassVar[int] = 30
+    DEFAULT_PLUGIN_NAME: t.ClassVar[str] = "meltano"
+
     default_keys: t.ClassVar[set[str]] = {
         # Base keys
         "timestamp",
@@ -242,8 +246,86 @@ class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
             include_keys: Whether to include specific keys in the output.
             kwargs: Keyword arguments to pass to the parent class.
         """
-        super().__init__(*args, **kwargs)
-        colors = kwargs.get("colors")
+        # Extract color settings from kwargs before passing to parent
+        # (colors is ignored when passing custom columns)
+        colors = kwargs.pop("colors", True)
+        force_colors = kwargs.pop("force_colors", False)
+        # Discard any existing columns since we build our own
+        kwargs.pop("columns", None)
+
+        # Get column styles based on color settings
+        styles = self.get_default_column_styles(colors, force_colors)
+
+        # Build level styles for LogLevelColumnFormatter
+        level_styles = {
+            "debug": styles.level_debug,
+            "info": styles.level_info,
+            "warning": styles.level_warn,
+            "warn": styles.level_warn,
+            "error": styles.level_error,
+            "critical": styles.level_critical,
+            "exception": styles.level_exception,
+            "notset": styles.level_notset,
+        }
+
+        # Build custom columns with plugin name column
+        columns = [
+            # Timestamp column
+            structlog.dev.Column(
+                "timestamp",
+                structlog.dev.KeyValueColumnFormatter(
+                    key_style=None,
+                    value_style=styles.timestamp,
+                    reset_style=styles.reset,
+                    value_repr=str,
+                ),
+            ),
+            # Level column
+            structlog.dev.Column(
+                "level",
+                structlog.dev.LogLevelColumnFormatter(
+                    level_styles=level_styles,
+                    reset_style=styles.reset,
+                ),
+            ),
+            # Name column (plugin name)
+            structlog.dev.Column(
+                "name",
+                structlog.dev.KeyValueColumnFormatter(
+                    key_style=None,  # No key label, just the value
+                    value_style=styles.kv_key,  # Cyan color
+                    reset_style=styles.reset,
+                    value_repr=str,
+                    width=self.DEFAULT_NAME_COLUMN_WIDTH,
+                ),
+            ),
+            # Event column
+            structlog.dev.Column(
+                "event",
+                structlog.dev.KeyValueColumnFormatter(
+                    key_style=None,
+                    value_style=styles.bright,  # Bold
+                    reset_style=styles.reset,
+                    value_repr=str,
+                    width=self.DEFAULT_EVENT_COLUMN_WIDTH,
+                ),
+            ),
+            # Default formatter for remaining keys
+            structlog.dev.Column(
+                "",  # Empty key = default formatter
+                structlog.dev.KeyValueColumnFormatter(
+                    key_style=styles.kv_key,
+                    value_style=styles.kv_value,
+                    reset_style=styles.reset,
+                    value_repr=self._repr,
+                ),
+            ),
+        ]
+
+        # Pass columns to parent (NOT colors, since columns takes precedence)
+        # We've already popped colors, force_colors, and columns from kwargs above
+        super().__init__(*args, columns=columns, **kwargs)  # type: ignore[misc]
+
         self._error_formatter = (
             plugin_error_renderer  # or construct one with the right flags
             or PluginErrorFormatter(no_color=not colors)
@@ -273,6 +355,9 @@ class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
         Returns:
             The rendered event dictionary.
         """
+        # Set default plugin name if not present
+        event_dict.setdefault("name", self.DEFAULT_PLUGIN_NAME)
+
         if self._include_keys:
             event_dict = {
                 k: v

--- a/tests/meltano/core/logging/test_logging_utils.py
+++ b/tests/meltano/core/logging/test_logging_utils.py
@@ -53,12 +53,12 @@ async def test_capture_subprocess_output() -> None:
     (
         pytest.param(
             LogFormat.colored,
-            "\x1b[2m2021-01-01T00:00:00Z\x1b[0m [\x1b[32m\x1b[1minfo     \x1b[0m] \x1b[1mtest                          \x1b[0m",  # noqa: E501
+            "\x1b[2m2021-01-01T00:00:00Z\x1b[0m [\x1b[32minfo     \x1b[0m] \x1b[36mmeltano     \x1b[0m \x1b[1mtest                          \x1b[0m",  # noqa: E501
             id="colored",
         ),
         pytest.param(
             LogFormat.uncolored,
-            "2021-01-01T00:00:00Z [info     ] test",
+            "2021-01-01T00:00:00Z [info     ] meltano      test",
             id="uncolored",
         ),
         pytest.param(

--- a/tests/meltano/core/logging/test_renderers.py
+++ b/tests/meltano/core/logging/test_renderers.py
@@ -480,20 +480,40 @@ class TestMeltanoConsoleRenderer:
             colors=False,
         )
 
-        event_dict = {
+        # No "name" key - should default to "meltano"
+        event_dict_missing_name = {
             "timestamp": "2021-01-01T00:00:00Z",
             "level": "info",
             "event": "Something happened",
-            # No "name" key - should default to "meltano"
         }
 
-        result = renderer(None, "info", event_dict)
+        result = renderer(None, "info", event_dict_missing_name)
         # "meltano" should appear as a column (default value)
         assert "meltano" in result
         # It should NOT appear as key=value
         assert "name=meltano" not in result
         # The event should be rendered
         assert "Something happened" in result
+
+        # `None` "name" key - should default to "meltano"
+        event_dict_none_name = {
+            "timestamp": "2021-01-01T00:00:00Z",
+            "level": "info",
+            "event": "Something happened",
+            "name": None,
+        }
+        result = renderer(None, "info", event_dict_none_name)
+        assert "meltano" in result
+
+        # Empty "name" key - should default to "meltano"
+        event_dict_empty_name = {
+            "timestamp": "2021-01-01T00:00:00Z",
+            "level": "info",
+            "event": "Something happened",
+            "name": "",
+        }
+        result = renderer(None, "info", event_dict_empty_name)
+        assert "meltano" in result
 
     def test_plugin_name_column(
         self,


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Example output:

```
2026-01-29T16:48:08.497429Z [info     ] meltano      Environment 'dev' is active
2026-01-29T16:48:08.657516Z [info     ] meltano      Running job with name 'dev:tap-fedidb-to-target-csv' and run ID '019c0aa7-b397-7a5c-96b4-9ecffdc419d3'
2026-01-29T16:48:08.702374Z [info     ] meltano      Using systemdb state backend
2026-01-29T16:48:08.703401Z [warning  ] meltano      No state was found, complete import.
2026-01-29T16:48:08.943381Z [info     ] tap-fedidb   tap-fedidb v0.5.3, Meltano SDK v0.53.5
2026-01-29T16:48:08.943835Z [info     ] tap-fedidb   Skipping parse of env var settings...
2026-01-29T16:48:08.944161Z [info     ] tap-fedidb   Skipping deselected stream 'popular_accounts'.
2026-01-29T16:48:08.944261Z [info     ] tap-fedidb   Skipping deselected stream 'servers'.
2026-01-29T16:48:08.944391Z [info     ] tap-fedidb   Skipping deselected stream 'software'.
2026-01-29T16:48:08.965030Z [info     ] target-csv   target-csv v0.3.0, Meltano SDK v0.53.5
2026-01-29T16:48:08.965193Z [info     ] target-csv   Skipping parse of env var settings...
2026-01-29T16:48:08.978007Z [info     ] target-csv   Reader 'target-csv' completed processing 0 lines of input (0 schemas, 0 records, 0 batch manifests, 0 state messages, 0 activate version messages).
2026-01-29T16:48:09.011797Z [info     ] meltano      Block run completed
2026-01-29T16:48:09.012194Z [info     ] meltano      Run completed
```

## Related Issues

* Closes https://github.com/meltano/meltano/issues/9586

## Summary by Sourcery

Tests:
- Update logging renderer tests to assert plugin names appear in a separate column (not as key=value) and that 'meltano' is used as the default name when missing.