### PR TITLE
test: Address asyncio event loop `ResourceWarning`s

### DIFF
--- a/tests/benchmarks/test_tap_benchmarks.py
+++ b/tests/benchmarks/test_tap_benchmarks.py
@@ -20,6 +20,8 @@ import pytest
 from meltano.core.plugin_invoker import PluginInvoker
 
 if t.TYPE_CHECKING:
+    from collections.abc import Generator
+
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.plugin.singer import SingerTap
     from meltano.core.project_add_service import ProjectAddService
@@ -82,6 +84,25 @@ class MockStderr:
 class TestTapBenchmarks:
     """Benchmarks for SingerTap catalog operations."""
 
+    @pytest.fixture
+    def event_loop(self) -> Generator[asyncio.AbstractEventLoop, None, None]:
+        """Provide a single event loop for all iterations of a benchmark.
+
+        Using asyncio.run() inside benchmark.pedantic() creates and tears down
+        an event loop on every iteration, which interferes with pytest-asyncio's
+        loop management and leaves unclosed loops. A single reusable loop avoids
+        this.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield loop
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.run_until_complete(loop.shutdown_default_executor())
+            loop.close()
+            asyncio.set_event_loop(None)
+
     @pytest.fixture(scope="class")
     def tap_plugin(self, project_add_service: ProjectAddService) -> SingerTap:
         """Create tap plugin once per test class."""
@@ -103,6 +124,7 @@ class TestTapBenchmarks:
     @pytest.mark.benchmark
     def test_discover_catalog(
         self,
+        event_loop: asyncio.AbstractEventLoop,
         session,
         tap_plugin: SingerTap,
         catalog_lines: list[bytes],
@@ -141,7 +163,7 @@ class TestTapBenchmarks:
 
         # Use pedantic mode with warmup for more stable async benchmarks
         benchmark.pedantic(
-            lambda: asyncio.run(run_discovery()),
+            lambda: event_loop.run_until_complete(run_discovery()),
             rounds=10,
             warmup_rounds=5,
         )
@@ -149,6 +171,7 @@ class TestTapBenchmarks:
     @pytest.mark.benchmark
     def test_apply_catalog_rules(
         self,
+        event_loop: asyncio.AbstractEventLoop,
         session,
         tap_plugin: SingerTap,
         catalog: dict,
@@ -170,7 +193,7 @@ class TestTapBenchmarks:
 
         # Use pedantic mode with warmup for more stable async benchmarks
         benchmark.pedantic(
-            lambda: asyncio.run(apply_rules()),
+            lambda: event_loop.run_until_complete(apply_rules()),
             rounds=10,
             warmup_rounds=5,
         )

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import platform
@@ -18,6 +19,8 @@ from meltano.core.plugin_install_service import PluginInstallReason
 from meltano.core.project_plugins_service import ProjectPluginsService
 
 if t.TYPE_CHECKING:
+    from collections.abc import Generator
+
     from click.testing import CliRunner
 
     from meltano.core.plugin.project_plugin import ProjectPlugin
@@ -31,6 +34,24 @@ def project_tap_mock(project_add_service):
 
 @pytest.mark.usefixtures("project_tap_mock")
 class TestCliInvoke:
+    @pytest.fixture(scope="class", autouse=True)
+    def event_loop(self) -> Generator[asyncio.AbstractEventLoop, None, None]:
+        """Manage the event loop for tests that call asyncio.run() via @run_async.
+
+        Each CLI invocation calls asyncio.run() which replaces and then nulls
+        the current event loop, stranding any loop pytest-asyncio may have
+        created at class scope. This fixture owns the loop lifecycle so teardown
+        is always explicit regardless of what asyncio.run() does.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield loop
+        finally:
+            if not loop.is_closed():
+                loop.close()
+            asyncio.set_event_loop(None)
+
     @pytest.fixture
     def mock_invoke(self, utility: ProjectPlugin, plugin_invoker_factory):
         process_mock = Mock()
@@ -288,6 +309,23 @@ class TestCliInvoke:
 
 class TestLogOutputHandler:
     """Tests for the _LogOutputHandler class."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def event_loop(self) -> Generator[asyncio.AbstractEventLoop, None, None]:
+        """Ensure any event loop pytest-asyncio creates is properly closed.
+
+        The tests here are purely synchronous, but
+        asyncio_default_fixture_loop_scope='class' can still create a loop that
+        goes unclosed without an explicit override.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield loop
+        finally:
+            if not loop.is_closed():
+                loop.close()
+            asyncio.set_event_loop(None)
 
     def test_writeline_with_singer_sdk_log(self, caplog: pytest.LogCaptureFixture):
         """Test parsing Singer SDK structured logs."""

--- a/tests/meltano/core/block/test_singer.py
+++ b/tests/meltano/core/block/test_singer.py
@@ -89,7 +89,6 @@ class TestSingerBlocks:
         invoker.cleanup = AsyncMock()
         return invoker
 
-    @pytest.mark.asyncio
     async def test_singer_block_start(
         self,
         elt_context,
@@ -137,7 +136,6 @@ class TestSingerBlocks:
             == asyncio.subprocess.PIPE
         )
 
-    @pytest.mark.asyncio
     async def test_singer_block_stop(
         self,
         elt_context,
@@ -167,7 +165,6 @@ class TestSingerBlocks:
         assert block.process_handle.terminate.called
         assert block.invoker.cleanup.called
 
-    @pytest.mark.asyncio
     async def test_singer_block_io(
         self,
         elt_context,
@@ -213,7 +210,6 @@ class TestSingerBlocks:
 
             assert cap_logs == expected_lines
 
-    @pytest.mark.asyncio
     async def test_singer_block_close_stdin(
         self,
         elt_context,


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Code following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Tests:
- Add a pytest fixture that provides a reusable asyncio event loop for tap benchmark tests to eliminate unclosed loop ResourceWarnings and align with pytest-asyncio loop management.