### PR TITLE
test: Fix flaky `test_exit_event_is_fired` test

### DIFF
--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -7,7 +7,7 @@ import uuid
 from contextlib import contextmanager
 from http import server as server_lib
 from threading import Thread
-from time import sleep
+from time import monotonic, sleep
 from unittest import mock
 
 import pytest
@@ -310,12 +310,15 @@ class TestTracker:
         # so poll with a timeout to avoid a race condition.
         deadline = 10.0
         poll_interval = 0.1
-        elapsed = 0.0
+        start = monotonic()
         event_summary = snowplow.all()
-        while event_summary["good"] == 0 and elapsed < deadline:  # pragma: no branch
+        while (  # pragma: no cover
+            event_summary["good"] == 0 and monotonic() - start < deadline
+        ):
             sleep(poll_interval)
-            elapsed += poll_interval
             event_summary = snowplow.all()
+
+        elapsed = monotonic() - start
 
         assert event_summary["good"] > 0, (
             f"Expected at least one good event within {deadline}s "

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -317,8 +317,14 @@ class TestTracker:
             elapsed += poll_interval
             event_summary = snowplow.all()
 
-        assert event_summary["good"] > 0
-        assert event_summary["bad"] == 0
+        assert event_summary["good"] > 0, (
+            f"Expected at least one good event within {deadline}s "
+            f"(elapsed={elapsed}s), got: {event_summary}"
+        )
+        assert event_summary["bad"] == 0, (
+            f"Expected zero bad events within {deadline}s "
+            f"(elapsed={elapsed}s), got: {event_summary}"
+        )
 
         exit_event = next(
             x["event"]

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -305,7 +305,18 @@ class TestTracker:
     def test_exit_event_is_fired(self, snowplow: SnowplowMicro) -> None:
         subprocess.run(("meltano", "invoke", "alpha-beta-fox"))  # noqa: S607
 
+        # Snowplow Micro may not have processed events yet even after the
+        # subprocess exits (it returns HTTP 200 before committing to storage),
+        # so poll with a timeout to avoid a race condition.
+        deadline = 10.0
+        poll_interval = 0.1
+        elapsed = 0.0
         event_summary = snowplow.all()
+        while event_summary["good"] == 0 and elapsed < deadline:
+            sleep(poll_interval)
+            elapsed += poll_interval
+            event_summary = snowplow.all()
+
         assert event_summary["good"] > 0
         assert event_summary["bad"] == 0
 

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -312,7 +312,7 @@ class TestTracker:
         poll_interval = 0.1
         elapsed = 0.0
         event_summary = snowplow.all()
-        while event_summary["good"] == 0 and elapsed < deadline:
+        while event_summary["good"] == 0 and elapsed < deadline:  # pragma: no branch
             sleep(poll_interval)
             elapsed += poll_interval
             event_summary = snowplow.all()


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Tests:
- Add polling with timeout in the Snowplow Micro-based `test_exit_event_is_fired` test to wait for events to be processed before asserting.