### PR TITLE
refactor: Added `reason` keyword argument to `PluginInstaller` callable protocol

### DIFF
--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -498,6 +498,7 @@ class PluginInstaller(t.Protocol):
         *,
         project: Project,
         plugin: ProjectPlugin,
+        reason: PluginInstallReason,
         **kwargs,  # noqa: ANN003
     ) -> None:
         """Install the plugin.
@@ -505,6 +506,7 @@ class PluginInstaller(t.Protocol):
         Args:
             project: Meltano Project.
             plugin: `ProjectPlugin` to install.
+            reason: Install reason.
             kwargs: Additional arguments for the installation of the plugin.
         """
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Enhancements:
- Extend the PluginInstaller protocol signature with a required reason argument and update its docstring to describe the new parameter.