### PR TITLE
ci: Display ty output directly in PRs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -208,7 +208,8 @@ def typing(session: nox.Session) -> None:
         session: Nox session.
     """
     _uv_sync(session, "--group=typing", "--all-extras")
-    session.run("ty", "check", *session.posargs)
+    output_format = "github" if os.getenv("GITHUB_ACTIONS") == "true" else "concise"
+    session.run("ty", "check", f"--output-format={output_format}", *session.posargs)
     session.run("mypy", *session.posargs)
 
 


### PR DESCRIPTION
<!--

Please, go through these steps when you submit a PR.

1. Make sure your branch is not protected. In particular, avoid making PRs from the `main` branch of your fork.

2. Give a descriptive title to your PR. We use semantic titles, and the accepted types and scopes are listed in https://github.com/meltano/meltano/blob/main/.github/semantic.yml.

   A good title should look like this:

   ```
   feat(cli): The `meltano run` command now accepts a `--timeout` option to limit the time it runs
   ```

3. Provide a description of your changes.

4. Put "Closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such).

-->

## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

<img width="808" height="471" alt="Screenshot 2026-02-06 at 2 44 25 p m" src="https://github.com/user-attachments/assets/156e03b8-e3b6-4dc9-912f-60bf497abd81" />

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Adjust typing session output for CI and silence a type-checking warning in the virtual environment service.

Enhancements:
- Format ty type-checking output for GitHub Actions when running in CI, falling back to a concise format locally.
- Suppress a specific ty type-checking warning for the virtual environment reuse check in venv_service.

## Summary by Sourcery

Adjust typing session configuration to emit CI-friendly type-checking output while preserving a concise format for local runs.

Enhancements:
- Select the ty type-checking output format dynamically based on whether the session is running in GitHub Actions or locally.

CI:
- Enable GitHub-formatted ty type-checking output when running in GitHub Actions to surface results directly in pull requests.