### PR TITLE
refactor: Use the `--clear` flag of virtualenv and uv to recreate the venv instead of removing it preemptively

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -372,7 +372,7 @@ class VenvService:
         Returns:
             The path to the install log file.
         """
-        return self.project.logs_dir(
+        return self.project.dirs.logs(
             "pip",
             self.namespace,
             self.name,
@@ -430,19 +430,6 @@ class VenvService:
         except FileNotFoundError:
             logger.debug("No cached configuration files to remove")
 
-    def clean(self) -> None:
-        """Destroy the virtual environment, if it exists."""
-        try:
-            shutil.rmtree(self.venv.root)
-            logger.debug(
-                "Removed old virtual environment for '%s/%s'",
-                self.namespace,
-                self.name,
-            )
-        except FileNotFoundError:
-            # If the VirtualEnv has never been created before do nothing
-            logger.debug("No old virtual environment to remove")
-
     async def create_venv(
         self,
         *,
@@ -461,6 +448,7 @@ class VenvService:
             sys.executable,
             "-m",
             "virtualenv",
+            "--clear",
             f"--python={self.venv.python_path}",
             str(self.venv.root),
             extract_stderr=extract_stderr,
@@ -598,7 +586,6 @@ class VenvService:
             The process running `pip install` with the provided args.
         """
         if clean:
-            self.clean()
             await self.create()
             await self.upgrade_installer(env=env)
 
@@ -729,6 +716,7 @@ class UvVenvService(VenvService):
         return await exec_async(
             self.uv,
             "venv",
+            "--clear",
             f"--python={self.venv.python_path}",
             str(self.venv.root),
             extract_stderr=extract_stderr,

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -60,7 +60,7 @@ class TestVenvService:
         return VenvService(project=project, namespace="namespace", name="name")
 
     def test_clean_run_files(self, project: Project, subject: VenvService) -> None:
-        run_dir = project.run_dir("name")
+        run_dir = project.dirs.run("name")
 
         file = run_dir / "test.file.txt"
         file.touch()
@@ -98,7 +98,7 @@ class TestVenvService:
             namespace=plugin_type,
             name=plugin_name,
         )
-        venv_dir = project.venvs_dir(plugin_type, plugin_name, make_dirs=True)
+        venv_dir = project.dirs.venvs(plugin_type, plugin_name, make_dirs=True)
         # Don't allow writing to the venv dir
         venv_dir.chmod(0o555)
 
@@ -119,7 +119,7 @@ class TestVenvService:
             )
 
         await subject.install(["example"], clean=True)
-        venv_dir = subject.project.venvs_dir("namespace", "name")
+        venv_dir = subject.project.dirs.venvs("namespace", "name")
 
         # ensure the venv is created
         assert venv_dir.exists()
@@ -268,7 +268,7 @@ class TestVirtualEnv:
     )
     def test_cross_platform(self, system: str, lib_dir: str, project: Project) -> None:
         with mock.patch("platform.system", return_value=system):
-            subject = VirtualEnv(project.venvs_dir("pytest", "pytest"))
+            subject = VirtualEnv(project.dirs.venvs("pytest", "pytest"))
             assert subject.lib_dir == subject.root / lib_dir
 
     def test_unknown_platform(self, project: Project) -> None:
@@ -279,7 +279,7 @@ class TestVirtualEnv:
                 match=r"(?i)Platform 'commodore64'.*?not supported.",
             ),
         ):
-            VirtualEnv(project.venvs_dir("pytest", "pytest"))
+            VirtualEnv(project.dirs.venvs("pytest", "pytest"))
 
 
 class TestUvVenvService(TestVenvService):

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -118,11 +118,17 @@ class TestVenvService:
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
             )
 
+        # Pre-create a venv with a marker file to ensure `clean=True` clears it
+        venv_dir = subject.project.dirs.venvs("namespace", "name", make_dirs=True)
+        marker_file = venv_dir / "pre_existing_marker.txt"
+        marker_file.write_text("marker")
+
         await subject.install(["example"], clean=True)
         venv_dir = subject.project.dirs.venvs("namespace", "name")
 
-        # ensure the venv is created
+        # ensure the venv is created and previous contents have been cleared
         assert venv_dir.exists()
+        assert not marker_file.exists()
 
         # ensure that the binary is python3
         assert (venv_dir / "bin/python").samefile(venv_dir / "bin/python3")


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Simplify virtual environment recreation by relying on virtualenv and uv `--clear` behavior instead of manually deleting the environment, and align venv- and log-related paths with the newer project directory API.

Enhancements:
- Use the `--clear` flag of virtualenv and uv to recreate virtual environments instead of preemptively removing their directories.
- Remove the now-unnecessary manual virtual environment cleanup method from the venv service.
- Update venv- and run-related path usage to rely on `project.dirs` accessors for logs, run, and venv directories.

Tests:
- Adjust venv service tests to use the updated `project.dirs` helpers and validate the new venv recreation behavior.