### PR TITLE
fix(cli): Make `meltano state set --input-file ...` work with click 8.1

### DIFF
--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -255,18 +255,6 @@ def merge_state(
     )
 
 
-def _read_state_from_file(
-    ctx: click.Context,
-    param: click.Option,  # noqa: ARG001
-    value: Path | None,
-) -> None:
-    if value is None:
-        return
-
-    with value.open() as state_f:
-        ctx.params["state"] = state_f.read()
-
-
 @meltano_state.command(cls=InstrumentedCmd, name="set")
 @prompt_for_confirmation(
     prompt="This will overwrite the state's current value. Continue?",
@@ -274,8 +262,6 @@ def _read_state_from_file(
 @click.option(
     "--input-file",
     type=click.Path(exists=True, path_type=Path),
-    callback=_read_state_from_file,
-    expose_value=False,
     help="Set state from json file containing Singer state.",
 )
 @click.option(
@@ -292,20 +278,28 @@ def set_state(
     project: Project,
     state_id: str,
     state: str,
+    input_file: Path | None,
     no_validate: bool,  # noqa: FBT001
 ) -> None:
     """Set state."""
-    state_service: StateService = (
-        state_service_from_state_id(project, state_id) or ctx.obj[STATE_SERVICE_KEY]
-    )
+    mutually_exclusive_options = {
+        "--input-file": input_file,
+        "STATE": state,
+    }
+    if not reduce(xor, (bool(x) for x in mutually_exclusive_options.values())):
+        raise MutuallyExclusiveOptionsError(*mutually_exclusive_options)
+    if input_file:
+        with input_file.open() as state_f:
+            state = state_f.read()
 
     if no_validate:
         logger.warning(
             "Skipping state validation. Invalid state may cause issues in future runs.",
         )
 
-    state = state or ""
-
+    state_service: StateService = (
+        state_service_from_state_id(project, state_id) or ctx.obj[STATE_SERVICE_KEY]
+    )
     try:
         state_service.set_state(state_id, state, validate=not no_validate)
     except json.JSONDecodeError as e:

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -179,6 +179,46 @@ class TestCliState:
                     assert_cli_runner(result)
                     assert state_service.get_state(state_id) == state_payload
 
+    def test_set_from_string_file_mutually_exclusive(
+        self,
+        tmp_path: Path,
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        """Test that mutually exclusive options are rejected."""
+        filepath = tmp_path / "file.json"
+        filepath.write_text("{}")
+
+        result = cli_runner.invoke(
+            cli,
+            [
+                "state",
+                "set",
+                "--force",
+                "test-state-id",
+                "--input-file",
+                filepath.as_posix(),
+                "{}",
+            ],
+        )
+        assert result.exit_code == 1
+        assert isinstance(result.exception, state.MutuallyExclusiveOptionsError)
+        assert "--input-file" in result.exception.options
+        assert "STATE" in result.exception.options
+
+        result = cli_runner.invoke(
+            cli,
+            [
+                "state",
+                "set",
+                "--force",
+                "test-state-id",
+            ],
+        )
+        assert result.exit_code == 1
+        assert isinstance(result.exception, state.MutuallyExclusiveOptionsError)
+        assert "--input-file" in result.exception.options
+        assert "STATE" in result.exception.options
+
     def test_set_invalid_json(
         self,
         state_service: StateService,


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Ensure the `meltano state set` CLI command correctly handles mutually exclusive input options and supports setting state from a file with newer Click versions.

Bug Fixes:
- Fix `meltano state set` so that using `--input-file` to set state works correctly with Click 8.1 while still supporting direct state input.

Enhancements:
- Enforce mutual exclusivity between the `--input-file` option and the positional `STATE` argument for the `meltano state set` command, raising a clear error when both or neither are provided.

Tests:
- Add tests verifying that `meltano state set` rejects calls that provide both `--input-file` and `STATE` or neither, and that the appropriate mutually exclusive options error is raised.