### PR TITLE
ci: Uninstall uv from Nox virtualenv to avoid syncing deps with the wrong uv executable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
 
       fail-fast: false
 
-    name: "Pytest on py${{ matrix.python-version }} (OS: ${{ matrix.os }}, DB: ${{ matrix.backend-db }}) (${{ matrix.markers || 'not concurrent' }})"
+    name: ${{ matrix.id }}
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     timeout-minutes: 20


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Ensure Nox sessions consistently use the correct uv executable when syncing dependencies and simplify CI job naming.

Enhancements:
- Configure Nox to reuse virtual environments and centralize uv-based dependency syncing into a dedicated helper that isolates uv from global configuration.

CI:
- Update the test workflow matrix job names to use a concise id field instead of the full descriptive name.