### PR TITLE
ci: Address variance in CodSpeed benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,4 +55,4 @@ jobs:
       uses: CodSpeedHQ/action@dbda7111f8ac363564b0c51b992d4ce76bb89f2f # v4.5.2
       with:
         mode: walltime
-        run: uv run pytest tests/benchmarks/ --codspeed
+        run: uv run pytest tests/benchmarks/ --codspeed -p no:randomly

--- a/tests/benchmarks/test_state_backend_benchmarks.py
+++ b/tests/benchmarks/test_state_backend_benchmarks.py
@@ -107,7 +107,6 @@ class TestStateBackendBenchmarks:
     def test_local_filesystem_repeated_updates_partial_state(
         self,
         subject: _LocalFilesystemStateStoreManager,
-        benchmark,
     ) -> None:
         """Benchmark repeated update() calls with partial state (locking path).
 
@@ -115,13 +114,10 @@ class TestStateBackendBenchmarks:
         updates with no completed_state payload, so we can compare against the
         optimized complete-state path under similar load.
         """
-        state = MeltanoState(
-            state_id="test-partial-repeated",
-            partial_state={"singer_state": {"bookmark": 1}},
-            completed_state={},
-        )
-
-        def do_update() -> None:
+        for i in range(50):
+            state = MeltanoState(
+                state_id="test-partial-repeated",
+                partial_state={"singer_state": {"bookmark": i}},
+                completed_state={},
+            )
             subject.update(state)
-
-        benchmark(do_update)

--- a/tests/benchmarks/test_tap_benchmarks.py
+++ b/tests/benchmarks/test_tap_benchmarks.py
@@ -1,5 +1,15 @@
+"""Benchmarks for SingerTap catalog operations.
+
+These benchmarks measure the performance of catalog discovery and rule
+application, which were affected by the async I/O changes in commit f3fa5b450.
+
+This exercises the anyio.open_file() read/write paths with real disk I/O,
+complementing the isolated _stream_redirect benchmarks.
+"""
+
 from __future__ import annotations
 
+import asyncio
 import json
 import typing as t
 from unittest import mock
@@ -7,196 +17,160 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from meltano.core.plugin import PluginType
 from meltano.core.plugin_invoker import PluginInvoker
 
 if t.TYPE_CHECKING:
-    from collections.abc import Callable
-
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.plugin.singer import SingerTap
     from meltano.core.project_add_service import ProjectAddService
 
 
-def generate_catalog(num_streams: int = 50, properties_per_stream: int = 100) -> dict:
-    """Generate a realistic Singer catalog for benchmarking.
-
-    Args:
-        num_streams: Number of streams in the catalog.
-        properties_per_stream: Number of properties per stream.
-
-    Returns:
-        A Singer catalog dictionary.
-    """
+def generate_catalog(num_streams: int = 10, properties_per_stream: int = 30) -> dict:
+    """Generate a realistic Singer catalog for benchmarking."""
     streams = []
     for i in range(num_streams):
-        properties = {}
-        for j in range(properties_per_stream):
-            properties[f"property_{j}"] = {
-                "type": ["null", "string"],
-                "description": f"Description for property {j} in stream {i}",
-            }
-
+        properties = {
+            f"property_{j}": {"type": ["null", "string"]}
+            for j in range(properties_per_stream)
+        }
         streams.append(
             {
                 "tap_stream_id": f"stream_{i}",
                 "stream": f"stream_{i}",
-                "schema": {
-                    "type": "object",
-                    "properties": properties,
-                },
-                "metadata": [
-                    {
-                        "breadcrumb": [],
-                        "metadata": {
-                            "selected": True,
-                            "replication-method": "INCREMENTAL",
-                            "replication-key": "updated_at",
-                        },
-                    },
-                    *[
-                        {
-                            "breadcrumb": ["properties", f"property_{j}"],
-                            "metadata": {"selected": True},
-                        }
-                        for j in range(properties_per_stream)
-                    ],
-                ],
+                "schema": {"type": "object", "properties": properties},
+                "metadata": [{"breadcrumb": [], "metadata": {"selected": True}}],
             }
         )
-
     return {"streams": streams}
 
 
-def create_mock_process(catalog_json: str) -> mock.Mock:
-    """Create a mock subprocess that simulates tap --discover output.
+class MockStdout:
+    """Mock stdout that yields catalog data line by line.
 
