### PR TITLE
docs: Add json-schema-for-humans schema documentation generation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -7,6 +7,8 @@
 # Generated files
 .docusaurus
 .cache-loader
+.schema-venv
+/static/schema
 
 # Misc
 .DS_Store

--- a/docs/docs/reference/schema.mdx
+++ b/docs/docs/reference/schema.mdx
@@ -1,0 +1,36 @@
+---
+title: Meltano YAML Schema
+description: JSON Schema reference for meltano.yml configuration file
+layout: doc
+sidebar_position: 3
+---
+
+# Meltano YAML Schema Reference
+
+This page provides a human-readable view of the JSON Schema for `meltano.yml` configuration files.
+
+The schema defines all valid properties and their types for Meltano project configuration.
+
+## View the Schema Documentation
+
+The generated schema documentation is available [here](/schema/index.html).
+
+## Schema File
+
+The source schema file is located at `src/meltano/schemas/meltano.schema.json` in the Meltano repository.
+
+## Using the Schema
+
+You can configure your IDE to use this schema for validation and autocomplete support when editing `meltano.yml` files. Most modern editors support JSON Schema validation for YAML files.
+
+### Visual Studio Code
+
+Add the following to your `.vscode/settings.json`:
+
+```json
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/meltano/meltano/main/src/meltano/schemas/meltano.schema.json": "meltano.yml"
+  }
+}
+```

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,8 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "build:with-schema": "npm run generate-schema && docusaurus build",
+    "generate-schema": "python3 scripts/generate-schema-docs.py",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/docs/scripts/generate-schema-docs.py
+++ b/docs/scripts/generate-schema-docs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Generate human-readable HTML documentation from meltano.schema.json
+using json-schema-for-humans.
+
+This script is called during the docs build process to generate
+schema documentation.
+
+Usage:
+    python3 scripts/generate-schema-docs.py
+
+Requirements:
+    pip install json-schema-for-humans==0.44.2
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def generate_schema_docs():
+    """Generate schema documentation using json-schema-for-humans."""
+    # Get paths
+    docs_dir = Path(__file__).parent.parent
+    repo_root = docs_dir.parent
+    schema_path = repo_root / "src" / "meltano" / "schemas" / "meltano.schema.json"
+    static_dir = docs_dir / "static" / "schema"
+    
+    # Ensure the static/schema directory exists
+    static_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Check if schema file exists
+    if not schema_path.exists():
+        print(f"Error: Schema file not found at {schema_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Check if json-schema-for-humans is installed
+    try:
+        import json_schema_for_humans
+    except ImportError:
+        print("Error: json-schema-for-humans is not installed.", file=sys.stderr)
+        print("Please install it with: pip install json-schema-for-humans==0.44.2", file=sys.stderr)
+        print("\nFor CI environments, you can skip schema generation by setting SKIP_SCHEMA_GENERATION=1", file=sys.stderr)
+        sys.exit(1)
+    
+    # Generate the schema documentation
+    output_file = static_dir / "index.html"
+    
+    cmd = [
+        sys.executable, "-m", "json_schema_for_humans.generate",
+        "--expand-buttons",
+        "--minify",
+        str(schema_path),
+        str(output_file)
+    ]
+    
+    print(f"Generating schema docs...")
+    subprocess.check_call(cmd)
+    
+    print(f"Schema documentation generated successfully at {output_file}")
+
+
+if __name__ == "__main__":
+    # Allow skipping schema generation in environments where the package is not available
+    if os.environ.get("SKIP_SCHEMA_GENERATION") == "1":
+        print("Skipping schema generation (SKIP_SCHEMA_GENERATION=1)")
+        sys.exit(0)
+    generate_schema_docs()

--- a/docs/scripts/generate-schema-docs.py
+++ b/docs/scripts/generate-schema-docs.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Generate human-readable HTML documentation from meltano.schema.json
+"""Generate human-readable HTML documentation from meltano.schema.json
 using json-schema-for-humans.
 
 This script is called during the docs build process to generate
@@ -12,6 +11,8 @@ Usage:
 Requirements:
     pip install json-schema-for-humans==0.44.2
 """
+
+from __future__ import annotations
 
 import os
 import subprocess
@@ -26,38 +27,46 @@ def generate_schema_docs():
     repo_root = docs_dir.parent
     schema_path = repo_root / "src" / "meltano" / "schemas" / "meltano.schema.json"
     static_dir = docs_dir / "static" / "schema"
-    
+
     # Ensure the static/schema directory exists
     static_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Check if schema file exists
     if not schema_path.exists():
         print(f"Error: Schema file not found at {schema_path}", file=sys.stderr)
         sys.exit(1)
-    
+
     # Check if json-schema-for-humans is installed
     try:
         import json_schema_for_humans
     except ImportError:
         print("Error: json-schema-for-humans is not installed.", file=sys.stderr)
-        print("Please install it with: pip install json-schema-for-humans==0.44.2", file=sys.stderr)
-        print("\nFor CI environments, you can skip schema generation by setting SKIP_SCHEMA_GENERATION=1", file=sys.stderr)
+        print(
+            "Please install it with: pip install json-schema-for-humans==0.44.2",
+            file=sys.stderr,
+        )
+        print(
+            "\nFor CI environments, you can skip schema generation by setting SKIP_SCHEMA_GENERATION=1",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    
+
     # Generate the schema documentation
     output_file = static_dir / "index.html"
-    
+
     cmd = [
-        sys.executable, "-m", "json_schema_for_humans.generate",
+        sys.executable,
+        "-m",
+        "json_schema_for_humans.generate",
         "--expand-buttons",
         "--minify",
         str(schema_path),
-        str(output_file)
+        str(output_file),
     ]
-    
-    print(f"Generating schema docs...")
+
+    print("Generating schema docs...")
     subprocess.check_call(cmd)
-    
+
     print(f"Schema documentation generated successfully at {output_file}")
 
 


### PR DESCRIPTION
This PR adds support for generating human-readable schema documentation using `json-schema-for-humans`.

## Changes

- Added `docs/scripts/generate-schema-docs.py` script that generates HTML documentation from `meltano.schema.json`
- Added npm script `generate-schema` to run the generator
- Added npm script `build:with-schema` for builds including schema generation
- Added reference page at `docs/docs/reference/schema.mdx` linking to the generated docs
- Updated `.gitignore` to exclude venv and generated schema files

## Usage

To generate schema documentation:
```bash
cd docs
pip install json-schema-for-humans==0.44.2
npm run generate-schema
```

Or build with schema generation:
```bash
cd docs
pip install json-schema-for-humans==0.44.2
npm run build:with-schema
```

## CI Integration

In CI environments where the Python package isn't available, set `SKIP_SCHEMA_GENERATION=1` to skip the schema generation step.

Closes #7327

## Summary by Sourcery

Add automated generation and publishing of human-readable Meltano schema documentation as part of the docs build.

New Features:
- Add a script to generate HTML documentation from the Meltano JSON schema using json-schema-for-humans.
- Expose npm scripts to generate schema docs and to run a docs build that includes schema generation.
- Add a reference docs page linking to the generated Meltano YAML schema documentation.

Build:
- Integrate schema doc generation into the docs build workflow with an optional SKIP_SCHEMA_GENERATION environment flag.

Documentation:
- Document how to access and use the generated Meltano YAML schema, including IDE integration guidance for VS Code.