### PR TITLE
chore: Bump Ruff to 0.14.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
           - "prettier@3.0.0"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.12
+    rev: v0.14.14
     hooks:
     - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/src/meltano/core/plugin/airflow.py
+++ b/src/meltano/core/plugin/airflow.py
@@ -127,7 +127,7 @@ class Airflow(BasePlugin):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        stdout, stderr = await handle.communicate()
+        stdout, _stderr = await handle.communicate()
         if handle.returncode:
             raise AsyncSubprocessError(
                 "Command `airflow config generate` failed",  # noqa: EM101
@@ -150,7 +150,7 @@ class Airflow(BasePlugin):
             stderr=subprocess.PIPE,
         )
 
-        stdout, stderr = await handle.communicate()
+        stdout, _stderr = await handle.communicate()
 
         if handle.returncode:
             raise AsyncSubprocessError(

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -530,7 +530,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
             environment.config.plugins.setdefault(plugin.type, [])
 
             # find the proper plugin to update
-            p_idx, p_outdated = next(
+            p_idx, _p_outdated = next(
                 (
                     (idx, plg)
                     for idx, plg in enumerate(environment.config.plugins[plugin.type])

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -251,7 +251,7 @@ class TestCli:
 
     def test_handle_meltano_error(self) -> None:
         exception = MeltanoError(reason="This failed", instruction="Try again")
-        with pytest.raises(CliError, match="This failed. Try again."):
+        with pytest.raises(CliError, match=r"This failed. Try again."):
             handle_meltano_error(exception)
 
     @pytest.mark.usefixtures("pushd")

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -1204,7 +1204,7 @@ class TestCliRunScratchpadOne:
             with pytest.raises(
                 AmbiguousMappingName,
                 match=(
-                    "Ambiguous mapping name mock-mapping-dupe, found multiple matches."
+                    r"Ambiguous mapping name mock-mapping-dupe, found multiple matches."
                 ),
             ):
                 cli_runner.invoke(cli, args, catch_exceptions=False)

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -448,7 +448,7 @@ class TestExtractLoadBlocks:
 
             with pytest.raises(
                 BlockSetValidationError,
-                match="^.*: last block in set should not be a producer",
+                match=r"^.*: last block in set should not be a producer",
             ):
                 elb.validate_set()
 
@@ -469,7 +469,7 @@ class TestExtractLoadBlocks:
             elb = ExtractLoadBlocks(elb_context, blocks)
             with pytest.raises(
                 BlockSetValidationError,
-                match="^.*: first block in set should not be consumer",
+                match=r"^.*: first block in set should not be consumer",
             ):
                 elb.validate_set()
 
@@ -496,7 +496,7 @@ class TestExtractLoadBlocks:
             elb = ExtractLoadBlocks(elb_context, blocks)
             with pytest.raises(
                 BlockSetValidationError,
-                match="^.*: intermediate blocks must be producers AND consumers",
+                match=r"^.*: intermediate blocks must be producers AND consumers",
             ):
                 elb.validate_set()
 

--- a/tests/meltano/core/block/test_singer.py
+++ b/tests/meltano/core/block/test_singer.py
@@ -197,7 +197,7 @@ class TestSingerBlocks:
 
             io_futures = [producer.proxy_stdout(), producer.proxy_stderr()]
 
-            done, _ = await asyncio.wait(
+            _done, _ = await asyncio.wait(
                 io_futures,
                 return_when=asyncio.FIRST_COMPLETED,
             )

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -115,7 +115,7 @@ class TestMeltanoHubService:
     def test_server_error(self, project: Project) -> None:
         with pytest.raises(
             HubConnectionError,
-            match="Could not connect to Meltano Hub. 500 Server Error",
+            match=r"Could not connect to Meltano Hub. 500 Server Error",
         ) as exc_info:
             project.hub_service.find_definition(
                 PluginType.EXTRACTORS,

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -435,7 +435,7 @@ class TestPluginSettingsService:
         assert subject.get("schema") is None
 
         subject.set("schema", "default", store=SettingValueStore.DOTENV)
-        value, metadata = subject.get_with_metadata("schema")
+        _value, _metadata = subject.get_with_metadata("schema")
 
         # Env is the default
         assert_env_value("default", "TARGET_MOCK_SCHEMA")

--- a/tests/meltano/core/test_db_compat.py
+++ b/tests/meltano/core/test_db_compat.py
@@ -21,7 +21,7 @@ class TestDatabaseCompatibility:
                 pytest.raises(
                     MeltanoDatabaseCompatibilityError,
                     match=(
-                        "Detected SQLite 3.25.0, but Meltano requires at least 3.25.1. "
+                        r"Detected SQLite 3.25.0, but Meltano requires at least 3.25.1. "  # noqa: E501
                         "Upgrade your database to be compatible with Meltano or use a "
                         "different database."
                     ),

--- a/tests/meltano/core/test_environment_service.py
+++ b/tests/meltano/core/test_environment_service.py
@@ -42,7 +42,7 @@ class TestEnvironmentService:
 
         with pytest.raises(
             EnvironmentAlreadyExistsError,
-            match="An Environment named 'environment_0' already exists.",
+            match=r"An Environment named 'environment_0' already exists.",
         ):
             subject.add_environment(environments[3])
 

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -204,7 +204,7 @@ class TestPluginRemoveService:
             "remove_from_file",
             side_effect=raise_permissionerror,
         ):
-            removed_plugins, total_plugins = subject.remove_plugins(plugins)
+            removed_plugins, _total_plugins = subject.remove_plugins(plugins)
 
         assert removed_plugins == 0
 
@@ -219,7 +219,7 @@ class TestPluginRemoveService:
 
         with mock.patch("meltano.core.plugin_location_remove.shutil.rmtree") as rmtree:
             rmtree.side_effect = raise_permissionerror
-            removed_plugins, total_plugins = subject.remove_plugins(plugins)
+            removed_plugins, _total_plugins = subject.remove_plugins(plugins)
 
         assert removed_plugins == 0
 

--- a/tests/meltano/core/test_project_init_service.py
+++ b/tests/meltano/core/test_project_init_service.py
@@ -71,7 +71,7 @@ def test_project_init_existing_meltano_yml(tmp_path: Path, pushd) -> None:
     with pytest.raises(
         ProjectInitServiceError,
         match=(
-            "A `meltano.yml` file already exists in the target directory. "
+            r"A `meltano.yml` file already exists in the target directory. "
             "Use `--force` to overwrite it."
         ),
     ):
@@ -118,6 +118,6 @@ def test_project_init_missing_parent_directory(tmp_path: Path, pushd) -> None:
     missing_dir.rmdir()  # remove the parent directory
     with pytest.raises(
         ProjectInitServiceError,
-        match="Could not create directory 'test_project'.",
+        match=r"Could not create directory 'test_project'.",
     ):
         project_init_service.init(activate=False)

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -276,7 +276,7 @@ class TestVirtualEnv:
             mock.patch("platform.system", return_value="commodore64"),
             pytest.raises(
                 MeltanoError,
-                match="(?i)Platform 'commodore64'.*?not supported.",
+                match=r"(?i)Platform 'commodore64'.*?not supported.",
             ),
         ):
             VirtualEnv(project.venvs_dir("pytest", "pytest"))


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update linting configuration to use the latest Ruff pre-commit hook and adjust code/tests to satisfy new linting rules.

Build:
- Bump Ruff pre-commit hook from v0.12.x to v0.14.14 in the pre-commit configuration.

Tests:
- Update pytest exception match patterns to use raw strings compatible with stricter linting rules.
- Adjust tests to ignore unused return values and variables flagged by the newer Ruff version.