-    The mock process yields the catalog JSON line by line through stdout,
-    which exercises the _stream_redirect function's async file I/O.
-
-    Args:
-        catalog_json: The JSON string to output through stdout.
-
-    Returns:
-        A mock process object.
+    This class avoids closure/iterator issues by using an index-based approach.
     """
-    # Split catalog into lines to simulate realistic subprocess output
-    # Singer taps typically output the full JSON, but we split by lines
-    # to exercise _stream_redirect's line-by-line reading
-    lines = catalog_json.encode("utf-8").split(b"\n")
-    line_iter = iter(lines)
 
-    def readline_side_effect() -> bytes:
-        try:
-            return next(line_iter) + b"\n"
-        except StopIteration:
+    def __init__(self, lines: list[bytes]) -> None:
+        self.lines = lines
+        self.index = 0
+
+    def reset(self) -> None:
+        """Reset to beginning for reuse."""
+        self.index = 0
+
+    def at_eof(self) -> bool:
+        return self.index >= len(self.lines)
+
+    async def readline(self) -> bytes:
+        if self.index >= len(self.lines):
             return b""
+        line = self.lines[self.index]
+        self.index += 1
+        return line
 
-    # Track EOF state based on whether we've exhausted lines
-    eof_called = {"count": 0, "total_lines": len(lines)}
 
-    def at_eof_side_effect() -> bool:
-        eof_called["count"] += 1
-        # Return False until we've read all lines, then True
-        return eof_called["count"] > eof_called["total_lines"]
+class MockStderr:
+    """Mock stderr that returns EOF immediately."""
 
-    process_mock = mock.Mock()
-    process_mock.wait = AsyncMock(return_value=0)
-    process_mock.returncode = 0
+    def at_eof(self) -> bool:
+        return True
 
-    # Mock stdout to yield catalog data line by line
-    process_mock.stdout.at_eof.side_effect = at_eof_side_effect
-    process_mock.stdout.readline = AsyncMock(side_effect=readline_side_effect)
-
-    # Mock stderr to return EOF immediately (no stderr output)
-    process_mock.stderr.at_eof.return_value = True
-    process_mock.stderr.readline = AsyncMock(return_value=b"")
-
-    return process_mock
+    async def readline(self) -> bytes:
+        return b""
 
 
 class TestTapBenchmarks:
-    """Benchmarks for SingerTap operations.
-
-    These benchmarks help prevent performance regressions like the one
-    identified in https://github.com/meltano/meltano/pull/9724, where
-    switching to async I/O for catalog file operations caused slowdowns.
-    """
+    """Benchmarks for SingerTap catalog operations."""
 
     @pytest.fixture(scope="class")
-    def subject(self, project_add_service: ProjectAddService) -> SingerTap:
+    def tap_plugin(self, project_add_service: ProjectAddService) -> SingerTap:
+        """Create tap plugin once per test class."""
+        from meltano.core.plugin import PluginType
+
         return project_add_service.add(PluginType.EXTRACTORS, "tap-mock")
 
-    @pytest.fixture
-    def large_catalog(self) -> dict:
-        """Generate a catalog for benchmarking.
+    @pytest.fixture(scope="class")
+    def catalog(self) -> dict:
+        """Pre-generate catalog once per test class."""
+        return generate_catalog()
 
-        Uses 10 streams x 30 properties = 300 total properties.
-        With pretty-printed JSON, this creates ~5k lines - enough to
-        detect regressions while keeping CI runtime reasonable.
-        """
-        return generate_catalog(num_streams=10, properties_per_stream=30)
-
-    @pytest.mark.benchmark
-    @pytest.mark.asyncio
-    async def test_discover_catalog(
-        self,
-        session,
-        plugin_invoker_factory: Callable[[ProjectPlugin], PluginInvoker],
-        subject: SingerTap,
-        large_catalog: dict,
-    ) -> None:
-        """Benchmark SingerTap.discover_catalog performance.
-
-        This benchmark measures the time to:
-        1. Run discovery via _stream_redirect (mocked subprocess stdout)
-        2. Write catalog data through async file I/O
-        3. Validate the catalog JSON
-
-        The _stream_redirect async file I/O was the source of the regression
-        in PR #9724, where async I/O was slower than sync I/O.
-        """
-        invoker = plugin_invoker_factory(subject)
-
-        # Pretty-print JSON to create more lines for _stream_redirect to process
-        catalog_json = json.dumps(large_catalog, indent=2)
-        process_mock = create_mock_process(catalog_json)
-
-        async with invoker.prepared(session):
-            invoker.invoke_async = AsyncMock(return_value=process_mock)
-            # Mock stderr_logger to avoid structlog compatibility issues
-            with mock.patch.object(
-                PluginInvoker,
-                "stderr_logger",
-                new_callable=mock.PropertyMock,
-                return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=False)),
-            ):
-                await subject.discover_catalog(invoker)
+    @pytest.fixture(scope="class")
+    def catalog_lines(self, catalog: dict) -> list[bytes]:
+        """Pre-compute catalog lines once per test class."""
+        catalog_json = json.dumps(catalog, indent=2)
+        return [line.encode() + b"\n" for line in catalog_json.split("\n")]
 
     @pytest.mark.benchmark
-    @pytest.mark.asyncio
-    async def test_apply_catalog_rules(
+    def test_discover_catalog(
         self,
         session,
-        plugin_invoker_factory: Callable[[ProjectPlugin], PluginInvoker],
-        subject: SingerTap,
-        large_catalog: dict,
+        tap_plugin: SingerTap,
+        catalog_lines: list[bytes],
+        plugin_invoker_factory: t.Callable[[ProjectPlugin], PluginInvoker],
+        benchmark,
     ) -> None:
-        """Benchmark SingerTap.apply_catalog_rules performance.
+        """Benchmark catalog discovery with mocked subprocess.
 
-        This benchmark measures the time to:
-        1. Read the catalog file
-        2. Apply metadata and schema rules
-        3. Write the modified catalog back
-
-        The file I/O and JSON parsing/serialization here was also affected
-        by the regression in PR #9724.
+        This exercises the _stream_redirect function writing to a real file,
+        which uses anyio.open_file() in async mode.
         """
