### PR TITLE
fix: Update the type annotation of `retry_seconds` in the state backend `acquire_lock` method to allow `float` values

### DIFF
--- a/docs/docs/guide/custom-state-backend.md
+++ b/docs/docs/guide/custom-state-backend.md
@@ -94,7 +94,7 @@ class MyStateManager(StateStoreManager):
         ...
 
     @contextmanager
-    def acquire_lock(self, state_id: str, *, retry_seconds: int = 1):
+    def acquire_lock(self, state_id: str, *, retry_seconds: float = 1.0):
         # Implement the logic to acquire a lock for the given state ID.
         # This method should be a context manager that acquires the lock
         # and releases it when the context exits.

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -242,7 +242,7 @@ class StateStoreManager(ABC):
         self,
         state_id: str,
         *,
-        retry_seconds: int,
+        retry_seconds: float,
     ) -> Generator[None, None, None]:
         """Acquire a naive lock for the given job's state.
 

--- a/src/meltano/core/state_store/db.py
+++ b/src/meltano/core/state_store/db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from contextlib import contextmanager
 
@@ -10,6 +11,11 @@ from sqlalchemy import select
 from meltano.core.job_state import JobState
 from meltano.core.state_store.base import MeltanoState, StateStoreManager
 from meltano.core.utils import merge
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator, Iterator
@@ -32,6 +38,7 @@ class DBStateStoreManager(StateStoreManager):
         super().__init__(**kwargs)
         self.session = session
 
+    @override
     def set(self, state: MeltanoState) -> None:
         """Set the job state for the given state_id.
 
@@ -81,6 +88,7 @@ class DBStateStoreManager(StateStoreManager):
 
         return None
 
+    @override
     def delete(self, state_id: str) -> None:
         """Clear state for the given state_id.
 
@@ -93,6 +101,7 @@ class DBStateStoreManager(StateStoreManager):
             self.session.delete(job_state)
             self.session.commit()
 
+    @override
     def clear_all(self) -> int:
         """Clear all states.
 
@@ -103,6 +112,7 @@ class DBStateStoreManager(StateStoreManager):
         self.session.commit()
         return count
 
+    @override
     def get_state_ids(self, pattern: str | None = None) -> Iterator[str]:
         """Get all state_ids available in this state store manager.
 
@@ -124,12 +134,13 @@ class DBStateStoreManager(StateStoreManager):
             for record in self.session.execute(select(JobState.state_id)).all()
         )
 
+    @override
     @contextmanager
     def acquire_lock(
         self,
-        state_id: str,  # noqa: ARG002
+        state_id: str,
         *,
-        retry_seconds: int = 1,  # noqa: ARG002
+        retry_seconds: float = 1,
     ) -> Generator[None, None, None]:
         """Acquire a naive lock for the given job's state.
 

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -268,7 +268,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
         self,
         state_id: str,
         *,
-        retry_seconds: int,
+        retry_seconds: float,
     ) -> Generator[None, None, None]:
         """Context manager for locking state_id during reads and writes.
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Allow fractional retry intervals in state backend lock acquisition and align type hints and overrides across implementations.

Bug Fixes:
- Permit float values for the retry_seconds parameter in state store acquire_lock methods to match actual usage.

Enhancements:
- Annotate state store manager methods with override for better type checking and maintenance.

Documentation:
- Update custom state backend guide to document retry_seconds as a float parameter in acquire_lock.