### PR TITLE
chore: Add some useful files for investigating performance regressions

### DIFF
--- a/perf/.gitignore
+++ b/perf/.gitignore
@@ -1,0 +1,2 @@
+logs/
+profiles/

--- a/perf/flamegraphs.sh
+++ b/perf/flamegraphs.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+function init {
+    rm -rdf ./profiles
+    rm -rdf ./logs
+    mkdir ./profiles
+    mkdir ./logs
+}
+
+function cleanup {
+    rm -rdf dist
+    rm -rdf .venv
+    rm -rdf ./project/.meltano/
+    rm -rdf ./project/output/warehouse.duckdb
+}
+
+function prepare {
+    uv venv -p 3.10
+    echo "Installing $1 into a virtualenv..."
+    VIRTUAL_ENV=.venv uv pip install "$1"
+    .venv/bin/meltano --version
+    .venv/bin/meltano --cwd ./project install
+}
+
+function run {
+    meltano_run=".venv/bin/meltano --cwd ./project run --refresh-catalog tap-mysql target-duckdb"
+    echo "Profiling command $meltano_run"
+    NO_COLOR=1 sudo sh -c "umask 0002 && py-spy record -o ./profiles/profile-$1.svg -- $meltano_run 2> ./logs/logs-$1.txt"
+}
+
+init
+
+# EXAMPLE: check a specific commit
+# https://github.com/meltano/meltano/commit/43bba8c9859a9f679d61716e98a3d5b753815f9d
+# cleanup
+# prepare 'meltano @ git+https://github.com/meltano/meltano.git@43bba8c9859a9f679d61716e98a3d5b753815f9d'
+# run 43bba8c9859a9f679d61716e98a3d5b753815f9d
+
+# v3.6.0
+cleanup
+prepare 'meltano==3.6.0'
+run v3.6
+
+# v3.7.9
+cleanup
+prepare 'meltano==3.7.9'
+run v3.7
+
+# v4.0.8
+cleanup
+prepare 'meltano==4.0.8'
+run v4.0.8
+
+# HEAD
+cleanup
+prepare 'meltano @ ../'
+run latest

--- a/perf/project/.gitignore
+++ b/perf/project/.gitignore
@@ -1,0 +1,3 @@
+/venv
+/.meltano
+.env

--- a/perf/project/compose.yml
+++ b/perf/project/compose.yml
@@ -1,0 +1,20 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: meltano-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: testdb
+      MYSQL_USER: meltano
+      MYSQL_PASSWORD: meltano123
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+
+volumes:
+  mysql_data:

--- a/perf/project/logging.yaml
+++ b/perf/project/logging.yaml
@@ -1,0 +1,19 @@
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  structured_plain_no_locals:
+    (): meltano.core.logging.console_log_formatter
+    colors: false
+    show_locals: false
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: structured_plain_no_locals
+    stream: "ext://sys.stderr"
+
+root:
+  level: INFO
+  handlers: [console]

