### PR TITLE
docs: Hide Postman collection page for deployments and remove last remaining `discovery.yml` request 

### DIFF
--- a/docs/docs/reference/cloud/api/postman-collection.md
+++ b/docs/docs/reference/cloud/api/postman-collection.md
@@ -2,6 +2,7 @@
 title: Postman Collection
 description: Get started with a Postman collection for the Meltano Cloud API - contains all the requests and documentation.
 sidebar_position: 1
+draft: true
 ---
 
 We automatically maintain a fully-tested Postman collection for the Meltano Cloud API, which contains all the requests documented for each [resource](resources) type.

--- a/docs/docs/reference/cloud/api/resources/dataplugins.md
+++ b/docs/docs/reference/cloud/api/resources/dataplugins.md
@@ -148,33 +148,6 @@ Initialises a new dataplugin.
 
 ---
 
-### Publish dataplugins from a `discovery.yml`
-
-:::info
-**POST** `/api/workspaces/{workspace-id}/discovery.yml`
-:::
-
-Publishes dataplugins from a [Meltano `discovery.yml`](https://docs.meltano.com/reference/settings#discovery_url).
-
-#### Prerequisites
-- Workspace `{workspace-id}` must exist
-
-
-#### Body
-[Meltano `discovery.yml`](https://docs.meltano.com/reference/settings#discovery_url)
-<Snippet path="dataplugins/publish-dataplugins-from-a-discovery-yml/request-body.md" />
-
-
-<Examples path="dataplugins/publish-dataplugins-from-a-discovery-yml" />
-
-#### Response
-`201 Created`
-
-[Dataplugin](#dataplugin) collection with HAL links.
-<Snippet path="dataplugins/publish-dataplugins-from-a-discovery-yml/response-body.md" />
-
----
-
 ### Create a dataplugin
 
 :::info


### PR DESCRIPTION
## Description

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX
* Ref MEL-401

## Summary by Sourcery

Update API documentation to reflect current capabilities and mark new Postman collection docs as draft.

Documentation:
- Remove documentation for the deprecated `discovery.yml` dataplugin publication endpoint.
- Mark the Postman collection documentation page for the Meltano Cloud API as a draft.