### PR TITLE
ci: Use `pytest-github-actions-annotate-failures` to see test failures directly in the GitHub UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ testing = [
   "pytest-asyncio>=1.3",
   "pytest-codspeed>=4.2.0",
   "pytest-docker~=3.1",
+  "pytest-github-actions-annotate-failures>=0.4.0",
   "pytest-order~=1.3",
   "pytest-randomly>=3.16,<5.0",
   "pytest-structlog~=1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1435,6 +1435,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
     { name = "pytest-docker" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
@@ -1462,6 +1463,7 @@ testing = [
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
     { name = "pytest-docker" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
@@ -1484,6 +1486,7 @@ typing = [
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
     { name = "pytest-docker" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
@@ -1558,6 +1561,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
     { name = "pytest-structlog", specifier = "~=1.1" },
@@ -1583,6 +1587,7 @@ testing = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
     { name = "pytest-structlog", specifier = "~=1.1" },
@@ -1605,6 +1610,7 @@ typing = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
     { name = "pytest-structlog", specifier = "~=1.1" },
@@ -2493,6 +2499,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/05/b7e47dc3e01b505838372e296bd780180b3b699a9a134bb8d6be85f3d567/pytest_docker-3.2.5.tar.gz", hash = "sha256:c9662567522911280b394af4da2edd57facaf644494601fac962ff1e396d7ab6", size = 13717, upload-time = "2025-11-12T13:42:19.641Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/e4/3a76a393f808edb0ee08ecc25e5c00bce0522a45b8fcf8693ec9441739c8/pytest_docker-3.2.5-py3-none-any.whl", hash = "sha256:79f3d209f928f45d4385cb825944861bc8a8cccd309804d9c9cd63bcef03edba", size = 8724, upload-time = "2025-11-12T13:42:18.631Z" },
+]
+
+[[package]]
+name = "pytest-github-actions-annotate-failures"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e1/8f2c242e6d75a26a8e5ddcc23f652a411e4aac3eedc4b923808ac0582685/pytest_github_actions_annotate_failures-0.4.0.tar.gz", hash = "sha256:77d6baa29c8c61c2dacc494fa76eb95a185f0ee61666714ac43fb12ea672d217", size = 10857, upload-time = "2026-03-02T18:57:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/bd/11809f5c78d5d8da2d0e004845d2382768bc20798b3e0988bca61efd349f/pytest_github_actions_annotate_failures-0.4.0-py3-none-any.whl", hash = "sha256:285fed86e16b0b7a8eac6acdcde31913798fb739b15ef5b86895b4f5e32bf237", size = 6039, upload-time = "2026-03-02T18:57:39.991Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
SSIA

## Summary by Sourcery

CI:
- Enable GitHub Actions test-failure annotations by adding the pytest-github-actions-annotate-failures plugin to the testing dependencies.