### PR TITLE
fix: Drop `None` values coming from `.env`

### DIFF
--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -76,7 +76,7 @@ class PluginSettingsService(SettingsService):
                 # expand state_id_suffix
                 self.project.environment.state_id_suffix = expand_env_vars(
                     self.project.environment.state_id_suffix,
-                    {  # ty: ignore[invalid-argument-type]
+                    {
                         **self.project.dotenv_env,
                         **self.env_override,
                     },

--- a/src/meltano/core/plugin/singer/mapper.py
+++ b/src/meltano/core/plugin/singer/mapper.py
@@ -72,7 +72,7 @@ class SingerMapper(SingerPlugin):
                 **invoker.plugin_config_processed,
                 **expand_env_vars(
                     self._get_mapping_config(invoker.plugin.extra_config),
-                    expandable_env,  # ty: ignore[invalid-argument-type]
+                    expandable_env,
                 ),
             }
             await config_file.write(json_dumps(config_payload, indent=2))

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -467,7 +467,7 @@ class PluginInstallService:
                 os.environ,
                 if_missing=EnvVarMissingBehavior(strict_env_var_mode),
             )
-            return {  # ty: ignore[invalid-return-type]
+            return {
                 "MELTANO__PYTHON_VERSION": (
                     f"{sys.version_info.major}.{sys.version_info.minor}"
                 ),

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -384,7 +384,7 @@ class PluginInvoker:
             expanded_active_env = (
                 expand_env_vars(
                     self.settings_service.project.environment.env,
-                    expanded_project_env,  # ty: ignore[invalid-argument-type]
+                    expanded_project_env,
                     if_missing=EnvVarMissingBehavior(strict_env_var_mode),
                 )
                 if self.settings_service.project.environment
@@ -435,7 +435,7 @@ class PluginInvoker:
             )
             venv_dir = str(venv.bin_dir)
             env["VIRTUAL_ENV"] = str(venv.root)
-            env["PATH"] = os.pathsep.join([venv_dir, env["PATH"]])  # ty: ignore[no-matching-overload]
+            env["PATH"] = os.pathsep.join([venv_dir, env["PATH"]])
 
         return env
 

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -421,13 +421,13 @@ class Project:
         return self.root.joinpath(".env")
 
     @cached_property
-    def dotenv_env(self) -> dict[str, str | None]:
+    def dotenv_env(self) -> dict[str, str]:
         """Get values from this project's .env file.
 
         Returns:
-            values found in this project's .env file
+            Values found in this project's .env file, with None values filtered out.
         """
-        return dotenv_values(self.dotenv)
+        return {k: v for k, v in dotenv_values(self.dotenv).items() if v is not None}
 
     def activate_environment(self, name: str) -> None:
         """Activate a Meltano environment.

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -369,7 +369,7 @@ class SettingsService(metaclass=ABCMeta):
             metadata["expandable"] = False
             expanded_value = do_expand_env_vars(  # type: ignore[type-var]
                 value,
-                env=expandable_env,  # ty: ignore[invalid-argument-type]
+                env=expandable_env,
                 if_missing=EnvVarMissingBehavior(int(strict_env_var_mode)),  # type: ignore[arg-type]
             )
             # https://github.com/meltano/meltano/issues/7189#issuecomment-1396112167

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -491,7 +491,7 @@ class DotEnvStoreManager(BaseEnvStoreManager):
             kwargs: Keyword arguments to pass to parent class.
         """
         super().__init__(*args, **kwargs)
-        self._env: dict[str, str | None] | None = None
+        self._env: dict[str, str] | None = None
 
     def ensure_supported(self, method: str = "get") -> None:
         """Ensure named method is supported.
@@ -509,7 +509,7 @@ class DotEnvStoreManager(BaseEnvStoreManager):
             raise StoreNotSupportedError(ProjectReadonly())
 
     @property
-    def env(self) -> dict[str, str | None]:
+    def env(self) -> dict[str, str]:
         """Return values from the .env file.
 
         Returns:


### PR DESCRIPTION
**Relates to #9785**

## Problem
When `dotenv_values` encounters a variable without a value (e.g., `ENV_VAR` without `=`), it returns `None` for that variable. This `None` value was being treated as the string \`'None'\` when expanding config values.

## Solution
Filter out `None` values from the `dotenv_env` dictionary in `Project.dotenv_env`. Variables without values are now simply not included in the environment, which matches the behavior of `load_dotenv` that ignores such variables.

## Changes
- Modified `Project.dotenv_env` property to filter out `None` values
- Updated return type annotation from `dict[str, str | None]` to `dict[str, str]`

## Testing
This is a minimal fix that ensures variables without values in .env files don't get expanded to the string `'None'`.

Example:
```.env
# Before fix: MY_VAR would expand to 'None'
# After fix: MY_VAR is not included in dotenv_env
MY_VAR
MY_OTHER_VAR=value
```

## Summary by Sourcery

Bug Fixes:
- Ensure dotenv environment excludes variables with no value instead of propagating them as the string 'None'.