### PR TITLE
test: Avoid real network call to PyPI in `TestVersionCheckService`

### DIFF
--- a/tests/meltano/core/test_version_check.py
+++ b/tests/meltano/core/test_version_check.py
@@ -166,11 +166,20 @@ class TestVersionCheckService:
         responses.add(responses.GET, PYPI_URL, status=HTTPStatus.INTERNAL_SERVER_ERROR)
         assert version_service.check_version() is None
 
+    @responses.activate
     def test_check_version_invalid_version(
         self,
         version_service: VersionCheckService,
     ) -> None:
         """Test version check when current version is invalid."""
+        pypi_response = {
+            "info": {
+                "version": "3.9.0",
+                "name": "meltano",
+            }
+        }
+        responses.add(responses.GET, PYPI_URL, json=pypi_response, status=HTTPStatus.OK)
+
         with mock.patch(
             "meltano.core.version_check.importlib.metadata.version",
             return_value="invalid",
@@ -302,7 +311,8 @@ class TestVersionCheckService:
 
         assert result1 is not None
         assert result1.latest_version == "3.9.0"
-        assert len(responses.calls) == 1
+        calls_after_first = len(responses.calls)
+        assert calls_after_first == 1
 
         # Second check - should use cache
         with mock.patch(
@@ -313,4 +323,4 @@ class TestVersionCheckService:
 
         assert result2 is not None
         assert result2.latest_version == "3.9.0"
-        assert len(responses.calls) == 1  # No additional API call
+        assert len(responses.calls) == calls_after_first  # No additional API call


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Improve version check tests to avoid real PyPI calls and make network call assertions more robust.

Tests:
- Mock PyPI responses in the invalid version test to prevent real network requests.
- Adjust cache-related test to assert on a stored responses call count instead of hard-coding the expected value.