-        invoker = plugin_invoker_factory(subject)
-        catalog_path = invoker.files["catalog"]
-        catalog_json = json.dumps(large_catalog)
+        invoker = plugin_invoker_factory(tap_plugin)
 
-        async with invoker.prepared(session):
-            # Write the catalog file for apply_catalog_rules to process
-            catalog_path.write_text(catalog_json)
-            await subject.apply_catalog_rules(invoker)
+        # Create mock objects once, reuse across the benchmark
+        mock_stdout = MockStdout(catalog_lines)
+        mock_stderr = MockStderr()
+
+        process_mock = mock.Mock()
+        process_mock.stdout = mock_stdout
+        process_mock.stderr = mock_stderr
+        process_mock.wait = AsyncMock(return_value=0)
+        process_mock.returncode = 0
+
+        async def run_discovery() -> None:
+            async with invoker.prepared(session):
+                mock_stdout.reset()
+                invoker.invoke_async = AsyncMock(return_value=process_mock)
+
+                with mock.patch.object(
+                    PluginInvoker,
+                    "stderr_logger",
+                    new_callable=mock.PropertyMock,
+                    return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=False)),
+                ):
+                    await tap_plugin.discover_catalog(invoker)
+
+        # Use pedantic mode with warmup for more stable async benchmarks
+        benchmark.pedantic(
+            lambda: asyncio.run(run_discovery()),
+            rounds=10,
+            warmup_rounds=5,
+        )
+
+    @pytest.mark.benchmark
+    def test_apply_catalog_rules(
+        self,
+        session,
+        tap_plugin: SingerTap,
+        catalog: dict,
+        plugin_invoker_factory: t.Callable[[ProjectPlugin], PluginInvoker],
+        benchmark,
+    ) -> None:
+        """Benchmark applying catalog rules with real file I/O.
+
+        This exercises the anyio.open_file() read/write paths that were
+        changed in commit f3fa5b450.
+        """
+        invoker = plugin_invoker_factory(tap_plugin)
+        catalog_json = json.dumps(catalog)
+
+        async def apply_rules() -> None:
+            async with invoker.prepared(session):
+                invoker.files["catalog"].write_text(catalog_json)
+                await tap_plugin.apply_catalog_rules(invoker)
+
+        # Use pedantic mode with warmup for more stable async benchmarks
+        benchmark.pedantic(
+            lambda: asyncio.run(apply_rules()),
+            rounds=10,
+            warmup_rounds=5,
+        )


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Improve reliability and stability of CodSpeed benchmark tests for Singer taps and state backend.

Enhancements:
- Simplify and shrink the generated Singer catalog used in tap benchmarks and refactor benchmark fixtures for reuse across runs.
- Replace ad-hoc mock subprocess creation with dedicated stdout/stderr mock classes and use pedantic benchmarking with warmup rounds for async tap benchmarks.
- Adjust the local filesystem state backend partial-update benchmark to perform many direct updates in a loop instead of benchmarking a single callable.

CI:
- Update the CodSpeed GitHub Actions workflow to disable pytest-randomly when running benchmark tests to reduce variance.