### PR TITLE
feat(cli): Add `meltano state export` and `meltano state import` commands

### DIFF
--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -395,16 +395,15 @@ def edit_state(ctx: click.Context, project: Project, state_id: str) -> None:
 
 
 @meltano_state.command(cls=InstrumentedCmd, name="export")
-@click.option("--pattern", type=str, help="Filter state IDs by pattern.")
 @click.pass_context
-def export_state_cmd(ctx: click.Context, pattern: str | None) -> None:
+def export_state_cmd(ctx: click.Context) -> None:
     """Export all state to JSON on stdout.
 
     Output is a JSON object mapping each state_id to its completed and partial state,
     suitable for piping into 'meltano state import'.
     """
     state_service: StateService = ctx.obj[STATE_SERVICE_KEY]
-    states = state_service.export_state(pattern)
+    states = state_service.export_state()
     click.echo(json.dumps(states, separators=(",", ":")))
 
 

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -394,6 +394,39 @@ def edit_state(ctx: click.Context, project: Project, state_id: str) -> None:
     )
 
 
+@meltano_state.command(cls=InstrumentedCmd, name="export")
+@click.option("--pattern", type=str, help="Filter state IDs by pattern.")
+@click.pass_context
+def export_state_cmd(ctx: click.Context, pattern: str | None) -> None:
+    """Export all state to JSON on stdout.
+
+    Output is a JSON array where each entry has 'state_id', 'completed', and 'partial'
+    keys, suitable for piping into 'meltano state import'.
+    """
+    state_service: StateService = ctx.obj[STATE_SERVICE_KEY]
+    states = state_service.export_state(pattern)
+    click.echo(json.dumps(states, separators=(",", ":")))
+
+
+@meltano_state.command(cls=InstrumentedCmd, name="import")
+@click.argument("input-file", type=click.File("r"), default="-")
+@click.pass_context
+def state_import_cmd(ctx: click.Context, input_file: t.IO[str]) -> None:
+    """Import state from a JSON file (or stdin when no file is given).
+
+    Reads the format produced by 'meltano state export' and overwrites any existing
+    state for each state ID present in the input.
+    """
+    state_service: StateService = ctx.obj[STATE_SERVICE_KEY]
+    try:
+        data = json.load(input_file)
+    except json.JSONDecodeError as e:
+        msg = f"Invalid JSON: {e}"
+        raise click.ClickException(msg) from e
+    count = state_service.import_state(data)
+    logger.info("Successfully imported %d state(s).", count)
+
+
 @meltano_state.command(cls=InstrumentedCmd, name="clear")
 @prompt_for_confirmation(prompt="This will clear state for the job(s). Continue?")
 @click.argument("state-id", required=False)

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -400,8 +400,8 @@ def edit_state(ctx: click.Context, project: Project, state_id: str) -> None:
 def export_state_cmd(ctx: click.Context, pattern: str | None) -> None:
     """Export all state to JSON on stdout.
 
-    Output is a JSON array where each entry has 'state_id', 'completed', and 'partial'
-    keys, suitable for piping into 'meltano state import'.
+    Output is a JSON object mapping each state_id to its completed and partial state,
+    suitable for piping into 'meltano state import'.
     """
     state_service: StateService = ctx.obj[STATE_SERVICE_KEY]
     states = state_service.export_state(pattern)
@@ -423,6 +423,9 @@ def state_import_cmd(ctx: click.Context, input_file: t.IO[str]) -> None:
     except json.JSONDecodeError as e:
         msg = f"Invalid JSON: {e}"
         raise click.ClickException(msg) from e
+    if not isinstance(data, dict):
+        msg = f"expected a JSON object, got {type(data).__name__}"
+        raise click.BadParameter(msg, param_hint="'INPUT_FILE'")
     count = state_service.import_state(data)
     logger.info("Successfully imported %d state(s).", count)
 

--- a/src/meltano/core/_compat.py
+++ b/src/meltano/core/_compat.py
@@ -4,11 +4,6 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info >= (3, 12):
-    from typing import override  # noqa: ICN003
-else:
-    from typing_extensions import override
-
 if sys.version_info >= (3, 13):
     from warnings import deprecated
 else:
@@ -16,7 +11,6 @@ else:
 
 __all__ = [
     "deprecated",
-    "override",
 ]
 
 

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -275,7 +275,7 @@ class StateService:
             A dict mapping each state_id to ``{"completed": ..., "partial": ...}``.
         """
         return {
-            s.state_id: json.loads(s.json())
+            s.state_id: s.to_dict()
             for s in self.state_store_manager.get_all(state_id_pattern)
         }
 

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -262,6 +262,41 @@ class StateService:
         """
         self.set_state(state_id_dst, json.dumps(self.get_state(state_id_src)))
 
+    def export_state(
+        self,
+        state_id_pattern: str | None = None,
+    ) -> dict[str, dict[str, t.Any]]:
+        """Export all states as a mapping preserving the completed/partial split.
+
+        Args:
+            state_id_pattern: An optional glob-style pattern of state_ids to export
+
+        Returns:
+            A dict mapping each state_id to ``{"completed": ..., "partial": ...}``.
+        """
+        return {
+            s.state_id: json.loads(s.json())
+            for s in self.state_store_manager.get_all(state_id_pattern)
+        }
+
+    def import_state(self, states: dict[str, dict[str, t.Any]]) -> int:
+        """Import states from a mapping, overwriting any existing state.
+
+        Args:
+            states: dict mapping state_id to ``{"completed": ..., "partial": ...}``
+
+        Returns:
+            The number of states written.
+        """
+        return self.state_store_manager.set_all(
+            MeltanoState(
+                state_id=state_id,
+                completed_state=entry.get("completed"),
+                partial_state=entry.get("partial"),
+            )
+            for state_id, entry in states.items()
+        )
+
     def move_state(self, state_id_src: str, state_id_dst: str) -> None:
         """Move state from Job state_id_src to Job state_id_dst.
 

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -262,22 +262,13 @@ class StateService:
         """
         self.set_state(state_id_dst, json.dumps(self.get_state(state_id_src)))
 
-    def export_state(
-        self,
-        state_id_pattern: str | None = None,
-    ) -> dict[str, dict[str, t.Any]]:
+    def export_state(self) -> dict[str, dict[str, t.Any]]:
         """Export all states as a mapping preserving the completed/partial split.
-
-        Args:
-            state_id_pattern: An optional glob-style pattern of state_ids to export
 
         Returns:
             A dict mapping each state_id to ``{"completed": ..., "partial": ...}``.
         """
-        return {
-            s.state_id: s.to_dict()
-            for s in self.state_store_manager.get_all(state_id_pattern)
-        }
+        return {s.state_id: s.to_dict() for s in self.state_store_manager.get_all()}
 
     def import_state(self, states: dict[str, dict[str, t.Any]]) -> int:
         """Import states from a mapping, overwriting any existing state.

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -217,7 +217,7 @@ class StateStoreManager(ABC):
             pattern: glob-style pattern to filter by
         """
         for state_id in self.get_state_ids(pattern):
