### PR TITLE
docs: Fix display of reference index admonition

### DIFF
--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -8,7 +8,7 @@ toc: false
 :::info
 **Contributions are welcome!**
 
-  If there's a document you want to see that's not here, we welcome contributions to add it! Submit a [pull request](https://github.com/meltano/meltano/tree/main/docs) with your doc and the Meltano team will help you polish it for release. You may also [submit an issue](https://github.com/meltano/meltano/issues/new) to help us gauge interest in new docs.
+If there's a document you want to see that's not here, we welcome contributions to add it! Submit a [pull request](https://github.com/meltano/meltano/tree/main/docs) with your doc and the Meltano team will help you polish it for release. You may also [submit an issue](https://github.com/meltano/meltano/issues/new) to help us gauge interest in new docs.
 :::
 
 ## Index

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -6,7 +6,8 @@ toc: false
 ---
 
 :::info
-  **Contributions are welcome!**
+**Contributions are welcome!**
+
   If there's a document you want to see that's not here, we welcome contributions to add it! Submit a [pull request](https://github.com/meltano/meltano/tree/main/docs) with your doc and the Meltano team will help you polish it for release. You may also [submit an issue](https://github.com/meltano/meltano/issues/new) to help us gauge interest in new docs.
 :::
 


### PR DESCRIPTION
## Description

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Documentation:
- Reformat the reference index contribution info admonition for proper display in the docs.