### PR TITLE
fix(core): Handle non-unicode characters in plugin logs on Windows

### DIFF
--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -291,6 +291,16 @@ class Out:
         self.last_line = line
         line = line.rstrip()
 
+        # Handle encoding issues on Windows where the console may not support
+        # all Unicode characters (e.g., cp1252 encoding). Replace characters
+        # that cannot be encoded in the system's default encoding.
+        try:
+            line.encode(sys.stdout.encoding or "utf-8", errors="strict")
+        except UnicodeEncodeError:
+            line = line.encode(sys.stdout.encoding or "utf-8", errors="replace").decode(
+                sys.stdout.encoding or "utf-8", errors="replace"
+            )
+
         if not line:
             return
 


### PR DESCRIPTION
### Bug description

On Windows systems with non-UTF8 console encodings (e.g., cp1252), logging messages containing non-ASCII characters (like Cyrillic text) would cause UnicodeEncodeError when being written to the console.

### Fix

Sanitizes log lines in the writeline method by detecting characters that cannot be encoded in the system's default encoding and replacing them with the replacement character (�).

### Issue

Fixes #8799

## Summary by Sourcery

Bug Fixes:
- Prevent UnicodeEncodeError when logging messages containing non-ASCII characters to Windows consoles that do not support all Unicode characters.