### PR TITLE
docs: Fix typos in DataHub tutorial documentation

### DIFF
--- a/docs/docs/tutorials/datahub.md
+++ b/docs/docs/tutorials/datahub.md
@@ -8,7 +8,7 @@ sidebar_position: 11
 
 Meltano supports multiple [utilities](/concepts/plugins#utilities), one of them is the [DataHub utility](https://hub.meltano.com/utilities/datahub). It provides an integration for the metadata platform called DataHub. You can find the reference at both the [utility-datahub level](https://github.com/z3z1ma/files-datahub/tree/main/bundle/utilities/datahub) as well as the [file-bundle-datahub level](https://github.com/z3z1ma/files-datahub).
 
-This guide explains how to use the datahub utility either with a local running instance, or with a remotely running instance. It will explain how to setup the utility, configure datahub sources and how to run ingestions.
+This guide explains how to use the datahub utility either with a local running instance, or with a remotely running instance. It will explain how to set up the utility, configure datahub sources and how to run ingestions.
 
 We assume you have some familiarity with DataHub and Meltano.
 

--- a/docs/docs/tutorials/datahub.md
+++ b/docs/docs/tutorials/datahub.md
@@ -10,9 +10,9 @@ Meltano supports multiple [utilities](/concepts/plugins#utilities), one of them 
 
 This guide explains how to use the datahub utility either with a local running instance, or with a remotely running instance. It will explain how to setup the utility, configure datahub sources and how to run ingestions.
 
-We assume you have some familarity with DataHub and Meltano.
+We assume you have some familiarity with DataHub and Meltano.
 
-Have your [DataHub GMS](https://datahubproject.io/docs/what/gms/) url and and auth token ready for the setup. Or do the local setup described below.
+Have your [DataHub GMS](https://datahubproject.io/docs/what/gms/) url and auth token ready for the setup. Or do the local setup described below.
 
 ## High-level Overview
 


### PR DESCRIPTION
## Summary

Fixes minor typos in the DataHub tutorial documentation.

## Changes

- Fixed "familarity" → "familiarity" 
- Fixed "url and and auth" → "url and auth"

## Location

- docs/docs/tutorials/datahub.md

## Summary by Sourcery

Documentation:
- Fix spelling and wording issues in the DataHub tutorial to improve readability.