### PR TITLE
ci: Fix pip installation tests on Python 3.14+

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -399,7 +399,15 @@ class PipPackageManager(PackageManager):
 
     @override
     async def list_installed(self, *args: str, python: str) -> list[dict[str, t.Any]]:
-        proc = await exec_async(python, "-m", "pip", "list", "--format=json", *args)
+        proc = await exec_async(
+            python,
+            "-m",
+            "pip",
+            "--no-color",
+            "list",
+            "--format=json",
+            *args,
+        )
         stdout, _ = await proc.communicate()
 
         # pip may include warnings before the JSON output


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Bug Fixes:
- Prevent pip installation list tests from failing due to colored/warning-prefixed output by adding the --no-color flag to pip list JSON calls.