### PR TITLE
packaging(deps): Require click 8.2.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "alembic>=1.14.0,<2",
   "anyio>=4.4.0,<5",
   "backports-strenum>=1.3.1,<2 ; python_version < '3.11'",
-  "click>=8.1,<8.4,!=8.2.2",
+  "click>=8.2,<8.4,!=8.2.2",
   "click-default-group>=1.2.4,<2",
   "dateparser>=1.2.1",
   "fasteners>=0.19,<0.21",

--- a/uv.lock
+++ b/uv.lock
@@ -1488,7 +1488,7 @@ requires-dist = [
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.24.0,<13" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1,<2" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35,<1.43" },
-    { name = "click", specifier = ">=8.1,!=8.2.2,<8.4" },
+    { name = "click", specifier = ">=8.2,!=8.2.2,<8.4" },
     { name = "click-default-group", specifier = ">=1.2.4,<2" },
     { name = "dateparser", specifier = ">=1.2.1" },
     { name = "fasteners", specifier = ">=0.19,<0.21" },


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

- Bumps the minimum version of Click to [8.2.0 published on May 10, 2025](https://pypi.org/project/click/8.2.0/)
- https://github.com/meltano/meltano/pull/9793 will let us be more aware of our mininum requirements inn the future

## Related Issues

- https://github.com/meltano/meltano/pull/9793

## Summary by Sourcery

Build:
- Increase the required Click package version to 8.2.x while keeping the upper bound and exclusion for 8.2.2.