### PR TITLE
fix(cli): Make logging less noisy when listing state IDs from a filesystem-based state backend

### DIFF
--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -93,6 +93,7 @@ class StateService:
         Returns:
             A dict with state_ids as keys and state payloads as values.
         """
+        logger.info("Reading state from %s", self.state_store_manager.label)
         return {
             state_id: self.get_state(state_id)
             for state_id in self.state_store_manager.get_state_ids(state_id_pattern)
@@ -202,6 +203,7 @@ class StateService:
         Returns:
             Dict representing state that would be used in the next run.
         """
+        logger.info("Reading state from %s", self.state_store_manager.label)
         if state := self.state_store_manager.get(state_id=state_id):
             return json.loads(state.json_merged())
         return {}
@@ -268,6 +270,7 @@ class StateService:
         Returns:
             A dict mapping each state_id to ``{"completed": ..., "partial": ...}``.
         """
+        logger.info("Exporting state from %s", self.state_store_manager.label)
         return {s.state_id: s.to_dict() for s in self.state_store_manager.get_all()}
 
     def import_state(self, states: dict[str, dict[str, t.Any]]) -> int:

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -320,7 +320,6 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
         Raises:
             Exception: if error not indicating file is not found is thrown
         """
-        logger.info("Reading state from %s", self.label)
         try:
             with self.get_reader(self.get_state_path(state_id)) as reader:
                 return MeltanoState.from_file(state_id, reader)


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Adjust state retrieval and logging behavior to reduce noisy filesystem backend logs while preserving visibility at the service layer.

Bug Fixes:
- Ensure listing state IDs uses the unified state objects from the state store manager instead of fetching each state individually to avoid redundant operations and logging noise.

Enhancements:
- Move state read and export logging from the filesystem state store implementation to the higher-level state service, logging per operation rather than per file read.