### PR TITLE
test: Address SQLite `ResourceWarning`s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,9 +178,6 @@ filterwarnings = [
   '''once:The 'version' field in meltano.yml is deprecated.*:DeprecationWarning''',
   'once::meltano.core._compat.MeltanoInternalDeprecationWarning',
   # Third-party warnings
-  'once::pytest.PytestUnraisableExceptionWarning',
-  'once::pytest.PytestUnhandledThreadExceptionWarning',
-  'once::ResourceWarning',
   'once:You are using a Python version .* which Google will stop supporting in new releases of google.api_core once it reaches its end of life:FutureWarning',
 ]
 log_level = "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,9 @@ filterwarnings = [
   '''once:The 'version' field in meltano.yml is deprecated.*:DeprecationWarning''',
   'once::meltano.core._compat.MeltanoInternalDeprecationWarning',
   # Third-party warnings
+  'once::pytest.PytestUnraisableExceptionWarning',
+  'once::pytest.PytestUnhandledThreadExceptionWarning',
+  'once::ResourceWarning',
   'once:You are using a Python version .* which Google will stop supporting in new releases of google.api_core once it reaches its end of life:FutureWarning',
 ]
 log_level = "INFO"

--- a/tests/fixtures/db/__init__.py
+++ b/tests/fixtures/db/__init__.py
@@ -55,7 +55,10 @@ def vacuum_db(engine_sessionmaker):
 @pytest.fixture(scope="class")
 def engine_sessionmaker(engine_uri):
     engine = create_engine(engine_uri, poolclass=NullPool, future=True)
-    return (engine, sessionmaker(bind=engine, future=True))
+    try:
+        yield (engine, sessionmaker(bind=engine, future=True))
+    finally:
+        engine.dispose()
 
 
 @pytest.fixture

--- a/tests/meltano/core/test_migration_service.py
+++ b/tests/meltano/core/test_migration_service.py
@@ -63,10 +63,8 @@ class TestMigrationService:
     @pytest.fixture
     def engine(self) -> Generator[Engine, None, None]:
         engine = create_engine("sqlite:///:memory:")
-        try:
-            yield engine
-        finally:
-            engine.dispose()
+        yield engine
+        engine.dispose()
 
     def test_upgrade(self, engine: Engine, tmp_path: Path) -> None:
         lock_path = tmp_path / "db.lock"

--- a/tests/meltano/core/test_migration_service.py
+++ b/tests/meltano/core/test_migration_service.py
@@ -63,8 +63,10 @@ class TestMigrationService:
     @pytest.fixture
     def engine(self) -> Generator[Engine, None, None]:
         engine = create_engine("sqlite:///:memory:")
-        yield engine
-        engine.dispose()
+        try:
+            yield engine
+        finally:
+            engine.dispose()
 
     def test_upgrade(self, engine: Engine, tmp_path: Path) -> None:
         lock_path = tmp_path / "db.lock"

--- a/tests/meltano/core/test_migration_service.py
+++ b/tests/meltano/core/test_migration_service.py
@@ -10,7 +10,10 @@ from sqlalchemy import create_engine
 from meltano.core.migration_service import MigrationError, MigrationService
 
 if t.TYPE_CHECKING:
+    from collections.abc import Generator
     from pathlib import Path
+
+    from sqlalchemy import Engine
 
 MIGRATION_TEMPLATE = """
 revision = {revision}
@@ -57,8 +60,13 @@ def _generate_migrations(
 
 
 class TestMigrationService:
-    def test_upgrade(self, tmp_path: Path) -> None:
+    @pytest.fixture
+    def engine(self) -> Generator[Engine, None, None]:
         engine = create_engine("sqlite:///:memory:")
+        yield engine
+        engine.dispose()
+
+    def test_upgrade(self, engine: Engine, tmp_path: Path) -> None:
         lock_path = tmp_path / "db.lock"
 
         migrations = _generate_migrations(tmp_path)
@@ -71,8 +79,7 @@ class TestMigrationService:
         )
         migration_service.upgrade()
 
-    def test_upgrade_without_lock(self, tmp_path: Path) -> None:
-        engine = create_engine("sqlite:///:memory:")
+    def test_upgrade_without_lock(self, engine: Engine, tmp_path: Path) -> None:
         lock_path = tmp_path / "db.lock"
 
         migration_service = MigrationService(
@@ -86,8 +93,7 @@ class TestMigrationService:
         ):
             migration_service.upgrade()
 
-    def test_upgrade_error(self, tmp_path: Path) -> None:
-        engine = create_engine("sqlite:///:memory:")
+    def test_upgrade_error(self, engine: Engine, tmp_path: Path) -> None:
         lock_path = tmp_path / "db.lock"
 
         migrations = _generate_migrations(tmp_path)

--- a/tests/meltano/core/test_sqlalchemy.py
+++ b/tests/meltano/core/test_sqlalchemy.py
@@ -16,8 +16,10 @@ class TestSQLAlchemyModels:
     @pytest.fixture
     def engine(self) -> Generator[sa.Engine, None, None]:
         engine = sa.create_engine("sqlite:///:memory:")
-        yield engine
-        engine.dispose()
+        try:
+            yield engine
+        finally:
+            engine.dispose()
 
     @pytest.fixture
     def table(self, engine: sa.Engine) -> sa.Table:

--- a/tests/meltano/core/test_sqlalchemy.py
+++ b/tests/meltano/core/test_sqlalchemy.py
@@ -16,10 +16,8 @@ class TestSQLAlchemyModels:
     @pytest.fixture
     def engine(self) -> Generator[sa.Engine, None, None]:
         engine = sa.create_engine("sqlite:///:memory:")
-        try:
-            yield engine
-        finally:
-            engine.dispose()
+        yield engine
+        engine.dispose()
 
     @pytest.fixture
     def table(self, engine: sa.Engine) -> sa.Table:

--- a/tests/meltano/core/test_sqlalchemy.py
+++ b/tests/meltano/core/test_sqlalchemy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing as t
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -7,11 +8,16 @@ import sqlalchemy as sa
 
 from meltano.core.sqlalchemy import DateTimeUTC
 
+if t.TYPE_CHECKING:
+    from collections.abc import Generator
+
 
 class TestSQLAlchemyModels:
     @pytest.fixture
-    def engine(self) -> sa.Engine:
-        return sa.create_engine("sqlite:///:memory:")
+    def engine(self) -> Generator[sa.Engine, None, None]:
+        engine = sa.create_engine("sqlite:///:memory:")
+        yield engine
+        engine.dispose()
 
     @pytest.fixture
     def table(self, engine: sa.Engine) -> sa.Table:


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude Code] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Ensure SQLite test engines are properly disposed to avoid resource warnings.

Bug Fixes:
- Dispose in-memory SQLite engines in tests via generator-based fixtures to prevent ResourceWarning leaks.

Tests:
- Refactor test fixtures to yield and dispose SQLAlchemy engines and engine/sessionmaker pairs instead of returning them directly.