### PR TITLE
refactor: Decouple Hub error handling from Requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,6 @@ typing = [
   "types-jsonschema>=4.23.0.20240813,<5",
   "types-psutil>=7.0.0.20250218,<8",
   "types-pyyaml>=6.0.12.20240917,<7",
-  "types-requests>=2.31.0,<3",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/src/meltano/core/_compat.py
+++ b/src/meltano/core/_compat.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import sys
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if sys.version_info >= (3, 13):
     from warnings import deprecated
 else:
@@ -11,6 +16,7 @@ else:
 
 __all__ = [
     "deprecated",
+    "override",
 ]
 
 

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -266,7 +266,7 @@ class MeltanoHubService(PluginRepository):
         logger.info("Fetching plugin definition from Meltano Hub", url=url)
         response = self._get(url)
 
-        if HTTPStatus.INTERNAL_SERVER_ERROR <= response.status_code < 600:
+        if response.status_code >= HTTPStatus.BAD_REQUEST:
             raise HubConnectionError(response.reason)
 
         return PluginDefinition(

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -12,6 +12,7 @@ from requests.adapters import HTTPAdapter
 from structlog.stdlib import get_logger
 from urllib3 import Retry
 
+from meltano.core.error import MeltanoError
 from meltano.core.hub.schema import IndexedPlugin, VariantRef
 from meltano.core.plugin import PluginDefinition, PluginRef, PluginType, Variant
 from meltano.core.plugin.error import PluginNotFoundError
@@ -25,7 +26,7 @@ if t.TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-class HubPluginTypeNotFoundError(Exception):
+class HubPluginTypeNotFoundError(MeltanoError):
     """Raised when a Hub plugin type is not found."""
 
     def __init__(self, plugin_type: PluginType):
@@ -35,33 +36,25 @@ class HubPluginTypeNotFoundError(Exception):
             plugin_type: The type of the plugin.
         """
         self.plugin_type = plugin_type
-
-    def __str__(self) -> str:
-        """Return a string representation of the error.
-
-        Returns:
-            The string representation of the error.
-        """
-        return (
+        super().__init__(
             f"{self.plugin_type.descriptor.capitalize()} is not supported in "
             f"Meltano Hub. Available plugin types: {PluginType.plurals()}"
         )
 
 
-class HubConnectionError(Exception):
+class HubConnectionError(MeltanoError):
     """Raised when a Hub connection error occurs."""
 
-    def __init__(self, reason: str):
+    def __init__(self, reason: str | None = None):
         """Create a new HubConnectionError.
 
         Args:
             reason: The reason for the error.
         """
-        message = f"Could not connect to Meltano Hub. {reason}"
-        super().__init__(message)
+        super().__init__(reason or "Could not connect to Meltano Hub")
 
 
-class HubPluginVariantNotFoundError(Exception):
+class HubPluginVariantNotFoundError(MeltanoError):
     """Raised when a Hub plugin variant is not found."""
 
     def __init__(
@@ -80,14 +73,7 @@ class HubPluginVariantNotFoundError(Exception):
         self.plugin_type = plugin_type
         self.plugin = plugin
         self.variant_name = variant_name
-
-    def __str__(self) -> str:
-        """Return a string representation of the error.
-
-        Returns:
-            The string representation of the error.
-        """
-        return (
+        super().__init__(
             f"{self.plugin_type.descriptor.capitalize()} '{self.plugin.name}' "
             f"variant '{self.variant_name}' is not known to Meltano. "
             f"Variants: {self.plugin.variant_labels}"
@@ -204,7 +190,7 @@ class MeltanoHubService(PluginRepository):
         """
         request = requests.Request(method, url)
         if click_context := click.get_current_context(silent=True):
-            request.headers["X-Meltano-Command"] = click_context.command_path
+            request.headers["X-Meltano-Command"] = click_context.command_path  # type: ignore[index] # ty:ignore[invalid-assignment]
 
         return self.session.prepare_request(request)
 
@@ -222,7 +208,7 @@ class MeltanoHubService(PluginRepository):
         """
         prep = self._build_request("GET", url)
         settings = self.session.merge_environment_settings(
-            prep.url,
+            prep.url,  # type: ignore[arg-type] # ty:ignore[invalid-argument-type]
             {},
             None,
             None,
@@ -232,7 +218,7 @@ class MeltanoHubService(PluginRepository):
         try:
             return self.session.send(prep, **settings)
         except requests.exceptions.ConnectionError as connection_err:
-            raise HubConnectionError("Could not reach Meltano Hub.") from connection_err  # noqa: EM101, TRY003
+            raise HubConnectionError from connection_err
 
     def find_definition(
         self,
@@ -280,15 +266,8 @@ class MeltanoHubService(PluginRepository):
         logger.info("Fetching plugin definition from Meltano Hub", url=url)
         response = self._get(url)
 
-        try:
-            response.raise_for_status()
-        except requests.HTTPError as http_err:
-            logger.exception(
-                "Can not retrieve plugin",
-                status_code=http_err.response.status_code,
-                error=http_err,
-            )
-            raise HubConnectionError(str(http_err)) from http_err
+        if HTTPStatus.INTERNAL_SERVER_ERROR <= response.status_code < 600:
+            raise HubConnectionError(response.reason)
 
         return PluginDefinition(
             **response.json(),
@@ -342,17 +321,15 @@ class MeltanoHubService(PluginRepository):
         url = self.plugin_type_endpoint(plugin_type)
         response = self._get(url)
 
-        try:
-            response.raise_for_status()
-        except requests.HTTPError as err:
-            logger.exception(
-                "Can not retrieve plugin type",
-                status_code=err.response.status_code,
-                error=err,
-            )
-            if err.response.status_code < HTTPStatus.TOO_MANY_REQUESTS:
-                raise HubPluginTypeNotFoundError(plugin_type) from err
-            raise HubConnectionError(err.response.reason) from err
+        if (
+            HTTPStatus.BAD_REQUEST
+            <= response.status_code
+            < HTTPStatus.TOO_MANY_REQUESTS
+        ):
+            raise HubPluginTypeNotFoundError(plugin_type)
+
+        if HTTPStatus.INTERNAL_SERVER_ERROR <= response.status_code < 600:
+            raise HubConnectionError(response.reason)
 
         plugins: dict[str, dict[str, t.Any]] = response.json()
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,8 +185,7 @@ class MockAdapter(BaseAdapter):
         response.request = request
         response.url = request.url
 
-        response_500 = self.RETURN_500.get(endpoint)
-        if response_500:
+        if response_500 := self.RETURN_500.get(endpoint):
             response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
             response.reason = "Internal Server Error"
             response._content = json.dumps(response_500).encode()

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import click
 import pytest
-from requests import HTTPError, Response
+from requests import Response
 from requests.adapters import BaseAdapter
 
 from meltano.cli import cli
@@ -115,21 +115,12 @@ class TestMeltanoHubService:
     def test_server_error(self, project: Project) -> None:
         with pytest.raises(
             HubConnectionError,
-            match=r"Could not connect to Meltano Hub. 500 Server Error",
-        ) as exc_info:
+            match=r"Internal Server Error",
+        ):
             project.hub_service.find_definition(
                 PluginType.EXTRACTORS,
                 "this-returns-500",
             )
-
-        assert isinstance(exc_info.value.__cause__, HTTPError)
-        assert isinstance(exc_info.value.__cause__.response, Response)
-        assert exc_info.value.__cause__.response.status_code == 500
-        assert exc_info.value.__cause__.response.json() == {"error": "Server error"}
-        assert exc_info.value.__cause__.response.url == (
-            "https://hub.meltano.com/meltano/api/v1/plugins/extractors"
-            "/this-returns-500--original"
-        )
 
     def test_request_headers(self, project: Project) -> None:
         with mock.patch("click.get_current_context") as get_context:

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -13,6 +13,7 @@ from requests.adapters import BaseAdapter
 
 from meltano.cli import cli
 from meltano.cli.hub import hub
+from meltano.core._compat import override
 from meltano.core.hub.client import (
     HubConnectionError,
     HubPluginTypeNotFoundError,
@@ -151,9 +152,11 @@ class TestMeltanoHubService:
         send_kwargs = {}
 
         class _Adapter(BaseAdapter):
+            @override
             def send(
                 self,
                 request,  # noqa: ARG002
+                *args,  # noqa: ARG002
                 **kwargs,
             ):
                 nonlocal send_kwargs
@@ -176,9 +179,11 @@ class TestMeltanoHubService:
         send_kwargs = {}
 
         class _Adapter(BaseAdapter):
+            @override
             def send(
                 self,
                 request,  # noqa: ARG002
+                *args,  # noqa: ARG002
                 **kwargs,
             ):
                 nonlocal send_kwargs

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -116,11 +116,14 @@ class TestMeltanoHubService:
         with pytest.raises(
             HubConnectionError,
             match=r"Internal Server Error",
-        ):
+        ) as exc_info:
             project.hub_service.find_definition(
                 PluginType.EXTRACTORS,
                 "this-returns-500",
             )
+
+        assert isinstance(exc_info.value, HubConnectionError)
+        assert str(exc_info.value) == "Internal Server Error."
 
     def test_request_headers(self, project: Project) -> None:
         with mock.patch("click.get_current_context") as get_context:

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 import typing as t
+from http import HTTPStatus
 from unittest import mock
 
 import click
 import pytest
+import requests
+import requests.exceptions
 from requests import Response
 from requests.adapters import BaseAdapter
 
 from meltano.cli import cli
 from meltano.cli.hub import hub
-from meltano.core.hub.client import HubConnectionError, HubPluginVariantNotFoundError
+from meltano.core.hub.client import (
+    HubConnectionError,
+    HubPluginTypeNotFoundError,
+    HubPluginVariantNotFoundError,
+)
 from meltano.core.plugin.base import PluginType, Variant
 from meltano.core.plugin.error import PluginNotFoundError
 
@@ -189,3 +196,40 @@ class TestMeltanoHubService:
         monkeypatch.setenv("HTTPS_PROXY", "https://www.example.com:3128/")
         hub._get(mock_url)
         assert send_kwargs["proxies"] == {"https": "https://www.example.com:3128/"}
+
+    def test_connection_error(self, project: Project) -> None:
+        with (
+            mock.patch.object(
+                project.hub_service.session,
+                "send",
+                side_effect=requests.exceptions.ConnectionError,
+            ),
+            pytest.raises(HubConnectionError) as exc_info,
+        ):
+            project.hub_service._get(project.hub_service.hub_api_url)
+
+        assert str(exc_info.value) == "Could not connect to Meltano Hub."
+        assert isinstance(exc_info.value.__cause__, requests.exceptions.ConnectionError)
+
+    def test_plugin_type_not_found_error(self, project: Project) -> None:
+        mock_response = Response()
+        mock_response.status_code = HTTPStatus.NOT_FOUND
+
+        with (
+            mock.patch.object(project.hub_service, "_get", return_value=mock_response),
+            pytest.raises(HubPluginTypeNotFoundError) as exc_info,
+        ):
+            project.hub_service.get_plugins_of_type(PluginType.EXTRACTORS)
+
+        assert "is not supported in Meltano Hub" in str(exc_info.value)
+
+    def test_server_error_on_index(self, project: Project) -> None:
+        mock_response = Response()
+        mock_response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+        mock_response.reason = "Internal Server Error"
+
+        with (
+            mock.patch.object(project.hub_service, "_get", return_value=mock_response),
+            pytest.raises(HubConnectionError, match="Internal Server Error"),
+        ):
+            project.hub_service.get_plugins_of_type(PluginType.EXTRACTORS)

--- a/uv.lock
+++ b/uv.lock
@@ -1453,7 +1453,6 @@ dev = [
     { name = "types-jsonschema" },
     { name = "types-psutil" },
     { name = "types-pyyaml" },
-    { name = "types-requests" },
 ]
 pre-commit = [
     { name = "prek" },
@@ -1502,7 +1501,6 @@ typing = [
     { name = "types-jsonschema" },
     { name = "types-psutil" },
     { name = "types-pyyaml" },
-    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -1577,7 +1575,6 @@ dev = [
     { name = "types-jsonschema", specifier = ">=4.23.0.20240813,<5" },
     { name = "types-psutil", specifier = ">=7.0.0.20250218,<8" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240917,<7" },
-    { name = "types-requests", specifier = ">=2.31.0,<3" },
 ]
 pre-commit = [{ name = "prek", specifier = "~=0.3" }]
 testing = [
@@ -1624,7 +1621,6 @@ typing = [
     { name = "types-jsonschema", specifier = ">=4.23.0.20240813,<5" },
     { name = "types-psutil", specifier = ">=7.0.0.20250218,<8" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240917,<7" },
-    { name = "types-requests", specifier = ">=2.31.0,<3" },
 ]
 
 [[package]]
@@ -3463,18 +3459,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/36/85/0d9fafce21be112e977a89677f1ce9d1aef921d745b17c758c93e861c11f/types_pyyaml-6.0.12.20260510.tar.gz", hash = "sha256:09c1f1cb65a6eebea1e2e51ccf4918b8288e152909609a35cdb0d805efd125ad", size = 17831, upload-time = "2026-05-10T05:26:28.136Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/ad/fd618a218925daada7b8a5e7326e662599fa5fdff4a4c44ab2795bd2d9ca/types_pyyaml-6.0.12.20260510-py3-none-any.whl", hash = "sha256:3492eb9ba4d9d833473214c4d5736cccf5f37d93f5854059721e1c84f785309d", size = 20304, upload-time = "2026-05-10T05:26:26.981Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.33.0.20260508"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/6b/eb226bdd61a982c9a03e02c657fb4ab001733506e6423906ac142331f2e3/types_requests-2.33.0.20260508.tar.gz", hash = "sha256:81b2ae5f0d20967714a6aa5ef9284c05570d7cb06b7de8f2a77b918b63ddd411", size = 23991, upload-time = "2026-05-08T04:50:56.818Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/96/080db0afdf2c5cc5fe512b41354e8d114fe8f65e9510c56ff8dfd40216ce/types_requests-2.33.0.20260508-py3-none-any.whl", hash = "sha256:fa01459cca184229713df03709db46a905325906d27e042cd4fd7ea3d15d3400", size = 20722, upload-time = "2026-05-08T04:50:55.548Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Refine Meltano Hub client error handling to use domain-specific exceptions and simplify HTTP response processing.

Enhancements:
- Update Hub error types to subclass MeltanoError and use clearer, centralized error messages for plugin type, variant, and connection failures.
- Simplify Hub client HTTP status handling by mapping 4xx responses to plugin type errors and 5xx responses to connection errors without relying on requests exceptions.
- Tighten internal hub client code with minor typing and style adjustments, including improved header and URL handling.

Build:
- Remove the types-requests typing dependency from the project configuration.

Tests:
- Adjust Hub service tests and test HTTP client fixture to validate the new error messages and 5xx response handling behavior.