### PR TITLE
refactor(cli): Ensure custom `click.ParamType` implementations correctly override their parent methods

### DIFF
--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import sys
 import typing as t
 import uuid
 from collections.abc import Callable, Coroutine
@@ -16,6 +17,11 @@ from meltano.core.plugin import PluginType
 from meltano.core.plugin_install_service import PluginInstallReason, install_plugins
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.utils import async_noop
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -171,6 +177,7 @@ class UUIDParamType(click.ParamType):
 
     name = "uuid"
 
+    @override
     def convert(
         self,
         value: str,
@@ -191,11 +198,12 @@ class PluginTypeArg(click.Choice):
         """Initialize the PluginTypeArg."""
         super().__init__(PluginType.cli_arguments(), *args, **kwargs)
 
+    @override
     def convert(
         self,
         value: str,
-        param: click.Parameter | None,  # noqa: ARG002
-        ctx: click.Context | None,  # noqa: ARG002
+        param: click.Parameter | None,
+        ctx: click.Context | None,
     ) -> PluginType:
         """Convert the value to a PluginType."""
         return PluginType.from_cli_argument(value)

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -29,6 +29,11 @@ from meltano.core.schedule_service import (
 )
 from meltano.core.task_sets_service import TaskSetsService
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
@@ -105,7 +110,13 @@ class CronParam(click.ParamType):
 
     name = "cron"
 
-    def convert(self, value: str, *_) -> str:
+    @override
+    def convert(
+        self,
+        value: str,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> str:
         """Validate and con interval."""
         if value not in CRON_INTERVALS and not is_valid_cron(value):
             raise BadCronError(value)

--- a/src/meltano/cli/schedule.py
+++ b/src/meltano/cli/schedule.py
@@ -117,7 +117,7 @@ class CronParam(click.ParamType):
         param: click.Parameter | None,
         ctx: click.Context | None,
     ) -> str:
-        """Validate and con interval."""
+        """Validate cron interval."""
         if value not in CRON_INTERVALS and not is_valid_cron(value):
             raise BadCronError(value)
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Ensure custom Click parameter types correctly override the base `convert` method and add type-checking support for method overriding annotations.

Enhancements:
- Align `CronParam` and other custom `click.ParamType` implementations with Click's `convert` method signature.
- Introduce `typing.override`/`typing_extensions.override` usage to enforce correct method overriding in custom parameter types.