### PR TITLE
test: Give a try to `pytest-asyncio` 1.4 pre-release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,8 @@ jobs:
 
     - name: Setup uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        cache-suffix: ${{ matrix.python-version }}-${{ matrix.backend-db }}
 
     - name: Install Nox
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Setup uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
-        cache-suffix: ${{ matrix.python-version }}-${{ matrix.backend-db }}
+        cache-suffix: ${{ matrix.id }}
 
     - name: Install Nox
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ testing = [
   "faker>=37.4.2",
   "moto>=5.1.0,!=5.2.0",
   "pytest>=9",
-  "pytest-asyncio>=1.3",
+  "pytest-asyncio>=1.4.0a2",
   "pytest-codspeed>=4.2.0",
   "pytest-docker~=3.1",
   "pytest-order~=1.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1597,7 +1597,7 @@ dev = [
     { name = "moto", specifier = ">=5.1.0,!=5.2.0" },
     { name = "mypy", specifier = "~=2.1.0" },
     { name = "pytest", specifier = ">=9" },
-    { name = "pytest-asyncio", specifier = ">=1.3" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0a2" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
     { name = "pytest-order", specifier = "~=1.3" },
@@ -1621,7 +1621,7 @@ testing = [
     { name = "faker", specifier = ">=37.4.2" },
     { name = "moto", specifier = ">=5.1.0,!=5.2.0" },
     { name = "pytest", specifier = ">=9" },
-    { name = "pytest-asyncio", specifier = ">=1.3" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0a2" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
     { name = "pytest-order", specifier = "~=1.3" },
@@ -1643,7 +1643,7 @@ typing = [
     { name = "moto", specifier = ">=5.1.0,!=5.2.0" },
     { name = "mypy", specifier = "~=2.1.0" },
     { name = "pytest", specifier = ">=9" },
-    { name = "pytest-asyncio", specifier = ">=1.3" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0a2" },
     { name = "pytest-codspeed", specifier = ">=4.2.0" },
     { name = "pytest-docker", specifier = "~=3.1" },
     { name = "pytest-order", specifier = "~=1.3" },
@@ -2509,16 +2509,16 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.3.0"
+version = "1.4.0a2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/7c/f0831e89e025cea4f7b0201743c02c1016d86b9d4d6e86da8d556f6e86e0/pytest_asyncio-1.4.0a2.tar.gz", hash = "sha256:7cdef3b22cdfe423829eb594a25f7c23c8b3ec2a82d014a56e5179038eb3e674", size = 57596, upload-time = "2026-05-02T07:40:45.489Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0f/eebdc66222f6942fe2962894c419f14693cb2401bdb5c000b86742aab004/pytest_asyncio-1.4.0a2-py3-none-any.whl", hash = "sha256:b6f8c01beaca5dc05c88a95b7a9df7660da4cef319cf685d886af6715261e9d4", size = 16957, upload-time = "2026-05-02T07:40:43.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA. Mostly interested in

> Fixed a `ResourceWarning: unclosed event loop` warning that could occur when a synchronous test called `asyncio.run()` or otherwise unset the current event loop after pytest-asyncio had run an async test or fixture.

https://github.com/pytest-dev/pytest-asyncio/releases/tag/v1.4.0a2

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Tests:
- Update pytest-asyncio testing dependency to require version 1.4.0a2 or newer.