### PR TITLE
ci: Leverage GitHub Action Docker cache

### DIFF
--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -83,6 +83,8 @@ runs:
         # it. Then we optionally push both of them to the registry.
         load: false
         push: false
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Load the amd64 image for scanning
       uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47 # v6.19.1
@@ -94,6 +96,7 @@ runs:
         tags: ${{ steps.prepare-tags.outputs.tags }}
         platforms: linux/amd64
         load: true
+        cache-from: type=gha
 
     - name: Get the ID of the image
       id: get-image-id
@@ -151,3 +154,4 @@ runs:
         tags: ${{ steps.prepare-tags.outputs.tags }}
         platforms: linux/amd64,linux/arm64
         push: true
+        cache-from: type=gha

--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -83,8 +83,8 @@ runs:
         # it. Then we optionally push both of them to the registry.
         load: false
         push: false
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ github.workflow }}-python${{ inputs.python-version }}-slim${{ inputs.slim }}
+        cache-to: type=gha,mode=max,scope=${{ github.workflow }}-python${{ inputs.python-version }}-slim${{ inputs.slim }}
 
     - name: Load the amd64 image for scanning
       uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47 # v6.19.1
@@ -96,7 +96,7 @@ runs:
         tags: ${{ steps.prepare-tags.outputs.tags }}
         platforms: linux/amd64
         load: true
-        cache-from: type=gha
+        cache-from: type=gha,scope=${{ github.workflow }}-python${{ inputs.python-version }}-slim${{ inputs.slim }}
 
     - name: Get the ID of the image
       id: get-image-id
@@ -154,4 +154,5 @@ runs:
         tags: ${{ steps.prepare-tags.outputs.tags }}
         platforms: linux/amd64,linux/arm64
         push: true
-        cache-from: type=gha
+        cache-from: type=gha,scope=${{ github.workflow }}-python${{ inputs.python-version }}-slim${{ inputs.slim }}
+        cache-to: type=gha,mode=max,scope=${{ github.workflow }}-python${{ inputs.python-version }}-slim${{ inputs.slim }}


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

Docs:

- https://docs.docker.com/build/cache/backends/gha/
- https://github.com/docker/build-push-action/?tab=readme-ov-file#inputs
- https://docs.docker.com/reference/cli/docker/buildx/build/#cache-from
- https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enable Docker build cache usage in the CI Docker build/scan/push workflow.

Build:
- Configure Docker Buildx steps to use GitHub Actions cache backend via cache-from and cache-to options in the composite docker-build-scan-push action.

CI:
- Update Docker build, scan, and push CI steps to reuse cached layers across runs using the GitHub Actions cache backend.