### PR TITLE
refactor: Bump Ruff to 0.15 and update code to the 2026 style guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
           - "prettier@3.0.0"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.0
     hooks:
     - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,7 +348,7 @@ build-backend = "hatchling.build"
 
 [tool.ruff]
 line-length = 88
-required-version = ">=0.13"
+required-version = ">=0.15"
 
 [tool.ruff.lint]
 future-annotations = true

--- a/src/meltano/cli/utils.py
+++ b/src/meltano/cli/utils.py
@@ -206,9 +206,9 @@ def _prompt_plugin_capabilities(plugin_type):  # noqa: ANN001, ANN202
         click.style("(capabilities)", fg="blue"),
         type=list,
         default=[],
-        value_proc=lambda value: [word.strip() for word in value.split(",")]
-        if value
-        else [],
+        value_proc=lambda value: (
+            [word.strip() for word in value.split(",")] if value else []
+        ),
     )
 
 
@@ -250,11 +250,11 @@ def _prompt_plugin_settings(plugin_type: PluginType) -> list[dict[str, t.Any]]:
             click.style("(settings)", fg="blue"),
             type=list,
             default=[],
-            value_proc=lambda value: [
-                setting.strip().partition(":") for setting in value.split(",")
-            ]
-            if value
-            else [],
+            value_proc=lambda value: (
+                [setting.strip().partition(":") for setting in value.split(",")]
+                if value
+                else []
+            ),
         )
         try:
             settings = [

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -485,11 +485,11 @@ class SingerTap(SingerPlugin):
                         raise failed_future.exception()  # type: ignore[misc]  # noqa: TRY301
                 exit_code = handle.returncode
             except Exception:
-                catalog_path.unlink()
+                catalog_path.unlink()  # noqa: ASYNC240
                 raise
 
             if exit_code != 0:
-                catalog_path.unlink()
+                catalog_path.unlink()  # noqa: ASYNC240
                 stderr_buff.seek(0)
                 raise PluginExecutionError(  # noqa: TRY003
                     "Catalog discovery failed: command "  # noqa: EM102

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -71,9 +71,11 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
             components joined by '/'
         """
         return reduce(
-            lambda comp1, comp2: f"{comp1}{comp2}"
-            if (comp1.endswith(self.delimiter) or comp2.startswith(self.delimiter))
-            else f"{comp1}{self.delimiter}{comp2}",
+            lambda comp1, comp2: (
+                f"{comp1}{comp2}"
+                if (comp1.endswith(self.delimiter) or comp2.startswith(self.delimiter))
+                else f"{comp1}{self.delimiter}{comp2}"
+            ),
             filter(None, components),
         )
 

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -951,11 +951,13 @@ _sanitize_filename_transformations = (
     # Remove Remove illegal character combination `._` from front and back:
     lambda x: x.strip("._"),
     # Add a leading `_` if necessary to avoid conflict with reserved Windows filenames:
-    lambda x: f"_{x}"
-    if platform.system() == "Windows"
-    and x
-    and x.split(".")[0].upper() in _reserved_windows_filenames
-    else x,
+    lambda x: (
+        f"_{x}"
+        if platform.system() == "Windows"
+        and x
+        and x.split(".")[0].upper() in _reserved_windows_filenames
+        else x
+    ),
 )
 
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update linting tooling to Ruff 0.15 and adjust existing code to comply with the updated style and async file operation rules.

Enhancements:
- Reformat inline lambda expressions for plugin prompts, path joining, and filename sanitization to conform to the updated Ruff style guide.
- Annotate tap discovery cleanup calls with async-specific linting ignores to satisfy new Ruff async safety checks.

Build:
- Bump Ruff pre-commit hook to v0.15.0 and align the configured required Ruff version in pyproject.toml.