### PR TITLE
chore: remove subscribe newsletter action

### DIFF
--- a/docs/src/components/homepage/FindOutMore.js
+++ b/docs/src/components/homepage/FindOutMore.js
@@ -20,14 +20,14 @@ const FindOutMoreList = [
       target: '_blank',
     },
   },
-  {
-    title: <>Subscribe to our Newsletter</>,
-    Svg: require('@site/static/img/homepage/subscribe.svg').default,
-    link: {
-      url: 'https://meltano.com/lp/meltastic-newsletter/',
-      target: '_blank',
-    },
-  },
+  // {
+  //   title: <>Subscribe to our Newsletter</>,
+  //   Svg: require('@site/static/img/homepage/subscribe.svg').default,
+  //   link: {
+  //     url: 'https://meltano.com/lp/meltastic-newsletter/',
+  //     target: '_blank',
+  //   },
+  // },
 ];
 
 // eslint-disable-next-line react/prop-types

--- a/docs/src/components/homepage/FindOutMore.js
+++ b/docs/src/components/homepage/FindOutMore.js
@@ -20,14 +20,6 @@ const FindOutMoreList = [
       target: '_blank',
     },
   },
-  // {
-  //   title: <>Subscribe to our Newsletter</>,
-  //   Svg: require('@site/static/img/homepage/subscribe.svg').default,
-  //   link: {
-  //     url: 'https://meltano.com/lp/meltastic-newsletter/',
-  //     target: '_blank',
-  //   },
-  // },
 ];
 
 // eslint-disable-next-line react/prop-types


### PR DESCRIPTION
## Description

Removes the "Subscribe to our Newsletter" card from the homepage FindOutMore component. The card linked to meltano.com/lp/meltastic-newsletter/, a landing page URL that is no longer in use, so the entry has been removed to avoid directing users to a dead link.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* https://trello.com/c/Qgi9IZAO/213-issues-and-improvements-on-website

## Summary by Sourcery

Bug Fixes:
- Eliminate a homepage link that pointed to an obsolete newsletter landing page to avoid directing users to a dead URL.