### PR TITLE
fix: Add a trailing newline character to manifest files produced by `meltano compile`

### DIFF
--- a/src/meltano/cli/compile.py
+++ b/src/meltano/cli/compile.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import typing as t
 from pathlib import Path
 
@@ -111,7 +110,7 @@ def compile_command(
                     indent=indent if indent > 0 else None,
                     sort_keys=True,
                 )
-                manifest_file.write(os.linesep)
+                manifest_file.write("\n")
         except OSError as ex:
             raise CliError(  # noqa: TRY003
                 f"Unable to write Meltano manifest {str(path)!r}: {ex}",  # noqa: EM102

--- a/src/meltano/cli/compile.py
+++ b/src/meltano/cli/compile.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import typing as t
 from pathlib import Path
 
@@ -110,6 +111,7 @@ def compile_command(
                     indent=indent if indent > 0 else None,
                     sort_keys=True,
                 )
+                manifest_file.write(os.linesep)
         except OSError as ex:
             raise CliError(  # noqa: TRY003
                 f"Unable to write Meltano manifest {str(path)!r}: {ex}",  # noqa: EM102

--- a/tests/meltano/cli/test_compile.py
+++ b/tests/meltano/cli/test_compile.py
@@ -33,7 +33,10 @@ def check_indent(json_path: Path, indent: int) -> None:
     # If the indent is as-expected, then a trip through `json.loads` and
     # `json.dumps` should produce the same text, usually. This isn't true in
     # general, but it's sufficient for our use in the tests here.
-    assert json.dumps(json.loads(text), indent=indent if indent > 0 else None) == text
+    assert (
+        json.dumps(json.loads(text), indent=indent if indent > 0 else None)
+        == text.strip()
+    )
 
 
 def get_schema_warnings(log: StructuredLogCapture) -> list[dict[str, t.Any]]:


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Bug Fixes:
- Add a trailing newline character when writing compiled manifest files to avoid missing-newline issues in generated manifests.