### PR TITLE
test: Consolidate AWS environment clean-up for tests mocking S3

### DIFF
--- a/tests/meltano/cli/test_upgrade.py
+++ b/tests/meltano/cli/test_upgrade.py
@@ -298,7 +298,14 @@ class TestCliUpgrade:
 
     @mock_aws
     @pytest.mark.usefixtures("project")
-    def test_upgrade_state(self, cli_runner, monkeypatch) -> None:
+    def test_upgrade_state(
+        self,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+
         state_ids = [f"dev:tap-{i}-to-target-{i}" for i in range(10)]
         conn = boto3.resource("s3", region_name="us-east-1")
         bucket = conn.create_bucket(Bucket="test-state-bucket")

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -410,6 +410,11 @@ class TestAZStorageStateStoreManager:
 
 
 class TestS3StateStoreManager:
+    @pytest.fixture(autouse=True)
+    def clean_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+
     @contextmanager
     def stubber(self) -> Iterator[Stubber]:
         with patch(
@@ -471,13 +476,7 @@ class TestS3StateStoreManager:
     def test_state_path(self, subject: S3StateStoreManager) -> None:
         assert subject.state_dir == "state"
 
-    def test_set_first_time(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        faker: faker.Faker,
-    ) -> None:
-        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-        monkeypatch.delenv("AWS_PROFILE", raising=False)
+    def test_set_first_time(self, faker: faker.Faker) -> None:
         state_id = faker.pystr()
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
@@ -487,13 +486,7 @@ class TestS3StateStoreManager:
             store_manager.client.create_bucket(Bucket=store_manager.bucket)
             store_manager.set(MeltanoState(state_id=state_id, completed_state={}))
 
-    def test_update_fail_object_in_glacier(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        faker: faker.Faker,
-    ) -> None:
-        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-        monkeypatch.delenv("AWS_PROFILE", raising=False)
+    def test_update_fail_object_in_glacier(self, faker: faker.Faker) -> None:
         state_id = faker.pystr()
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
@@ -519,12 +512,7 @@ class TestS3StateStoreManager:
             assert isinstance(exc.__cause__, botocore.exceptions.ClientError)
             assert exc.__cause__.response["Error"]["Code"] == "InvalidObjectState"
 
-    def test_update_fail_bucket_does_not_exist(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-        monkeypatch.delenv("AWS_PROFILE", raising=False)
+    def test_update_fail_bucket_does_not_exist(self) -> None:
         with moto.mock_aws():
             store_manager = S3StateStoreManager(
                 uri="s3://test_access_key_id:test_secret_access_key@meltano/state",

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -141,7 +141,7 @@ def test_pluggable_state_backend(project: Project, monkeypatch: pytest.MonkeyPat
                 reason=(
                     "Nested settings are not yet supported; "
                     "`_settings_to_manager_kwargs` only exposes the last path "
-                    "component as the key. See comment above for the intended contract."
+                    "component as the key."
                 ),
                 strict=True,
             ),
@@ -327,6 +327,11 @@ class TestGCSStateBackend:
 
 
 class TestS3StateBackend:
+    @pytest.fixture(autouse=True)
+    def clean_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+
     @pytest.fixture
     def bucket(self) -> str:
         return "some_bucket"
@@ -428,7 +433,6 @@ class TestS3StateBackend:
     def test_get(
         self,
         project: Project,
-        monkeypatch: pytest.MonkeyPatch,
         bucket: str,
         prefix: str,
         s3_uri: str,
@@ -442,8 +446,6 @@ class TestS3StateBackend:
         state = MeltanoState(state_id=state_id, completed_state={"key": "value"})
 
         with moto.mock_aws():
-            monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-            monkeypatch.delenv("AWS_PROFILE", raising=False)
             s3_state_store.client.create_bucket(Bucket=bucket)
 
             state_key = f"{prefix}/{state_id}/state.json"
@@ -459,7 +461,6 @@ class TestS3StateBackend:
     def test_set(
         self,
         project: Project,
-        monkeypatch: pytest.MonkeyPatch,
         bucket: str,
         prefix: str,
         s3_uri: str,
@@ -473,8 +474,6 @@ class TestS3StateBackend:
         state = MeltanoState(state_id=state_id, completed_state={"key": "value"})
 
         with moto.mock_aws():
-            monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-            monkeypatch.delenv("AWS_PROFILE", raising=False)
             s3_state_store.client.create_bucket(Bucket=bucket)
 
             s3_state_store.set(state)
@@ -492,7 +491,6 @@ class TestS3StateBackend:
 
     def test_migrate_deduplicates_prefix(
         self,
-        monkeypatch: pytest.MonkeyPatch,
         bucket: str,
         prefix: str,
         aws_access_key_id: str,
@@ -510,8 +508,6 @@ class TestS3StateBackend:
         body = b'{"completed": {}, "partial": {}}'
 
         with moto.mock_aws():
-            monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-            monkeypatch.delenv("AWS_PROFILE", raising=False)
             manager.client.create_bucket(Bucket=bucket)
             manager.client.put_object(
                 Bucket=bucket,
@@ -527,7 +523,6 @@ class TestS3StateBackend:
 
     def test_migrate_ignores_clean_files(
         self,
-        monkeypatch: pytest.MonkeyPatch,
         bucket: str,
         prefix: str,
         aws_access_key_id: str,
@@ -544,8 +539,6 @@ class TestS3StateBackend:
         body = b'{"completed": {}, "partial": {}}'
 
         with moto.mock_aws():
-            monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-            monkeypatch.delenv("AWS_PROFILE", raising=False)
             manager.client.create_bucket(Bucket=bucket)
             manager.client.put_object(
                 Bucket=bucket,
@@ -555,7 +548,7 @@ class TestS3StateBackend:
 
             manager.migrate()
 
-            # Only the original key should exist — no extra copies
+            # Only the original key should exist
             objects = manager.client.list_objects_v2(Bucket=bucket)
             keys = [obj["Key"] for obj in objects["Contents"]]
             assert keys == [clean_key]


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Unify and centralize AWS-related environment cleanup across S3-backed state tests to ensure consistent, isolated behavior when mocking S3, and tighten test expectations and comments around S3 state migration and upgrade flows.

Enhancements:
- Clarify test comments and expected behavior for S3 state backend migration, including simplifying wording and removing obsolete explanatory text.

Tests:
- Introduce autouse fixtures in S3 state store and S3 state backend test classes to consistently clear AWS_DEFAULT_REGION and AWS_PROFILE before each test.
- Refactor S3-related tests to rely on shared environment-cleanup fixtures instead of per-test monkeypatching, reducing duplication and improving isolation.
- Update the CLI upgrade state test to explicitly clear AWS-related environment variables before interacting with mocked S3.