--- a/perf/project/meltano.yml
+++ b/perf/project/meltano.yml
@@ -1,0 +1,159 @@
+default_environment: dev
+project_id: 019ba0c4-064f-7b15-92ff-60abac4a6a54
+environments:
+- name: dev
+- name: staging
+- name: prod
+send_anonymous_usage_stats: false
+plugins:
+  extractors:
+  # Refresh with:
+  # meltano add tap-mysql --python python3.10 --from-ref path/to/matatika-catalog/matatika-catalog-core/src/main/resources/plugins/extractors/tap-mysql--matatika.yml
+  - name: tap-mysql
+    namespace: tap_mysql
+    python: python3.10
+    label: MySQL - MariaDB
+    variant: matatika
+    docs: ${websiteBaseUrl}/data-details/tap-mysql/
+    repo: https://github.com/Matatika/pipelinewise-tap-mysql
+    pip_url: git+https://github.com/Matatika/pipelinewise-tap-mysql.git@v1.0.0 cryptography
+    description: "MySQL and MariaDB are popular open-source relational database management
+      systems.\n\nMySQL and MariaDB are powerful and flexible database management
+      system that allows users to store, organize, and retrieve data efficiently.
+      It is widely used in web applications and is known for its reliability, scalability,
+      and ease of use. MySQL and MariaDB support a wide range of programming languages
+      and platforms, making it a popular choice for developers and businesses of all
+      sizes. It offers features such as transaction support, replication, and clustering,
+      and can be used for a variety of applications, from small personal projects
+      to large enterprise systems. Overall, MySQL/MariaDB is a versatile and reliable
+      database management system that is widely used in the industry."
+    logo_url: /assets/logos/extractors/mysql.png
+    capabilities:
+    - catalog
+    - discover
+    - state
+    settings_group_validation:
+    - - host
+      - port
+      - user
+      - password
+    settings:
+    - name: host
+      value: localhost
+      label: Host
+      description: The hostname or IP address of the MySQL/MariaDB server.
+      # required: true
+    - name: port
+      kind: integer
+      value: 3306
+      label: Port
+      description: The port number to use for the connection.
+    - name: user
+      label: User
+      description: The username to use for authentication.
+      # required: true
+    - name: password
+      label: Password
+      description: The password to use for authentication.
+      sensitive: true
+      # required: true
+    - name: database
+      label: Database
+      description: The name of the database to connect to.
+    - name: cursorclass
+      label: Cursor Class
+      description: The class to use for the cursor.
+    - name: server_id
+      kind: integer
+      label: Server ID
+      description: The server ID to use for replication.
+    - name: filter_dbs
+      label: Filter DBs
+      description: A list of databases to include or exclude from replication.
+    - name: use_gtid
+      kind: boolean
+      value: false
+      label: Use GTID
+      description: Whether to use global transaction identifiers for replication.
+    - name: engine
+      value: mysql
+      label: Engine
+      description: The storage engine to use for the connection.
+    - name: ssl
+      kind: boolean
+      value: false
+      label: SSL
+      description: Whether to use SSL encryption for the connection.
+      value_post_processor: stringify
+    - name: ssl_ca
+      label: SSL CA
+      description: The path to the SSL CA certificate file.
+    - name: ssl_cert
+      label: SSL Certificate
+      description: The path to the SSL certificate file.
+    - name: ssl_key
+      label: SSL Key
+      description: The path to the SSL key file.
+    - name: internal_hostname
+      label: Internal Hostname
+      description: The internal hostname to use for the connection.
+    - name: session_sqls
+      kind: array
+      value:
+      - SET @@session.time_zone='+0:00'
+      - SET @@session.wait_timeout=28800
+      - SET @@session.net_read_timeout=3600
+      - SET @@session.innodb_lock_wait_timeout=3600
+      label: Session SQLs
+      description: A list of SQL statements to execute when the connection is established.
+    - name: ssh_tunnel.host
+      kind: string
+      label: SSH Tunnel Host
+      description: Address of the bastion host, this is the host we'll connect to
+        via ssh
+    - name: ssh_tunnel.port
+      kind: integer
+      value: 22
+      label: SSH Tunnel Port
+      description: Port to connect to bastion host
+    - name: ssh_tunnel.private_key
+      kind: string
+      label: SSH Tunnel Private Key
+      description: A base64 encoded Private Key for authentication to the bastion
+        host w/ key pair auth
+      sensitive: true
+      # encoding: base64
+    - name: ssh_tunnel.private_key_password
+      kind: string
+      label: SSH Tunnel Private Key Password
+      description: Private Key Password, leave None if no password is set
+      sensitive: true
+    - name: ssh_tunnel.username
+      kind: string
+      label: SSH Tunnel Username
+      description: Username to connect to bastion host
+    - name: ssh_tunnel.password
+      kind: string
+      label: SSH Tunnel Password
+      description: Password to connect to bastion host w/ basic auth
+      sensitive: true
+    - name: ssh_tunnel.host_setting_name
+      value: host
+      hidden: true
+    - name: ssh_tunnel.port_setting_name
+      value: port
+      hidden: true
+    config:
+      host: localhost
+      user: meltano
+      database: testdb
+    metadata:
+      '*':
+        replication-method: FULL_TABLE
+  loaders:
+  - name: target-duckdb
+    variant: jwills
+    pip_url: target-duckdb~=0.8
+version: 1
+venv:
+  backend: uv

