### PR TITLE
ci: Re-roll Docker images on a schedule against the latest Python base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,10 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |  # zizmor: ignore[template-injection]
         tag=$(gh release list --repo ${{ github.repository }} --exclude-pre-releases --limit 1000 --json tagName --jq '.[].tagName' | sort -V | tail -1)
+        if [[ -z "$tag" ]]; then
+          echo "::error::No stable releases found; cannot determine tag for re-roll"
+          exit 1
+        fi
         echo "tag=$tag" >> $GITHUB_OUTPUT
 
     - name: Check out the repository
@@ -111,10 +115,19 @@ jobs:
         - true
 
     steps:
+    - name: Set registry
+      id: set-registry
+      run: |
+        if [[ "${{ github.event_name }}" == "release" && "${{ github.event.action }}" == "published" ]] || [[ "${{ github.event_name }}" == "schedule" ]]; then
+          echo "registry=docker.io" >> "$GITHUB_OUTPUT"
+        else
+          echo "registry=ghcr.io" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Set the workflow inputs
       id: set-inputs
       env:
-        REGISTRY: ${{ (github.event_name == 'release' && github.event.action == 'published' || github.event_name == 'schedule') && 'docker.io' || 'ghcr.io' }}
+        REGISTRY: ${{ steps.set-registry.outputs.registry }}
       # This step makes it so that the same workflow inputs can be accessed
       # regardless of what event triggered it.
       run: |
@@ -129,7 +142,7 @@ jobs:
 
     - name: Get latest published release version
       id: get-latest-version
-      if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'schedule'
+      if: steps.set-registry.outputs.registry == 'docker.io'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |  # zizmor: ignore[template-injection]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,27 @@ jobs:
   build:
     name: Wheel and SDist
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       name: ${{ steps.baipp.outputs.package_name }}
       version: ${{ steps.baipp.outputs.package_version }}
 
     steps:
+    - name: Get latest release tag (re-roll)
+      id: get-release-tag
+      if: github.event_name == 'schedule'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |  # zizmor: ignore[template-injection]
+        tag=$(gh release list --repo ${{ github.repository }} --exclude-pre-releases --limit 1000 --json tagName --jq '.[].tagName' | sort -V | tail -1)
+        echo "tag=$tag" >> $GITHUB_OUTPUT
+
     - name: Check out the repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+        ref: ${{ steps.get-release-tag.outputs.tag || github.sha }}
 
     - name: Setup uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -65,7 +77,7 @@ jobs:
         uv run scripts/alembic_freeze.py
 
     - name: Release Marker
-      if: github.event_name == 'release' && github.event.action == 'published'
+      if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'schedule'
       # The release marker differentiates installations 'in the wild' versus internal dev builds and tests
       run: touch src/meltano/core/tracking/.release_marker
 
@@ -102,7 +114,7 @@ jobs:
     - name: Set the workflow inputs
       id: set-inputs
       env:
-        REGISTRY: ${{ github.event_name == 'release' && github.event.action == 'published' && 'docker.io' || 'ghcr.io' }}
+        REGISTRY: ${{ (github.event_name == 'release' && github.event.action == 'published' || github.event_name == 'schedule') && 'docker.io' || 'ghcr.io' }}
       # This step makes it so that the same workflow inputs can be accessed
       # regardless of what event triggered it.
       run: |
@@ -117,7 +129,7 @@ jobs:
 
     - name: Get latest published release version
       id: get-latest-version
-      if: github.event_name == 'release' && github.event.action == 'published'
+      if: (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'schedule'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |  # zizmor: ignore[template-injection]
@@ -180,7 +192,8 @@ jobs:
         # - The trigger is a push to the main branch
         # - The trigger is a workflow dispatch
         # - The trigger is a release and the action is 'published'
-        push: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || ( github.event_name == 'workflow_dispatch' ) || ( github.event_name == 'release' && github.event.action == 'published' )}}
+        # - The trigger is a weekly schedule (re-roll latest release with updated base image)
+        push: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || ( github.event_name == 'workflow_dispatch' ) || ( github.event_name == 'release' && github.event.action == 'published' ) || github.event_name == 'schedule' }}
         token: ${{ secrets.GITHUB_TOKEN }}
         tags: ${{ env.IMAGE_TAGS }}
         registry: ${{ steps.set-inputs.outputs.registry }}


### PR DESCRIPTION
## Description

The weekly scheduled run of this workflow already built and scanned Docker images, but never actually pushed them anywhere — the `push:` condition was `false` for `schedule` events, and the registry was always `ghcr.io` for non-release triggers.

This change makes the weekly schedule perform a full re-roll of the latest stable release onto the current Python base images and push the result to Docker Hub. Specifically:

- **`build` job**: on `schedule`, resolves the highest semver stable release tag (using `sort -V` over all non-prerelease tags, guarding against backport releases overwriting a newer version), then checks out that tag before building the wheel
- **`build_docker` job**: routes `schedule` events to `docker.io` (same as `release: published`), enables `push:` for `schedule`, and runs the `get-latest-version` step on `schedule` so the `latest`-tag anti-backport guard applies to re-rolls as well
- **Release Marker**: extended to `schedule` events so re-rolled images are correctly identified as production builds
- **`pypi_release`**: unchanged — still gated strictly on `release: published`

## Checklist

- [X] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

<!-- Generated-by: Claude Code (claude-sonnet-4-6) following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding) -->

## Related Issues

* References https://github.com/meltano/meltano/discussions/10008

## Summary by Sourcery

Enable the scheduled CI workflow to fully rebuild and publish Docker images for the latest stable release using the current Python base image.

CI:
- Allow the build job on scheduled runs to resolve and check out the latest stable release tag before building artifacts.
- Mark scheduled builds as production via the existing release marker mechanism.
- Route scheduled Docker builds to Docker Hub, enable image pushing on scheduled events, and reuse the latest-version logic for these pushes.