### PR TITLE
refactor: Make `meltano.core.logging.utils.SafeStreamHandler` opt-in and document how to use it

### DIFF
--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -139,6 +139,38 @@ loggers:
 
 For a detailed explanation of the above of the file format, see the [python logging documentation](https://docs.python.org/3/library/logging.config.html#configuration-file-format).
 
+## Handling non-Unicode characters in plugin logs
+
+On Windows, the default console encoding (e.g. `cp1252`) cannot represent all Unicode characters. When a plugin emits log lines containing non-ASCII text — for example, a tap that surfaces Cyrillic or CJK characters — the standard `logging.StreamHandler` raises a `UnicodeEncodeError` and drops the log entry entirely.
+
+Meltano ships a `SafeStreamHandler` that catches these errors and falls back to `backslashreplace` encoding, so unencodable characters are escaped (e.g. `сам`) instead of causing a crash or silent data loss.
+
+This handler is **not used by default**. To opt in, reference it by its fully-qualified class name in a custom `logging.yaml` and point Meltano at that file via `cli.log_config` (or the `--log-config` CLI option / `MELTANO_CLI_LOG_CONFIG` environment variable):
+
+```yaml
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  structured_colored:
+    (): meltano.core.logging.console_log_formatter
+    colors: true
+
+handlers:
+  console:
+    class: meltano.core.logging.utils.SafeStreamHandler
+    level: INFO
+    formatter: structured_colored
+    stream: "ext://sys.stderr"
+
+root:
+  level: INFO
+  propagate: yes
+  handlers: [console]
+```
+
+The only change relative to a standard config is replacing `class: logging.StreamHandler` with `class: meltano.core.logging.utils.SafeStreamHandler`. All other handler options (formatters, levels, streams) work identically.
+
 ## Local development config example
 
 While working with Meltano locally it's sometimes nice to have more terse logging on the console, but still have DEBUG

--- a/docs/docs/guide/logging.md
+++ b/docs/docs/guide/logging.md
@@ -143,7 +143,7 @@ For a detailed explanation of the above of the file format, see the [python logg
 
 On Windows, the default console encoding (e.g. `cp1252`) cannot represent all Unicode characters. When a plugin emits log lines containing non-ASCII text — for example, a tap that surfaces Cyrillic or CJK characters — the standard `logging.StreamHandler` raises a `UnicodeEncodeError` and drops the log entry entirely.
 
-Meltano ships a `SafeStreamHandler` that catches these errors and falls back to `backslashreplace` encoding, so unencodable characters are escaped (e.g. `сам`) instead of causing a crash or silent data loss.
+Meltano ships a `SafeStreamHandler` that catches these errors and falls back to `backslashreplace` encoding, so unencodable characters are escaped instead of causing a crash or silent data loss. For example, the Cyrillic word `сам` would be written as `\u0441\u0430\u043c`.
 
 This handler is **not used by default**. To opt in, reference it by its fully-qualified class name in a custom `logging.yaml` and point Meltano at that file via `cli.log_config` (or the `--log-config` CLI option / `MELTANO_CLI_LOG_CONFIG` environment variable):
 

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -40,7 +40,11 @@ class SafeStreamHandler(logging.StreamHandler):
     On Windows, the default console encoding (e.g. cp1252) may not support
     all Unicode characters, causing UnicodeEncodeError when logging plugin
     output containing non-ASCII text. This handler falls back to
-    'backslashreplace' error handling to avoid crashing.
+    'backslashreplace' error handling — unencodable characters are escaped
+    rather than raising an error and dropping the log entry.
+
+    This handler is not used by default. See the Meltano logging guide for
+    instructions on opting in via a custom ``logging.yaml`` config.
     """
 
     def emit(self, record: logging.LogRecord) -> None:
@@ -223,7 +227,7 @@ def default_config(
         },
         "handlers": {
             "console": {
-                "class": "meltano.core.logging.utils.SafeStreamHandler",
+                "class": "logging.StreamHandler",
                 "level": numeric_level if log_level == "DISABLED" else log_level,
                 "formatter": log_format,
                 "stream": "ext://sys.stderr",


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #9875

## Summary by Sourcery

Make SafeStreamHandler an opt-in logging handler and document how to configure it in Meltano.

Enhancements:
- Change the default console logging handler to use logging.StreamHandler instead of SafeStreamHandler so SafeStreamHandler becomes opt-in via custom log configuration.

Documentation:
- Extend the logging guide with instructions and example configuration for enabling SafeStreamHandler to handle non-Unicode plugin log output.