### PR TITLE
fix(cli): Apply `.env` to `os.environ` so in-process SDK clients see project env vars

### DIFF
--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import click
 import structlog
+from dotenv import load_dotenv
 
 from meltano import __version__
 from meltano.cli.utils import InstrumentedGroup
@@ -126,6 +127,7 @@ def cli(
 
     try:
         project = Project.find(dotenv_file=env_file)
+        load_dotenv(dotenv_path=project.dotenv, override=False)
         setup_logging(project)
         logger.debug(
             "Meltano %s, Python %s, %s (%s)",

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -13,7 +13,7 @@ from operator import eq
 
 import dotenv
 import sqlalchemy
-import sqlalchemy.orm
+import sqlalchemy.exc
 import structlog
 
 from meltano.core.environment import NoActiveEnvironment
@@ -371,7 +371,7 @@ class BaseEnvStoreManager(SettingsStoreManager):
 
     @property
     @abstractmethod
-    def env(self):  # noqa: ANN201
+    def env(self) -> dict[str, str]:
         """Abstract environment values property."""
 
     def get(
@@ -443,13 +443,17 @@ class EnvStoreManager(BaseEnvStoreManager):
     label = "the environment"
 
     @property
-    def env(self) -> dict[str, str | None]:
+    def env(self) -> dict[str, str]:
         """Return values from the calling terminals environment.
 
         Returns:
-            Values found in the calling terminals environment.
+            Values found in the calling terminals environment, excluding any
+            keys that originated from the project's .env file (those are
+            handled by DotEnvStoreManager, even if load_dotenv has injected
+            them into os.environ for in-process SDK use).
         """
-        return self.settings_service.env
+        dotenv = self.project.dotenv_env
+        return {k: v for k, v in self.settings_service.env.items() if k not in dotenv}
 
     def get(
         self,
@@ -1009,7 +1013,7 @@ class DbStoreManager(SettingsStoreManager):
 
             self.log(f"Read key '{name}' from system database: {value!r}")
             return value, {}  # noqa: TRY300
-        except (sqlalchemy.orm.exc.NoResultFound, KeyError):
+        except (sqlalchemy.exc.NoResultFound, KeyError):
             return None, {}
 
     def set(


### PR DESCRIPTION
## Description

Variables set in a project's `.env` (e.g. `AWS_PROFILE`, `AZURE_TENANT_ID`, `GOOGLE_APPLICATION_CREDENTIALS`) were invisible to cloud SDK clients (boto3, azure-storage-blob, google-cloud-storage) running inside the Meltano process.

Meltano reads `.env` via `dotenv_values()` into an internal dict that is passed to plugin *subprocesses* as part of their environment, but the values were never injected into `os.environ`. Cloud SDK clients read `os.environ` directly, so they never saw those values. The only workaround was to set the variable in the shell before invoking Meltano (e.g. `AWS_PROFILE=arch-prod meltano state get ...`).

**Fix:**

1. Call `load_dotenv(override=False)` in the CLI entry point right after the project is located. This injects any `.env` variable not already set in the shell into `os.environ`, so SDK clients pick it up. Shell variables always take precedence (`override=False`), preserving the existing priority order.

2. `EnvStoreManager.env` now subtracts `project.dotenv_env` keys before returning. This ensures that a variable in `.env` is still reported as coming from `.env` (not "the environment") in `meltano config get`, and that `AutoStoreManager` write-store decisions are unaffected.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6 following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes #10037

## Summary by Sourcery

Load project .env variables into the Meltano CLI process environment while preserving correct configuration source reporting between environment and .env stores.

Bug Fixes:
- Ensure variables defined in a project .env file are visible to in-process SDK clients by loading them into os.environ when the project is located.
- Maintain accurate attribution of settings to .env rather than the environment by filtering .env-sourced keys out of the environment settings store.

Enhancements:
- Tighten type annotations and align SQLAlchemy exception handling with the sqlalchemy.exc.NoResultFound import.