### PR TITLE
refactor: Use global constant for the state file name `state.json`

### DIFF
--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -36,6 +36,8 @@ if t.TYPE_CHECKING:
 
 logger = structlog.stdlib.get_logger(__name__)
 
+_STATE_FILENAME = "state.json"
+
 
 class InvalidStateBackendConfigurationException(Exception):
     """State backend configuration is invalid."""
@@ -195,7 +197,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
         Returns:
             the path to the file/blob storing complete state for the given state_id.
         """
-        return self.get_path(state_id, filename="state.json")
+        return self.get_path(state_id, filename=_STATE_FILENAME)
 
     def get_state_dir(self, state_id: str) -> str:
         """Get the path to the state directory for the given state_id.
@@ -363,7 +365,9 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
 class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
     """State backend for local filesystem."""
 
-    label: str = "Local Filesystem"
+    @property
+    def label(self) -> str:
+        return "Local Filesystem"  # pragma: no cover
 
     @override
     def __init__(self, **kwargs: t.Any) -> None:
@@ -389,8 +393,8 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
         """
         return isinstance(err, FileNotFoundError)
 
-    @override
     @property
+    @override
     def client(self) -> None:
         """Get a client for performing fs operations.
 
@@ -399,8 +403,8 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
         """
         return None
 
-    @override
     @property
+    @override
     def state_dir(self) -> str:
         """Get the path that state should be stored at.
 
@@ -447,9 +451,9 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
             for state_file in glob.glob(
                 os.path.join(
                     self.state_dir,
-                    os.path.join(pattern, "state.json")
+                    os.path.join(pattern, _STATE_FILENAME)
                     if pattern
-                    else os.path.join("*", "state.json"),
+                    else os.path.join("*", _STATE_FILENAME),
                 ),
             )
         ]
@@ -486,8 +490,11 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
 class _WindowsFilesystemStateStoreManager(_LocalFilesystemStateStoreManager):
     """State backend for local Windows filesystem."""
 
-    label: str = "Local Windows Filesystem"
     delimiter = "\\"
+
+    @property
+    def label(self) -> str:
+        return "Local Windows Filesystem"  # pragma: no cover
 
     @override
     def __init__(self, **kwargs: t.Any) -> None:
@@ -534,7 +541,7 @@ class _WindowsFilesystemStateStoreManager(_LocalFilesystemStateStoreManager):
         for state_file in glob.glob(
             os.path.join(
                 self.state_dir,
-                os.path.join("*", "state.json"),
+                os.path.join("*", _STATE_FILENAME),
             ),
         ):
             state_id = b64decode(
@@ -566,8 +573,8 @@ class CloudStateStoreManager(BaseFilesystemStateStoreManager):
         super().__init__(**kwargs)
         self.prefix = prefix or self.parsed.path
 
-    @override
     @property
+    @override
     def state_dir(self) -> str:
         """Get the prefix that state should be stored at.
 
@@ -626,7 +633,7 @@ class CloudStateStoreManager(BaseFilesystemStateStoreManager):
         )
         for filepath in self.list_all_files(with_prefix=False):
             parts = filepath.split(self.delimiter)
-            if parts[-1] == "state.json" and filepath.count(stripped_prefix) > 1:
+            if parts[-1] == _STATE_FILENAME and filepath.count(stripped_prefix) > 1:
                 new_path = filepath.replace(duplicated_substr, self.prefix)
                 new_path = new_path.replace(
                     self.delimiter * 2,
@@ -649,16 +656,15 @@ class CloudStateStoreManager(BaseFilesystemStateStoreManager):
         Returns:
             List of state_ids
         """
-        if pattern:
-            pattern_re = re.compile(pattern.replace("*", ".*"))
+        pattern_re = re.compile(pattern.replace("*", ".*")) if pattern else None
         state_ids = set()
         for filepath in self.list_all_files():
             if "/" not in filepath:
                 continue
 
             (state_id, filename) = filepath.split("/")[-2:]
-            if filename == "state.json" and (
-                (not pattern) or pattern_re.match(state_id)
+            if filename == _STATE_FILENAME and (
+                (not pattern_re) or pattern_re.match(state_id)
             ):
                 state_ids.add(state_id)
         return list(state_ids)

--- a/src/meltano/core/state_store/s3/backend.py
+++ b/src/meltano/core/state_store/s3/backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from functools import cached_property
 
@@ -12,6 +13,11 @@ from meltano.core.state_store.filesystem import (
     CloudStateStoreManager,
     InvalidStateBackendConfigurationException,
 )
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator
@@ -53,6 +59,7 @@ class S3StateStoreManager(CloudStateStoreManager):
         self.endpoint_url = endpoint_url
 
     @staticmethod
+    @override
     def is_file_not_found_error(err: Exception) -> bool:
         """Check if err is equivalent to file not being found.
 
@@ -67,6 +74,7 @@ class S3StateStoreManager(CloudStateStoreManager):
         )
 
     @property
+    @override
     def extra_transport_params(self) -> dict[str, t.Any]:
         """Extra transport params for ``smart_open.open``.
 
@@ -82,6 +90,7 @@ class S3StateStoreManager(CloudStateStoreManager):
         }
 
     @cached_property
+    @override
     def client(self) -> S3Client:
         """Get an authenticated boto3.Client.
 
@@ -111,6 +120,7 @@ class S3StateStoreManager(CloudStateStoreManager):
         session = boto3.Session()
         return session.client("s3", config=config)
 
+    @override
     def delete_file(self, file_path: str) -> None:
         """Delete the file/blob at the given path.
 

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -666,6 +666,13 @@ class TestS3StateStoreManager:
             )
             assert set(subject.get_state_ids()) == {"state_id_1", "state_id_2"}
 
+            stubber.add_response(
+                "list_objects_v2",
+                response,
+                expected_params={"Bucket": subject.bucket, "Prefix": "/state"},
+            )
+            assert set(subject.get_state_ids(pattern="dev*")) == set()
+
 
 class TestGCSStateStoreManager:
     @pytest.fixture


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refactor filesystem and S3 state store backends to centralize the state file name and align method/property overrides with typing expectations.

Enhancements:
- Introduce a shared constant for the state file name and replace hard-coded "state.json" usages across filesystem-based state stores.
- Change filesystem state store manager labels and certain attributes to properties and adjust override annotations for better type checking and coverage control.
- Simplify and tighten pattern-matching logic when listing state IDs in remote filesystem state stores.
- Import and apply the typing override decorator in the S3 backend to explicitly mark overridden methods.