### PR TITLE
docs: Fixed some broken links in the `environments` page

### DIFF
--- a/docs/docs/concepts/environments.md
+++ b/docs/docs/concepts/environments.md
@@ -73,8 +73,8 @@ plugins:
 :::info
 
   <p><strong>Environments vs Python Virtual Environments</strong></p>
-  <p>For installable Python plugins (i.e. those with a <a href="project#plugins"><code>pip_url</code></a> property) configured across multiple Environments, the same Python virtual environment and executable are reused.</p>
-  <p>To install different versions of the same plugin, you can use <a href="plugins#plugin-inheritance">plugin inheritance</a> and set a different <code>pip_url</code> in the inherited plugin.</p>
+  <p>For installable Python plugins (i.e. those with a <a href="/reference/plugin-definition-syntax#pip_url"><code>pip_url</code></a> property) configured across multiple Environments, the same Python virtual environment and executable are reused.</p>
+  <p>To install different versions of the same plugin, you can use <a href="/concepts/plugins#plugin-inheritance">plugin inheritance</a> and set a different <code>pip_url</code> in the inherited plugin.</p>
 :::
 
 ## Inheritance


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Documentation:
- Fix broken links on the environments documentation page to the plugin definition syntax and plugin inheritance sections.