### PR TITLE
feat: Make `StateStoreManager` a context manager with a default no-op `.close()` method

### DIFF
--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -119,7 +119,7 @@ def meltano_state(project: Project, ctx: click.Context) -> None:
     """  # noqa: D301
     _, sessionmaker = project_engine(project)
     session = sessionmaker(future=True)
-    ctx.obj[STATE_SERVICE_KEY] = StateService(project, session)
+    ctx.obj[STATE_SERVICE_KEY] = ctx.with_resource(StateService(project, session))
 
 
 @meltano_state.command(cls=InstrumentedCmd, name="list")

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -305,18 +305,18 @@ class SingerTap(SingerPlugin):
         Returns:
             the state for the given job
         """
-        state_service = StateService(project=project, session=session)
-        try:
-            state = state_service.get_state(job_name)
-        except Exception as err:  # pragma: no cover
-            logger.error(  # noqa: TRY400
-                err.args[0],
-                state_backend=state_service.state_store_manager.label,
-            )
-            msg = "Failed to retrieve state"
-            raise PluginExecutionError(msg) from err
+        with StateService(project=project, session=session) as state_service:
+            try:
+                state = state_service.get_state(job_name)
+            except Exception as err:  # pragma: no cover
+                logger.error(  # noqa: TRY400
+                    err.args[0],
+                    state_backend=state_service.state_store_manager.label,
+                )
+                msg = "Failed to retrieve state"
+                raise PluginExecutionError(msg) from err
 
-        return state.get(SINGER_STATE_KEY)
+            return state.get(SINGER_STATE_KEY)
 
     @hook("before_invoke")
     async def discover_catalog_hook(

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -9,9 +9,15 @@ from __future__ import annotations
 
 import datetime
 import json
+import sys
 import typing as t
 
 import structlog
+
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: ICN003
+else:
+    from typing_extensions import Self
 
 from meltano.core.job import Job, Payload, State
 from meltano.core.job_state import SINGER_STATE_KEY
@@ -49,6 +55,19 @@ class StateService:
         self.project = project or Project.find()
         self.session = session
         self._state_store_manager: StateStoreManager | None = None
+
+    def __enter__(self) -> Self:
+        """Enter the context manager."""
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Exit the context manager, closing the state store manager."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the state store manager, if one was created."""
+        if self._state_store_manager is not None:
+            self._state_store_manager.close()
 
     def list_state(self, state_id_pattern: str | None = None) -> dict:
         """List all state found in the db.

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import sys
 import typing as t
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: ICN003
+else:
+    from typing_extensions import Self
 
 from meltano.core.utils import merge
 
@@ -111,6 +117,21 @@ class StateStoreManager(ABC):
 
         Args:
             kwargs: additional keyword arguments
+        """
+
+    def __enter__(self) -> Self:
+        """Enter the context manager."""
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Exit the context manager."""
+        self.close()
+
+    def close(self) -> None:  # noqa: B027
+        """Close any resources held by the state store manager.
+
+        Subclasses should override this to clean up backend-specific resources
+        (e.g., database connections, file handles).
         """
 
     @t.final

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -18,6 +18,7 @@ from meltano.core.utils import merge
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator, Iterable
+    from types import TracebackType
 
 
 class UnsupportedStateBackendURIError(Exception):
@@ -123,7 +124,12 @@ class StateStoreManager(ABC):
         """Enter the context manager."""
         return self
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Exit the context manager."""
         self.close()
 

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -178,29 +178,29 @@ class UpgradeService:
         """
         from meltano.core.state_store.filesystem import CloudStateStoreManager
 
-        state_service = StateService(project=project)
-        manager = state_service.state_store_manager
-        if isinstance(manager, CloudStateStoreManager):
-            click.secho("Applying migrations to project state...", fg="blue")
-            for filepath in manager.list_all_files(with_prefix=False):
-                parts = filepath.split(manager.delimiter)
-                if (
-                    parts[-1] == "state.json"
-                    and filepath.count(manager.prefix.strip(manager.delimiter)) > 1
-                ):
-                    duplicated_substr = manager.delimiter.join(
-                        [
-                            manager.prefix.strip(manager.delimiter),
-                            manager.prefix.strip(manager.delimiter),
-                        ],
-                    )
-                    new_path = filepath.replace(duplicated_substr, manager.prefix)
-                    new_path = new_path.replace(
-                        manager.delimiter * 2,
-                        manager.delimiter,
-                    )
-                    manager.copy_file(filepath, new_path)
-                    click.secho(f"Copied state from {filepath} to {new_path}")
+        with StateService(project=project) as state_service:
+            manager = state_service.state_store_manager
+            if isinstance(manager, CloudStateStoreManager):
+                click.secho("Applying migrations to project state...", fg="blue")
+                for filepath in manager.list_all_files(with_prefix=False):
+                    parts = filepath.split(manager.delimiter)
+                    if (
+                        parts[-1] == "state.json"
+                        and filepath.count(manager.prefix.strip(manager.delimiter)) > 1
+                    ):
+                        duplicated_substr = manager.delimiter.join(
+                            [
+                                manager.prefix.strip(manager.delimiter),
+                                manager.prefix.strip(manager.delimiter),
+                            ],
+                        )
+                        new_path = filepath.replace(duplicated_substr, manager.prefix)
+                        new_path = new_path.replace(
+                            manager.delimiter * 2,
+                            manager.delimiter,
+                        )
+                        manager.copy_file(filepath, new_path)
+                        click.secho(f"Copied state from {filepath} to {new_path}")
 
     def upgrade(
         self,

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -45,6 +45,32 @@ else:
     from importlib_metadata import EntryPoint, EntryPoints
 
 
+class TestStateStoreManagerContextManager:
+    def test_context_manager(self) -> None:
+        manager = DummyStateStoreManager()
+        with manager as m:
+            assert m is manager
+
+    def test_close_called_on_exit(self) -> None:
+        manager = DummyStateStoreManager()
+        with mock.patch.object(manager, "close") as mock_close:
+            with manager:
+                pass
+            mock_close.assert_called_once()
+
+    def test_close_called_on_exception(self) -> None:
+        manager = DummyStateStoreManager()
+        msg = "test"
+        with mock.patch.object(manager, "close") as mock_close:
+            with pytest.raises(RuntimeError, match=msg), manager:
+                raise RuntimeError(msg)
+            mock_close.assert_called_once()
+
+    def test_close_is_noop_by_default(self) -> None:
+        manager = DummyStateStoreManager()
+        manager.close()  # Should not raise
+
+
 def test_unknown_state_backend_scheme(project: Project):
     project.settings.set(["state_backend", "uri"], "unknown://")
     with pytest.raises(


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This should make it easier for state backend implementations to avoid leaking resources (db connections, etc.).

## Related Issues

* Closes https://github.com/meltano/meltano/issues/9818

## Summary by Sourcery

Make state management components usable as context managers to ensure state store resources are properly closed.

Enhancements:
- Add context manager protocol and a default no-op close() implementation to StateStoreManager so backends can clean up resources safely.
- Make StateService a context manager that closes its underlying StateStoreManager when exiting.
- Update state migration logic to use StateService as a context manager for safer resource handling.
- Use Click’s ctx.with_resource to manage StateService lifecycle in the CLI state commands.

Tests:
- Add unit tests verifying StateStoreManager’s context manager behavior, including close() being called on normal exit and exceptions and being a no-op by default.