### PR TITLE
fix: Add warning when using ephemeral state ID in el/elt commands

### DIFF
--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -341,12 +341,21 @@ async def _run_el_command(
         state_strategy=state_strategy,
     )
 
-    job = Job(
-        job_name=state_id
-        or (
+    if not state_id:
+        state_id = (
             f"{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H%M%S')}"
             f"--{extractor}--{loader}"
-        ),
+        )
+        logger.warning(
+            "No state ID provided. "
+            "Using an ephemeral state ID '%s'. "
+            "Incremental replication state will not be reused between runs. "
+            "To persist state across runs, pass `--state-id=<your_id>`.",
+            state_id,
+        )
+
+    job = Job(
+        job_name=state_id,
         run_id=run_id,
     )
     _, Session = project_engine(project)  # noqa: N806

--- a/tests/meltano/cli/test_elt.py
+++ b/tests/meltano/cli/test_elt.py
@@ -874,6 +874,43 @@ class TestCliEltScratchpadOne:
                 result.exception,
             )
 
+    @pytest.mark.backend("sqlite")
+    @pytest.mark.usefixtures("use_test_log_config", "project")
+    @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
+    def test_elt_ephemeral_state_id_warning(
+        self,
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        command: str,
+    ) -> None:
+        args = [command, tap.name, target.name]
+
+        create_subprocess_exec = AsyncMock(side_effect=(tap_process, target_process))
+        with (
+            mock.patch.object(SingerTap, "discover_catalog"),
+            mock.patch.object(SingerTap, "apply_catalog_rules"),
+            mock.patch("meltano.core.plugin_invoker.asyncio") as asyncio_mock,
+        ):
+            asyncio_mock.create_subprocess_exec = create_subprocess_exec
+
+            result = cli_runner.invoke(cli, args)
+            assert_cli_runner(result)
+
+            assert_log_lines(
+                result.stdout + result.stderr,
+                [
+                    LogEntry(
+                        None,
+                        None,
+                        "No state ID provided.",
+                        "warning",
+                    ),
+                ],
+            )
+
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_dump_catalog(
         self,

--- a/tests/meltano/cli/test_elt.py
+++ b/tests/meltano/cli/test_elt.py
@@ -899,8 +899,10 @@ class TestCliEltScratchpadOne:
             result = cli_runner.invoke(cli, args)
             assert_cli_runner(result)
 
+            output = result.stdout + result.stderr
+
             assert_log_lines(
-                result.stdout + result.stderr,
+                output,
                 [
                     LogEntry(
                         None,
@@ -910,6 +912,40 @@ class TestCliEltScratchpadOne:
                     ),
                 ],
             )
+
+            assert "Using an ephemeral state ID" in output
+            assert "Incremental replication state will not be reused" in output
+            assert "--state-id" in output
+
+    @pytest.mark.backend("sqlite")
+    @pytest.mark.usefixtures("use_test_log_config", "project")
+    @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
+    def test_elt_explicit_state_id_no_warning(
+        self,
+        cli_runner,
+        tap,
+        target,
+        tap_process,
+        target_process,
+        command: str,
+    ) -> None:
+        state_id = f"pytest_test_{command}_explicit"
+        args = [command, "--state-id", state_id, tap.name, target.name]
+
+        create_subprocess_exec = AsyncMock(side_effect=(tap_process, target_process))
+        with (
+            mock.patch.object(SingerTap, "discover_catalog"),
+            mock.patch.object(SingerTap, "apply_catalog_rules"),
+            mock.patch("meltano.core.plugin_invoker.asyncio") as asyncio_mock,
+        ):
+            asyncio_mock.create_subprocess_exec = create_subprocess_exec
+
+            result = cli_runner.invoke(cli, args)
+            assert_cli_runner(result)
+
+            output = result.stdout + result.stderr
+            assert "No state ID provided" not in output
+            assert "ephemeral state ID" not in output
 
     @pytest.mark.parametrize("command", ("elt", "el"), ids=["elt", "el"])
     def test_dump_catalog(


### PR DESCRIPTION
## Description

When `meltano elt` or `meltano el` is run without `--state-id`, an ephemeral timestamp-based state ID is generated silently. This means incremental replication state is not persisted between runs, which can be surprising — especially for users who expect state to "just work" across pipeline executions.

This PR adds a warning log message when no `--state-id` is provided, informing the user that:
- An ephemeral state ID is being used
- Incremental replication state will not be reused
- They should pass `--state-id=<your_id>` to persist state

The warning is emitted in `_run_el_command()` before the `Job` is created, covering both the `el` and `elt` commands.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

## Related Issues

* Closes #2683

## Summary by Sourcery

Warn when el/elt commands fall back to ephemeral state IDs to avoid unintended non-persistent incremental state.

New Features:
- Log a warning when el/elt commands run without an explicit --state-id, indicating that an ephemeral state ID is being used and incremental state will not be persisted.

Tests:
- Add CLI tests for el and elt commands to assert that the ephemeral state ID warning is emitted when no --state-id is provided.