### PR TITLE
feat: Create `.gitignore` automatically in the `.meltano` directory

### DIFF
--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -261,7 +261,7 @@ class Project:
             else:
                 raise
 
-        project.dirs.add_cachedir_tag()
+        project.dirs.ensure_system_files()
         logger.debug("Activated project at %s", project.root)
 
         # set the default project

--- a/src/meltano/core/project_dirs_service.py
+++ b/src/meltano/core/project_dirs_service.py
@@ -73,7 +73,7 @@ class ProjectDirsService:
         try:
             cachedir_tag_file.write_text(cachedir_tag_text, encoding="utf-8")
         except OSError:  # pragma: no cover
-            logger.debug("Failed to write %s", cachedir_tag_file)
+            logger.debug("Failed to write %s", cachedir_tag_file, exc_info=True)
 
     def _ensure_gitignore(self) -> None:
         """Generate a .gitignore inside .meltano."""
@@ -84,7 +84,7 @@ class ProjectDirsService:
         try:
             gitignore.write_text("*\n", encoding="utf-8")
         except OSError:  # pragma: no cover
-            logger.debug("Failed to write %s", gitignore)
+            logger.debug("Failed to write %s", gitignore, exc_info=True)
 
     @makedirs
     def meltano(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:  # noqa: ARG002

--- a/src/meltano/core/project_dirs_service.py
+++ b/src/meltano/core/project_dirs_service.py
@@ -7,6 +7,7 @@ import typing as t
 from dataclasses import KW_ONLY, dataclass
 
 import platformdirs
+from structlog.stdlib import get_logger
 
 from meltano.core.utils import makedirs, sanitize_filename
 
@@ -16,6 +17,8 @@ if t.TYPE_CHECKING:
     from meltano.core._types import StrPath
     from meltano.core.plugin.base import PluginRef
     from meltano.core.project import Project
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -46,25 +49,42 @@ class ProjectDirsService:
         """
         return self.root.joinpath(*joinpaths)
 
-    @property
-    def cachedir_tag(self) -> Path:
-        """Path to CACHEDIR.TAG file."""
-        return self.sys_dir / "CACHEDIR.TAG"
+    def ensure_system_files(self) -> None:
+        """Ensure standard files .meltano."""
+        self._ensure_gitignore()
+        self._ensure_cachedir_tag()
 
-    def add_cachedir_tag(self) -> None:
+    def _ensure_cachedir_tag(self) -> None:
         """Generate a file indicating that this is not meant to be backed up.
 
         See https://bford.info/cachedir/ for the spec.
         """
-        cachedir_tag_file = self.cachedir_tag
-        if not cachedir_tag_file.exists():
-            cachedir_tag_text = textwrap.dedent("""
-                Signature: 8a477f597d28d172789f06886806bc55
-                # This file is a cache directory tag created by Meltano.
-                # For information about cache directory tags, see:
-                #   https://bford.info/cachedir/
-            """).strip()
+        cachedir_tag_file = self.sys_dir / "CACHEDIR.TAG"
+        if cachedir_tag_file.exists():
+            return
+
+        cachedir_tag_text = textwrap.dedent("""
+            Signature: 8a477f597d28d172789f06886806bc55
+            # This file is a cache directory tag created by Meltano.
+            # For information about cache directory tags, see:
+            #   https://bford.info/cachedir/
+        """).strip()
+
+        try:
             cachedir_tag_file.write_text(cachedir_tag_text, encoding="utf-8")
+        except OSError:  # pragma: no cover
+            logger.debug("Failed to write %s", cachedir_tag_file)
+
+    def _ensure_gitignore(self) -> None:
+        """Generate a .gitignore inside .meltano."""
+        gitignore = self.sys_dir / ".gitignore"
+        if gitignore.exists():
+            return
+
+        try:
+            gitignore.write_text("*\n", encoding="utf-8")
+        except OSError:  # pragma: no cover
+            logger.debug("Failed to write %s", gitignore)
 
     @makedirs
     def meltano(self, *joinpaths: StrPath, make_dirs: bool = True) -> Path:  # noqa: ARG002

--- a/tests/meltano/core/test_project_dirs_service.py
+++ b/tests/meltano/core/test_project_dirs_service.py
@@ -12,7 +12,36 @@ class TestProjectDirsService:
         sys_dir = tmp_path_factory.mktemp(".meltano")
         return ProjectDirsService(root=root, sys_dir=sys_dir)
 
-    def test_add_cachedir_tag(self, subject: ProjectDirsService) -> None:
-        assert not subject.cachedir_tag.exists()
-        subject.add_cachedir_tag()
-        assert subject.cachedir_tag.exists()
+    def test_ensure_cachedir_tag(
+        self,
+        subject: ProjectDirsService,
+        subtests: pytest.Subtests,
+    ) -> None:
+        path = subject.sys_dir / "CACHEDIR.TAG"
+
+        with subtests.test("creates file"):
+            assert not path.exists()
+            subject._ensure_cachedir_tag()
+            assert path.read_text().startswith("Signature:")
+
+        with subtests.test("preserves existing file"):
+            path.write_text("Old content")
+            subject._ensure_cachedir_tag()
+            assert path.read_text() == "Old content"
+
+    def test_ensure_gitignore(
+        self,
+        subject: ProjectDirsService,
+        subtests: pytest.Subtests,
+    ) -> None:
+        path = subject.sys_dir / ".gitignore"
+
+        with subtests.test("creates file"):
+            assert not path.exists()
+            subject._ensure_gitignore()
+            assert path.read_text() == "*\n"
+
+        with subtests.test("preserves existing file"):
+            path.write_text("Old content")
+            subject._ensure_gitignore()
+            assert path.read_text() == "Old content"


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

This way even if the user didn't go through `meltano init` and just copied or hand-cranked a `meltano.yml`, the `.meltano/` directory will still be ignored.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Ensure standard system files are created in the .meltano directory when a project is activated.

New Features:
- Automatically create a .gitignore inside the .meltano directory to ignore its contents by default.

Enhancements:
- Create the CACHEDIR.TAG file lazily and robustly when ensuring system files, with logging on failures.

Tests:
- Add tests verifying creation and preservation behavior of CACHEDIR.TAG and .gitignore in the .meltano directory.