### PR TITLE
fix: Fix race condition in `get_user_config_service` singleton

### DIFF
--- a/src/meltano/core/user_config.py
+++ b/src/meltano/core/user_config.py
@@ -185,6 +185,10 @@ def get_user_config_service(config_path: Path | None = None) -> UserConfigServic
         return _user_config_service
 
     with _user_config_service_lock:
+        if _user_config_service is not None and (
+            config_path is None or config_path == _user_config_service.config_path
+        ):
+            return _user_config_service
         _user_config_service = UserConfigService(config_path)
         return _user_config_service
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

Multiple threads could simultaneously pass the `_user_config_service is
not None` check and each create a new instance after acquiring the lock.
Add the same guard inside the lock (double-checked locking).

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Bug Fixes:
- Prevent multiple threads from creating separate UserConfigService instances by adding a double-checked guard inside the lock in get_user_config_service.