### PR TITLE
WIP: propagate termination signals to plugin subprocesses

### DIFF
--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -19,6 +19,7 @@ from meltano.core._state import StateStrategy
 from meltano.core.block.block_parser import BlockParser, validate_block_sets
 from meltano.core.block.extract_load import ExtractLoadBlocks
 from meltano.core.block.plugin_command import InvokerCommand
+from meltano.core.job.job import _was_sigint_received
 from meltano.core.logging.utils import change_console_log_level
 from meltano.core.plugin_install_service import PluginInstallReason
 from meltano.core.project_settings_service import ProjectSettingsService
@@ -308,16 +309,19 @@ async def _run_blocks(
             with tracker.with_contexts(tracking_ctx):
                 tracker.track_block_event(blk_name, BlockEvents.failed)
             ctx.exit(1)
-        except asyncio.CancelledError:
-            # Handle graceful termination on timeout
-            logger.info(
-                "Attempting graceful termination of current block",
-                block_type=current_block.__class__.__name__,
-            )
-            if isinstance(current_block, ExtractLoadBlocks):
-                await current_block.terminate(graceful=True)
-            else:
-                await current_block.stop(kill=False)
+        except asyncio.CancelledError as e:
+            # Only attempt graceful termination for timeout or plain cancellation.
+            # SIGTERM is handled in _start_blocks. SIGINT is skipped because the
+            # subprocess already received SIGINT from the terminal process group.
+            if not _was_sigint_received() and e.args != ("SIGTERM",):
+                logger.info(
+                    "Attempting graceful termination of current block",
+                    block_type=current_block.__class__.__name__,
+                )
+                if isinstance(current_block, ExtractLoadBlocks):
+                    await current_block.terminate(graceful=True)
+                else:
+                    await current_block.stop(kill=False)
             raise
         except Exception as bare_err:
             # make sure we also fire block failed events for all other exceptions

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -628,8 +628,9 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
                 await block.pre(self.context)
                 await block.start()
             yield
-        except asyncio.CancelledError:
-            await asyncio.shield(self.terminate(graceful=True))
+        except asyncio.CancelledError as e:
+            if e.args == ("SIGTERM",):
+                await asyncio.shield(self.terminate(graceful=True))
             raise
         finally:
             await self._cleanup()

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -628,6 +628,9 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
                 await block.pre(self.context)
                 await block.start()
             yield
+        except asyncio.CancelledError:
+            await asyncio.shield(self.terminate(graceful=True))
+            raise
         finally:
             await self._cleanup()
 

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -35,6 +35,12 @@ if t.TYPE_CHECKING:
 HEARTBEATLESS_JOB_VALID_HOURS = 24
 HEARTBEAT_VALID_MINUTES = 5
 
+_sigint_received: bool = False
+
+
+def _was_sigint_received() -> bool:
+    return _sigint_received
+
 
 class InconsistentStateError(Error):
     """Occur upon a wrong operation for the current state."""
@@ -395,17 +401,32 @@ class Job(SystemModel):
         self,
         session: Session,  # noqa: ARG002
     ) -> AsyncGenerator[None, None]:
+        global _sigint_received
+        _sigint_received = False
+
         loop = asyncio.get_running_loop()
         task = asyncio.current_task()
         sigterm_received = False
 
-        def handler() -> None:
+        def sigterm_handler() -> None:
             nonlocal sigterm_received
             sigterm_received = True
             if task is not None:
-                task.cancel()
+                task.cancel("SIGTERM")
 
-        loop.add_signal_handler(signal.SIGTERM, handler)
+        original_sigint = signal.getsignal(signal.SIGINT)
+
+        def sigint_wrapper(sig: int, frame: t.Any) -> None:  # noqa: ANN401
+            global _sigint_received
+            _sigint_received = True
+            if callable(original_sigint):
+                t.cast("t.Callable[[int, t.Any], None]", original_sigint)(sig, frame)
+
+        with suppress(
+            NotImplementedError
+        ):  # Windows: loop.add_signal_handler is unavailable
+            loop.add_signal_handler(signal.SIGTERM, sigterm_handler)
+        signal.signal(signal.SIGINT, sigint_wrapper)
         try:
             yield
         except asyncio.CancelledError:
