### PR TITLE
refactor: Handle catalog stream redirection for sync and async targets separately

### DIFF
--- a/tests/meltano/core/plugin/singer/test_tap.py
+++ b/tests/meltano/core/plugin/singer/test_tap.py
@@ -1026,11 +1026,15 @@ class TestSingerTap:
                 return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=False)),
             ),
             mock.patch(
-                "meltano.core.plugin.singer.tap._stream_redirect",
-            ) as stream_mock,
+                "meltano.core.plugin.singer.tap._stream_redirect_async",
+            ) as async_stream_mock,
+            mock.patch(
+                "meltano.core.plugin.singer.tap._stream_redirect_sync",
+            ) as sync_stream_mock,
         ):
             await subject.run_discovery(invoker, catalog_path)
-            assert stream_mock.call_count == 2
+            assert async_stream_mock.call_count == 1
+            assert sync_stream_mock.call_count == 1
 
         with (
             mock.patch.object(
@@ -1040,7 +1044,7 @@ class TestSingerTap:
                 return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=True)),
             ),
             mock.patch(
-                "meltano.core.plugin.singer.tap._stream_redirect",
+                "meltano.core.plugin.singer.tap._stream_redirect_async",
             ) as stream_mock2,
         ):
             await subject.run_discovery(invoker, catalog_path)
@@ -1058,7 +1062,7 @@ class TestSingerTap:
                 return_value=mock.Mock(isEnabledFor=mock.Mock(return_value=True)),
             ),
             mock.patch(
-                "meltano.core.plugin.singer.tap._stream_redirect",
+                "meltano.core.plugin.singer.tap._stream_redirect_async",
             ) as stream_mock3,
             mock.patch(
                 "meltano.core.plugin.singer.tap.capture_subprocess_output",


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enhancements:
- Split stream redirection into dedicated async and sync helpers to simplify and clarify stream handling during tap discovery.