### PR TITLE
fix: handle null values from dotenv correctly

### DIFF
--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -634,7 +634,11 @@ def expand_env_vars(
         if match["escape"]:
             return restored
         try:
-            val = str(env[var])
+            env_val = env[var]
+            if env_val is None:
+                # Treat null values from dotenv as unset (same as KeyError)
+                raise KeyError(var)
+            val = str(env_val)
         except KeyError as ex:
             logger.debug(
                 f"Variable '${var}' is not set in the provided env dictionary.",  # noqa: G004


### PR DESCRIPTION
## Bug Description
When an environment variable is defined in `.env` without a value (e.g., `TAP_NAME` instead of `TAP_NAME=value`), `dotenv_values` returns `None` for that key. The `expand_env_vars` function was converting this `None` to the string `"None"`, resulting in incorrect config values like `"tap-None"`.

## Example
Given `meltano.yml`:
```yaml
plugins:
  extractors:
    - name: tap-pypistats
      config:
        packages:
          - tap-$TAP_NAME
```

And `.env`:
```
TAP_NAME
```

Before this fix:
```
$ meltano config print tap-pypistats
{
  "packages": [
    "tap-None"
  ]
}
```

After this fix:
```
$ meltano config print tap-pypistats
{
  "packages": [
    "tap-"
  ]
}
```

## Solution
Check if the env value is `None` before converting to string and treat it the same as a missing key (resulting in an empty string or the appropriate `if_missing` behavior).

Fixes #9785

## Summary by Sourcery

Bug Fixes:
- Avoid converting null values from dotenv into the string 'None' during environment variable expansion, instead treating them as missing keys.