### PR TITLE
ci: Prevent cache poisoning attacks in th release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
 
     - name: Setup uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: false
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -110,6 +112,8 @@ jobs:
         persist-credentials: false
     - name: Setup uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: false
 
     - name: Get latest published release version
       id: get-latest-version


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

As reported by zizmor:

```
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> .github/workflows/build.yml:42:7
   |
 3 | / on:
 4 | |   push:
 5 | |     branches-ignore:
 6 | |     - 'gh-readonly-queue/**'
...  |
18 | |   release:
19 | |     types: [published]
   | |______________________- generally used when publishing artifacts generated at runtime
...
42 |         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> .github/workflows/build.yml:112:7
    |
  3 | / on:
  4 | |   push:
  5 | |     branches-ignore:
  6 | |     - 'gh-readonly-queue/**'
...   |
 18 | |   release:
 19 | |     types: [published]
    | |______________________- generally used when publishing artifacts generated at runtime
...
112 |         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix
```

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Harden the GitHub Actions build workflow against cache poisoning by disabling caching in the uv setup steps.

Bug Fixes:
- Prevent potential cache poisoning in the release workflow by turning off uv action caching.

CI:
- Update the build workflow to configure astral-sh/setup-uv with caching disabled for all uses.
