### PR TITLE
feat: Add `CACHEDIR.TAG` file automatically to `.meltano` directory

### DIFF
--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -261,6 +261,7 @@ class Project:
             else:
                 raise
 
+        project.dirs.add_cachedir_tag()
         logger.debug("Activated project at %s", project.root)
 
         # set the default project

--- a/src/meltano/core/project_dirs_service.py
+++ b/src/meltano/core/project_dirs_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import textwrap
 import typing as t
 from dataclasses import KW_ONLY, dataclass
 
@@ -44,6 +45,26 @@ class ProjectDirsService:
             project root joined with provided subdirs and/or file
         """
         return self.root.joinpath(*joinpaths)
+
+    @property
+    def cachedir_tag(self) -> Path:
+        """Path to CACHEDIR.TAG file."""
+        return self.sys_dir / "CACHEDIR.TAG"
+
+    def add_cachedir_tag(self) -> None:
+        """Generate a file indicating that this is not meant to be backed up.
+
+        See https://bford.info/cachedir/ for the spec.
+        """
+        cachedir_tag_file = self.cachedir_tag
+        if not cachedir_tag_file.exists():
+            cachedir_tag_text = textwrap.dedent("""
+                Signature: 8a477f597d28d172789f06886806bc55
+                # This file is a cache directory tag created by Meltano.
+                # For information about cache directory tags, see:
+                #   https://bford.info/cachedir/
+            """).strip()
+            cachedir_tag_file.write_text(cachedir_tag_text, encoding="utf-8")
 
     @makedirs
     def meltano(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:  # noqa: ARG002

--- a/tests/meltano/core/test_project_dirs_service.py
+++ b/tests/meltano/core/test_project_dirs_service.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from meltano.core.project_dirs_service import ProjectDirsService
+
+
+class TestProjectDirsService:
+    @pytest.fixture
+    def subject(self, tmp_path_factory: pytest.TempPathFactory) -> ProjectDirsService:
+        root = tmp_path_factory.mktemp("project")
+        sys_dir = tmp_path_factory.mktemp(".meltano")
+        return ProjectDirsService(root=root, sys_dir=sys_dir)
+
+    def test_add_cachedir_tag(self, subject: ProjectDirsService) -> None:
+        assert not subject.cachedir_tag.exists()
+        subject.add_cachedir_tag()
+        assert subject.cachedir_tag.exists()


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

> The standard proposes that if a particular file named CACHEDIR.TAG is present in a directory, the contents of that directory and all its subdirectories need not be archived.
>
> The first 43 bytes of a CACHEDIR.TAG file are the ASCII string "Signature: 8a477f597d28d172789f06886806bc55". Any following bytes are insignificant.[^1]

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes https://github.com/meltano/meltano/issues/8896

[^1]: http://fileformats.archiveteam.org/wiki/Cache_Directory_Tagging_Standard

## Summary by Sourcery

Add automatic creation of a cache directory tag file in the project system directory to mark it as non-backup data.

New Features:
- Introduce generation of a CACHEDIR.TAG file in the project system directory when a project is activated.

Tests:
- Add unit test coverage for creating the CACHEDIR.TAG file in the project directory service.