### PR TITLE
fix: inherit env_override variables from parent plugin settings service

### DIFF
--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -49,7 +49,7 @@ class PluginSettingsService(SettingsService):
         if self.inherited_settings_service:
             # Safe shallow copy clone to avoid reference mutability side-effects
             parent_env = dict(self.inherited_settings_service.env_override)
-            
+
         self.env_override = {
             # parent/inherited configuration environment values:
             **parent_env,

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -47,8 +47,9 @@ class PluginSettingsService(SettingsService):
         # Fetch environment configs from parent plugin if inherit_from is used
         parent_env = {}
         if self.inherited_settings_service:
-            parent_env = self.inherited_settings_service.env_override
-
+            # Safe shallow copy clone to avoid reference mutability side-effects
+            parent_env = dict(self.inherited_settings_service.env_override)
+            
         self.env_override = {
             # parent/inherited configuration environment values:
             **parent_env,

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -44,7 +44,14 @@ class PluginSettingsService(SettingsService):
                 self.plugin.name,
             )
 
+        # Fetch environment configs from parent plugin if inherit_from is used
+        parent_env = {}
+        if self.inherited_settings_service:
+            parent_env = self.inherited_settings_service.env_override
+
         self.env_override = {
+            # parent/inherited configuration environment values:
+            **parent_env,
             # project level environment variables:
             **self.project.settings.env,
             # project level settings as env vars (e.g. `MELTANO_PROJECT_ID`):

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -44,15 +44,13 @@ class PluginSettingsService(SettingsService):
                 self.plugin.name,
             )
 
-        # Fetch environment configs from parent plugin if inherit_from is used
-        parent_env = {}
-        if self.inherited_settings_service:
-            # Safe shallow copy clone to avoid reference mutability side-effects
-            parent_env = dict(self.inherited_settings_service.env_override)
-
         self.env_override = {
-            # parent/inherited configuration environment values:
-            **parent_env,
+            # Fetch environment configs from parent plugin if inherit_from is used
+            **(
+                self.inherited_settings_service.env_override
+                if self.inherited_settings_service
+                else {}
+            ),
             # project level environment variables:
             **self.project.settings.env,
             # project level settings as env vars (e.g. `MELTANO_PROJECT_ID`):

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -1095,12 +1095,28 @@ class TestPluginSettingsService:
         self,
         plugin_settings_service_factory,
         inherited_tap: ProjectPlugin,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test child plugins safely clone parent env_override."""
         # 1. Initialize the child service (which builds its parent)
         child_service = plugin_settings_service_factory(inherited_tap)
         parent_service = child_service.inherited_settings_service
+        assert parent_service is not None
 
         # 2. Verify mutation isolation (child state won't poison parent)
         child_service.env_override["CHILD_EXCLUSIVE_KEY"] = "isolated"
         assert "CHILD_EXCLUSIVE_KEY" not in parent_service.env_override
+
+        # 3. Verify parent's `env:` block inheritance
+        parent = inherited_tap.parent
+        monkeypatch.setattr(parent, "env", {"PARENT_ENV_VAR": "from_parent_env"})
+        child_service = plugin_settings_service_factory(inherited_tap)
+        assert child_service.env_override.get("PARENT_ENV_VAR") == "from_parent_env"
+
+        # 4. Child's own env_override kwarg takes priority over parent's `env:` block.
+        monkeypatch.setattr(parent, "env", {"SHARED_ENV_VAR": "from_parent"})
+        child_service = plugin_settings_service_factory(
+            inherited_tap,
+            env_override={"SHARED_ENV_VAR": "from_child"},
+        )
+        assert child_service.env_override.get("SHARED_ENV_VAR") == "from_child"

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -1096,14 +1096,14 @@ class TestPluginSettingsService:
         plugin_settings_service_factory,
         inherited_tap: ProjectPlugin,
     ) -> None:
-        """Test that child plugins safely clone parent env_override instead of referencing it."""
-        # 1. Initialize the child service (which automatically builds its parent)
+        """Test child plugins safely clone parent env_override."""
+        # 1. Initialize the child service (which builds its parent)
         child_service = plugin_settings_service_factory(inherited_tap)
         parent_service = child_service.inherited_settings_service
-
-        # 2. Assert they are NOT the exact same dictionary object in memory (shallow copy check)
+        
+        # 2. Assert they are distinct memory objects (shallow copy)
         assert child_service.env_override is not parent_service.env_override
 
-        # 3. Verify mutation isolation (modifying child does not poison parent state)
+        # 3. Verify mutation isolation (child state won't poison parent)
         child_service.env_override["CHILD_EXCLUSIVE_KEY"] = "isolated"
         assert "CHILD_EXCLUSIVE_KEY" not in parent_service.env_override

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -1094,22 +1094,16 @@ class TestPluginSettingsService:
     def test_inherited_env_override(
         self,
         plugin_settings_service_factory,
-        tap: ProjectPlugin,
         inherited_tap: ProjectPlugin,
-        monkeypatch,
     ) -> None:
-        """Test that child plugins correctly inherit env_override from their parent."""
-        # 1. Set a specific env var on the parent plugin
-        parent_service = plugin_settings_service_factory(tap)
-        parent_env_key = "DBT_POSTGRES_HOST"
-        parent_env_val = "parent-host"
-
-        # Manually inject into the parent's environment context
-        monkeypatch.setitem(parent_service.env_override, parent_env_key, parent_env_val)
-
-        # 2. Initialize the child service (which inherits from tap)
+        """Test that child plugins safely clone parent env_override instead of referencing it."""
+        # 1. Initialize the child service (which automatically builds its parent)
         child_service = plugin_settings_service_factory(inherited_tap)
-
-        # 3. Assert that the child now sees the parent's environment variable
-        # Our fix ensures the child service merges the parent's env_override
-        assert child_service.env_override.get(parent_env_key) == parent_env_val
+        parent_service = child_service.inherited_settings_service
+        
+        # 2. Assert they are NOT the exact same dictionary object in memory (shallow copy check)
+        assert child_service.env_override is not parent_service.env_override
+        
+        # 3. Verify mutation isolation (modifying child does not poison parent state)
+        child_service.env_override["CHILD_EXCLUSIVE_KEY"] = "isolated"
+        assert "CHILD_EXCLUSIVE_KEY" not in parent_service.env_override

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -1090,3 +1090,26 @@ class TestPluginSettingsService:
         )
         subject.set("stacked_env_var", "${NONEXISTENT_ENV_VAR}")
         assert subject.get("stacked_env_var") is None
+
+    def test_inherited_env_override(
+        self,
+        plugin_settings_service_factory,
+        tap: ProjectPlugin,
+        inherited_tap: ProjectPlugin,
+        monkeypatch,
+    ) -> None:
+        """Test that child plugins correctly inherit env_override from their parent."""
+        # 1. Set a specific env var on the parent plugin
+        parent_service = plugin_settings_service_factory(tap)
+        parent_env_key = "DBT_POSTGRES_HOST"
+        parent_env_val = "parent-host"
+        
+        # Manually inject into the parent's environment context
+        monkeypatch.setitem(parent_service.env_override, parent_env_key, parent_env_val)
+
+        # 2. Initialize the child service (which inherits from tap)
+        child_service = plugin_settings_service_factory(inherited_tap)
+
+        # 3. Assert that the child now sees the parent's environment variable
+        # Our fix ensures the child service merges the parent's env_override
+        assert child_service.env_override.get(parent_env_key) == parent_env_val

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -1100,10 +1100,10 @@ class TestPluginSettingsService:
         # 1. Initialize the child service (which automatically builds its parent)
         child_service = plugin_settings_service_factory(inherited_tap)
         parent_service = child_service.inherited_settings_service
-        
+
         # 2. Assert they are NOT the exact same dictionary object in memory (shallow copy check)
         assert child_service.env_override is not parent_service.env_override
-        
+
         # 3. Verify mutation isolation (modifying child does not poison parent state)
         child_service.env_override["CHILD_EXCLUSIVE_KEY"] = "isolated"
         assert "CHILD_EXCLUSIVE_KEY" not in parent_service.env_override

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -1101,9 +1101,6 @@ class TestPluginSettingsService:
         child_service = plugin_settings_service_factory(inherited_tap)
         parent_service = child_service.inherited_settings_service
 
-        # 2. Assert they are distinct memory objects (shallow copy)
-        assert child_service.env_override is not parent_service.env_override
-
-        # 3. Verify mutation isolation (child state won't poison parent)
+        # 2. Verify mutation isolation (child state won't poison parent)
         child_service.env_override["CHILD_EXCLUSIVE_KEY"] = "isolated"
         assert "CHILD_EXCLUSIVE_KEY" not in parent_service.env_override

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -26,7 +26,7 @@ from meltano.core.settings_store import (
 from meltano.core.utils import EnvironmentVariableNotSetError
 
 if t.TYPE_CHECKING:
-    from collections.abc import Callable, Generator
+    from collections.abc import Generator
 
     from sqlalchemy.orm import Session
 
@@ -34,10 +34,12 @@ if t.TYPE_CHECKING:
     from meltano.core.plugin.settings_service import PluginSettingsService
     from meltano.core.project import Project
 
-    PluginSettingsServiceFactory: t.TypeAlias = Callable[
-        [ProjectPlugin],
-        PluginSettingsService,
-    ]
+    class PluginSettingsServiceFactory(t.Protocol):
+        def __call__(
+            self,
+            plugin: ProjectPlugin,
+            env_override: dict | None = None,
+        ) -> PluginSettingsService: ...
 
 
 @pytest.mark.order(0)
@@ -86,7 +88,7 @@ def subject(tap, plugin_settings_service_factory) -> PluginSettingsService:
 
 
 @pytest.fixture
-def environment(project: Project) -> Generator[Environment, None, None]:
+def environment(project: Project) -> Generator[Environment | None, None, None]:
     project.activate_environment("dev")
     try:
         yield project.environment
@@ -223,7 +225,10 @@ class TestPluginSettingsService:
         """Casting is disabled for expandable strings."""
         monkeypatch.setenv("PORT", "4444")
         service = plugin_settings_service_factory(inherited_tap)
+
         parent = service.inherited_settings_service
+        assert parent is not None
+
         parent.set(
             "port",
             "5555",
@@ -1093,7 +1098,7 @@ class TestPluginSettingsService:
 
     def test_inherited_env_override(
         self,
-        plugin_settings_service_factory,
+        plugin_settings_service_factory: PluginSettingsServiceFactory,
         inherited_tap: ProjectPlugin,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -1103,7 +1103,7 @@ class TestPluginSettingsService:
         parent_service = plugin_settings_service_factory(tap)
         parent_env_key = "DBT_POSTGRES_HOST"
         parent_env_val = "parent-host"
-        
+
         # Manually inject into the parent's environment context
         monkeypatch.setitem(parent_service.env_override, parent_env_key, parent_env_val)
 

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -1100,7 +1100,7 @@ class TestPluginSettingsService:
         # 1. Initialize the child service (which builds its parent)
         child_service = plugin_settings_service_factory(inherited_tap)
         parent_service = child_service.inherited_settings_service
-        
+
         # 2. Assert they are distinct memory objects (shallow copy)
         assert child_service.env_override is not parent_service.env_override
 


### PR DESCRIPTION
Closes #9298

### Summary & Details
When a utility plugin utilizes `inherit_from`, child plugins inherit configurations but fail to properly resolve the parent context's default environment variables during validation or initial subprocess invocation. This happens because `PluginSettingsService.__init__` instantiates `self.env_override` strictly using local plugin, project, and environment configs without evaluating the upstream configuration layers accessible via `self.inherited_settings_service`.

As a result, commands like `meltano invoke child_plugin` trigger early validation faults (e.g., `ParsingError` or required configuration blocks throwing missing environment parameter exceptions) despite those variables being cleanly populated on the parent utility declaration.

### Proposed Changes
- Modified `PluginSettingsService.__init__` to check for an active `self.inherited_settings_service`.
- Injected the parent settings manager's compiled `env_override` dictionary into the local plugin `env_override` configuration map prior to evaluation.
- This ensures parent-defined environment layouts cascade fully down to inherited children utilities, matching expected configuration behaviors.

## Summary by Sourcery

Bug Fixes:
- Fix child plugins not receiving parent-defined environment variables in env_override when inherit_from is used, preventing validation and invocation errors.