### PR TITLE
fix(core): Handle env var expansion from variables without a value coming from dotenv files

### DIFF
--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -230,7 +230,12 @@ def test_unflatten() -> None:
         ),
     ),
 )
-def test_expand_env_vars(input_value, env, kwargs, expected_output) -> None:
+def test_expand_env_vars(
+    input_value: str,
+    env: dict[str, str | None],
+    kwargs: dict,
+    expected_output: str,
+) -> None:
     assert expand_env_vars(input_value, env, **kwargs) == expected_output
 
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

The `dotenv_values` function from the `python-dotenv` package can be set to `None`[^1]:

<blockquote>

### Variable without a value

A variable can have no value:

```bash
FOO
```

It results in `dotenv_values` associating that variable name with the value
`None` (e.g. `{"FOO": None}`. `load_dotenv`, on the other hand, simply ignores
such variables.

This shouldn't be confused with `FOO=`, in which case the variable is associated
with the empty string.

</blockquote>

This means that if we have the following `meltano.yml` and `.env`

```yaml
plugins:
  extractors:
  - name: tap-pypistats
    variant: edgarrmondragon
    pip_url: tap-pypistats
    config:
      packages:
      - tap-$TAP_NAME
```

```dotenv
TAP_NAME
```

produce this behavior during env var expansion

```console
$ meltano --log-level warning config print tap-pypistats
{
  "packages": [
    "tap-None"
  ]
}
```

## Related Issues

NA

[^1]: https://github.com/theskumar/python-dotenv/tree/main?tab=readme-ov-file#variable-without-a-value

## Summary by Sourcery

Handle environment variable expansion correctly when dotenv provides variables without values and ensure these cases are covered by tests.

Bug Fixes:
- Prevent environment variable expansion from treating dotenv variables with no value as the string "None".
- Ensure variables with no value from dotenv are treated as empty or ignored according to the configured missing-variable behavior.

Tests:
- Add coverage for dotenv variables with no value versus empty string in plugin settings dotenv handling.
- Extend environment variable expansion tests to cover cases where variables are present but have a None value from dotenv.
- Adjust plugin settings test fixture setup to clear and refresh dotenv state before each test.