--- a/perf/project/output/.gitignore
+++ b/perf/project/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/perf/project/plugins/loaders/target-duckdb--jwills.lock
+++ b/perf/project/plugins/loaders/target-duckdb--jwills.lock
@@ -1,0 +1,136 @@
+{
+  "plugin_type": "loaders",
+  "name": "target-duckdb",
+  "namespace": "target_duckdb",
+  "variant": "jwills",
+  "label": "DuckDB",
+  "docs": "https://hub.meltano.com/loaders/target-duckdb--jwills",
+  "repo": "https://github.com/jwills/target-duckdb",
+  "pip_url": "target-duckdb~=0.8",
+  "description": "DuckDB loader",
+  "logo_url": "https://hub.meltano.com/assets/logos/loaders/duckdb.png",
+  "settings_group_validation": [
+    [
+      "default_target_schema",
+      "filepath"
+    ]
+  ],
+  "settings": [
+    {
+      "name": "add_metadata_columns",
+      "kind": "boolean",
+      "value": false,
+      "label": "Add Metadata Columns",
+      "description": "Metadata columns add extra row level information about data ingestions, (i.e. when was the row read in source, when was inserted or deleted in postgres etc.) Metadata columns are creating automatically by adding extra columns to the tables with a column prefix _SDC_. The column names are following the stitch naming conventions documented at https://www.stitchdata.com/docs/data-structure/integration-schemas#sdc-columns. Enabling metadata columns will flag the deleted rows by setting the _SDC_DELETED_AT metadata column. Without the add_metadata_columns option the deleted rows from singer taps will not be recognisable in DuckDB."
+    },
+    {
+      "name": "batch_size_rows",
+      "kind": "integer",
+      "value": 100000,
+      "label": "Batch Size Rows",
+      "description": "Maximum number of rows in each batch. At the end of each batch, the rows in the batch are loaded into DuckDB."
+    },
+    {
+      "name": "data_flattening_max_level",
+      "kind": "integer",
+      "value": 0,
+      "label": "Data Flattening Max Level",
+      "description": "Object type RECORD items from taps can be transformed to flattened columns by creating columns automatically.\n\nWhen value is 0 (default) then flattening functionality is turned off.\n"
+    },
+    {
+      "name": "database",
+      "kind": "string",
+      "label": "Database name",
+      "description": "Alias of `dbname`."
+    },
+    {
+      "name": "dbname",
+      "kind": "string",
+      "label": "Database",
+      "description": "The database name to write to; this will be inferred from the path property if it is not specified."
+    },
+    {
+      "name": "default_target_schema",
+      "kind": "string",
+      "value": "$MELTANO_EXTRACT__LOAD_SCHEMA",
+      "label": "Default Target Schema",
+      "description": "Name of the schema where the tables will be created. If schema_mapping is not defined then every stream sent by the tap is loaded into this schema."
+    },
+    {
+      "name": "delimiter",
+      "kind": "string",
+      "value": ",",
+      "label": "Delimiter",
+      "description": "The delimiter to use for the CSV files that are used for record imports."
+    },
+    {
+      "name": "filepath",
+      "kind": "string",
+      "value": "${MELTANO_PROJECT_ROOT}/output/warehouse.duckdb",
+      "label": "File Path",
+      "description": "Alias of `path`.",
+      "placeholder": "/path/to/local/file.duckdb"
+    },
+    {
+      "name": "flush_all_streams",
+      "kind": "boolean",
+      "value": false,
+      "label": "Flush All Streams",
+      "description": "Flush and load every stream into DuckDB when one batch is full. Warning - This may trigger the COPY command to use files with low number of records."
+    },
+    {
+      "name": "hard_delete",
+      "kind": "boolean",
+      "value": false,
+      "label": "Hard Delete",
+      "description": "When hard_delete option is true then DELETE SQL commands will be performed in DuckDB to delete rows in tables. It's achieved by continuously checking the _SDC_DELETED_AT metadata column sent by the singer tap. Due to deleting rows requires metadata columns, hard_delete option automatically enables the add_metadata_columns option as well."
+    },
+    {
+      "name": "path",
+      "kind": "string",
+      "label": "Connection Path",
+      "description": "The path to use for the `duckdb.connect` call; either a local file or a MotherDuck connection uri.",
+      "placeholder": "/path/to/local/file.duckdb"
+    },
+    {
+      "name": "primary_key_required",
+      "kind": "boolean",
+      "value": true,
+      "label": "Primary Key Required",
+      "description": "Log based and Incremental replications on tables with no Primary Key cause duplicates when merging UPDATE events. When set to true, stop loading data if no Primary Key is defined."
+    },
+    {
+      "name": "quotechar",
+      "kind": "string",
+      "value": "\"",
+      "label": "Quote Character",
+      "description": "The quote character to use for the CSV files that are used for record imports."
+    },
+    {
+      "name": "schema_mapping",
+      "kind": "object",
+      "label": "schema_mapping",
+      "description": "Useful if you want to load multiple streams from one tap to multiple DuckDB schemas.\n\nIf the tap sends the stream_id in <schema_name>-<table_name> format then this option overwrites the default_target_schema value.\n"
+    },
+    {
+      "name": "temp_dir",
+      "kind": "string",
+      "label": "Temporary Directory",
+      "description": "Directory of temporary CSV files with RECORD messages."
+    },
+    {
+      "name": "token",
+      "kind": "string",
+      "label": "Token",
+      "description": "For MotherDuck connections, the auth token to use.",
+      "sensitive": true
+    },
+    {
+      "name": "validate_records",
+      "kind": "boolean",
+      "value": false,
+      "label": "Validate Records",
+      "description": "Validate every single record message to the corresponding JSON schema. This option is disabled by default and invalid RECORD messages will fail only at load time by DuckDB. Enabling this option will detect invalid records earlier but could cause performance degradation."
+    }
+  ]
+}

