### PR TITLE
ci: Run dependency review check on `pull_request` triggers instead of `pull_request_target`

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,14 +1,9 @@
 name: Dependency Review
 
 on:
-  schedule:
-    - cron: '12 12 * * *'
-  # pull_request_target is safe because this only performs static analysis
-  pull_request_target:  # zizmor: ignore[dangerous-triggers]
+  pull_request:
     paths:
       - '**.lock'
-  workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -27,7 +22,6 @@ jobs:
           persist-credentials: false
 
       - name: GitHub dependency vulnerability check
-        if: ${{ github.event_name == 'pull_request_target' }}
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           allow-ghsas: |


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

The risks of `pull_request_target` are just not worth it.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* https://github.com/meltano/meltano/pull/9682
* https://github.com/meltano/meltano/pull/9786

## Summary by Sourcery

Update dependency review workflow to run on pull_request events and simplify triggers.

CI:
- Run dependency review check on pull_request events instead of pull_request_target.
- Remove scheduled and manual workflow triggers and always run the dependency review action when the workflow is triggered.