-            if state := self.get(state_id):
+            if state := self.get(state_id):  # pragma: no branch
                 yield state
 
     def set_all(self, states: Iterable[MeltanoState]) -> int:

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -206,6 +206,35 @@ class StateStoreManager(ABC):
         """
         ...
 
+    def get_all(self, pattern: str | None = None) -> Iterable[MeltanoState]:
+        """Yield all states, optionally filtered by pattern.
+
+        Override for bulk-retrieval efficiency.
+
+        Args:
+            pattern: glob-style pattern to filter by
+        """
+        for state_id in self.get_state_ids(pattern):
+            if state := self.get(state_id):
+                yield state
+
+    def set_all(self, states: Iterable[MeltanoState]) -> int:
+        """Set multiple states, returning the count written.
+
+        Override for bulk-write efficiency.
+
+        Args:
+            states: iterable of MeltanoState objects to persist
+
+        Returns:
+            The number of set states.
+        """
+        count = 0
+        for state in states:
+            self.set(state)
+            count += 1
+        return count
+
     def clear_all(self) -> int:
         """Clear all states.
 

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -72,15 +72,17 @@ class MeltanoState:
         """
         return cls.from_json(state_id=state_id, json_str=file_obj.read())
 
+    def to_dict(self) -> dict[str, t.Any]:
+        """Convert the state object to a dictionary."""
+        return {"completed": self.completed_state, "partial": self.partial_state}
+
     def json(self) -> str:
         """Get the json representation of this MeltanoState.
 
         Returns:
             json representation of this MeltanoState
         """
-        return json.dumps(
-            {"completed": self.completed_state, "partial": self.partial_state},
-        )
+        return json.dumps(self.to_dict())
 
     def json_merged(self) -> str:
         """Return the json representation of partial state merged onto complete state.

--- a/src/meltano/core/state_store/db.py
+++ b/src/meltano/core/state_store/db.py
@@ -114,21 +114,26 @@ class DBStateStoreManager(StateStoreManager):
 
     @override
     def get_all(self, pattern: str | None = None) -> Iterator[MeltanoState]:
-        """Yield all states in a single query, optionally filtered by pattern.
+        """Yield all states in a memory-efficient way, optionally filtered by pattern.
 
         Args:
-            pattern: glob-style pattern to filter by
+            pattern: glob-style pattern to filter by.
         """
         query = self.session.query(JobState)
         if pattern:
-            query = query.filter(JobState.state_id.like(pattern.replace("*", "%")))
+            like_pattern = pattern.replace("*", "%")
+            query = query.filter(JobState.state_id.like(like_pattern))
+
+        # Use yield_per so rows are fetched in bounded batches instead of all at once.
+        query = query.yield_per(1000)
+
         return (
             MeltanoState(
                 state_id=js.state_id,
                 partial_state=js.partial_state,
                 completed_state=js.completed_state,
             )
-            for js in query.all()
+            for js in query
         )
 
     @override

--- a/src/meltano/core/state_store/db.py
+++ b/src/meltano/core/state_store/db.py
@@ -18,7 +18,7 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterator
+    from collections.abc import Generator, Iterable, Iterator
 
     from sqlalchemy.orm import Session
 
@@ -111,6 +111,53 @@ class DBStateStoreManager(StateStoreManager):
         count = self.session.query(JobState).delete()
         self.session.commit()
         return count
+
+    @override
+    def get_all(self, pattern: str | None = None) -> Iterator[MeltanoState]:
+        """Yield all states in a single query, optionally filtered by pattern.
+
+        Args:
+            pattern: glob-style pattern to filter by
+        """
+        query = self.session.query(JobState)
+        if pattern:
+            query = query.filter(JobState.state_id.like(pattern.replace("*", "%")))
+        return (
+            MeltanoState(
+                state_id=js.state_id,
+                partial_state=js.partial_state,
+                completed_state=js.completed_state,
+            )
+            for js in query.all()
+        )
+
+    @override
+    def set_all(self, states: Iterable[MeltanoState]) -> int:
+        """Replace multiple states in bulk using a single transaction.
+
+        Deletes any existing rows for the given state IDs, then inserts the
+        new ones — all in one commit.
+
+        Args:
+            states: iterable of MeltanoState objects to persist
+        """
+        state_list = list(states)
+        if not state_list:
+            return 0
+        state_ids = [s.state_id for s in state_list]
+        self.session.query(JobState).filter(
+            JobState.state_id.in_(state_ids),
+        ).delete(synchronize_session=False)
+        for state in state_list:
+            self.session.add(
+                JobState(
+                    state_id=state.state_id,
+                    partial_state=state.partial_state,
+                    completed_state=state.completed_state,
+                ),
+            )
+        self.session.commit()
+        return len(state_list)
 
     @override
     def get_state_ids(self, pattern: str | None = None) -> Iterator[str]:

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import glob
 import os
 import platform
@@ -545,7 +546,7 @@ class _WindowsFilesystemStateStoreManager(_LocalFilesystemStateStoreManager):
             List of state_ids
         """
         state_ids = set()
