### PR TITLE
feat: Add default logging.yaml when meltano init is invoked

### DIFF
--- a/src/meltano/core/bundle/initialize.yml
+++ b/src/meltano/core/bundle/initialize.yml
@@ -37,12 +37,12 @@ logging.yaml: |
       (): meltano.core.logging.console_log_formatter
       colors: true
       show_locals: false
-    
+
     # JSON formatted logs for production - machine readable
     json:
       (): meltano.core.logging.json_formatter
       callsite_parameters: true
-    
+
     # Plain text format - useful for simple output
     plain:
       (): meltano.core.logging.plain_formatter
@@ -77,13 +77,13 @@ logging.yaml: |
       level: INFO
       handlers: [console, file]
       propogate: no
-    
+
     # Plugin subprocess logging (taps, targets, etc.)
     meltano.core.plugin:
       level: INFO
       handlers: [console, file]
       propogate: no
-    
+
     # Debug logging for troubleshooting
     # Uncomment the following to enable debug logging:
     # meltano.core.runner:

--- a/src/meltano/core/bundle/initialize.yml
+++ b/src/meltano/core/bundle/initialize.yml
@@ -24,3 +24,69 @@ transform/.gitkeep: ""
 analyze/.gitkeep: ""
 notebook/.gitkeep: ""
 orchestrate/.gitkeep: ""
+logging.yaml: |
+  version: 1
+  disable_existing_loggers: false
+
+  # Meltano logging configuration
+  # For more details, see: https://docs.meltano.com/guide/logging
+
+  formatters:
+    # Colored console output for development - human readable with colors
+    colored:
+      (): meltano.core.logging.console_log_formatter
+      colors: true
+      show_locals: false
+    
+    # JSON formatted logs for production - machine readable
+    json:
+      (): meltano.core.logging.json_formatter
+      callsite_parameters: true
+    
+    # Plain text format - useful for simple output
+    plain:
+      (): meltano.core.logging.plain_formatter
+
+  handlers:
+    # Console handler for output to stdout/stderr
+    console:
+      class: logging.StreamHandler
+      level: INFO
+      formatter: colored
+      stream: ext://sys.stderr
+
+    # File handler for persistent logs
+    file:
+      class: logging.handlers.RotatingFileHandler
+      level: DEBUG
+      formatter: json
+      filename: .meltano/logs/meltano.log
+      maxBytes: 10485760  # 10MB
+      backupCount: 5
+
+  # Root logger configuration
+  root:
+    level: INFO
+    handlers: [console, file]
+    propogate: yes
+
+  # Specific logger configurations
+  loggers:
+    # Meltano core logging
+    meltano:
+      level: INFO
+      handlers: [console, file]
+      propogate: no
+    
+    # Plugin subprocess logging (taps, targets, etc.)
+    meltano.core.plugin:
+      level: INFO
+      handlers: [console, file]
+      propogate: no
+    
+    # Debug logging for troubleshooting
+    # Uncomment the following to enable debug logging:
+    # meltano.core.runner:
+    #   level: DEBUG
+    #   handlers: [console, file]
+    #   propogate: no


### PR DESCRIPTION
## Summary

This PR adds a default `logging.yaml` file when `meltano init` is invoked, helping users discover logging configuration options and providing a sensible starting point for customization.

## Changes

Updated `src/meltano/core/bundle/initialize.yml` to include a new `logging.yaml` entry with:

### Formatters
- `colored`: Colored console output for development (human readable)
- `json`: JSON formatted logs for production (machine readable)
- `plain`: Plain text format for simple output

### Handlers
- `console`: Outputs to stderr with colored formatter at INFO level
- `file`: Rotating file handler that writes JSON logs to `.meltano/logs/meltano.log`
  - 10MB per file, 5 backups
  - DEBUG level for more verbose persistent logging

### Loggers
- Root logger: INFO level, outputs to both console and file
- `meltano`: INFO level for core meltano logging
- `meltano.core.plugin`: INFO level for plugin subprocess logging
- Commented example for debug logging

## Benefits

1. **Discoverability**: Users immediately see that logging is configurable
2. **Sensible defaults**: Works well for both development and production
3. **Documentation**: Includes comments with links to full documentation
4. **Production ready**: JSON structured logging to file enables proper log aggregation

## Testing

1. Run `meltano init test-project`
2. Verify `logging.yaml` is created in the project root
3. Run `meltano run` and verify both console and file logging work

Closes #3049

## Summary by Sourcery

New Features:
- Include a pre-populated logging.yaml in the project initialization bundle defining default formatters, handlers, and loggers for Meltano.