--- a/perf/project/seed_database.py
+++ b/perf/project/seed_database.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#   "mysql-connector-python>=8.0.0",
+# ]
+# requires_python = ">=3.10"
+# ///
+
+"""Seed MySQL database with 100 tables, each with 25 columns and 1000 records."""
+
+from __future__ import annotations
+
+import random
+import string
+from datetime import datetime, timedelta, timezone
+
+import mysql.connector
+
+
+def random_string(length: int = 10) -> str:
+    """Generate a random string."""
+    return "".join(random.choices(string.ascii_letters + string.digits, k=length))  # noqa: S311
+
+
+def random_date() -> datetime:
+    """Generate a random date within the last year."""
+    start = datetime.now(timezone.utc) - timedelta(days=365)
+    random_days = random.randint(0, 365)  # noqa: S311
+    return start + timedelta(days=random_days)
+
+
+def create_connection() -> mysql.connector.connection.MySQLConnection:
+    """Create a connection to the MySQL database."""
+    return mysql.connector.connect(
+        host="localhost",
+        port=3306,
+        user="meltano",
+        password="meltano123",  # noqa: S106
+        database="testdb",
+    )
+
+
+def create_table(cursor: mysql.connector.cursor.MySQLCursor, table_num: int) -> str:
+    """Create a table with 25 columns."""
+    table_name = f"table_{table_num:03d}"
+
+    columns = ["id INT AUTO_INCREMENT PRIMARY KEY"]
+
+    # Add 24 more columns (various types)
+    for i in range(24):
+        col_num = i + 1
+        if i % 4 == 0:
+            columns.append(f"varchar_col_{col_num} VARCHAR(255)")
+        elif i % 4 == 1:
+            columns.append(f"int_col_{col_num} INT")
+        elif i % 4 == 2:
+            columns.append(f"decimal_col_{col_num} DECIMAL(10, 2)")
+        else:
+            columns.append(f"datetime_col_{col_num} DATETIME")
+
+    create_sql = f"CREATE TABLE IF NOT EXISTS `{table_name}` ({', '.join(columns)})"
+    cursor.execute(create_sql)
+    return table_name
+
+
+def seed_table(
+    cursor: mysql.connector.cursor.MySQLCursor,
+    table_name: str,
+    num_records: int = 1000,
+) -> None:
+    """Seed a table with the specified number of records."""
+    # Build the insert statement
+    value_placeholders = ", ".join(["%s"] * 24)
+    insert_sql = (
+        f"INSERT INTO `{table_name}` (varchar_col_1, int_col_2, decimal_col_3, datetime_col_4, "  # noqa: E501, S608
+        f"varchar_col_5, int_col_6, decimal_col_7, datetime_col_8, "
+        f"varchar_col_9, int_col_10, decimal_col_11, datetime_col_12, "
+        f"varchar_col_13, int_col_14, decimal_col_15, datetime_col_16, "
+        f"varchar_col_17, int_col_18, decimal_col_19, datetime_col_20, "
+        f"varchar_col_21, int_col_22, decimal_col_23, datetime_col_24) "
+        f"VALUES ({value_placeholders})"
+    )
+
+    # Generate and insert records in batches
+    batch_size = 100
+    for batch_start in range(0, num_records, batch_size):
+        batch_data = []
+        batch_end = min(batch_start + batch_size, num_records)
+
+        for _ in range(batch_end - batch_start):
+            record = []
+            for i in range(24):
+                if i % 4 == 0:
+                    record.append(random_string(20))
+                elif i % 4 == 1:
+                    record.append(random.randint(1, 1000000))  # noqa: S311
+                elif i % 4 == 2:
+                    record.append(round(random.uniform(1, 10000), 2))  # noqa: S311
+                else:
+                    record.append(random_date())
+            batch_data.append(record)
+
+        cursor.executemany(insert_sql, batch_data)
+
+
+def main() -> None:
+    """Main function to seed the database."""
+    print("Connecting to MySQL database...")  # noqa: T201
+    conn = create_connection()
+    cursor = conn.cursor()
+
+    print("Starting database seeding...")  # noqa: T201
+    print("Creating 100 tables with 25 columns each...")  # noqa: T201
+
+    for table_num in range(1, 101):
+        print(f"Processing table {table_num}/100...", end="\r")  # noqa: T201
+
+        # Create table
+        table_name = create_table(cursor, table_num)
+
+        # Seed table with 1000 records
+        seed_table(cursor, table_name, num_records=1000)
+
+        conn.commit()
+
+    print("\nSeeding completed successfully!")  # noqa: T201
+    print("Created 100 tables with 25 columns each and 1000 records per table.")  # noqa: T201
+    print("Total records inserted: 100,000")  # noqa: T201
+
+    cursor.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Uses py-spy to generate flamegraphs.

## Related Issues

* https://github.com/meltano/meltano/pull/9724

## Summary by Sourcery

Add a self-contained performance profiling setup for Meltano using py-spy and a synthetic MySQL workload.

New Features:
- Introduce a dedicated perf project configuration with a MySQL extractor and DuckDB loader for benchmarking.
- Provide a database seeding script that generates a large synthetic MySQL schema and dataset for performance tests.
- Add a flamegraph helper script to profile Meltano runs across multiple versions using py-spy.
- Include Docker Compose configuration and logging settings to support the local performance testing environment.

Chores:
- Add perf-specific .gitignore and plugin lock files to isolate generated artifacts in the performance testing setup.