-        pattern_re = re.compile(pattern.replace("*", ".*")) if pattern else None
+        pattern_re = re.compile(fnmatch.translate(pattern)) if pattern else None
 
         for state_file in glob.glob(
             os.path.join(
@@ -665,7 +666,7 @@ class CloudStateStoreManager(BaseFilesystemStateStoreManager):
         Returns:
             List of state_ids
         """
-        pattern_re = re.compile(pattern.replace("*", ".*")) if pattern else None
+        pattern_re = re.compile(fnmatch.translate(pattern)) if pattern else None
         state_ids = set()
         for filepath in self.list_all_files():
             if "/" not in filepath:

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -437,14 +437,13 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
         Path(self.get_state_dir(state_id)).mkdir(parents=True, exist_ok=True)
 
     @override
-    def set(self, state: MeltanoState) -> None:
-        """Set state for the given state_id, creating its directory if needed.
-
-        Args:
-            state: the state to set
-        """
-        self.create_state_id_dir_if_not_exists(state.state_id)
-        super().set(state)
+    def set_all(self, states: Iterable[MeltanoState]) -> int:
+        count = 0
+        for state in states:
+            self.create_state_id_dir_if_not_exists(state.state_id)
+            self.set(state)
+            count += 1
+        return count
 
     @override
     def get_state_ids(self, pattern: str | None = None) -> Iterable[str]:

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -437,6 +437,16 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
         Path(self.get_state_dir(state_id)).mkdir(parents=True, exist_ok=True)
 
     @override
+    def set(self, state: MeltanoState) -> None:
+        """Set state for the given state_id, creating its directory if needed.
+
+        Args:
+            state: the state to set
+        """
+        self.create_state_id_dir_if_not_exists(state.state_id)
+        super().set(state)
+
+    @override
     def get_state_ids(self, pattern: str | None = None) -> Iterable[str]:
         """Get list of state_ids stored in the backend.
 

--- a/src/meltano/core/state_store/s3/backend.py
+++ b/src/meltano/core/state_store/s3/backend.py
@@ -194,8 +194,10 @@ class S3StateStoreManager(CloudStateStoreManager):
         if with_prefix:
             kwargs["Prefix"] = self.prefix
 
-        for state_obj in self.client.list_objects_v2(**kwargs).get("Contents", []):
-            yield state_obj["Key"]
+        paginator = self.client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(**kwargs):
+            for state_obj in page.get("Contents", []):
+                yield state_obj["Key"]
 
     def copy_file(self, src: str, dst: str) -> None:
         """Copy a file from one path to another.

--- a/src/meltano/core/state_store/s3/backend.py
+++ b/src/meltano/core/state_store/s3/backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 import typing as t
 from functools import cached_property
@@ -9,7 +10,9 @@ from functools import cached_property
 import boto3
 from botocore.config import Config
 
+from meltano.core.state_store.base import MeltanoState
 from meltano.core.state_store.filesystem import (
+    _STATE_FILENAME,
     CloudStateStoreManager,
     InvalidStateBackendConfigurationException,
 )
@@ -20,7 +23,7 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterable, Iterator
 
     from mypy_boto3_s3 import S3Client
 
@@ -119,6 +122,52 @@ class S3StateStoreManager(CloudStateStoreManager):
             )
         session = boto3.Session()
         return session.client("s3", config=config)
+
+    @override
+    def get_all(self, pattern: str | None = None) -> Iterator[MeltanoState]:
+        """Yield all states using a single paginated listing.
+
+        Uses a paginator to handle buckets with more than 1000 objects, then
+        fetches each ``state.json`` directly via ``GetObject`` — avoiding the
+        double-iteration of ``get_state_ids`` + ``get``.
+
+        Args:
+            pattern: glob-style pattern to filter state IDs by
+        """
+        pattern_re = re.compile(pattern.replace("*", ".*")) if pattern else None
+        paginator = self.client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=self.state_dir):
+            for obj in page.get("Contents", []):
+                key: str = obj["Key"]
+                parts = key.split("/")
+                if len(parts) < 2 or parts[-1] != _STATE_FILENAME:
+                    continue
+                state_id = parts[-2]
+                if pattern_re and not pattern_re.match(state_id):
+                    continue
+                response = self.client.get_object(Bucket=self.bucket, Key=key)
+                yield MeltanoState.from_json(state_id, response["Body"].read().decode())
+
+    @override
+    def set_all(self, states: Iterable[MeltanoState]) -> int:
+        """Write multiple states via direct ``PutObject`` calls.
+
+        Bypasses ``smart_open``'s multipart-upload setup, which is wasteful
+        for the small JSON payloads that state files typically contain.
+
+        Args:
+            states: iterable of MeltanoState objects to persist
+        """
+        count = 0
+        for state in states:
+            self.client.put_object(
+                Bucket=self.bucket,
+                Key=self.get_state_path(state.state_id),
+                Body=state.json().encode(),
+                ContentType="application/json",
+            )
+            count += 1
+        return count
 
     @override
     def delete_file(self, file_path: str) -> None:

--- a/src/meltano/core/state_store/s3/backend.py
+++ b/src/meltano/core/state_store/s3/backend.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 import sys
 import typing as t
 from functools import cached_property
@@ -10,9 +9,7 @@ from functools import cached_property
 import boto3
 from botocore.config import Config
 
-from meltano.core.state_store.base import MeltanoState
 from meltano.core.state_store.filesystem import (
-    _STATE_FILENAME,
     CloudStateStoreManager,
     InvalidStateBackendConfigurationException,
 )
@@ -23,9 +20,11 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterable, Iterator
+    from collections.abc import Generator, Iterable
 
     from mypy_boto3_s3 import S3Client
+
+    from meltano.core.state_store.base import MeltanoState
 
 
 class S3StateStoreManager(CloudStateStoreManager):
@@ -124,31 +123,6 @@ class S3StateStoreManager(CloudStateStoreManager):
         return session.client("s3", config=config)
 
     @override
-    def get_all(self, pattern: str | None = None) -> Iterator[MeltanoState]:
-        """Yield all states using a single paginated listing.
-
-        Uses a paginator to handle buckets with more than 1000 objects, then
-        fetches each ``state.json`` directly via ``GetObject`` — avoiding the
-        double-iteration of ``get_state_ids`` + ``get``.
-
-        Args:
-            pattern: glob-style pattern to filter state IDs by
-        """
-        pattern_re = re.compile(pattern.replace("*", ".*")) if pattern else None
-        paginator = self.client.get_paginator("list_objects_v2")
-        for page in paginator.paginate(Bucket=self.bucket, Prefix=self.state_dir):
-            for obj in page.get("Contents", []):
-                key: str = obj["Key"]
-                parts = key.split("/")
-                if len(parts) < 2 or parts[-1] != _STATE_FILENAME:
-                    continue
-                state_id = parts[-2]
-                if pattern_re and not pattern_re.match(state_id):
-                    continue
-                response = self.client.get_object(Bucket=self.bucket, Key=key)
-                yield MeltanoState.from_json(state_id, response["Body"].read().decode())
-
-    @override
     def set_all(self, states: Iterable[MeltanoState]) -> int:
         """Write multiple states via direct ``PutObject`` calls.
 
@@ -181,6 +155,7 @@ class S3StateStoreManager(CloudStateStoreManager):
             Delete={"Objects": [{"Key": file_path}]},
         )
 
+    @override
     def list_all_files(self, *, with_prefix: bool = True) -> Generator[str, None, None]:
         """List all files in the backend.
 
@@ -192,13 +167,14 @@ class S3StateStoreManager(CloudStateStoreManager):
         """
         kwargs: dict[str, t.Any] = {"Bucket": self.bucket}
         if with_prefix:
-            kwargs["Prefix"] = self.prefix
+            kwargs["Prefix"] = self.state_dir
 
         paginator = self.client.get_paginator("list_objects_v2")
         for page in paginator.paginate(**kwargs):
             for state_obj in page.get("Contents", []):
                 yield state_obj["Key"]
 
+    @override
     def copy_file(self, src: str, dst: str) -> None:
         """Copy a file from one path to another.
 

--- a/tests/fixtures/state_backends.py
+++ b/tests/fixtures/state_backends.py
@@ -1,21 +1,6 @@
 from __future__ import annotations
 
-import fnmatch
-import sys
-import typing as t
-from contextlib import contextmanager
-
-if sys.version_info >= (3, 12):
-    from typing import override  # noqa: ICN003
-else:
-    from typing_extensions import override
-
 from meltano.core.state_store import StateStoreManager
-
-if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
-
-    from meltano.core.state_store.base import MeltanoState
 
 
 class DummyStateStoreManager(StateStoreManager):
@@ -23,60 +8,13 @@ class DummyStateStoreManager(StateStoreManager):
 
     def __init__(self, **kwargs): ...
 
-    @override
     def set(self, state): ...
 
-    @override
     def get(self, state_id): ...
 
-    @override
     def delete(self, state_id): ...
 
-    @override
-    def get_state_ids(self, pattern=None):
+    def get_state_ids(self, pattern=None):  # noqa: ARG002
         return ()  # pragma: no cover
 
-    @override
     def acquire_lock(self, state_id): ...
-
-
-class InMemoryStateStoreManager(StateStoreManager):
-    """Minimal in-memory backend for testing the base-class get_all/set_all fallbacks.
-
-    Does NOT override get_all or set_all — tests that use this class verify the
-    default implementations in StateStoreManager.
-    """
-
-    label: str = "In-memory (test)"
-
-    def __init__(self, **kwargs: t.Any) -> None:
-        super().__init__(**kwargs)
-        self._store: dict[str, MeltanoState] = {}
-
-    @override
-    def set(self, state: MeltanoState) -> None:
-        self._store[state.state_id] = state
-
-    @override
-    def get(self, state_id: str) -> MeltanoState | None:
-        return self._store.get(state_id)
-
-    @override
-    def delete(self, state_id: str) -> None:
-        self._store.pop(state_id, None)
-
-    @override
-    def get_state_ids(self, pattern: str | None = None) -> Iterable[str]:
-        if pattern is None:
-            return list(self._store)
-        return [sid for sid in self._store if fnmatch.fnmatch(sid, pattern)]
-
-    @override
-    @contextmanager
-    def acquire_lock(
-        self,
-        state_id: str,
-        *,
-        retry_seconds: float = 1,
-    ) -> Generator[None, None, None]:
-        yield

--- a/tests/fixtures/state_backends.py
+++ b/tests/fixtures/state_backends.py
@@ -1,6 +1,21 @@
 from __future__ import annotations
 
+import fnmatch
+import sys
+import typing as t
+from contextlib import contextmanager
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 from meltano.core.state_store import StateStoreManager
+
+if t.TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+    from meltano.core.state_store.base import MeltanoState
 
 
 class DummyStateStoreManager(StateStoreManager):
@@ -8,13 +23,60 @@ class DummyStateStoreManager(StateStoreManager):
 
     def __init__(self, **kwargs): ...
 
+    @override
     def set(self, state): ...
 
+    @override
     def get(self, state_id): ...
 
+    @override
     def delete(self, state_id): ...
 
-    def get_state_ids(self, pattern=None):  # noqa: ARG002
+    @override
+    def get_state_ids(self, pattern=None):
         return ()  # pragma: no cover
 
+    @override
     def acquire_lock(self, state_id): ...
+
+
+class InMemoryStateStoreManager(StateStoreManager):
+    """Minimal in-memory backend for testing the base-class get_all/set_all fallbacks.
+
+    Does NOT override get_all or set_all — tests that use this class verify the
+    default implementations in StateStoreManager.
+    """
+
+    label: str = "In-memory (test)"
+
+    def __init__(self, **kwargs: t.Any) -> None:
+        super().__init__(**kwargs)
+        self._store: dict[str, MeltanoState] = {}
+
+    @override
+    def set(self, state: MeltanoState) -> None:
+        self._store[state.state_id] = state
+
+    @override
+    def get(self, state_id: str) -> MeltanoState | None:
+        return self._store.get(state_id)
+
+    @override
+    def delete(self, state_id: str) -> None:
+        self._store.pop(state_id, None)
+
+    @override
+    def get_state_ids(self, pattern: str | None = None) -> Iterable[str]:
+        if pattern is None:
+            return list(self._store)
+        return [sid for sid in self._store if fnmatch.fnmatch(sid, pattern)]
+
+    @override
+    @contextmanager
+    def acquire_lock(
+        self,
+        state_id: str,
+        *,
+        retry_seconds: float = 1,
+    ) -> Generator[None, None, None]:
+        yield

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -1030,23 +1030,3 @@ class TestCliState:
             state_service.get_state(state_id) == original_merged[state_id]
             for state_id in state_ids
         )
-
-    def test_export_import_roundtrip_preserves_split_state(
-        self,
-        state_service: StateService,
-        cli_runner: MeltanoCliRunner,
-    ) -> None:
-        original_export = state_service.export_state()
-
-        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
-            export_result = cli_runner.invoke(cli, ["state", "export"])
-            assert_cli_runner(export_result)
-
-            state_service.clear_all_states()
-
-            import_result = cli_runner.invoke(
-                cli, ["state", "import"], input=export_result.stdout
-            )
-            assert_cli_runner(import_result)
-
-        assert state_service.export_state() == original_export

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -918,6 +918,12 @@ class TestCliState:
         state_ids: list[str],
         cli_runner: MeltanoCliRunner,
     ) -> None:
+        # Add a state with a different env prefix so the pattern actually filters
+        staging_id = "staging:tap-extra-to-target-extra"
+        state_service.import_state(
+            {staging_id: {"completed": {"singer_state": {}}, "partial": {}}}
+        )
+
         first_id = state_ids[0]
         env = first_id.split(":")[0]
         with mock.patch("meltano.cli.state.StateService", return_value=state_service):
@@ -927,8 +933,8 @@ class TestCliState:
         assert_cli_runner(result)
         data = json.loads(result.stdout)
         assert isinstance(data, dict)
-        assert len(data) == len(state_ids)
-        assert all(state_id.startswith(f"{env}:") for state_id in data)
+        assert set(data) == set(state_ids)
+        assert staging_id not in data
 
     def test_import_from_file(
         self,
@@ -988,6 +994,18 @@ class TestCliState:
         assert result.exit_code == 1
         assert "Invalid JSON" in result.stderr
 
+    @pytest.mark.parametrize("invalid_input", ("[]", "123"), ids=["array", "number"])
+    def test_import_structurally_invalid_json_wrong_type(
+        self,
+        state_service: StateService,
+        cli_runner: MeltanoCliRunner,
+        invalid_input: str,
+    ) -> None:
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            result = cli_runner.invoke(cli, ["state", "import"], input=invalid_input)
+        assert result.exit_code != 0
+        assert "expected a JSON object" in result.stderr
+
     def test_export_import_roundtrip(
         self,
         state_service: StateService,
@@ -1012,3 +1030,23 @@ class TestCliState:
             state_service.get_state(state_id) == original_merged[state_id]
             for state_id in state_ids
         )
+
+    def test_export_import_roundtrip_preserves_split_state(
+        self,
+        state_service: StateService,
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        original_export = state_service.export_state()
+
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            export_result = cli_runner.invoke(cli, ["state", "export"])
+            assert_cli_runner(export_result)
+
+            state_service.clear_all_states()
+
+            import_result = cli_runner.invoke(
+                cli, ["state", "import"], input=export_result.stdout
+            )
+            assert_cli_runner(import_result)
+
+        assert state_service.export_state() == original_export

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -912,30 +912,6 @@ class TestCliState:
         assert set(data) == set(state_ids)
         assert all("completed" in val and "partial" in val for val in data.values())
 
-    def test_export_pattern(
-        self,
-        state_service: StateService,
-        state_ids: list[str],
-        cli_runner: MeltanoCliRunner,
-    ) -> None:
-        # Add a state with a different env prefix so the pattern actually filters
-        staging_id = "staging:tap-extra-to-target-extra"
-        state_service.import_state(
-            {staging_id: {"completed": {"singer_state": {}}, "partial": {}}}
-        )
-
-        first_id = state_ids[0]
-        env = first_id.split(":")[0]
-        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
-            result = cli_runner.invoke(
-                cli, ["state", "export", "--pattern", f"{env}:*"]
-            )
-        assert_cli_runner(result)
-        data = json.loads(result.stdout)
-        assert isinstance(data, dict)
-        assert set(data) == set(state_ids)
-        assert staging_id not in data
-
     def test_import_from_file(
         self,
         tmp_path: Path,

--- a/tests/meltano/cli/test_state.py
+++ b/tests/meltano/cli/test_state.py
@@ -897,3 +897,118 @@ class TestCliState:
 
         current_state = state_service.get_state(state_id)
         assert current_state == original_state
+
+    def test_export(
+        self,
+        state_service: StateService,
+        state_ids: list[str],
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            result = cli_runner.invoke(cli, ["state", "export"])
+        assert_cli_runner(result)
+        data = json.loads(result.stdout)
+        assert isinstance(data, dict)
+        assert set(data) == set(state_ids)
+        assert all("completed" in val and "partial" in val for val in data.values())
+
+    def test_export_pattern(
+        self,
+        state_service: StateService,
+        state_ids: list[str],
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        first_id = state_ids[0]
+        env = first_id.split(":")[0]
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            result = cli_runner.invoke(
+                cli, ["state", "export", "--pattern", f"{env}:*"]
+            )
+        assert_cli_runner(result)
+        data = json.loads(result.stdout)
+        assert isinstance(data, dict)
+        assert len(data) == len(state_ids)
+        assert all(state_id.startswith(f"{env}:") for state_id in data)
+
+    def test_import_from_file(
+        self,
+        tmp_path: Path,
+        state_service: StateService,
+        state_ids: list[str],
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        original_merged = {sid: state_service.get_state(sid) for sid in state_ids}
+        export_data = state_service.export_state()
+        filepath = tmp_path / "states.json"
+        filepath.write_text(json.dumps(export_data))
+
+        state_service.clear_all_states()
+        assert not state_service.list_state()
+
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            result = cli_runner.invoke(cli, ["state", "import", str(filepath)])
+        assert_cli_runner(result)
+
+        assert all(
+            state_service.get_state(state_id) == original_merged[state_id]
+            for state_id in state_ids
+        )
+
+    def test_import_from_stdin(
+        self,
+        state_service: StateService,
+        state_ids: list[str],
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        original_merged = {sid: state_service.get_state(sid) for sid in state_ids}
+        export_data = state_service.export_state()
+
+        state_service.clear_all_states()
+
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            result = cli_runner.invoke(
+                cli,
+                ["state", "import"],
+                input=json.dumps(export_data),
+            )
+        assert_cli_runner(result)
+
+        assert all(
+            state_service.get_state(state_id) == original_merged[state_id]
+            for state_id in state_ids
+        )
+
+    def test_import_invalid_json(
+        self,
+        state_service: StateService,
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            result = cli_runner.invoke(cli, ["state", "import"], input="{ invalid json")
+        assert result.exit_code == 1
+        assert "Invalid JSON" in result.stderr
+
+    def test_export_import_roundtrip(
+        self,
+        state_service: StateService,
+        state_ids: list[str],
+        cli_runner: MeltanoCliRunner,
+    ) -> None:
+        original_merged = {sid: state_service.get_state(sid) for sid in state_ids}
+
+        with mock.patch("meltano.cli.state.StateService", return_value=state_service):
+            export_result = cli_runner.invoke(cli, ["state", "export"])
+            assert_cli_runner(export_result)
+
+            state_service.clear_all_states()
+            assert not state_service.list_state()
+
+            import_result = cli_runner.invoke(
+                cli, ["state", "import"], input=export_result.stdout
+            )
+            assert_cli_runner(import_result)
+
+        assert all(
+            state_service.get_state(state_id) == original_merged[state_id]
+            for state_id in state_ids
+        )

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import typing as t
 from http import HTTPStatus
 from unittest import mock
@@ -13,7 +14,6 @@ from requests.adapters import BaseAdapter
 
 from meltano.cli import cli
 from meltano.cli.hub import hub
-from meltano.core._compat import override
 from meltano.core.hub.client import (
     HubConnectionError,
     HubPluginTypeNotFoundError,
@@ -21,6 +21,11 @@ from meltano.core.hub.client import (
 )
 from meltano.core.plugin.base import PluginType, Variant
 from meltano.core.plugin.error import PluginNotFoundError
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from collections import Counter
@@ -155,8 +160,8 @@ class TestMeltanoHubService:
             @override
             def send(
                 self,
-                request,  # noqa: ARG002
-                *args,  # noqa: ARG002
+                request,
+                *args,
                 **kwargs,
             ):
                 nonlocal send_kwargs
@@ -182,8 +187,8 @@ class TestMeltanoHubService:
             @override
             def send(
                 self,
-                request,  # noqa: ARG002
-                *args,  # noqa: ARG002
+                request,
+                *args,
                 **kwargs,
             ):
                 nonlocal send_kwargs

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -323,7 +323,7 @@ class TestLocalFilesystemStateStoreManager:
         self, subject: _LocalFilesystemStateStoreManager
     ) -> None:
         for i in range(3):
-            subject.set(
+            subject.update(
                 MeltanoState(
                     state_id=f"job-{i}",
                     completed_state={"singer_state": {"v": i}},
@@ -338,8 +338,12 @@ class TestLocalFilesystemStateStoreManager:
         self, subject: _LocalFilesystemStateStoreManager
     ) -> None:
         for sid in ("tap-a-to-target-x", "tap-b-to-target-x", "other"):
-            subject.set(
-                MeltanoState(state_id=sid, completed_state={}, partial_state={})
+            subject.update(
+                MeltanoState(
+                    state_id=sid,
+                    completed_state={},
+                    partial_state={},
+                )
             )
         result = list(subject.get_all(pattern="tap-*"))
         assert {s.state_id for s in result} == {

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -318,6 +318,63 @@ class TestLocalFilesystemStateStoreManager:
         assert subject.clear_all() == initial_count
         assert len(list(Path(state_path).iterdir())) == 0
 
+    @pytest.mark.usefixtures("state_path")
+    def test_get_all_yields_all_states(
+        self, subject: _LocalFilesystemStateStoreManager
+    ) -> None:
+        for i in range(3):
+            subject.set(
+                MeltanoState(
+                    state_id=f"job-{i}",
+                    completed_state={"singer_state": {"v": i}},
+                    partial_state={},
+                )
+            )
+        result = list(subject.get_all())
+        assert {s.state_id for s in result} == {"job-0", "job-1", "job-2"}
+
+    @pytest.mark.usefixtures("state_path")
+    def test_get_all_with_pattern(
+        self, subject: _LocalFilesystemStateStoreManager
+    ) -> None:
+        for sid in ("tap-a-to-target-x", "tap-b-to-target-x", "other"):
+            subject.set(
+                MeltanoState(state_id=sid, completed_state={}, partial_state={})
+            )
+        result = list(subject.get_all(pattern="tap-*"))
+        assert {s.state_id for s in result} == {
+            "tap-a-to-target-x",
+            "tap-b-to-target-x",
+        }
+
+    @pytest.mark.usefixtures("state_path")
+    def test_get_all_empty_store(
+        self, subject: _LocalFilesystemStateStoreManager
+    ) -> None:
+        assert list(subject.get_all()) == []
+
+    @pytest.mark.usefixtures("state_path")
+    def test_set_all_writes_states(
+        self, subject: _LocalFilesystemStateStoreManager
+    ) -> None:
+        states = [
+            MeltanoState(
+                state_id=f"job-{i}",
+                completed_state={"singer_state": {"v": i}},
+                partial_state={},
+            )
+            for i in range(3)
+        ]
+        count = subject.set_all(iter(states))
+        assert count == 3
+        assert all(subject.get(f"job-{i}") is not None for i in range(3))
+
+    @pytest.mark.usefixtures("state_path")
+    def test_set_all_empty_iterable(
+        self, subject: _LocalFilesystemStateStoreManager
+    ) -> None:
+        assert subject.set_all([]) == 0
+
 
 class TestAZStorageStateStoreManager:
     @pytest.fixture

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -662,14 +662,14 @@ class TestS3StateStoreManager:
             stubber.add_response(
                 "list_objects_v2",
                 response,
-                expected_params={"Bucket": subject.bucket, "Prefix": "/state"},
+                expected_params={"Bucket": subject.bucket, "Prefix": "state"},
             )
             assert set(subject.get_state_ids()) == {"state_id_1", "state_id_2"}
 
             stubber.add_response(
                 "list_objects_v2",
                 response,
-                expected_params={"Bucket": subject.bucket, "Prefix": "/state"},
+                expected_params={"Bucket": subject.bucket, "Prefix": "state"},
             )
             assert set(subject.get_state_ids(pattern="dev*")) == set()
 

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -650,3 +650,121 @@ class TestS3StateBackend:
             objects = manager.client.list_objects_v2(Bucket=bucket)
             keys = [obj["Key"] for obj in objects["Contents"]]
             assert keys == [clean_key]
+
+    @pytest.fixture
+    def s3_manager(
+        self,
+        bucket: str,
+        prefix: str,
+        aws_access_key_id: str,
+        aws_secret_access_key: str,
+    ) -> S3StateStoreManager:
+        return S3StateStoreManager(
+            uri=f"s3://{bucket}/{prefix}",
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            lock_timeout_seconds=10,
+        )
+
+    def test_get_all_returns_all_states(
+        self,
+        bucket: str,
+        prefix: str,
+        s3_manager: S3StateStoreManager,
+    ) -> None:
+        state_ids = ["job-a", "job-b", "job-c"]
+        with moto.mock_aws():
+            s3_manager.client.create_bucket(Bucket=bucket)
+            for sid in state_ids:
+                s3_manager.client.put_object(
+                    Bucket=bucket,
+                    Key=f"{prefix}/{sid}/state.json",
+                    Body=b'{"completed":{"singer_state":{"bookmarks":{}}},"partial":{}}',
+                    ContentType="application/json",
+                )
+            results = list(s3_manager.get_all())
+        assert {s.state_id for s in results} == set(state_ids)
+
+    def test_get_all_with_pattern(
+        self,
+        bucket: str,
+        prefix: str,
+        s3_manager: S3StateStoreManager,
+    ) -> None:
+        with moto.mock_aws():
+            s3_manager.client.create_bucket(Bucket=bucket)
+            for sid in ("tap-a-to-target-x", "tap-b-to-target-x", "other"):
+                s3_manager.client.put_object(
+                    Bucket=bucket,
+                    Key=f"{prefix}/{sid}/state.json",
+                    Body=b'{"completed":{},"partial":{}}',
+                    ContentType="application/json",
+                )
+            results = list(s3_manager.get_all(pattern="tap-*"))
+        assert {s.state_id for s in results} == {
+            "tap-a-to-target-x",
+            "tap-b-to-target-x",
+        }
+
+    def test_get_all_empty_bucket(
+        self,
+        bucket: str,
+        s3_manager: S3StateStoreManager,
+    ) -> None:
+        with moto.mock_aws():
+            s3_manager.client.create_bucket(Bucket=bucket)
+            results = list(s3_manager.get_all())
+        assert results == []
+
+    def test_set_all_writes_states(
+        self,
+        bucket: str,
+        prefix: str,
+        s3_manager: S3StateStoreManager,
+    ) -> None:
+        states = [
+            MeltanoState(
+                state_id=f"job-{i}",
+                completed_state={"singer_state": {"bookmarks": {}}},
+                partial_state={},
+            )
+            for i in range(4)
+        ]
+        with moto.mock_aws():
+            s3_manager.client.create_bucket(Bucket=bucket)
+            count = s3_manager.set_all(iter(states))
+            assert count == 4
+            listed = s3_manager.client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+            keys = {obj["Key"] for obj in listed.get("Contents", [])}
+            for state in states:
+                assert f"{prefix}/{state.state_id}/state.json" in keys
+
+    def test_set_all_content_type_is_json(
+        self,
+        bucket: str,
+        prefix: str,
+        s3_manager: S3StateStoreManager,
+    ) -> None:
+        state = MeltanoState(
+            state_id="my-job",
+            completed_state={"singer_state": {}},
+            partial_state={},
+        )
+        with moto.mock_aws():
+            s3_manager.client.create_bucket(Bucket=bucket)
+            s3_manager.set_all([state])
+            response = s3_manager.client.get_object(
+                Bucket=bucket,
+                Key=f"{prefix}/{state.state_id}/state.json",
+            )
+            assert response["ContentType"] == "application/json"
+
+    def test_set_all_empty_iterable(
+        self,
+        bucket: str,
+        s3_manager: S3StateStoreManager,
+    ) -> None:
+        with moto.mock_aws():
+            s3_manager.client.create_bucket(Bucket=bucket)
+            count = s3_manager.set_all([])
+        assert count == 0

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -736,8 +736,7 @@ class TestS3StateBackend:
             assert count == 4
             listed = s3_manager.client.list_objects_v2(Bucket=bucket, Prefix=prefix)
             keys = {obj["Key"] for obj in listed.get("Contents", [])}
-            for state in states:
-                assert f"{prefix}/{state.state_id}/state.json" in keys
+            assert all(f"{prefix}/{s.state_id}/state.json" in keys for s in states)
 
     def test_set_all_content_type_is_json(
         self,

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -14,7 +14,7 @@ from google.auth.credentials import AnonymousCredentials
 from google.cloud.exceptions import NotFound
 from google.cloud.storage import Blob
 
-from fixtures.state_backends import DummyStateStoreManager
+from fixtures.state_backends import DummyStateStoreManager, InMemoryStateStoreManager
 from meltano.core.error import MeltanoError
 from meltano.core.setting_definition import SettingDefinition
 from meltano.core.state_store import (
@@ -69,6 +69,95 @@ class TestStateStoreManagerContextManager:
     def test_close_is_noop_by_default(self) -> None:
         manager = DummyStateStoreManager()
         manager.close()  # Should not raise
+
+
+class TestStateStoreManagerFallbacks:
+    """Tests for the default get_all / set_all code paths in StateStoreManager.
+
+    Uses InMemoryStateStoreManager, which does NOT override get_all or set_all,
+    so every test here exercises the base-class fallback implementations.
+    """
+
+    @pytest.fixture
+    def manager(self) -> InMemoryStateStoreManager:
+        return InMemoryStateStoreManager()
+
+    @pytest.fixture
+    def populated_manager(
+        self, manager: InMemoryStateStoreManager
+    ) -> InMemoryStateStoreManager:
+        for i in range(3):
+            manager.set(
+                MeltanoState(
+                    state_id=f"job-{i}",
+                    completed_state={"singer_state": {"v": i}},
+                    partial_state={},
+                )
+            )
+        return manager
+
+    def test_get_all_yields_all_states(
+        self, populated_manager: InMemoryStateStoreManager
+    ) -> None:
+        result = list(populated_manager.get_all())
+        assert {s.state_id for s in result} == {"job-0", "job-1", "job-2"}
+
+    def test_get_all_passes_pattern_to_get_state_ids(
+        self, populated_manager: InMemoryStateStoreManager
+    ) -> None:
+        with mock.patch.object(
+            populated_manager,
+            "get_state_ids",
+            wraps=populated_manager.get_state_ids,
+        ) as mock_ids:
+            list(populated_manager.get_all(pattern="job-*"))
+        mock_ids.assert_called_once_with("job-*")
+
+    def test_get_all_skips_states_where_get_returns_none(
+        self, manager: InMemoryStateStoreManager
+    ) -> None:
+        manager.set(MeltanoState(state_id="real", completed_state={}, partial_state={}))
+        original_get = manager.get
+
+        def _get(state_id: str) -> MeltanoState | None:
+            return None if state_id == "ghost" else original_get(state_id)
+
+        with (
+            mock.patch.object(manager, "get_state_ids", return_value=["real", "ghost"]),
+            mock.patch.object(manager, "get", side_effect=_get),
+        ):
+            result = list(manager.get_all())
+        assert len(result) == 1
+        assert result[0].state_id == "real"
+
+    def test_get_all_empty_store(self, manager: InMemoryStateStoreManager) -> None:
+        assert list(manager.get_all()) == []
+
+    def test_set_all_writes_each_state(
+        self, manager: InMemoryStateStoreManager
+    ) -> None:
+        states = [
+            MeltanoState(
+                state_id=f"job-{i}",
+                completed_state={"singer_state": {"v": i}},
+                partial_state={},
+            )
+            for i in range(3)
+        ]
+        count = manager.set_all(iter(states))
+        assert count == 3
+        for i in range(3):
+            assert manager.get(f"job-{i}") is not None
+
+    def test_set_all_returns_count(self, manager: InMemoryStateStoreManager) -> None:
+        states = [
+            MeltanoState(state_id=f"x-{i}", completed_state={}, partial_state={})
+            for i in range(5)
+        ]
+        assert manager.set_all(states) == 5
+
+    def test_set_all_empty_iterable(self, manager: InMemoryStateStoreManager) -> None:
+        assert manager.set_all([]) == 0
 
 
 def test_unknown_state_backend_scheme(project: Project):

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -14,7 +14,7 @@ from google.auth.credentials import AnonymousCredentials
 from google.cloud.exceptions import NotFound
 from google.cloud.storage import Blob
 
-from fixtures.state_backends import DummyStateStoreManager, InMemoryStateStoreManager
+from fixtures.state_backends import DummyStateStoreManager
 from meltano.core.error import MeltanoError
 from meltano.core.setting_definition import SettingDefinition
 from meltano.core.state_store import (
@@ -69,95 +69,6 @@ class TestStateStoreManagerContextManager:
     def test_close_is_noop_by_default(self) -> None:
         manager = DummyStateStoreManager()
         manager.close()  # Should not raise
-
-
-class TestStateStoreManagerFallbacks:
-    """Tests for the default get_all / set_all code paths in StateStoreManager.
-
-    Uses InMemoryStateStoreManager, which does NOT override get_all or set_all,
-    so every test here exercises the base-class fallback implementations.
-    """
-
-    @pytest.fixture
-    def manager(self) -> InMemoryStateStoreManager:
-        return InMemoryStateStoreManager()
-
-    @pytest.fixture
-    def populated_manager(
-        self, manager: InMemoryStateStoreManager
-    ) -> InMemoryStateStoreManager:
-        for i in range(3):
-            manager.set(
-                MeltanoState(
-                    state_id=f"job-{i}",
-                    completed_state={"singer_state": {"v": i}},
-                    partial_state={},
-                )
-            )
-        return manager
-
-    def test_get_all_yields_all_states(
-        self, populated_manager: InMemoryStateStoreManager
-    ) -> None:
-        result = list(populated_manager.get_all())
-        assert {s.state_id for s in result} == {"job-0", "job-1", "job-2"}
-
-    def test_get_all_passes_pattern_to_get_state_ids(
-        self, populated_manager: InMemoryStateStoreManager
-    ) -> None:
-        with mock.patch.object(
-            populated_manager,
-            "get_state_ids",
-            wraps=populated_manager.get_state_ids,
-        ) as mock_ids:
-            list(populated_manager.get_all(pattern="job-*"))
-        mock_ids.assert_called_once_with("job-*")
-
-    def test_get_all_skips_states_where_get_returns_none(
-        self, manager: InMemoryStateStoreManager
-    ) -> None:
-        manager.set(MeltanoState(state_id="real", completed_state={}, partial_state={}))
-        original_get = manager.get
-
-        def _get(state_id: str) -> MeltanoState | None:
-            return None if state_id == "ghost" else original_get(state_id)
-
-        with (
-            mock.patch.object(manager, "get_state_ids", return_value=["real", "ghost"]),
-            mock.patch.object(manager, "get", side_effect=_get),
-        ):
-            result = list(manager.get_all())
-        assert len(result) == 1
-        assert result[0].state_id == "real"
-
-    def test_get_all_empty_store(self, manager: InMemoryStateStoreManager) -> None:
-        assert list(manager.get_all()) == []
-
-    def test_set_all_writes_each_state(
-        self, manager: InMemoryStateStoreManager
-    ) -> None:
-        states = [
-            MeltanoState(
-                state_id=f"job-{i}",
-                completed_state={"singer_state": {"v": i}},
-                partial_state={},
-            )
-            for i in range(3)
-        ]
-        count = manager.set_all(iter(states))
-        assert count == 3
-        for i in range(3):
-            assert manager.get(f"job-{i}") is not None
-
-    def test_set_all_returns_count(self, manager: InMemoryStateStoreManager) -> None:
-        states = [
-            MeltanoState(state_id=f"x-{i}", completed_state={}, partial_state={})
-            for i in range(5)
-        ]
-        assert manager.set_all(states) == 5
-
-    def test_set_all_empty_iterable(self, manager: InMemoryStateStoreManager) -> None:
-        assert manager.set_all([]) == 0
 
 
 def test_unknown_state_backend_scheme(project: Project):

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -101,6 +101,22 @@ def test_pluggable_state_backend(project: Project, monkeypatch: pytest.MonkeyPat
         assert isinstance(state_store, DummyStateStoreManager)
 
 
+def test_set_fallback() -> None:
+    manager = DummyStateStoreManager()
+    states = [
+        MeltanoState(
+            state_id=f"dev:tap-a-to-target-{i}",
+            completed_state={"singer_state": {"bookmark": i}},
+            partial_state={},
+        )
+        for i in range(3)
+    ]
+    with mock.patch.object(manager, "set") as mock_set:
+        count = manager.set_all(states)
+    assert count == 3
+    assert mock_set.call_count == 3
+
+
 @pytest.mark.parametrize(
     ("setting", "namespace", "expected"),
     # NOTE: The "nested-setting" parametrized case below is currently xfail because

--- a/tests/meltano/core/state_store/test_state_store.py
+++ b/tests/meltano/core/state_store/test_state_store.py
@@ -173,6 +173,76 @@ class TestSystemDBStateBackend:
         db_state_store = state_store_manager_from_project_settings(project.settings)
         assert isinstance(db_state_store, DBStateStoreManager)
 
+    @pytest.fixture
+    def db_store(self, session) -> DBStateStoreManager:
+        return DBStateStoreManager(session=session)
+
+    @pytest.fixture
+    def populated_db_store(self, db_store: DBStateStoreManager) -> DBStateStoreManager:
+        states = [
+            MeltanoState(
+                state_id=f"dev:tap-a-to-target-{i}",
+                completed_state={"singer_state": {"bookmark": i}},
+                partial_state={},
+            )
+            for i in range(3)
+        ]
+        for s in states:
+            db_store.set(s)
+        return db_store
+
+    def test_get_all_returns_all_states(
+        self, populated_db_store: DBStateStoreManager
+    ) -> None:
+        result = list(populated_db_store.get_all())
+        assert len(result) == 3
+        assert {s.state_id for s in result} == {
+            "dev:tap-a-to-target-0",
+            "dev:tap-a-to-target-1",
+            "dev:tap-a-to-target-2",
+        }
+
+    def test_get_all_with_pattern(
+        self, populated_db_store: DBStateStoreManager
+    ) -> None:
+        result = list(populated_db_store.get_all("dev:tap-a-to-target-1"))
+        assert len(result) == 1
+        assert result[0].state_id == "dev:tap-a-to-target-1"
+
+    def test_get_all_empty(self, db_store: DBStateStoreManager) -> None:
+        assert list(db_store.get_all()) == []
+
+    def test_set_all_inserts_states(self, db_store: DBStateStoreManager) -> None:
+        states = [
+            MeltanoState(
+                state_id=f"dev:tap-b-to-target-{i}",
+                completed_state={"singer_state": {"v": i}},
+                partial_state={},
+            )
+            for i in range(4)
+        ]
+        count = db_store.set_all(iter(states))
+        assert count == 4
+        assert len(list(db_store.get_all())) == 4
+
+    def test_set_all_overwrites_existing(
+        self, populated_db_store: DBStateStoreManager
+    ) -> None:
+        new_states = [
+            MeltanoState(
+                state_id="dev:tap-a-to-target-0",
+                completed_state={"singer_state": {"bookmark": 99}},
+                partial_state={},
+            ),
+        ]
+        populated_db_store.set_all(iter(new_states))
+        result = populated_db_store.get("dev:tap-a-to-target-0")
+        assert result is not None
+        assert result.completed_state == {"singer_state": {"bookmark": 99}}
+
+    def test_set_all_empty_iterable(self, db_store: DBStateStoreManager) -> None:
+        assert db_store.set_all(iter([])) == 0
+
 
 class TestLocalFilesystemStateBackend:
     @pytest.fixture


### PR DESCRIPTION
## Description

Adds two new subcommands to `meltano state` to facilitate migrating Singer state between backends (e.g. from S3 to Snowflake):

```shell
# Export state from one backend
meltano --env-file s3.env state export > states.json

# Import into another backend
meltano --env-file snowflake.env state import states.json

# Or pipe directly
meltano --env-file s3.env state export | meltano --env-file snowflake.env state import
```

### `meltano state export`

Writes all state to stdout as a JSON mapping keyed by state ID. Each value preserves both `completed` and `partial` state (not just the merged view), making round-trips lossless:

```json
{
  "dev:tap-github-to-target-postgres": {"completed": {"singer_state": {...}}, "partial": {}},
  ...
}
```

### `meltano state import [FILE|-]`

Reads the mapping produced by `export` from a file argument or from stdin (when no file is given). Overwrites each state ID in the target backend directly via `set()` rather than `update()`, so no unintended merging occurs.

### `StateStoreManager.get_all()` / `set_all()`

Two new non-abstract bulk methods on the base class default to iterating individual `get`/`set` calls. Backends can override them for efficiency (e.g. a single bulk DB query).

## Checklist

- [X] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6 following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes #10019
