### PR TITLE
ci: Revert change to triggers in dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,8 @@ name: Dependency Review
 on:
   schedule:
     - cron: '12 12 * * *'
-  pull_request:
+  # pull_request_target is safe because this only performs static analysis
+  pull_request_target:  # zizmor: ignore[dangerous-triggers]
     paths:
       - '**.lock'
   workflow_dispatch:
@@ -26,5 +27,4 @@ jobs:
           persist-credentials: false
 
       - name: GitHub dependency vulnerability check
-        if: ${{ github.event_name == 'pull_request_target' }}
         uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* https://github.com/meltano/meltano/pull/9682

## Summary by Sourcery

CI:
- Adjust the dependency review GitHub Actions workflow to trigger on pull_request_target instead of pull_request, limited to lockfile changes.