### PR TITLE
ci: Skip Grype checks for the ./docs directory in the Docker image, where it is not used

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,6 +1,10 @@
 # Grype configuration to reduce noise from vulnerabilities outside our control
 # https://github.com/anchore/grype#specifying-matches-to-ignore
 
+# Exclude paths that are not included in the published Docker images
+exclude:
+  - "./docs/**"
+
 ignore:
   # Ignore vulnerabilities with no fix available - we can't do anything about these
   - fix-state: not-fixed


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Build:
- Update Grype configuration to skip scanning the ./docs directory, which is not included in Docker images.