### PR TITLE
fix: Avoid emitting an `Unknown setting ...` warning when setting a nested "extra" setting like `_metadata.*.replication-method`

### DIFF
--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -499,7 +499,13 @@ class SettingsService(metaclass=ABCMeta):
 
         setting_def = self.find_setting(name)
         if setting_def is None:
-            warnings.warn(f"Unknown setting {name!r}", RuntimeWarning, stacklevel=2)
+            root_name, _, _ = name.partition(".")
+            if root_name == name or self.find_setting(root_name) is None:
+                warnings.warn(
+                    f"Unknown setting {name!r}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
         metadata: dict[str, t.Any] = {
             "name": name,

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -684,7 +684,6 @@ class TestPluginSettingsService:
 
     @pytest.mark.order(3)
     @pytest.mark.usefixtures("tap")
-    @pytest.mark.filterwarnings("ignore:Unknown setting:RuntimeWarning")
     def test_nested_keys(self, session, subject, project) -> None:
         def set_config(path, value) -> None:
             subject.set(path, value, store=SettingValueStore.MELTANO_YML)

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import platform
 import re
 import typing as t
+import warnings
 from datetime import datetime, timezone
 
 import dotenv
@@ -699,50 +700,53 @@ class TestPluginSettingsService:
         def final_config():
             return subject.as_dict(session=session)
 
-        set_config("metadata.stream.replication-key", "created_at")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
 
-        assert yml_config()["metadata.stream.replication-key"] == "created_at"
-        assert final_config()["metadata.stream.replication-key"] == "created_at"
+            set_config("metadata.stream.replication-key", "created_at")
 
-        set_config(["metadata", "stream", "replication-key"], "created_at")
+            assert yml_config()["metadata.stream.replication-key"] == "created_at"
+            assert final_config()["metadata.stream.replication-key"] == "created_at"
 
-        yml = yml_config()
-        assert "metadata.stream.replication-key" not in yml
-        assert yml["metadata"]["stream"]["replication-key"] == "created_at"
-        assert final_config()["metadata.stream.replication-key"] == "created_at"
+            set_config(["metadata", "stream", "replication-key"], "created_at")
 
-        set_config(["metadata", "stream", "replication-method"], "INCREMENTAL")
+            yml = yml_config()
+            assert "metadata.stream.replication-key" not in yml
+            assert yml["metadata"]["stream"]["replication-key"] == "created_at"
+            assert final_config()["metadata.stream.replication-key"] == "created_at"
 
-        yml = yml_config()
-        assert "metadata.stream.replication-key" not in yml
-        assert "metadata.stream.replication-method" not in yml
-        assert yml["metadata"]["stream"]["replication-key"] == "created_at"
-        assert yml["metadata"]["stream"]["replication-method"] == "INCREMENTAL"
-        final = final_config()
-        assert final["metadata.stream.replication-key"] == "created_at"
-        assert final["metadata.stream.replication-method"] == "INCREMENTAL"
+            set_config(["metadata", "stream", "replication-method"], "INCREMENTAL")
 
-        set_config(["metadata.stream.replication-key"], "created_at")
-        unset_config(["metadata.stream.replication-method"])
+            yml = yml_config()
+            assert "metadata.stream.replication-key" not in yml
+            assert "metadata.stream.replication-method" not in yml
+            assert yml["metadata"]["stream"]["replication-key"] == "created_at"
+            assert yml["metadata"]["stream"]["replication-method"] == "INCREMENTAL"
+            final = final_config()
+            assert final["metadata.stream.replication-key"] == "created_at"
+            assert final["metadata.stream.replication-method"] == "INCREMENTAL"
 
-        yml = yml_config()
-        assert "metadata" not in yml
-        assert yml["metadata.stream.replication-key"] == "created_at"
-        assert final_config()["metadata.stream.replication-key"] == "created_at"
+            set_config(["metadata.stream.replication-key"], "created_at")
+            unset_config(["metadata.stream.replication-method"])
 
-        set_config(["metadata", "stream.replication-key"], "created_at")
+            yml = yml_config()
+            assert "metadata" not in yml
+            assert yml["metadata.stream.replication-key"] == "created_at"
+            assert final_config()["metadata.stream.replication-key"] == "created_at"
 
-        yml = yml_config()
-        assert "metadata.stream.replication-key" not in yml
-        assert yml["metadata"]["stream.replication-key"] == "created_at"
-        assert final_config()["metadata.stream.replication-key"] == "created_at"
+            set_config(["metadata", "stream.replication-key"], "created_at")
 
-        unset_config(["metadata", "stream.replication-key"])
+            yml = yml_config()
+            assert "metadata.stream.replication-key" not in yml
+            assert yml["metadata"]["stream.replication-key"] == "created_at"
+            assert final_config()["metadata.stream.replication-key"] == "created_at"
 
-        yml = yml_config()
-        assert "metadata.stream.replication-key" not in yml
-        assert "metadata" not in yml
-        assert "metadata.stream.replication-key" not in final_config()
+            unset_config(["metadata", "stream.replication-key"])
+
+            yml = yml_config()
+            assert "metadata.stream.replication-key" not in yml
+            assert "metadata" not in yml
+            assert "metadata.stream.replication-key" not in final_config()
 
     @pytest.mark.usefixtures("tap")
     @pytest.mark.filterwarnings("ignore:Unknown setting:RuntimeWarning")


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

Because `find_setting` does an exact name/alias match and correctly returns `None` for the nested setting path (`_metadata`, `*`, `replication-method`), a warning is raised, even though `_metadata` is a known setting.

Performance should not be significantly affected:

- The extra `find_setting` call only runs when the primary `find_setting(name)` already returned `None` (miss), and the name contains a `.` (i.e., `root_name != name`)
- `find_setting` is a linear scan over `self.definitions()`, which is cached in `self._setting_defs` after the first call. A typical plugin has ~10–50 settings. And `set_with_metadata` is called once per CLI invocation, not in any hot loop.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude Code] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes https://github.com/meltano/meltano/issues/7987

## Summary by Sourcery

Avoid emitting warnings for unknown settings when setting nested extra settings whose root key is a known setting.

Bug Fixes:
- Prevent spurious 'Unknown setting' warnings when configuring nested extra settings such as metadata subkeys.

Tests:
- Relax test expectations by no longer filtering out runtime warnings for unknown settings in the nested keys plugin settings test.