### PR TITLE
chore: Add dependabot updates for pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 enable-beta-ecosystems: true
 updates:
+  - package-ecosystem: pre-commit"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: pip
     directory: "/.github/workflows"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 enable-beta-ecosystems: true
 updates:
-  - package-ecosystem: pre-commit"
+  - package-ecosystem: pre-commit
     directory: "/"
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    cooldown:
-      default-days: 7
   - package-ecosystem: pip
     directory: "/.github/workflows"
     schedule:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.55.0 # Keep this in sync with the eslint "additional_dependency" below!
+    language: javascript
     hooks:
       - id: eslint
         files: \.[jt]sx?$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.55.0 # Keep this in sync with the eslint "additional_dependency" below!
-    language: javascript
+    language: node
     hooks:
       - id: eslint
         files: \.[jt]sx?$


### PR DESCRIPTION
## Related

- https://github.com/dependabot/dependabot-core/issues/1524#issuecomment-3929250369
- Blocked by check-jsonschema not having the latest schema for `dependabot.yml`
  - https://github.com/SchemaStore/schemastore/pull/5381
  - Interestingly: https://github.com/SchemaStore/schemastore/pull/5381#discussion_r2830518974
- Blocked by https://github.com/zizmorcore/zizmor/issues/1639

## Summary by Sourcery

Configure automated updates and compatibility for pre-commit tooling.

Enhancements:
- Specify JavaScript as the language for the eslint pre-commit hook to ensure proper execution.

Build:
- Add Dependabot configuration to manage weekly pre-commit hook updates.