### PR TITLE
test: Handle Python 3.15 warning coming from transitive dependency pygments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ concurrency:
 
 env:
   FORCE_COLOR: "1"
-  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
   UV_PYTHON_DOWNLOADS: "never"
 
 permissions: {}

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,7 @@ main_python_version = Path(".python-version").read_text().strip()
 
 def _uv_sync(session: nox.Session, *args: str) -> None:
     env = {
+        "PYO3_USE_ABI3_FORWARD_COMPATIBILITY": "1",
         "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
         "UV_NO_CONFIG": "1",
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ filterwarnings = [
   'once::pytest.PytestUnhandledThreadExceptionWarning',
   'once::ResourceWarning',
   'once:You are using a Python version .* which Google will stop supporting in new releases of google.api_core once it reaches its end of life:FutureWarning',
+  "once:os.path.commonprefix\\(\\) is deprecated. Use os.path.commonpath\\(\\) for longest path prefix.:DeprecationWarning:pygments",  # https://github.com/pygments/pygments/issues/3039
 ]
 log_cli = true
 log_cli_format = "%(message)s"


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

- https://github.com/pygments/pygments/issues/3039
- https://github.com/python/cpython/issues/74453
- https://github.com/python/cpython/pull/144436

## Summary by Sourcery

Adjust test configuration to handle a new Python 3.15 deprecation warning from pygments and scope a Pyo3 compatibility flag to nox-managed environments.

Build:
- Add a pytest warning filter in pyproject.toml to ignore the pygments DeprecationWarning about os.path.commonprefix on Python 3.15.

CI:
- Remove the global PYO3_USE_ABI3_FORWARD_COMPATIBILITY environment variable from the GitHub Actions test workflow and rely on environment configuration within nox sessions instead.

Tests:
- Set PYO3_USE_ABI3_FORWARD_COMPATIBILITY within the nox _uv_sync session environment so that test environments retain the required Pyo3 ABI compatibility setting.