### PR TITLE
test: Update tests to read correctly from stderr in older versions of click

### DIFF
--- a/tests/fixtures/cli.py
+++ b/tests/fixtures/cli.py
@@ -42,6 +42,8 @@ def cli_runner(pushd, snowplow_optional: SnowplowMicro | None):
     log_level = root_logger.level
     try:
         runner = MeltanoCliRunner(snowplow=snowplow_optional)
+        # TODO: Remove this once support for Click<8.2 is dropped
+        runner.mix_stderr = False
         yield runner
     finally:
         root_logger.setLevel(log_level)

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -645,7 +645,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
             assert result.exit_code == 1
-            assert "`dbt run` failed" in result.output
+            assert "`dbt run` failed" in result.stderr
 
             matcher = EventMatcher(result.stderr)
             assert matcher.event_matches(
@@ -716,7 +716,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert "Extractor failed" in result.output
+            assert "Extractor failed" in result.stderr
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -807,7 +807,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert "Loader failed" in result.output
+            assert "Loader failed" in result.stderr
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -876,7 +876,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert "Loader failed" in result.output
+            assert "Loader failed" in result.stderr
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -952,7 +952,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert "Extractor and loader failed" in result.output
+            assert "Extractor and loader failed" in result.stderr
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -1033,7 +1033,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args)
 
-            assert "Output line length limit exceeded" in result.output
+            assert "Output line length limit exceeded" in result.stderr
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -1238,7 +1238,7 @@ class TestCliRunScratchpadOne:
         with mock.patch.object(PluginInvoker, "invoke_async", new=invoke_async):
             result = cli_runner.invoke(cli, args, catch_exceptions=True)
 
-            assert "Mappers failed" in result.output
+            assert "Mappers failed" in result.stderr
             assert result.exit_code == 1
 
             matcher = EventMatcher(result.stderr)
@@ -1584,7 +1584,7 @@ class TestCliRunScratchpadOne:
 
         result = cli_runner.invoke(cli, args, catch_exceptions=True)
         assert result.exit_code == 2
-        assert "Invalid value for '--timeout'" in result.output
+        assert "Invalid value for '--timeout'" in result.stderr
 
     @pytest.mark.backend("sqlite")
     @pytest.mark.usefixtures(


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Adjust CLI tests and runner configuration to read error output from stderr instead of mixed output for compatibility with older Click versions.

Bug Fixes:
- Update CLI failure tests to assert against stderr output rather than stdout to match Click behavior on older versions.

Tests:
- Configure the Meltano CLI test runner to avoid mixing stderr into stdout so tests can reliably inspect error output.