### PR TITLE
packaging(deps): Require click 8.2.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "alembic>=1.14.0,<2",
   "anyio>=4.4.0,<5",
   "backports-strenum>=1.3.1,<2 ; python_version < '3.11'",
-  "click>=8.1,<8.4,!=8.2.2",
+  "click>=8.2,<8.4,!=8.2.2",
   "click-default-group>=1.2.4,<2",
   "dateparser>=1.2.1",
   "fasteners>=0.19,<0.21",

--- a/uv.lock
+++ b/uv.lock
@@ -1502,7 +1502,7 @@ requires-dist = [
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.24.0,<13" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1,<2" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35,<2" },
-    { name = "click", specifier = ">=8.1,!=8.2.2,<8.4" },
+    { name = "click", specifier = ">=8.2,!=8.2.2,<8.4" },
     { name = "click-default-group", specifier = ">=1.2.4,<2" },
     { name = "dateparser", specifier = ">=1.2.1" },
     { name = "fasteners", specifier = ">=0.19,<0.21" },


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

Bumps the minimum version of Click to [8.2.0 published on May 10, 2025](https://pypi.org/project/click/8.2.0/)

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* https://github.com/meltano/meltano/pull/9793
* https://github.com/meltano/meltano/pull/9796 got lost in the ether somehow 😬 

## Summary by Sourcery

Build:
- Increase the Click package requirement from 8.1 to 8.2 while retaining the <8.4 upper bound and exclusion of 8.2.2.