### PR TITLE
ci: Use `pytest-github-actions-annotate-failures` exclusively in CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -117,7 +117,13 @@ def pytest_meltano(session: nox.Session) -> None:
     elif backend_db == "postgresql_psycopg2":
         extras.append("psycopg2")
 
-    _uv_sync(session, "--group=testing", *(f"--extra={extra}" for extra in extras))
+    sync_args = ["--group=testing"]
+
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        sync_args.append("--group=ci")
+
+    sync_args.extend(f"--extra={extra}" for extra in extras)
+    _uv_sync(session, *sync_args)
     _run_pytest(session)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,9 @@ gs = "meltano.core.state_store.google.backend:GCSStateStoreManager"
 s3 = "meltano.core.state_store.s3.backend:S3StateStoreManager"
 
 [dependency-groups]
+ci = [
+    "pytest-github-actions-annotate-failures>=0.4.0",
+]
 coverage = [
   "coverage[toml]>=7.10",
 ]
@@ -128,7 +131,6 @@ testing = [
   "pytest-asyncio>=1.3",
   "pytest-codspeed>=4.2.0",
   "pytest-docker~=3.1",
-  "pytest-github-actions-annotate-failures>=0.4.0",
   "pytest-order~=1.3",
   "pytest-randomly>=3.16,<5.0",
   "pytest-structlog~=1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1421,6 +1421,9 @@ s3 = [
 ]
 
 [package.dev-dependencies]
+ci = [
+    { name = "pytest-github-actions-annotate-failures" },
+]
 coverage = [
     { name = "coverage", extra = ["toml"] },
 ]
@@ -1437,7 +1440,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
     { name = "pytest-docker" },
-    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
@@ -1465,7 +1467,6 @@ testing = [
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
     { name = "pytest-docker" },
-    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
@@ -1488,7 +1489,6 @@ typing = [
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
     { name = "pytest-docker" },
-    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-order" },
     { name = "pytest-randomly" },
     { name = "pytest-structlog" },
@@ -1549,6 +1549,7 @@ requires-dist = [
 provides-extras = ["azure", "containers", "gcs", "mssql", "postgres", "psycopg2", "s3"]
 
 [package.metadata.requires-dev]
+ci = [{ name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" }]
 coverage = [{ name = "coverage", extras = ["toml"], specifier = ">=7.10" }]
 dev = [
     { name = "backports-strenum" },
@@ -1563,7 +1564,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
-    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
     { name = "pytest-structlog", specifier = "~=1.1" },
@@ -1589,7 +1589,6 @@ testing = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
-    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
     { name = "pytest-structlog", specifier = "~=1.1" },
@@ -1612,7 +1611,6 @@ typing = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
-    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" },
     { name = "pytest-order", specifier = "~=1.3" },
     { name = "pytest-randomly", specifier = ">=3.16,<5.0" },
     { name = "pytest-structlog", specifier = "~=1.1" },


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

CI:
- Introduce a dedicated `ci` dependency group providing `pytest-github-actions-annotate-failures` for GitHub Actions runs.