### PR TITLE
refactor: Use `Project.dirs` API in more places

### DIFF
--- a/src/meltano/core/logging/job_logging_service.py
+++ b/src/meltano/core/logging/job_logging_service.py
@@ -52,7 +52,7 @@ class JobLoggingService:  # noqa: D101
         Returns:
             The logs directory for the given state ID.
         """
-        return self.project.job_logs_dir(state_id, *joinpaths, make_dirs=make_dirs)  # type: ignore[deprecated]
+        return self.project.dirs.job_logs(state_id, *joinpaths, make_dirs=make_dirs)
 
     def generate_log_name(
         self,

--- a/tests/meltano/cli/test_initialize.py
+++ b/tests/meltano/cli/test_initialize.py
@@ -48,7 +48,7 @@ class TestCliInit:
         for meltano_dir in meltano_dirs:
             assert meltano_dir.is_dir()
 
-        meltano_yml = project.root_dir("meltano.yml").read_text()
+        meltano_yml = project.dirs.root_dir("meltano.yml").read_text()
         assert "send_anonymous_usage_stats: false" in meltano_yml
         assert "project_id:" in meltano_yml
 

--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -19,6 +19,8 @@ if t.TYPE_CHECKING:
 
     from click.testing import CliRunner
 
+    from meltano.core.project import Project
+
 
 class TestCliUpgrade:
     @pytest.mark.usefixtures("project")
@@ -155,7 +157,7 @@ class TestCliUpgrade:
 
     @pytest.mark.order(before="test_upgrade_files_glob_path")
     @pytest.mark.usefixtures("session")
-    def test_upgrade_files(self, project, cli_runner: CliRunner) -> None:
+    def test_upgrade_files(self, project: Project, cli_runner: CliRunner) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -171,7 +173,7 @@ class TestCliUpgrade:
         assert_cli_runner(result)
 
         # Don't update file if unchanged
-        file_path = project.root_dir("orchestrate/dags/meltano.py")
+        file_path = project.dirs.root_dir("orchestrate/dags/meltano.py")
         file_content = file_path.read_text()
 
         result = cli_runner.invoke(cli, ["upgrade", "files"])
@@ -186,7 +188,7 @@ class TestCliUpgrade:
         file_path.write_text("Overwritten!")
 
         # The behavior being tested assumes that the file is not locked.
-        shutil.rmtree(project.root_dir("plugins/files"), ignore_errors=True)
+        shutil.rmtree(project.dirs.root_dir("plugins/files"), ignore_errors=True)
         result = cli_runner.invoke(cli, ["upgrade", "files"])
         output = result.stdout + result.stderr
         assert_cli_runner(result)
@@ -249,7 +251,11 @@ class TestCliUpgrade:
         assert "Updated orchestrate/dags/meltano.py" in output
 
     @pytest.mark.usefixtures("session")
-    def test_upgrade_files_glob_path(self, project, cli_runner: CliRunner) -> None:
+    def test_upgrade_files_glob_path(
+        self,
+        project: Project,
+        cli_runner: CliRunner,
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
@@ -258,7 +264,7 @@ class TestCliUpgrade:
         result = cli_runner.invoke(cli, ["add", "--plugin-type=files", "airflow"])
         assert_cli_runner(result)
 
-        file_path = project.root_dir("orchestrate/dags/meltano.py")
+        file_path = project.dirs.root_dir("orchestrate/dags/meltano.py")
         file_path.write_text("Overwritten!")
 
         # override airflow--meltano.lock update extra config


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor project path handling to use the new Project.dirs API in tests and logging while keeping behavior unchanged.

Enhancements:
- Replace direct calls to Project.root_dir and job_logs_dir with the Project.dirs path helpers in CLI tests and job logging service for more consistent directory management.

Tests:
- Update CLI initialization and upgrade tests to reference project files and directories through Project.dirs and add explicit Project typing for the project fixture.