### PR TITLE
fix(cli): Avoid displaying noisy traceback when trying to modify a read-only project

### DIFF
--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -109,7 +109,7 @@ def _run_cli() -> None:
         except ProjectReadonly as err:
             raise CliError(  # noqa: TRY003
                 f"The requested action could not be completed: {err}",  # noqa: EM102
-            ) from err
+            ) from None
         except KeyboardInterrupt:
             raise
         except MeltanoError as err:


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Bug Fixes:
- Prevent noisy traceback output when a read-only project error is raised by suppressing exception chaining in the CLI.