### PR TITLE
ci: Set up CodSpeed benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,58 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    paths:
+      - src/**
+      - tests/benchmark/**
+      - uv.lock
+      - .github/workflows/benchmark.yml
+  push:
+    branches: [main]
+    paths:
+      - src/**
+      - tests/benchmark/**
+      - uv.lock
+      - .github/workflows/benchmark.yml
+  workflow_dispatch:
+    inputs: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+  UV_PYTHON_DOWNLOADS: "never"
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: "Run benchmarks with CodSpeed"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        persist-credentials: false
+
+    - name: Setup Python
+      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+
+    - name: Install dependencies
+      run: |
+        uv sync --group testing
+
+    - name: Run benchmarks
+      uses: CodSpeedHQ/action@dbda7111f8ac363564b0c51b992d4ce76bb89f2f # v4.5.2
+      with:
+        mode: simulation
+        run: uv run pytest tests/benchmarks/ --codspeed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ testing = [
   "moto>=5.0.21,<6",
   "pytest>=9",
   "pytest-asyncio>=1.3",
+  "pytest-codspeed>=4.2.0",
   "pytest-docker~=3.1",
   "pytest-order~=1.3",
   "pytest-randomly>=3.16,<5.0",

--- a/tests/benchmarks/test_tap_benchmarks.py
+++ b/tests/benchmarks/test_tap_benchmarks.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+import typing as t
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+
+from meltano.core.plugin import PluginType
+from meltano.core.plugin_invoker import PluginInvoker
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from meltano.core.plugin.project_plugin import ProjectPlugin
+    from meltano.core.plugin.singer import SingerTap
+    from meltano.core.project_add_service import ProjectAddService
+
+
+def generate_catalog(num_streams: int = 50, properties_per_stream: int = 100) -> dict:
+    """Generate a realistic Singer catalog for benchmarking.
+
+    Args:
+        num_streams: Number of streams in the catalog.
+        properties_per_stream: Number of properties per stream.
+
+    Returns:
+        A Singer catalog dictionary.
+    """
+    streams = []
+    for i in range(num_streams):
+        properties = {}
+        for j in range(properties_per_stream):
+            properties[f"property_{j}"] = {
+                "type": ["null", "string"],
+                "description": f"Description for property {j} in stream {i}",
+            }
+
+        streams.append(
+            {
+                "tap_stream_id": f"stream_{i}",
+                "stream": f"stream_{i}",
+                "schema": {
+                    "type": "object",
+                    "properties": properties,
+                },
+                "metadata": [
+                    {
+                        "breadcrumb": [],
+                        "metadata": {
+                            "selected": True,
+                            "replication-method": "INCREMENTAL",
+                            "replication-key": "updated_at",
+                        },
+                    },
+                    *[
+                        {
+                            "breadcrumb": ["properties", f"property_{j}"],
+                            "metadata": {"selected": True},
+                        }
+                        for j in range(properties_per_stream)
+                    ],
+                ],
+            }
+        )
+
+    return {"streams": streams}
+
+
+def create_mock_process(catalog_json: str) -> mock.Mock:
+    """Create a mock subprocess that simulates tap --discover output.
+
+    The mock process yields the catalog JSON line by line through stdout,
+    which exercises the _stream_redirect function's async file I/O.
+
+    Args:
+        catalog_json: The JSON string to output through stdout.
+
+    Returns:
+        A mock process object.
+    """
+    # Split catalog into lines to simulate realistic subprocess output
+    # Singer taps typically output the full JSON, but we split by lines
+    # to exercise _stream_redirect's line-by-line reading
+    lines = catalog_json.encode("utf-8").split(b"\n")
+    line_iter = iter(lines)
+
+    def readline_side_effect() -> bytes:
+        try:
+            return next(line_iter) + b"\n"
+        except StopIteration:
+            return b""
+
+    # Track EOF state based on whether we've exhausted lines
+    eof_called = {"count": 0, "total_lines": len(lines)}
+
+    def at_eof_side_effect() -> bool:
+        eof_called["count"] += 1
+        # Return False until we've read all lines, then True
+        return eof_called["count"] > eof_called["total_lines"]
+
+    process_mock = mock.Mock()
+    process_mock.wait = AsyncMock(return_value=0)
+    process_mock.returncode = 0
+
+    # Mock stdout to yield catalog data line by line
+    process_mock.stdout.at_eof.side_effect = at_eof_side_effect
+    process_mock.stdout.readline = AsyncMock(side_effect=readline_side_effect)
+
+    # Mock stderr to return EOF immediately (no stderr output)
+    process_mock.stderr.at_eof.return_value = True
+    process_mock.stderr.readline = AsyncMock(return_value=b"")
+
+    return process_mock
+
+
+class TestTapBenchmarks:
+    """Benchmarks for SingerTap operations.
+
+    These benchmarks help prevent performance regressions like the one
+    identified in https://github.com/meltano/meltano/pull/9724, where
+    switching to async I/O for catalog file operations caused slowdowns.
+    """
+
+    @pytest.fixture(scope="class")
+    def subject(self, project_add_service: ProjectAddService) -> SingerTap:
+        return project_add_service.add(PluginType.EXTRACTORS, "tap-mock")
+
+    @pytest.fixture
+    def large_catalog(self) -> dict:
+        """Generate a catalog for benchmarking.
+
+        Uses 10 streams x 30 properties = 300 total properties.
+        With pretty-printed JSON, this creates ~5k lines - enough to
+        detect regressions while keeping CI runtime reasonable.
+        """
+        return generate_catalog(num_streams=10, properties_per_stream=30)
+
+    @pytest.mark.benchmark
+    @pytest.mark.asyncio
+    async def test_discover_catalog(
+        self,
+        session,
+        plugin_invoker_factory: Callable[[ProjectPlugin], PluginInvoker],
+        subject: SingerTap,
+        large_catalog: dict,
+    ) -> None:
+        """Benchmark SingerTap.discover_catalog performance.
+
+        This benchmark measures the time to:
+        1. Run discovery via _stream_redirect (mocked subprocess stdout)
+        2. Write catalog data through async file I/O
+        3. Validate the catalog JSON
+
+        The _stream_redirect async file I/O was the source of the regression
+        in PR #9724, where async I/O was slower than sync I/O.
+        """
+        invoker = plugin_invoker_factory(subject)
+
+        # Pretty-print JSON to create more lines for _stream_redirect to process
+        catalog_json = json.dumps(large_catalog, indent=2)
+        process_mock = create_mock_process(catalog_json)
+
+        async with invoker.prepared(session):
+            invoker.invoke_async = AsyncMock(return_value=process_mock)
+            # Mock stderr_logger to avoid structlog compatibility issues
+            with mock.patch.object(
+                PluginInvoker,
+                "stderr_logger",
+                new_callable=mock.PropertyMock,
+                return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=False)),
+            ):
+                await subject.discover_catalog(invoker)
+
+    @pytest.mark.benchmark
+    @pytest.mark.asyncio
+    async def test_apply_catalog_rules(
+        self,
+        session,
+        plugin_invoker_factory: Callable[[ProjectPlugin], PluginInvoker],
+        subject: SingerTap,
+        large_catalog: dict,
+    ) -> None:
+        """Benchmark SingerTap.apply_catalog_rules performance.
+
+        This benchmark measures the time to:
+        1. Read the catalog file
+        2. Apply metadata and schema rules
+        3. Write the modified catalog back
+
+        The file I/O and JSON parsing/serialization here was also affected
+        by the regression in PR #9724.
+        """
+        invoker = plugin_invoker_factory(subject)
+        catalog_path = invoker.files["catalog"]
+        catalog_json = json.dumps(large_catalog)
+
+        async with invoker.prepared(session):
+            # Write the catalog file for apply_catalog_rules to process
+            catalog_path.write_text(catalog_json)
+            await subject.apply_catalog_rules(invoker)

--- a/uv.lock
+++ b/uv.lock
@@ -1415,6 +1415,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-codspeed" },
     { name = "pytest-docker" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
@@ -1441,6 +1442,7 @@ testing = [
     { name = "moto" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-codspeed" },
     { name = "pytest-docker" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
@@ -1462,6 +1464,7 @@ typing = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-codspeed" },
     { name = "pytest-docker" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
@@ -1535,6 +1538,7 @@ dev = [
     { name = "mypy", specifier = ">=1.16.0,<2" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-asyncio", specifier = ">=1.3" },
+    { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
@@ -1559,6 +1563,7 @@ testing = [
     { name = "moto", specifier = ">=5.0.21,<6" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-asyncio", specifier = ">=1.3" },
+    { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
@@ -1580,6 +1585,7 @@ typing = [
     { name = "mypy", specifier = ">=1.16.0,<2" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-asyncio", specifier = ">=1.3" },
+    { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
@@ -2433,6 +2439,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-codspeed"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/e8/27fcbe6516a1c956614a4b61a7fccbf3791ea0b992e07416e8948184327d/pytest_codspeed-4.2.0.tar.gz", hash = "sha256:04b5d0bc5a1851ba1504d46bf9d7dbb355222a69f2cd440d54295db721b331f7", size = 113263, upload-time = "2025-10-24T09:02:55.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/b8/d599a466c50af3f04001877ae8b17c12b803f3b358235736b91a0769de0d/pytest_codspeed-4.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:609828b03972966b75b9b7416fa2570c4a0f6124f67e02d35cd3658e64312a7b", size = 261943, upload-time = "2025-10-24T09:02:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/74/19/ccc1a2fcd28357a8db08ba6b60f381832088a3850abc262c8e0b3406491a/pytest_codspeed-4.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23a0c0fbf8bb4de93a3454fd9e5efcdca164c778aaef0a9da4f233d85cb7f5b8", size = 250782, upload-time = "2025-10-24T09:02:39.617Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2d/f0083a2f14ecf008d961d40439a71da0ae0d568e5f8dc2fccd3e8a2ab3e4/pytest_codspeed-4.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2de87bde9fbc6fd53f0fd21dcf2599c89e0b8948d49f9bad224edce51c47e26b", size = 261960, upload-time = "2025-10-24T09:02:40.665Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/0c/1f514c553db4ea5a69dfbe2706734129acd0eca8d5101ec16f1dd00dbc0f/pytest_codspeed-4.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95aeb2479ca383f6b18e2cc9ebcd3b03ab184980a59a232aea6f370bbf59a1e3", size = 250808, upload-time = "2025-10-24T09:02:42.07Z" },
+    { url = "https://files.pythonhosted.org/packages/81/04/479905bd6653bc981c0554fcce6df52d7ae1594e1eefd53e6cf31810ec7f/pytest_codspeed-4.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d4fefbd4ae401e2c60f6be920a0be50eef0c3e4a1f0a1c83962efd45be38b39", size = 262084, upload-time = "2025-10-24T09:02:43.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/46/d6f345d7907bac6cbb6224bd697ecbc11cf7427acc9e843c3618f19e3476/pytest_codspeed-4.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:309b4227f57fcbb9df21e889ea1ae191d0d1cd8b903b698fdb9ea0461dbf1dfe", size = 251100, upload-time = "2025-10-24T09:02:44.168Z" },
+    { url = "https://files.pythonhosted.org/packages/de/dc/e864f45e994a50390ff49792256f1bdcbf42f170e3bc0470ee1a7d2403f3/pytest_codspeed-4.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72aab8278452a6d020798b9e4f82780966adb00f80d27a25d1274272c54630d5", size = 262057, upload-time = "2025-10-24T09:02:45.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1c/f1d2599784486879cf6579d8d94a3e22108f0e1f130033dab8feefd29249/pytest_codspeed-4.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:684fcd9491d810ded653a8d38de4835daa2d001645f4a23942862950664273f8", size = 251013, upload-time = "2025-10-24T09:02:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fd/eafd24db5652a94b4d00fe9b309b607de81add0f55f073afb68a378a24b6/pytest_codspeed-4.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50794dabea6ec90d4288904452051e2febace93e7edf4ca9f2bce8019dd8cd37", size = 262065, upload-time = "2025-10-24T09:02:48.018Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/14/8d9340d7dc0ae647991b28a396e16b3403e10def883cde90d6b663d3f7ec/pytest_codspeed-4.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0ebd87f2a99467a1cfd8e83492c4712976e43d353ee0b5f71cbb057f1393aca", size = 251057, upload-time = "2025-10-24T09:02:49.102Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/48cf6afbca55bc7c8c93c3d4ae926a1068bcce3f0241709db19b078d5418/pytest_codspeed-4.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbbb2d61b85bef8fc7e2193f723f9ac2db388a48259d981bbce96319043e9830", size = 267983, upload-time = "2025-10-24T09:02:50.558Z" },
+    { url = "https://files.pythonhosted.org/packages/33/86/4407341efb5dceb3e389635749ce1d670542d6ca148bd34f9d5334295faf/pytest_codspeed-4.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:748411c832147bfc85f805af78a1ab1684f52d08e14aabe22932bbe46c079a5f", size = 256732, upload-time = "2025-10-24T09:02:51.603Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0e/8cb71fd3ed4ed08c07aec1245aea7bc1b661ba55fd9c392db76f1978d453/pytest_codspeed-4.2.0-py3-none-any.whl", hash = "sha256:e81bbb45c130874ef99aca97929d72682733527a49f84239ba575b5cb843bab0", size = 113726, upload-time = "2025-10-24T09:02:54.785Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->



## Related Issues

* Closes #8341
* #9724

## Summary by Sourcery

Set up CodSpeed-powered performance benchmarks for Singer taps and integrate them into CI.

New Features:
- Add a benchmarks dependency group including pytest-codspeed for running performance tests.
- Introduce benchmark tests for SingerTap discovery and catalog rule application against large synthetic catalogs.

CI:
- Add a GitHub Actions workflow to run CodSpeed benchmarks on pushes, pull requests, and manual triggers using the benchmarks dependency group.

Tests:
- Create benchmark test suite for SingerTap catalog discovery and catalog rule application to detect performance regressions.