### PR TITLE
fix: Parse strucuted logs coming from mapper plugins

### DIFF
--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.cicd.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.cicd.json
@@ -2399,9 +2399,11 @@
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_ID": "md5(record.get('ipv4prefix', record.get('ipv6prefix')))",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV4": "record.get('ipv4prefix', '')",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV6": "record.get('ipv6prefix', '')",
+          "MELTANO_MAP_TRANSFORMER__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP_TRANSFORMER__MAPPING": "true",
           "MELTANO_MAP_TRANSFORMER__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP_TRANSFORMER__MAPPING_NAME": "coalesce-gcp-ips",
+          "MELTANO_MAP__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP__MAPPING": "true",
           "MELTANO_MAP__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP__MAPPING_NAME": "coalesce-gcp-ips"

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.jigsaw.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.jigsaw.json
@@ -2296,9 +2296,11 @@
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_ID": "md5(record.get('ipv4prefix', record.get('ipv6prefix')))",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV4": "record.get('ipv4prefix', '')",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV6": "record.get('ipv6prefix', '')",
+          "MELTANO_MAP_TRANSFORMER__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP_TRANSFORMER__MAPPING": "true",
           "MELTANO_MAP_TRANSFORMER__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP_TRANSFORMER__MAPPING_NAME": "coalesce-gcp-ips",
+          "MELTANO_MAP__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP__MAPPING": "true",
           "MELTANO_MAP__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP__MAPPING_NAME": "coalesce-gcp-ips"

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.json
@@ -2283,9 +2283,11 @@
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_ID": "md5(record.get('ipv4prefix', record.get('ipv6prefix')))",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV4": "record.get('ipv4prefix', '')",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV6": "record.get('ipv6prefix', '')",
+          "MELTANO_MAP_TRANSFORMER__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP_TRANSFORMER__MAPPING": "true",
           "MELTANO_MAP_TRANSFORMER__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP_TRANSFORMER__MAPPING_NAME": "coalesce-gcp-ips",
+          "MELTANO_MAP__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP__MAPPING": "true",
           "MELTANO_MAP__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP__MAPPING_NAME": "coalesce-gcp-ips"

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.prod.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.prod.json
@@ -2406,9 +2406,11 @@
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_ID": "md5(record.get('ipv4prefix', record.get('ipv6prefix')))",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV4": "record.get('ipv4prefix', '')",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV6": "record.get('ipv6prefix', '')",
+          "MELTANO_MAP_TRANSFORMER__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP_TRANSFORMER__MAPPING": "true",
           "MELTANO_MAP_TRANSFORMER__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP_TRANSFORMER__MAPPING_NAME": "coalesce-gcp-ips",
+          "MELTANO_MAP__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP__MAPPING": "true",
           "MELTANO_MAP__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP__MAPPING_NAME": "coalesce-gcp-ips"

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.staging.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.staging.json
@@ -2402,9 +2402,11 @@
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_ID": "md5(record.get('ipv4prefix', record.get('ipv6prefix')))",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV4": "record.get('ipv4prefix', '')",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV6": "record.get('ipv6prefix', '')",
+          "MELTANO_MAP_TRANSFORMER__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP_TRANSFORMER__MAPPING": "true",
           "MELTANO_MAP_TRANSFORMER__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP_TRANSFORMER__MAPPING_NAME": "coalesce-gcp-ips",
+          "MELTANO_MAP__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP__MAPPING": "true",
           "MELTANO_MAP__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP__MAPPING_NAME": "coalesce-gcp-ips"

--- a/integration/meltano-manifest/expected-manifests/meltano-manifest.userdev.json
+++ b/integration/meltano-manifest/expected-manifests/meltano-manifest.userdev.json
@@ -2417,9 +2417,11 @@
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_ID": "md5(record.get('ipv4prefix', record.get('ipv6prefix')))",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV4": "record.get('ipv4prefix', '')",
           "MELTANO_MAP_TRANSFORMER_STREAM_MAPS_GCP_IPS_IPV6": "record.get('ipv6prefix', '')",
+          "MELTANO_MAP_TRANSFORMER__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP_TRANSFORMER__MAPPING": "true",
           "MELTANO_MAP_TRANSFORMER__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP_TRANSFORMER__MAPPING_NAME": "coalesce-gcp-ips",
+          "MELTANO_MAP__LOG_PARSER": "singer-sdk",
           "MELTANO_MAP__MAPPING": "true",
           "MELTANO_MAP__MAPPINGS": "[{\"name\": \"coalesce-gcp-ips\", \"config\": {\"stream_maps\": {\"gcp_ips\": {\"ipv4prefix\": null, \"ipv6prefix\": null, \"ipv4\": \"record.get('ipv4prefix', '')\", \"ipv6\": \"record.get('ipv6prefix', '')\", \"id\": \"md5(record.get('ipv4prefix', record.get('ipv6prefix')))\"}}}}]",
           "MELTANO_MAP__MAPPING_NAME": "coalesce-gcp-ips"

--- a/src/meltano/core/plugin/singer/mapper.py
+++ b/src/meltano/core/plugin/singer/mapper.py
@@ -29,6 +29,7 @@ class SingerMapper(SingerPlugin):
     __plugin_type__ = PluginType.MAPPERS
 
     EXTRA_SETTINGS: t.ClassVar[list[SettingDefinition]] = [
+        *SingerPlugin.EXTRA_SETTINGS,
         SettingDefinition(
             name="_mappings",
             kind=SettingKind.ARRAY,


### PR DESCRIPTION
See also

- https://github.com/meltano/meltano/discussions/9656\#discussioncomment-16833074
- https://github.com/meltano/hub/pull/2254

## Summary by Sourcery

Bug Fixes:
- Ensure Singer mapper plugins also expose and honor the standard extra settings defined for Singer plugins.