### PR TITLE
fix(cli): Avoid displaying noisy traceback when passing a bad plugin type

### DIFF
--- a/src/meltano/cli/params.py
+++ b/src/meltano/cli/params.py
@@ -206,4 +206,7 @@ class PluginTypeArg(click.Choice):
         ctx: click.Context | None,
     ) -> PluginType:
         """Convert the value to a PluginType."""
-        return PluginType.from_cli_argument(value)
+        try:
+            return PluginType.from_cli_argument(value)
+        except ValueError as exc:
+            self.fail(str(exc), param, ctx)

--- a/tests/meltano/cli/test_add.py
+++ b/tests/meltano/cli/test_add.py
@@ -1060,6 +1060,21 @@ class TestCliAdd:
                 force=False,
             )
 
+    def test_add_bad_plugin_type(self, cli_runner: MeltanoCliRunner) -> None:
+        res = cli_runner.invoke(
+            cli,
+            [
+                "add",
+                "--plugin-type=not-a-valid-type",
+                "tap-mock",
+            ],
+        )
+        assert res.exit_code == 2
+        assert (
+            "Invalid value for '--plugin-type': 'not-a-valid-type' is not a valid PluginType"  # noqa: E501
+            in res.stderr
+        )
+
     @pytest.mark.usefixtures("reset_project_context")
     def test_add_with_python_version_auto_selection(
         self,


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Bug Fixes:
- Convert invalid CLI plugin type errors into standard Click failures instead of propagating raw ValueError tracebacks.