### PR TITLE
ci: Prevent backport releases from overwriting `latest` Docker Hub tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        latest=$(gh release list --repo ${{ github.repository }} --exclude-pre-releases --limit 100 --json tagName --jq '.[].tagName | ltrimstr("v")' | sort -V | tail -1)
+        latest=$(gh release list --repo ${{ github.repository }} --exclude-pre-releases --limit 1000 --json tagName --jq '.[].tagName | ltrimstr("v")' | sort -V | tail -1)
         echo "version=$latest" >> $GITHUB_OUTPUT
 
     - name: Generate tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,22 +111,37 @@ jobs:
     - name: Setup uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
+    - name: Get latest published release version
+      id: get-latest-version
+      if: github.event_name == 'release' && github.event.action == 'published'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        latest=$(gh release list --repo ${{ github.repository }} --exclude-pre-releases --limit 100 --json tagName --jq '.[].tagName | ltrimstr("v")' | sort -V | tail -1)
+        echo "version=$latest" >> $GITHUB_OUTPUT
+
     - name: Generate tags
       id: generate-tags
-      run: >
-        python scripts/generate_docker_tags.py
-        --git-sha $GITHUB_SHA
-        --package-version ${NEEDS_BUILD_OUTPUTS_VERSION}
-        --python-version $PYTHON_VERSION
-        --default-python ${DEFAULT_PYTHON}
-        --registry ${STEPS_SET_INPUTS_OUTPUTS_REGISTRY}
-        > tags
+      run: |
+        extra_args=()
+        if [[ -n "$LATEST_VERSION" ]]; then
+          extra_args+=(--latest-version "$LATEST_VERSION")
+        fi
+        python scripts/generate_docker_tags.py \
+          --git-sha "$GITHUB_SHA" \
+          --package-version "$NEEDS_BUILD_OUTPUTS_VERSION" \
+          --python-version "$PYTHON_VERSION" \
+          --default-python "$DEFAULT_PYTHON" \
+          --registry "$STEPS_SET_INPUTS_OUTPUTS_REGISTRY" \
+          "${extra_args[@]}" \
+          > tags
       env:
         DOCKER_TAGS_SLIM: ${{ matrix.slim && '1' || '0' }}
         GITHUB_SHA: ${{ github.sha }}
         NEEDS_BUILD_OUTPUTS_VERSION: ${{ needs.build.outputs.version }}
         PYTHON_VERSION: ${{ matrix.python-version }}
         STEPS_SET_INPUTS_OUTPUTS_REGISTRY: ${{ steps.set-inputs.outputs.registry }}
+        LATEST_VERSION: ${{ steps.get-latest-version.outputs.version }}
 
     - name: Assemble image tags
       id: assemble-tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         if [[ -n "$LATEST_VERSION" ]]; then
           extra_args+=(--latest-version "$LATEST_VERSION")
         fi
-        python scripts/generate_docker_tags.py \
+        ./scripts/generate_docker_tags.py \
           --git-sha "$GITHUB_SHA" \
           --package-version "$NEEDS_BUILD_OUTPUTS_VERSION" \
           --python-version "$PYTHON_VERSION" \

--- a/scripts/generate_docker_tags.py
+++ b/scripts/generate_docker_tags.py
@@ -33,6 +33,16 @@ def main() -> None:
         action="store_true",
         help="Generate tags for slim images",
     )
+    parser.add_argument(
+        "--latest-version",
+        default=None,
+        help=(
+            "The current latest published version. When provided and the registry is "
+            "not 'ghcr.io', 'latest' tags are only generated if --package-version >= "
+            "--latest-version. This prevents backport releases from overwriting the "
+            "'latest' tag with an older version."
+        ),
+    )
     args = parser.parse_args()
 
     is_default_python = args.default_python == args.python_version
@@ -42,6 +52,15 @@ def main() -> None:
     # Add suffix for slim images
     slim = args.slim or os.getenv("DOCKER_TAGS_SLIM") == "1"
     suffix = "-slim" if slim else ""
+
+    # For non-ghcr.io registries, only apply 'latest' if this version is >=
+    # the current latest published version. This prevents backport releases
+    # (e.g. v3.9.2 published after v4.1.2) from overwriting 'latest'.
+    is_overall_latest = (
+        args.latest_version is None
+        or args.registry == "ghcr.io"
+        or version >= Version(args.latest_version)
+    )
 
     # To save space, only publish the `latest` tag for each
     # images to the GitHub registry
@@ -66,8 +85,8 @@ def main() -> None:
                 )
 
     # ghcr.io: publish `latest` for ALL versions
-    # docker.io: only publish `latest` for final releases
-    if not version.is_prerelease or args.registry == "ghcr.io":
+    # docker.io: only publish `latest` for final releases that are the overall latest
+    if (not version.is_prerelease or args.registry == "ghcr.io") and is_overall_latest:
         tags.append(f"latest-python{args.python_version}{suffix}")
 
         if is_default_python:

--- a/scripts/generate_docker_tags.py
+++ b/scripts/generate_docker_tags.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#   "packaging>=26",
+# ]
+# ///
 
 """Script to generate docker tags for Meltano images.
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

Before (without `--latest-version`):

```console
$ ./scripts/generate_docker_tags.py \
    -r docker.io \
    -v v3.9.2 \
    -p 3.10 \
    -d 3.10 \
    --git-sha $(git rev-parse HEAD)
v3.9.2-python3.10
v3-python3.10
v3.9-python3.10
SHA-27ec4d0b7ac2fb0ebb54ec6083e8f46ff84f4de2
v3
v3.9
v3.9.2
latest-python3.10
latest
```

After:

```console
$ ./scripts/generate_docker_tags.py \
    -r docker.io \
    -v v3.9.2 \
    -p 3.10 \
    -d 3.10 \
    --git-sha $(git rev-parse HEAD) \
    --latest-version v4.1.2
v3.9.2-python3.10
v3-python3.10
v3.9-python3.10
SHA-27ec4d0b7ac2fb0ebb54ec6083e8f46ff84f4de2
v3
v3.9
v3.9.2
```

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* https://github.com/meltano/meltano/issues/9941

## Summary by Sourcery

Adjust Docker image tagging to avoid backport releases overwriting the latest tag on Docker Hub.

New Features:
- Add support in the Docker tag generation script to accept the current latest published version and conditionally generate latest tags based on version comparison.

Enhancements:
- Update the build workflow to fetch the latest published release version and pass it to the Docker tag generation script so that latest tags are only applied to non-ghcr.io registries when building the overall latest release.