### PR TITLE
chore: Remove redundant `typing.cast` instances

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,6 +279,7 @@ exclude = [
   "src/meltano/migrations/",
 ]
 local_partial_types = true
+warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
@@ -324,20 +325,15 @@ exclude = [
   "src/meltano/core/behavior/name_eq.py",
   "src/meltano/core/block/extract_load.py",
   "src/meltano/core/block/plugin_command.py",
-  "src/meltano/core/environment_service.py",
   "src/meltano/core/job/job.py",
   "src/meltano/core/manifest/manifest.py",
   "src/meltano/core/plugin/airflow.py",
   "src/meltano/core/plugin/base.py",
-  "src/meltano/core/plugin/singer/base.py",
-  "src/meltano/core/plugin/singer/catalog.py",
   "src/meltano/core/plugin/meltano_file.py",
   "src/meltano/core/plugin/project_plugin.py",
   "src/meltano/core/project_plugins_service.py",
   "src/meltano/core/runner/dbt.py",
   "src/meltano/core/runner/singer.py",
-  "src/meltano/core/schedule.py",
-  "src/meltano/core/schedule_service.py",
   "src/meltano/core/settings_store.py",
   "src/meltano/core/sqlalchemy.py",
   "src/meltano/core/tracking/**",

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations  # noqa: D100
 
 import json
 import logging
+import sys
 import typing as t
 from textwrap import dedent
 
@@ -13,6 +14,11 @@ from meltano.core.constants import LOG_PARSER_SINGER_SDK
 from meltano.core.plugin import BasePlugin
 from meltano.core.setting_definition import SettingDefinition, json_dumps
 from meltano.core.utils import nest_object, uuid7
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -67,8 +73,9 @@ class SingerPlugin(BasePlugin):
         # errors from Canonical.
         self._instance_uuid: str | None = None
 
-    def process_config(self, flat_config: dict) -> dict:  # noqa: D102
-        non_null_config = {k: v for k, v in flat_config.items() if v is not None}
+    @override
+    def process_config(self, config: dict) -> dict:
+        non_null_config = {k: v for k, v in config.items() if v is not None}
         processed_config = nest_object(non_null_config)
         # Result at this point will contain duplicate entries for nested config
         # options. We need to pop those redundant entries recursively.

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -352,7 +352,7 @@ class SelectionType(StrEnum):
         """
         return self not in {SelectionType.EXCLUDED, SelectionType.UNSUPPORTED}
 
-    def __add__(self, other: object) -> SelectionType:
+    def __add__(self, other: object) -> SelectionType:  # ty:ignore[invalid-method-override]
         """Combine two selection types.
 
         Args:

--- a/src/meltano/core/schedule.py
+++ b/src/meltano/core/schedule.py
@@ -284,8 +284,8 @@ class ELTSchedule(Schedule):
             NotImplementedError: If the schedule is a job.
         """
         return [
-            t.cast("str", self.extractor),
-            t.cast("str", self.loader),
+            self.extractor,
+            self.loader,
             f"--transform={self.transform}",
             f"--state-id={self.name}",
         ]


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Refine type checking and configuration handling across core scheduling and Singer plugin components.

Bug Fixes:
- Remove unnecessary type casts in schedule argument construction to rely on correct underlying types.
- Adjust SelectionType addition method typing to satisfy stricter type checking rules.

Enhancements:
- Annotate Singer base plugin configuration processing with an override decorator and simplify its parameter typing.
- Enable mypy's redundant cast warnings and reduce the list of excluded core modules from static analysis.