### PR TITLE
ci: Validate lowest dependency constraints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,12 +45,14 @@ jobs:
     strategy:
       matrix:
         include:
+        - { python-version: '3.10', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py310-ubuntu-sqlite-lowest-requirements' }
         - { python-version: '3.10', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py310-ubuntu-sqlite' }
         - { python-version: '3.11', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py311-ubuntu-sqlite' }
         - { python-version: '3.12', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py312-ubuntu-sqlite' }
         - { python-version: '3.13', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py313-ubuntu-sqlite' }
         - { python-version: '3.14', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py314-ubuntu-sqlite' }
         - { python-version: '3.15', os: ubuntu-24.04-arm, backend-db: sqlite, id: 'py315-ubuntu-sqlite' }
+        - { python-version: '3.10', os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py310-ubuntu-psycopg3-lowest-requirements' }
         - { python-version: '3.10', os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py310-ubuntu-psycopg3' }
         - { python-version: '3.11', os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py311-ubuntu-psycopg3' }
         - { python-version: '3.12', os: ubuntu-24.04-arm, backend-db: postgresql, id: 'py312-ubuntu-psycopg3' }
@@ -125,6 +127,7 @@ jobs:
 
     - name: Run pytest
       env:
+        NOXSESSION: ${{ case(endsWith(matrix.id, 'lowest-requirements'), 'pytest-lowest-requirements', 'pytest') }}
         SQLALCHEMY_WARN_20: 1
         COLUMNS: 160
         # Pytest
@@ -145,7 +148,7 @@ jobs:
         MSSQL_DB: pytest_warehouse
       shell: bash
       run: |
-        nox --verbose -t test -- -m "${PYTEST_MARKERS}"
+        nox --verbose -- -m "${PYTEST_MARKERS}"
 
     - name: Upload coverage data
       if: always()


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

So we can validate our lower dependency bounds.

## Related Issues

* https://github.com/meltano/meltano/issues/9791
* https://github.com/meltano/meltano/pull/9792

## Summary by Sourcery

Add CI session to run pytest with lowest compatible dependency versions and adjust dependency constraints to support this validation.

New Features:
- Introduce a dedicated nox session to run tests against the lowest supported dependency versions.

Enhancements:
- Tighten and update dependency lower bounds for uv and google-cloud-storage to reflect supported minimum versions.
- Align CI test workflow to use the updated NOXPYTHON environment variable for selecting Python versions.