### PR TITLE
fix: allow `inherit_from` in environment plugin configs in JSON schema

### DIFF
--- a/src/meltano/schemas/meltano.schema.json
+++ b/src/meltano/schemas/meltano.schema.json
@@ -1212,6 +1212,10 @@
             "name": {
               "type": "string"
             },
+            "inherit_from": {
+              "type": "string",
+              "description": "An existing plugin to inherit from."
+            },
             "config": {
               "type": "object"
             },


### PR DESCRIPTION
## Description

Add `inherit_from` to the `environments/$defs/plugins` schema definition so that environment-scoped plugin overrides can specify `inherit_from` without triggering schema validation errors.

Previously, using `inherit_from` inside `environments[].config.plugins.extractors[]` (or any environment plugin override) would produce:

```
Schema validation errors were encountered.
  $.environments[0].config.plugins.extractors[11]: Unevaluated properties are not allowed ('inherit_from' was unexpected)
```

The root cause was that `inherit_from` was defined in top-level plugin schemas but missing from the `environments/$defs/plugins` definition, which enforces `unevaluatedProperties: false`.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* N/A

## Summary by Sourcery

Bug Fixes:
- Fix schema validation errors when inherit_from is used in environment plugin override configurations by adding it to the environments plugin schema definition.