### PR TITLE
chore: Bump meltano-dbt-ext to 0.4.x in examples and integration tests

### DIFF
--- a/docs/docs/getting-started/part3.mdx
+++ b/docs/docs/getting-started/part3.mdx
@@ -117,7 +117,8 @@ dbt initialized                dbt_ext_type=postgres dbt_profiles_dir=PosixPath(
 ```yaml
   utilities:
   - name: dbt-postgres
-~=```
+    pip_url: dbt-core dbt-postgres meltano-dbt-ext~=0.4.0
+```
 :::
 
 You can verify that this worked by viewing that the `transform` directory is newly populated with dbt configuration files.

--- a/docs/docs/getting-started/part3.mdx
+++ b/docs/docs/getting-started/part3.mdx
@@ -117,8 +117,7 @@ dbt initialized                dbt_ext_type=postgres dbt_profiles_dir=PosixPath(
 ```yaml
   utilities:
   - name: dbt-postgres
-    pip_url: dbt-core dbt-postgres meltano-dbt-ext~=0.3.0
-```
+~=```
 :::
 
 You can verify that this worked by viewing that the `transform` directory is newly populated with dbt configuration files.

--- a/integration/example-library/meltano-manifest/plugins/utilities/dbt-snowflake--dbt-labs.lock
+++ b/integration/example-library/meltano-manifest/plugins/utilities/dbt-snowflake--dbt-labs.lock
@@ -6,7 +6,7 @@
   "label": "dbt Snowflake",
   "docs": "https://hub.meltano.com/utilities/dbt-snowflake--dbt-labs",
   "repo": "https://github.com/dbt-labs/dbt-snowflake",
-  "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.3.0",
+  "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.4.0",
   "executable": "dbt_invoker",
   "logo_url": "https://hub.meltano.com/assets/logos/utilities/dbt.png",
   "settings": [

--- a/integration/example-library/meltano-manifest/transformers.meltano.yml
+++ b/integration/example-library/meltano-manifest/transformers.meltano.yml
@@ -2,7 +2,7 @@ plugins:
   utilities:
   - name: dbt-snowflake
     variant: dbt-labs
-    pip_url: dbt-core~=1.3.0 dbt-snowflake~=1.3.0 meltano-dbt-ext~=0.3.0
+    pip_url: dbt-core~=1.3.0 dbt-snowflake~=1.3.0 meltano-dbt-ext~=0.4.0
     commands:
       create_userdev_env:
         args: "run-operation create_userdev_env --args \"{'db_list': ['RAW'], 'dry_run':\

--- a/integration/example-library/meltano-run/ending-meltano.yml
+++ b/integration/example-library/meltano-run/ending-meltano.yml
@@ -18,7 +18,7 @@ plugins:
   utilities:
   - name: dbt-postgres
     variant: dbt-labs
-    pip_url: dbt-core dbt-postgres meltano-dbt-ext~=0.3.0
+    pip_url: dbt-core dbt-postgres meltano-dbt-ext~=0.4.0
 environments:
 - name: dev
   config:

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.cicd.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.cicd.json
@@ -2746,7 +2746,7 @@
         "logo_url": "https://hub.meltano.com/assets/logos/utilities/dbt.png",
         "name": "dbt-snowflake",
         "namespace": "dbt_snowflake",
-        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.3.0",
+        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.4.0",
         "plugin_type": "utilities",
         "repo": "https://github.com/dbt-labs/dbt-snowflake",
         "settings": [

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.jigsaw.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.jigsaw.json
@@ -2643,7 +2643,7 @@
         "logo_url": "https://hub.meltano.com/assets/logos/utilities/dbt.png",
         "name": "dbt-snowflake",
         "namespace": "dbt_snowflake",
-        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.3.0",
+        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.4.0",
         "plugin_type": "utilities",
         "repo": "https://github.com/dbt-labs/dbt-snowflake",
         "settings": [

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.json
@@ -2612,7 +2612,7 @@
         "logo_url": "https://hub.meltano.com/assets/logos/utilities/dbt.png",
         "name": "dbt-snowflake",
         "namespace": "dbt_snowflake",
-        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.3.0",
+        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.4.0",
         "plugin_type": "utilities",
         "repo": "https://github.com/dbt-labs/dbt-snowflake",
         "settings": [

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.prod.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.prod.json
@@ -2747,7 +2747,7 @@
         "logo_url": "https://hub.meltano.com/assets/logos/utilities/dbt.png",
         "name": "dbt-snowflake",
         "namespace": "dbt_snowflake",
-        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.3.0",
+        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.4.0",
         "plugin_type": "utilities",
         "repo": "https://github.com/dbt-labs/dbt-snowflake",
         "settings": [

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.staging.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.staging.json
@@ -2743,7 +2743,7 @@
         "logo_url": "https://hub.meltano.com/assets/logos/utilities/dbt.png",
         "name": "dbt-snowflake",
         "namespace": "dbt_snowflake",
-        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.3.0",
+        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.4.0",
         "plugin_type": "utilities",
         "repo": "https://github.com/dbt-labs/dbt-snowflake",
         "settings": [

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.userdev.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.userdev.json
@@ -2765,7 +2765,7 @@
         "logo_url": "https://hub.meltano.com/assets/logos/utilities/dbt.png",
         "name": "dbt-snowflake",
         "namespace": "dbt_snowflake",
-        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.3.0",
+        "pip_url": "dbt-core dbt-snowflake meltano-dbt-ext~=0.4.0",
         "plugin_type": "utilities",
         "repo": "https://github.com/dbt-labs/dbt-snowflake",
         "settings": [


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Related Issues

NA

## Summary by Sourcery

Update example and integration configurations to use meltano-dbt-ext 0.4.x instead of 0.3.x.

Documentation:
- Refresh getting-started documentation snippet to reference the newer meltano-dbt-ext version.

Tests:
- Update integration example library and manifest fixtures to depend on meltano-dbt-ext 0.4.x.