### PR TITLE
test: Handle third-party warnings programmatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,10 +178,6 @@ filterwarnings = [
   '''once:The 'version' field in meltano.yml is deprecated.*:DeprecationWarning''',
   'once::meltano.core._compat.MeltanoInternalDeprecationWarning',
   # Third-party warnings
-  'once::pytest.PytestUnraisableExceptionWarning',
-  'once::pytest.PytestUnhandledThreadExceptionWarning',
-  'once::ResourceWarning',
-  'once:You are using a Python version .* which Google will stop supporting in new releases of google.api_core once it reaches its end of life:FutureWarning',
 ]
 log_level = "INFO"
 markers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import typing as t
 from collections import Counter
 from copy import deepcopy
@@ -58,6 +59,16 @@ def pytest_runtest_setup(item) -> None:
     # both as SYSTEM and WAREHOUSE.
     if backend_marker and backend_marker.args[0] != PYTEST_BACKEND:
         pytest.skip()
+
+
+def pytest_configure(config: pytest.Config):
+    if sys.version_info < (3, 11):
+        config.addinivalue_line(
+            "filterwarnings",
+            r"ignore:You are using a Python version \(3\.10\.\d+\) which Google will "
+            "stop supporting in new releases of google.api_core once it reaches its "
+            "end of life:FutureWarning",
+        )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Handle specific third-party FutureWarnings in pytest configuration rather than in the global project config.

Build:
- Remove several third-party warning filters from the pyproject.toml pytest configuration to rely on in-code handling instead.

Tests:
- Configure pytest to ignore google.api_core Python 3.10 FutureWarning programmatically via pytest_configure.