### PR TITLE
refactor: Use `ProjectDirsService` in all remaining places

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,7 +284,7 @@ Location: `src/meltano/cli/` (32+ command files)
 
 **Deprecation Process**:
 - Use `@deprecated` decorator for legacy functionality
-- Issue `MeltanoInternalDeprecationWarning` warnings
+- Issue `MeltanoInternalDeprecationWarning` warnings for things that are only used internally in Meltano core, or by addons (i.e. state backends, etc.)
 - Document migration path in deprecation message
 - Controlled removal across versions
 

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -307,7 +307,7 @@ class ELBContextBuilder:
             The run directory for the current job.
         """
         if self._job:  # pragma: no cover
-            return self.project.job_dir(self._job.job_name, str(self._job.run_id))
+            return self.project.dirs.job(self._job.job_name, str(self._job.run_id))
 
         return None
 

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -160,7 +160,7 @@ class ELTContext(ELContextProtocol):
             The job dir, if a Job is provided, else None.
         """
         if self.job:
-            return self.project.job_dir(self.job.job_name, str(self.job.run_id))  # type: ignore[deprecated]
+            return self.project.dirs.job(self.job.job_name, str(self.job.run_id))
 
         return None
 

--- a/src/meltano/core/logging/job_logging_service.py
+++ b/src/meltano/core/logging/job_logging_service.py
@@ -162,7 +162,7 @@ class JobLoggingService:  # noqa: D101
             log_path.unlink()
 
     def legacy_logs_dir(self, state_id, *joinpaths):  # noqa: ANN001, ANN002, ANN201, D102
-        job_dir = self.project.run_dir("elt").joinpath(slugify(state_id), *joinpaths)  # type: ignore[deprecated]
+        job_dir = self.project.dirs.run("elt").joinpath(slugify(state_id), *joinpaths)
         return job_dir if job_dir.exists() else None
 
     def logs_dirs(self, state_id, *joinpaths):  # noqa: ANN001, ANN002, ANN201, D102

--- a/src/meltano/core/plugin_location_remove.py
+++ b/src/meltano/core/plugin_location_remove.py
@@ -150,7 +150,7 @@ class LockedDefinitionRemoveManager(PluginLocationRemoveManager):
             plugin: The plugin to remove.
             project: The Meltano project.
         """
-        lockfile_dir = project.root_plugins_dir(plugin.type)  # type: ignore[deprecated]
+        lockfile_dir = project.dirs.root_plugins(plugin.type)
         glob_expr = f"{plugin.name}*.lock"
         super().__init__(
             plugin,
@@ -186,7 +186,7 @@ class InstallationRemoveManager(PluginLocationRemoveManager):
             plugin: The plugin to remove.
             project: The Meltano project.
         """
-        path = project.plugin_dir(plugin, make_dirs=False)  # type: ignore[deprecated]
+        path = project.dirs.plugin(plugin, make_dirs=False)
         super().__init__(plugin, str(path.parent.relative_to(project.root)))
         self.path = path
 

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -16,7 +16,7 @@ import structlog
 from dotenv import dotenv_values
 
 from meltano.core import yaml
