### PR TITLE
ci: Revert "ci(deps): Bump snowplow-micro to 3.0.1 (#9761)"

### DIFF
--- a/tests/fixtures/docker/docker-compose.yml
+++ b/tests/fixtures/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   snowplow:
-    image: "snowplow/snowplow-micro:3.0.1-distroless"
+    image: "snowplow/snowplow-micro:2.3.0-distroless"
     user: "1000:0"
     command: --collector-config /config/micro.conf --iglu /config/iglu.json
     ports:


### PR DESCRIPTION
Leads to too much flakiness due to race conditions.

This reverts commit cd0899a934671cd721a9e107044926c53b7bae0b.

<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Revert the Snowplow Micro dependency bump in CI and restore the previous tracking test behavior.

CI:
- Revert Snowplow Micro Docker image from version 3.0.1 to 2.3.0 in the test docker-compose configuration.

Tests:
- Re-enable the exit event tracking test by removing the xfail mark and simplifying the event assertions to match the reverted Snowplow Micro behavior.