### PR TITLE
fix(logging): Handle non-unicode characters in plugin logs on Windows

### DIFF
--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -188,6 +188,7 @@ def default_config(
                 "level": numeric_level if log_level == "DISABLED" else log_level,
                 "formatter": log_format,
                 "stream": "ext://sys.stderr",
+                "encoding": "utf-8",
             },
         },
         "loggers": {


### PR DESCRIPTION
## Description

This PR fixes the UnicodeEncodeError that occurs when logging non-ASCII characters on Windows systems.

### Problem
On Windows, the console stream uses cp1252 encoding by default, which cannot handle non-ASCII Unicode characters (e.g., Cyrillic text like "самых"). This causes a UnicodeEncodeError when plugin logs contain such characters.

### Solution
Add explicit UTF-8 encoding to the console handler configuration in the default logging config. This ensures that all characters can be properly encoded regardless of the system's default encoding.

### Changes
- Added "encoding": "utf-8" to the console handler in default_config()

Fixes #8799

## Summary by Sourcery

Bug Fixes:
- Prevent UnicodeEncodeError on Windows console logging by explicitly setting UTF-8 encoding for the default console log handler.