@@ -413,7 +434,9 @@ class Job(SystemModel):
                 raise SystemExit(143) from None
             raise
         finally:
-            loop.remove_signal_handler(signal.SIGTERM)
+            with suppress(NotImplementedError):  # Windows
+                loop.remove_signal_handler(signal.SIGTERM)
+            signal.signal(signal.SIGINT, original_sigint)
 
     def _error_message(self, err: BaseException) -> str:
         if isinstance(err, SystemExit):

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import signal
 import typing as t
-from contextlib import asynccontextmanager, contextmanager, suppress
+from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from enum import Enum, IntEnum
 
@@ -27,7 +27,7 @@ from meltano.core.sqlalchemy import (
 from meltano.core.utils import new_run_id
 
 if t.TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Generator
+    from collections.abc import AsyncGenerator
 
     from sqlalchemy.orm import Session
 
@@ -278,9 +278,8 @@ class Job(SystemModel):
             self.start()
             self.save(session)
 
-            with self._handling_sigterm(session):
-                async with self._heartbeating(session):
-                    yield
+            async with self._handling_sigterm(session), self._heartbeating(session):
+                yield
 
             self.success()
             self.save(session)
@@ -391,21 +390,30 @@ class Job(SystemModel):
             with suppress(asyncio.CancelledError):
                 await heartbeat_future
 
-    @contextmanager
-    def _handling_sigterm(
+    @asynccontextmanager
+    async def _handling_sigterm(
         self,
         session: Session,  # noqa: ARG002
-    ) -> Generator[None, None, None]:
-        def handler(*_) -> t.NoReturn:
-            sigterm_status = 143
-            raise SystemExit(sigterm_status)
+    ) -> AsyncGenerator[None, None]:
+        loop = asyncio.get_running_loop()
+        task = asyncio.current_task()
+        sigterm_received = False
 
-        original_termination_handler = signal.signal(signal.SIGTERM, handler)
+        def handler() -> None:
+            nonlocal sigterm_received
+            sigterm_received = True
+            if task is not None:
+                task.cancel()
 
+        loop.add_signal_handler(signal.SIGTERM, handler)
         try:
             yield
+        except asyncio.CancelledError:
+            if sigterm_received:
+                raise SystemExit(143) from None
+            raise
         finally:
-            signal.signal(signal.SIGTERM, original_termination_handler)
+            loop.remove_signal_handler(signal.SIGTERM)
 
     def _error_message(self, err: BaseException) -> str:
         if isinstance(err, SystemExit):

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -23,7 +23,7 @@ if t.TYPE_CHECKING:
 
 
 class TestJob:
-    def sample_job(self, payload=None):
+    def sample_job(self, payload=None) -> Job:
         return Job(
             job_name="meltano:sample-elt",
             state=State.IDLE,
@@ -132,9 +132,14 @@ class TestJob:
             )
         subject = self.sample_job({"original_state": 1}).save(session)
 
-        with pytest.raises(SystemExit):
+        async def _run_with_sigterm() -> None:
             async with subject.run(session):
                 signal.raise_signal(signal.SIGTERM)
+                # I/O poll needed to dispatch the signal callback
+                await asyncio.sleep(0.01)
+
+        with pytest.raises(SystemExit):
+            await _run_with_sigterm()
 
         assert subject.state is State.FAIL
         assert subject.ended_at is not None


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: Claude Code following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes https://github.com/meltano/meltano/issues/9981

## Summary by Sourcery

Propagate termination signals to job and plugin subprocess execution so SIGTERM and SIGINT are handled consistently and jobs exit with the correct status.

Bug Fixes:
- Ensure SIGTERM cancels running jobs and exits with the conventional 143 status instead of relying on a synchronous signal handler.
- Avoid performing duplicate or inappropriate graceful shutdown when cancellations are caused by SIGTERM or user SIGINT, relying on subprocess signal delivery instead.

Enhancements:
- Introduce asynchronous SIGTERM handling integrated with the event loop and job heartbeat lifecycle.
- Track whether SIGINT was received during job execution so downstream cancellation handling can distinguish user interrupts from timeouts.
- Ensure extract-load blocks perform a graceful terminate on SIGTERM-triggered cancellation during startup.