### PR TITLE
fix: Check if the stdlib (and not structlog) logger is enabled for DEBUG to log Singer stdout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,13 +148,6 @@ jobs:
         name: coverage-data-${{ matrix.id }}
         path: ".coverage.*"
 
-    - name: Upload test logs
-      if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: test-logs-${{ matrix.id }}
-        path: pytest.log
-
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,13 +183,6 @@ filterwarnings = [
   'once::ResourceWarning',
   'once:You are using a Python version .* which Google will stop supporting in new releases of google.api_core once it reaches its end of life:FutureWarning',
 ]
-log_cli = true
-log_cli_format = "%(message)s"
-log_cli_level = "CRITICAL"
-log_file = "pytest.log"
-log_file_date_format = "%Y-%m-%d %H:%M:%S"
-log_file_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
-log_file_level = "DEBUG"
 log_level = "INFO"
 markers = [
   "backend(type): backend specific test",

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -654,7 +654,8 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
             }
             stdout_logger = block.invoker.stdout_logger.bind(**context)
             stderr_logger = block.invoker.stderr_logger.bind(**context)
-            if stdout_logger.isEnabledFor(logging.DEBUG):
+
+            if block.invoker.get_logger("stdout", "stdlib").isEnabledFor(logging.DEBUG):
                 block.stdout_link(
                     self.output_logger.out(
                         block.string_id,

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import asyncio.subprocess
 import enum
+import logging
 import os
 import sys
 import typing as t
@@ -594,6 +595,32 @@ class PluginInvoker:
         else:
             self.output_handlers = {src: [handler]}
 
+    @t.overload
+    def get_logger(
+        self,
+        io: t.Literal["stderr", "stdout"],
+        kind: t.Literal["structlog"],
+    ) -> BoundLogger: ...
+
+    @t.overload
+    def get_logger(
+        self,
+        io: t.Literal["stderr", "stdout"],
+        kind: t.Literal["stdlib"],
+    ) -> logging.Logger: ...
+
+    def get_logger(
+        self,
+        io: t.Literal["stderr", "stdout"],
+        kind: t.Literal["structlog", "stdlib"],
+    ) -> BoundLogger | logging.Logger:
+        """Get a logger for this plugin."""
+        name = f"meltano.plugin.{io}.{self.plugin.type}.{self.plugin.name}"
+        if kind == "structlog":
+            return get_logger(name, stdio=io)
+
+        return logging.getLogger(name)  # noqa: TID251
+
     @property
     def stdout_logger(self) -> BoundLogger:
         """Get the logger for the plugin stdout.
@@ -601,10 +628,7 @@ class PluginInvoker:
         Returns:
             The logger for the plugin stdout.
         """
-        return get_logger(
-            f"meltano.plugin.stdout.{self.plugin.type}.{self.plugin.name}",
-            stdio="stdout",
-        )
+        return self.get_logger("stdout", "structlog")
 
     @property
     def stderr_logger(self) -> BoundLogger:
@@ -613,10 +637,7 @@ class PluginInvoker:
         Returns:
             The logger for the plugin stderr.
         """
-        return get_logger(
-            f"meltano.plugin.stderr.{self.plugin.type}.{self.plugin.name}",
-            stdio="stderr",
-        )
+        return self.get_logger("stderr", "structlog")
 
     def get_log_parser(self) -> str | None:
         """Get the log parser for the plugin.

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -244,6 +244,22 @@ class TestExtractLoadBlocks:
         target.wait = AsyncMock(return_value=0)
         return target
 
+    @pytest.mark.usefixtures("log_level_debug")
+    def test_log_level_debug_affects_invoker_logger(
+        self,
+        tap,
+        tap_config_dir,
+        plugin_invoker_factory,
+    ) -> None:
+        """log_level_debug must enable DEBUG on the logger _link_io checks.
+
+        If the fixture stops covering the right logger namespace or the logger
+        name constructed by get_logger changes, this test fails immediately
+        rather than silently omitting the stdout link in test_link_io.
+        """
+        invoker = plugin_invoker_factory(tap, config_dir=tap_config_dir)
+        assert invoker.get_logger("stdout", "stdlib").isEnabledFor(logging.DEBUG)
+
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("session", "subject", "log", "log_level_debug")
     async def test_link_io(

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -171,13 +171,16 @@ class TestELBContextBuilder:
 class TestExtractLoadBlocks:
     @pytest.fixture
     def log_level_debug(self):
-        root_logger = logging.getLogger()  # noqa: TID251
-        log_level = root_logger.level
+        # Set the intermediate logger rather than root: pytest's catching_logs
+        # overrides root to log_level (INFO) during the test call, which would
+        # suppress DEBUG even after setting root to DEBUG in fixture setup.
+        logger = logging.getLogger("meltano.plugin.stdout")  # noqa: TID251
+        orig = logger.level
+        logger.setLevel(logging.DEBUG)
         try:
-            root_logger.setLevel(logging.DEBUG)
             yield
         finally:
-            root_logger.setLevel(log_level)
+            logger.setLevel(orig)
 
     @pytest.fixture
     def log(self, tmp_path: Path) -> t.Generator[t.IO[str], None, None]:


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

This also makes tests that rely on debug logs being enabled more robust.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Ensure Singer stdout debug logging is gated by the standard-library logger and align tests and CI logging configuration accordingly.

Bug Fixes:
- Use the standard-library logger enablement to decide whether to attach Singer stdout debug logging handlers instead of relying on the structlog logger state.

Enhancements:
- Introduce a helper on plugin invokers to obtain either structlog- or stdlib-based loggers for plugin stdout and stderr.
- Adjust tests that depend on debug logging to toggle the appropriate plugin stdout logger level, making them more robust against pytest log capturing behavior.

CI:
- Remove pytest log file generation and associated GitHub Actions artifact upload for test logs to simplify CI logging output.

Tests:
- Update extract/load block tests to configure the intermediate plugin stdout logger at DEBUG level rather than the root logger, preventing interference from pytest's logging capture configuration.