### PR TITLE
test: Remove Click < 8.2 compatibility workarounds

### DIFF
--- a/tests/fixtures/cli.py
+++ b/tests/fixtures/cli.py
@@ -41,10 +41,7 @@ def cli_runner(pushd, snowplow_optional: SnowplowMicro | None):
     root_logger = logging.getLogger()  # noqa: TID251
     log_level = root_logger.level
     try:
-        runner = MeltanoCliRunner(snowplow=snowplow_optional)
-        # TODO: Remove this once support for Click<8.2 is dropped
-        runner.mix_stderr = False
-        yield runner
+        yield MeltanoCliRunner(snowplow=snowplow_optional)
     finally:
         root_logger.setLevel(log_level)
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Tests:
- Simplify the CLI test runner fixture by dropping the mix_stderr override now that Click<8.2 is no longer supported.