### PR TITLE
fix: Handle null values from dotenv correctly

### DIFF
--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -634,7 +634,10 @@ def expand_env_vars(
         if match["escape"]:
             return restored
         try:
-            val = str(env[var])
+            env_val = env[var]
+            # Handle None values from dotenv (e.g., ENV_VAR without a value)
+            # See: https://github.com/meltano/meltano/issues/9785
+            val = "" if env_val is None else str(env_val)
         except KeyError as ex:
             logger.debug(
                 f"Variable '${var}' is not set in the provided env dictionary.",  # noqa: G004

--- a/tests/meltano/core/test_utils.py
+++ b/tests/meltano/core/test_utils.py
@@ -228,6 +228,13 @@ def test_unflatten() -> None:
             "MY_DB$TableName",
             id="escape",
         ),
+        pytest.param(
+            "prefix-$ENV_VAR-suffix",
+            {"ENV_VAR": None},
+            {},
+            "prefix--suffix",
+            id="none-value-from-dotenv",
+        ),
     ),
 )
 def test_expand_env_vars(input_value, env, kwargs, expected_output) -> None:


### PR DESCRIPTION
Fixes #9785

When an environment variable is defined in `.env` without a value (e.g., `TAP_NAME` instead of `TAP_NAME=value`), python-dotenv returns `None` for that variable. Previously, `str(None)` was used, resulting in the string `'None'` being substituted.

Example:
```dotenv
TAP_NAME
```

```yaml
# meltano.yml
plugins:
  extractors:
  - name: tap-pypistats
    config:
      packages:
      - tap-$TAP_NAME
```

Before this fix:
```
"packages": ["tap-None"]
```

After this fix:
```
"packages": ["tap-"]
```

Changes:
- Update `expand_env_vars()` to handle `None` values from dotenv by treating them as empty strings
- Add test case for None value handling

## Summary by Sourcery

Handle environment variables with null values returned from dotenv so they are treated as empty strings during environment variable expansion.

Bug Fixes:
- Prevent environment variable expansion from converting null dotenv values into the literal string 'None' by treating them as empty strings instead.

Tests:
- Add a test case covering expansion behavior when an environment variable is present in dotenv with a null value.