### PR TITLE
docs: Document `meltano state export` and `meltano state import`

### DIFF
--- a/docs/docs/reference/command-line-interface.mdx
+++ b/docs/docs/reference/command-line-interface.mdx
@@ -1935,6 +1935,63 @@ meltano state set --force --no-validate dev:tap-gitlab-to-target-jsonl '{"custom
 # WARNING: Skipping state validation. Invalid state may cause issues in future runs.
 ```
 
+### export
+
+Export all state to stdout as a JSON object, suitable for backup or migration to another state backend.
+
+The output maps each state ID to its `completed` and `partial` state, preserving the internal split so that a round-trip export → import is lossless.
+
+#### How to use
+
+```bash
+# Write all state to a file
+meltano state export > states.json
+
+# Pipe directly into another backend
+meltano --env-file src.env state export | meltano --env-file dst.env state import
+```
+
+#### Examples
+
+```bash
+# Migrate state from an S3 backend to Snowflake
+meltano --env-file s3.env state export > states.json
+meltano --env-file snowflake.env state import states.json
+
+# Quick backup before making changes
+meltano state export > backup.json
+```
+
+### import
+
+Import state from a JSON file (or stdin when no file is given), overwriting any existing state for each state ID present in the input.
+
+The expected format is the JSON object produced by `meltano state export`.
+
+#### How to use
+
+```bash
+# Read from a file
+meltano state import <file>
+
+# Read from stdin (e.g. piped from export)
+meltano state export | meltano state import
+```
+
+#### Parameters
+
+- `FILE` — path to a JSON file in the format produced by `meltano state export`. When omitted, state is read from stdin.
+
+#### Examples
+
+```bash
+# Restore from a backup
+meltano state import backup.json
+
+# Migrate state between backends
+meltano --env-file s3.env state export | meltano --env-file snowflake.env state import
+```
+
 ### Using `state` with Environments
 
 The `state` command can accept the `--environment` flag to target a specific [Meltano Environment](https://docs.meltano.com/concepts/environments). However, the [`default_environment` setting](https://docs.meltano.com/concepts/environments#default-environments) in your `meltano.yml` file will be ignored.


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

Follows #10020.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Document the new `meltano state export` and `meltano state import` CLI subcommands and their usage within the state management reference.

Documentation:
- Add reference documentation for exporting Meltano state as JSON via `meltano state export`, including examples for backups and backend migration.
- Add reference documentation for importing Meltano state from JSON via `meltano state import`, including stdin/file usage and parameter details.