### PR TITLE
docs: Fix typo 'the the' -> 'the' in manifest.py docstring

### DIFF
--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -481,7 +481,7 @@ def apply_scaffold(manifest: dict[str, t.Any], locations: Iterable[str]) -> None
 
     Args:
         manifest: The manifest dictionary to update in-place.
-        locations: The locations (as jq filters) which will be added to the the
+        locations: The locations (as jq filters) which will be added to the
             manifest as necessary.
     """
     _apply_scaffold(


### PR DESCRIPTION
This PR fixes a small typo in the docstring of the  method in manifest.py where 'the the' was written instead of 'the'.

## Summary by Sourcery

Documentation:
- Fix a duplicated word typo in the manifest.apply_scaffold docstring.