### PR TITLE
fix: Ensure custom dotenv file is preserved in project instance and `--env-file` is honored

### DIFF
--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -119,6 +119,7 @@ class Project:
             "root": self.root,
             "environment": self.environment,
             "readonly": self.readonly,
+            "dotenv_file": self.dotenv_file,
             **kwargs,
         }
         cls = type(self)

--- a/tests/meltano/core/test_project.py
+++ b/tests/meltano/core/test_project.py
@@ -139,6 +139,13 @@ class TestProject:
         assert contents.startswith("# Please don't delete me :)\n")
         assert "a_new_key: New Key" in contents
 
+    def test_refresh_preserves_dotenv_file(self, project: Project, tmp_path) -> None:
+        env_file = tmp_path / "custom.env"
+        env_file.write_text("SOME_VAR=value\n")
+        project.dotenv_file = env_file
+        project.refresh()
+        assert project.dotenv_file == env_file
+
 
 class TestIncompatibleProject:
     @pytest.fixture


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Preserve the configured dotenv file when refreshing a Project instance so that custom env files and the --env-file option continue to be honored.

Bug Fixes:
- Ensure Project.refresh() carries over the existing dotenv_file attribute instead of resetting it.
- Add a regression test verifying that a custom dotenv file set on the Project persists after refresh().