### PR TITLE
ci: Switch to CodSpeed walltime instrument

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   benchmark:
     name: "Run benchmarks with CodSpeed"
-    runs-on: ubuntu-latest
+    runs-on: codspeed-macro
     timeout-minutes: 10
 
     steps:
@@ -54,5 +54,5 @@ jobs:
     - name: Run benchmarks
       uses: CodSpeedHQ/action@dbda7111f8ac363564b0c51b992d4ce76bb89f2f # v4.5.2
       with:
-        mode: simulation
+        mode: walltime
         run: uv run pytest tests/benchmarks/ --codspeed


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update CodSpeed benchmark workflow to use dedicated runner and walltime instrumentation.

CI:
- Change benchmark workflow runner to the CodSpeed-specific `codspeed-macro` environment.
- Switch CodSpeed action benchmarking mode from simulation to walltime.