### PR TITLE
test: Fix flaky `test_set_from_string_file_mutually_exclusive`

### DIFF
--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -179,6 +179,7 @@ class TestCliState:
                     assert_cli_runner(result)
                     assert state_service.get_state(state_id) == state_payload
 
+    @pytest.mark.usefixtures("project")
     def test_set_from_string_file_mutually_exclusive(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

- Fixes flaky `test_set_from_string_file_mutually_exclusive` by adding the missing `project` fixture
- The test was missing the fixture, so `@pass_project(migrate=True)` would raise `click.UsageError` (exit code 2) before the mutual exclusivity check (exit code 1) could run — depending on whether a previous test left a Meltano project in the CWD

Closes #9820

## Test plan

- [x] `pytest tests/meltano/cli/test_state.py::TestCliState::test_set_from_string_file_mutually_exclusive` passes consistently
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Stabilize test_set_from_string_file_mutually_exclusive by marking it to use the project fixture.