-from meltano.core._compat import MeltanoInternalDeprecationWarning, deprecated
+from meltano.core._compat import deprecated
 from meltano.core.config_service import ConfigService
 from meltano.core.environment import Environment
 from meltano.core.error import (
@@ -383,7 +383,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.root_dir` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     def root_dir(self, *joinpaths: StrPath) -> Path:
         """Return the root directory of this project, optionally joined with path.
@@ -466,7 +466,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.meltano` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def meltano_dir(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
@@ -483,7 +483,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.venvs` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def venvs_dir(self, *prefixes: StrPath, make_dirs: bool = True) -> Path:
@@ -500,7 +500,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.run` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def run_dir(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
@@ -517,7 +517,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.logs` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def logs_dir(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
@@ -534,7 +534,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.job` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def job_dir(
@@ -557,7 +557,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.job_logs` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def job_logs_dir(
@@ -580,7 +580,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.plugin` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def plugin_dir(
@@ -603,7 +603,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.root_plugins` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def root_plugins_dir(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:
@@ -620,7 +620,7 @@ class Project:
 
     @deprecated(
         "Use `dirs.plugin_lock_path` instead.",
-        category=MeltanoInternalDeprecationWarning,
+        category=DeprecationWarning,
     )
     @makedirs
     def plugin_lock_path(

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -101,7 +101,7 @@ class ProjectSettingsService(SettingsService):
             project_id = None
 
         if project_id is None:
-            analytics_path = self.project.meltano_dir() / "analytics.json"  # type: ignore[deprecated]
+            analytics_path = self.project.dirs.meltano() / "analytics.json"
             try:
                 with analytics_path.open() as analytics_json_file:
                     project_id = json.load(analytics_json_file)["project_id"]

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -296,21 +296,21 @@ class TestCli:
     def test_cwd_option(
         self,
         cli_runner,
-        test_cli_project,
+        test_cli_project: Project,
         tmp_path: Path,
     ) -> t.NoReturn:
         project = test_cli_project
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             assert_cli_runner(cli_runner.invoke(cli, ("dragon",)))
-            assert Path.cwd() == project.root_dir()
+            assert Path.cwd() == project.dirs.root
 
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             assert_cli_runner(
                 cli_runner.invoke(cli, ("--cwd", str(tmp_path), "dragon")),
             )
             assert Path.cwd() == tmp_path
 
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             filepath = tmp_path / "file.txt"
             filepath.touch()
             with pytest.raises(click.BadParameter, match="is a file"):
@@ -319,7 +319,7 @@ class TestCli:
                     ("--cwd", str(filepath), "dragon"),
                 ).exception.__context__
 
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             dirpath = tmp_path / "subdir"
             with pytest.raises(click.BadParameter, match="does not exist"):
                 raise cli_runner.invoke(
@@ -327,7 +327,7 @@ class TestCli:
                     ("--cwd", str(dirpath), "dragon"),
                 ).exception.__context__
 
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             dirpath.mkdir()
             assert_cli_runner(cli_runner.invoke(cli, ("--cwd", str(dirpath), "dragon")))
             assert Path.cwd() == dirpath
@@ -339,7 +339,7 @@ class TestCli:
         tmp_path: Path,
     ):
         project = test_cli_project
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             dotenv_path = tmp_path / ".env"
             dotenv_path.write_text("MELTANO_DEFAULT_ENVIRONMENT=custom\n")
             result = cli_runner.invoke(
@@ -356,7 +356,7 @@ class TestCli:
             assert result.exit_code == 0
             assert "MELTANO_DEFAULT_ENVIRONMENT='custom'" in result.output
 
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             dotenv_path = project.root.joinpath("prod.env")
             dotenv_path.write_text("MELTANO_DEFAULT_ENVIRONMENT=custom\n")
             result = cli_runner.invoke(
@@ -652,7 +652,7 @@ class TestVersionCheck:
         """Test that version check integration works."""
         # This test verifies the version check is integrated into CLI commands.
         # The actual version check logic is thoroughly tested in test_version_check.py
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             result = cli_runner.invoke(cli, ["config", "list", "meltano"])
 
         # The command should execute successfully
@@ -669,7 +669,7 @@ class TestVersionCheck:
         project: Project,
     ) -> None:
         """Test that excluded commands work correctly."""
-        with cd(project.root_dir()):
+        with cd(project.dirs.root):
             # Test 'version' command works
             result = cli_runner.invoke(cli, ["--version"])
             assert result.exit_code == 0
@@ -693,7 +693,7 @@ class TestVersionCheck:
                 "meltano.core.version_check.editable_installation",
                 return_value=None,
             ),
-            cd(project.root_dir()),
+            cd(project.dirs.root),
         ):
             result = cli_runner.invoke(cli, ["config", "meltano", "list"])
 
@@ -711,7 +711,7 @@ class TestVersionCheck:
                 "meltano.core.version_check.editable_installation",
                 return_value=None,
             ),
-            cd(project.root_dir()),
+            cd(project.dirs.root),
         ):
             # Set the project setting to disable version check
             result = cli_runner.invoke(
@@ -741,7 +741,7 @@ class TestVersionCheck:
                     upgrade_command=None,
                 ),
             ),
-            cd(project.root_dir()),
+            cd(project.dirs.root),
         ):
             result = cli_runner.invoke(cli, ["config", "list", "meltano"])
 

--- a/tests/meltano/cli/test_lock.py
+++ b/tests/meltano/cli/test_lock.py
@@ -36,7 +36,7 @@ class TestLock:
         cli_runner: CliRunner,
         project: Project,
     ) -> None:
-        lockfiles = list(project.root_plugins_dir().glob("./*/*.lock"))
+        lockfiles = list(project.dirs.root_plugins().glob("./*/*.lock"))
         assert len(lockfiles) == 2
 
         result = cli_runner.invoke(
@@ -110,7 +110,7 @@ class TestLock:
         cli_runner: CliRunner,
         project: Project,
     ) -> None:
-        lockfiles = list(project.root_plugins_dir().glob("./*/*.lock"))
+        lockfiles = list(project.dirs.root_plugins().glob("./*/*.lock"))
         # 1 tap, 1 target
         assert len(lockfiles) == 2
 

--- a/tests/meltano/core/plugin/test_airflow.py
+++ b/tests/meltano/core/plugin/test_airflow.py
@@ -14,6 +14,7 @@ from meltano.core.plugin_invoker import asyncio
 
 if t.TYPE_CHECKING:
     from meltano.core.plugin.airflow import AirflowInvoker
+    from meltano.core.project import Project
 
 AIRFLOW_CONFIG = """
 
@@ -30,11 +31,11 @@ class TestAirflow:
     async def test_before_configure(
         self,
         subject,
-        project,
+        project: Project,
         session,
         plugin_invoker_factory,
     ) -> None:
-        run_dir = project.run_dir("airflow")
+        run_dir = project.dirs.run("airflow")
 
         handle_mock = mock.Mock()
         handle_mock.name = subject.name
@@ -69,7 +70,7 @@ class TestAirflow:
             elif {"db", "init"}.issubset(popen_args):
                 assert kwargs["env"]["AIRFLOW_HOME"] == str(run_dir)
 
-                project.plugin_dir(subject, "airflow.db").touch()
+                project.dirs.plugin(subject, "airflow.db").touch()
             else:
                 return original_exec(cmd, *popen_args, **kwargs)
             return handle_mock
@@ -99,7 +100,7 @@ class TestAirflow:
                 assert configure.call_count == 2
 
                 assert run_dir.joinpath("airflow.cfg").exists()
-                assert project.plugin_dir(subject, "airflow.db").exists()
+                assert project.dirs.plugin(subject, "airflow.db").exists()
 
                 airflow_cfg = ConfigParser()
                 with run_dir.joinpath("airflow.cfg").open() as cfg:

--- a/tests/meltano/core/plugin/test_superset.py
+++ b/tests/meltano/core/plugin/test_superset.py
@@ -17,7 +17,10 @@ if t.TYPE_CHECKING:
     from pathlib import Path
     from types import ModuleType
 
+    from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.plugin.superset import SupersetInvoker
+    from meltano.core.project import Project
+    from meltano.core.project_add_service import ProjectAddService
 
 
 def load_module_from_path(name: str, path: Path) -> ModuleType:
@@ -41,7 +44,7 @@ def load_module_from_path(name: str, path: Path) -> ModuleType:
 
 class TestSuperset:
     @pytest.fixture(scope="class")
-    def subject(self, project_add_service):
+    def subject(self, project_add_service: ProjectAddService) -> ProjectPlugin:
         with mock.patch.object(PluginInstallService, "install_plugin"):
             return project_add_service.add(PluginType.UTILITIES, "superset")
 
@@ -51,8 +54,8 @@ class TestSuperset:
     )
     async def test_hooks(
         self,
-        subject,
-        project,
+        subject: ProjectPlugin,
+        project: Project,
         session,
         plugin_invoker_factory,
         monkeypatch,
@@ -61,7 +64,7 @@ class TestSuperset:
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/3444",
             )
-        run_dir = project.run_dir("superset")
+        run_dir = project.dirs.run("superset")
         config_path = run_dir.joinpath("superset_config.py")
 
         handle_mock = mock.Mock()
@@ -77,7 +80,7 @@ class TestSuperset:
 
             # first time, it creates the `superset.db`
             if {"db", "upgrade"}.issubset(popen_args):
-                project.plugin_dir(subject, "superset.db").touch()
+                project.dirs.plugin(subject, "superset.db").touch()
             # second time, it inits
             elif "init" in popen_args:  # noqa: SIM114
                 return handle_mock
@@ -112,16 +115,14 @@ class TestSuperset:
                 assert commands[2][1] == "--version"
 
                 assert config_path.exists()
-                assert project.plugin_dir(subject, "superset.db").exists()
+                db_path = project.dirs.plugin(subject, "superset.db")
+                assert db_path.exists()
 
                 config_module = load_module_from_path("superset_config", config_path)
 
                 config_keys = dir(config_module)
                 assert "SQLALCHEMY_DATABASE_URI" in config_keys
-                assert (
-                    f"sqlite:///{project.plugin_dir(subject, 'superset.db')}"
-                    == config_module.SQLALCHEMY_DATABASE_URI
-                )
+                assert f"sqlite:///{db_path}" == config_module.SQLALCHEMY_DATABASE_URI
                 assert "SECRET_KEY" in config_keys
 
             # Test custom setting

--- a/tests/meltano/core/test_locked_definition_service.py
+++ b/tests/meltano/core/test_locked_definition_service.py
@@ -32,7 +32,7 @@ class TestLockedDefinitionService:
             variant="meltano",
             foo="bar",
         )
-        path = subject.project.plugin_lock_path(
+        path = subject.project.dirs.plugin_lock_path(
             definition.plugin_type,
             definition.name,
             variant_name=definition.variant,

--- a/tests/meltano/core/test_plugin_invoker.py
+++ b/tests/meltano/core/test_plugin_invoker.py
@@ -22,6 +22,8 @@ from meltano.core.venv_service import VirtualEnv
 if t.TYPE_CHECKING:
     from pathlib import Path
 
+    from meltano.core.project import Project
+
 
 class TestPluginInvoker:
     @pytest.fixture
@@ -37,7 +39,13 @@ class TestPluginInvoker:
             yield subject
 
     @pytest.mark.asyncio
-    async def test_env(self, project, tap, session, plugin_invoker_factory) -> None:
+    async def test_env(
+        self,
+        project: Project,
+        tap,
+        session,
+        plugin_invoker_factory,
+    ) -> None:
         project.dotenv.touch()
         dotenv.set_key(project.dotenv, "DUMMY_ENV_VAR", "from_dotenv")
         dotenv.set_key(project.dotenv, "TAP_MOCK_TEST", "from_dotenv")
@@ -65,7 +73,7 @@ class TestPluginInvoker:
         assert env["MELTANO_EXTRACT__SELECT"] == env["TAP_MOCK__SELECT"] == '["*.*"]'
 
         # Plugin execution environment
-        venv = VirtualEnv(project.venvs_dir(tap.type, tap.name))
+        venv = VirtualEnv(project.dirs.venvs(tap.type, tap.name))
         assert env["VIRTUAL_ENV"] == str(venv.root)
         assert env["PATH"].startswith(str(venv.bin_dir))
         assert "PYTHONPATH" not in env

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -73,11 +73,11 @@ class TestPluginRemoveService:
 
     @pytest.fixture
     def install(self, subject: PluginRemoveService) -> Generator[None, None, None]:
-        tap_gitlab_installation = subject.project.meltano_dir().joinpath(
+        tap_gitlab_installation = subject.project.dirs.meltano().joinpath(
             "extractors",
             "tap-gitlab",
         )
-        target_csv_installation = subject.project.meltano_dir().joinpath(
+        target_csv_installation = subject.project.dirs.meltano().joinpath(
             "loaders",
             "target-csv",
         )
@@ -89,12 +89,12 @@ class TestPluginRemoveService:
 
     @pytest.fixture
     def lock(self, subject: PluginRemoveService) -> Generator[None, None, None]:
-        tap_gitlab_lockfile = subject.project.plugin_lock_path(
+        tap_gitlab_lockfile = subject.project.dirs.plugin_lock_path(
             "extractors",
             "tap-gitlab",
             variant_name="meltanolabs",
         )
-        target_csv_lockfile = subject.project.plugin_lock_path(
+        target_csv_lockfile = subject.project.dirs.plugin_lock_path(
             "loaders",
             "target-csv",
             variant_name="meltanolabs",
@@ -144,12 +144,12 @@ class TestPluginRemoveService:
                     meltano_yml[plugin.type, plugin.name]
 
             # check removed installation
-            path = subject.project.meltano_dir().joinpath(plugin.type, plugin.name)
+            path = subject.project.dirs.meltano().joinpath(plugin.type, plugin.name)
             assert not path.exists()
 
             # check removed lock files
             lock_file_paths = list(
-                subject.project.root_plugins_dir(plugin.type).glob(
+                subject.project.dirs.root_plugins(plugin.type).glob(
                     f"{plugin.name}*.lock",
                 ),
             )

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
 
 
 def load_analytics_json(project: Project) -> dict[str, t.Any]:
-    with project.meltano_dir().joinpath("analytics.json").open() as analytics_json_file:
+    with (project.dirs.meltano() / "analytics.json").open() as analytics_json_file:
         return json.load(analytics_json_file)
 
 
@@ -47,7 +47,7 @@ def check_analytics_json(project: Project) -> None:
 
 @contextmanager
 def delete_analytics_json(project: Project) -> Generator[None, None, None]:
-    (project.meltano_dir() / "analytics.json").unlink(missing_ok=True)
+    (project.dirs.meltano() / "analytics.json").unlink(missing_ok=True)
     try:
         yield
     finally:
@@ -200,7 +200,7 @@ class TestTracker:
     ) -> None:
         with delete_analytics_json(project):
             # Use `delete_analytics_json` to ensure `analytics.json` is restored after
-            analytics_json_path = project.meltano_dir() / "analytics.json"
+            analytics_json_path = project.dirs.meltano() / "analytics.json"
             with analytics_json_path.open("w") as analytics_json_file:
                 analytics_json_file.write(analytics_json_content)
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* #9580

## Summary by Sourcery

Refactor remaining project path usages to consistently rely on ProjectDirsService across core code and tests.

Enhancements:
- Replace deprecated project path helper methods with ProjectDirsService directory accessors in core services and utilities.
- Relax deprecation warning categories for legacy project path helpers to use standard DeprecationWarning instead of internal-only warnings.
- Adjust plugin lock and location handling to resolve paths via the centralized project directory service.

Documentation:
- Clarify deprecation guidance for when to emit MeltanoInternalDeprecationWarning in AGENTS.md.

Tests:
- Update CLI, plugin, locking, tracking, and invoker tests to use ProjectDirsService-based paths and improve type annotations for project-related fixtures.