### PR TITLE
feat(core): Added `StateStoreManager.migrate()` interface which state backend implementations can override to provide a state migration mechanism

### DIFF
--- a/docs/docs/guide/custom-state-backend.md
+++ b/docs/docs/guide/custom-state-backend.md
@@ -78,22 +78,34 @@ class MyStateManager(StateStoreManager):
 
     def set(self, state: MeltanoState) -> None:
         # Implement the logic to store the state in your custom backend
+        ...
 
-    def get(self) -> MeltanoState | None:
+    def get(self, state_id: str) -> MeltanoState | None:
         # Implement the logic to retrieve the state from your custom backend
+        ...
 
-    def clear(self) -> None:
-        # Implement the logic to clear the state from your custom backend
+    def delete(self, state_id: str) -> None:
+        # Implement the logic to delete the state for a given state ID
+        ...
 
-    def get_state_ids(self) -> list[str]:
-        # Implement the logic to retrieve the list of state IDs from your custom backend
+    def get_state_ids(self, pattern: str | None = None) -> list[str]:
+        # Implement the logic to retrieve the list of state IDs from
+        # your custom backend, optionally filtered by a glob pattern
+        ...
 
     @contextmanager
     def acquire_lock(self, state_id: str, *, retry_seconds: int = 1):
-        # Implement the logic to acquire a lock for the given state ID
+        # Implement the logic to acquire a lock for the given state ID.
         # This method should be a context manager that acquires the lock
         # and releases it when the context exits.
         yield
+
+    def migrate(self) -> None:
+        # Optionally implement migration logic for your custom backend.
+        # This is called by `meltano upgrade` to perform any necessary
+        # data migrations (e.g., fixing path prefixes, schema changes).
+        # The default implementation is a no-op.
+        ...
 ```
 
 To let Meltano know about your custom state manager, you need to add the following configuration to your `pyproject.toml`:

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -229,6 +229,13 @@ class StateStoreManager(ABC):
         """
         ...
 
+    def migrate(self) -> None:  # noqa: B027
+        """Migrate state from a previous version of the manager.
+
+        Subclasses should override this to perform any necessary migrations
+        on the state data (e.g., fixing path prefixes, schema changes).
+        """
+
     @abstractmethod
     @contextmanager
     def acquire_lock(


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

This allows backend implementations to do something like

```python
class MyStateManager(StateStoreManager):
    def migrate(self):
        # Do stuff
```

which will be invoked when running `meltano upgrade`.

## Related Issues

* https://github.com/meltano/meltano/issues/7938

## Summary by Sourcery

Introduce a pluggable state migration hook on state store managers and apply it during project upgrades.

New Features:
- Add a default StateStoreManager.migrate() interface for state backend implementations to perform custom state migrations.
- Expose state migration via UpgradeService.migrate_state so backends can run migrations during `meltano upgrade`.

Enhancements:
- Move the S3/cloud state prefix de-duplication logic from UpgradeService into CloudStateStoreManager.migrate for better encapsulation and reuse.
- Improve custom state backend documentation to reflect the current StateStoreManager interface, including migrate and updated method signatures.

Documentation:
- Update the custom state backend guide to document the migrate hook and align method signatures with the current StateStoreManager API.

Tests:
- Add tests verifying that S3StateStoreManager.migrate de-duplicates duplicated prefix paths and leaves correctly prefixed files unchanged.