### PR TITLE
ci: Block releases when Grype finds vulnerabilities

### DIFF
--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -121,14 +121,18 @@ runs:
 
     - name: Provide a link to results
       shell: bash
-      continue-on-error: true
       run: |
         echo "View scan results at:"
         echo "https://github.com/meltano/meltano/security/code-scanning?query=ref:${GITHUB_REF}+tool:Grype"
-        sleep 10 # Give GitHub some time to process the uploaded report
-        NUM_ISSUES="$(curl --no-progress-meter -H "Authorization: token ${INPUTS_TOKEN}" \
-            "https://api.github.com/repos/meltano/meltano/code-scanning/alerts?tool_name=Grype&state=open&ref=${GITHUB_REF}" \
-            | jq length)"
+        # Retry up to 6 times (60s total) for GitHub to finish processing the uploaded SARIF report
+        for i in {1..6}; do
+          sleep 10
+          NUM_ISSUES="$(curl --no-progress-meter -H "Authorization: token ${INPUTS_TOKEN}" \
+              "https://api.github.com/repos/meltano/meltano/code-scanning/alerts?tool_name=Grype&state=open&ref=${GITHUB_REF}" \
+              | jq length)"
+          [[ "$NUM_ISSUES" =~ ^[0-9]+$ ]] && break
+          echo "Attempt $i: could not get a numeric response, retrying..."
+        done
         [ "$NUM_ISSUES" = '0' ] # Error if there are any alerts that are neither fixed nor dismissed
       env:
         INPUTS_TOKEN: ${{ inputs.token }}

--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -123,7 +123,7 @@ runs:
       shell: bash
       run: |
         echo "View scan results at:"
-        echo "https://github.com/meltano/meltano/security/code-scanning?query=ref:${GITHUB_REF}+tool:Grype"
+        echo "https://github.com/meltano/meltano/security/code-scanning?query=ref:${GITHUB_REF}+tool:Grype+is:open"
         # Retry up to 6 times (60s total) for GitHub to finish processing the uploaded SARIF report
         for i in {1..6}; do
           sleep 10

--- a/.github/actions/docker-build-scan-push/action.yml
+++ b/.github/actions/docker-build-scan-push/action.yml
@@ -127,11 +127,17 @@ runs:
         # Retry up to 6 times (60s total) for GitHub to finish processing the uploaded SARIF report
         for i in {1..6}; do
           sleep 10
-          NUM_ISSUES="$(curl --no-progress-meter -H "Authorization: token ${INPUTS_TOKEN}" \
-              "https://api.github.com/repos/meltano/meltano/code-scanning/alerts?tool_name=Grype&state=open&ref=${GITHUB_REF}" \
-              | jq length)"
+          RESPONSE="$(curl --fail-with-body --no-progress-meter -H "Authorization: token ${INPUTS_TOKEN}" \
+              "https://api.github.com/repos/meltano/meltano/code-scanning/alerts?tool_name=Grype&state=open&ref=${GITHUB_REF}")"
+          CURL_EXIT_CODE=$?
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Attempt $i: failed to fetch code scanning alerts from GitHub API (curl exit code: $CURL_EXIT_CODE), retrying..."
+            continue
+          fi
+
+          NUM_ISSUES="$(jq length <<<"$RESPONSE")"
           [[ "$NUM_ISSUES" =~ ^[0-9]+$ ]] && break
-          echo "Attempt $i: could not get a numeric response, retrying..."
+          echo "Attempt $i: could not get a numeric response from GitHub API, retrying..."
         done
         [ "$NUM_ISSUES" = '0' ] # Error if there are any alerts that are neither fixed nor dismissed
       env:


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

We can then address or dismiss the vulns and retry the job.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

CI:
- Improve the Grype SARIF scan step to poll GitHub for a valid numeric alert count and use the open-alerts query link, ensuring releases are blocked when vulnerabilities are present.