### PR TITLE
fix: Avoid displaying tracebacks when known CLI-level errors occur

### DIFF
--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -114,6 +114,8 @@ def _run_cli() -> None:
             raise
         except MeltanoError as err:
             handle_meltano_error(err)
+        except CliError:
+            raise
         except Exception as err:
             raise CliError(f"{troubleshooting_message}\n{err}") from err  # noqa: EM102, TRY003
     except CliError as cli_error:


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

Makes it easier to look at when common errors happen.

## Related Issues

- Closes https://github.com/meltano/meltano/issues/9702

## Summary by Sourcery

Bug Fixes:
- Prevent known CliError exceptions from being wrapped in a generic troubleshooting message so they surface cleanly to users.