### PR TITLE
chore: Fix types in `meltano.core.plugin.settings_service`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,7 +294,6 @@ module = [
   "meltano.core.plugin.dbt.*",
   "meltano.core.plugin.meltano_file",
   "meltano.core.plugin.project_plugin",
-  "meltano.core.plugin.settings_service",
   "meltano.core.runner.*",
   "meltano.core.tracking.*",
   "meltano.core.utils.*",

--- a/src/meltano/core/meltano_file.py
+++ b/src/meltano/core/meltano_file.py
@@ -27,7 +27,7 @@ class MeltanoFile(Canonical):
 
     version: int
     requires_meltano: str | None
-    plugins: dict[PluginType, list[ProjectPlugin]]
+    plugins: Canonical
     schedules: list[Schedule]
     environments: list[Environment]
     jobs: list[TaskSets]

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -22,8 +22,8 @@ class PluginSettingsService(SettingsService):
         self,
         project: Project,
         plugin: ProjectPlugin,
-        *args,  # noqa: ANN002
-        **kwargs,  # noqa: ANN003
+        *args: t.Any,
+        **kwargs: t.Any,
     ):
         """Create a new plugin settings manager.
 

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -18,6 +18,7 @@ from meltano.core.plugin_lock_service import PluginLockService
 if t.TYPE_CHECKING:
     from collections.abc import Generator
 
+    from meltano.core.behavior.canonical import Canonical
     from meltano.core.environment import EnvironmentPluginConfig
     from meltano.core.plugin.base import BasePlugin
     from meltano.core.plugin.project_plugin import ProjectPlugin
@@ -120,7 +121,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
         self._prefer_source = DefinitionSource.LOCAL
 
     @cached_property
-    def current_plugins(self) -> dict[PluginType, list[ProjectPlugin]]:
+    def current_plugins(self) -> Canonical:
         """Return the current plugins.
 
         Returns:
@@ -131,7 +132,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
     @contextmanager
     def update_plugins(
         self,
-    ) -> Generator[dict[PluginType, list[ProjectPlugin]], None, None]:
+    ) -> Generator[Canonical, None, None]:
         """Update the current plugins.
 
         Yields:
@@ -308,7 +309,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
         plugin_name: str,
         plugin: ProjectPlugin,
     ) -> ProjectPlugin | None:
-        mapping_name = plugin.extra_config.get("_mapping_name")
+        mapping_name: str | None = plugin.extra_config.get("_mapping_name")
         if mapping_name == plugin_name:
             all_mappings = self.find_plugins_by_mapping_name(mapping_name)
             if len(all_mappings) > 1:

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -367,7 +367,7 @@ class SettingsService(metaclass=ABCMeta):
         )
         if expand_env_vars and metadata.get("expandable", False):
             metadata["expandable"] = False
-            expanded_value = do_expand_env_vars(  # type: ignore[type-var]
+            expanded_value = do_expand_env_vars(
                 value,
                 env=expandable_env,
                 if_missing=EnvVarMissingBehavior(int(strict_env_var_mode)),  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -573,12 +573,7 @@ ENV_VAR_PATTERN = re.compile(
     re.VERBOSE,
 )
 
-Expandable = t.TypeVar(
-    "Expandable",
-    str,
-    Mapping[str, "Expandable"],
-    Sequence["Expandable"],
-)
+Expandable: t.TypeAlias = str | Mapping[str, "Expandable"] | list["Expandable"]
 
 
 class EnvVarMissingBehavior(IntEnum):
@@ -589,13 +584,53 @@ class EnvVarMissingBehavior(IntEnum):
     ignore = 2
 
 
+@t.overload
 def expand_env_vars(
-    raw_value: Expandable,
+    raw_value: None,
     env: Mapping[str, str],
     *,
     if_missing: EnvVarMissingBehavior = EnvVarMissingBehavior.use_empty_str,
     flat: bool = False,
-) -> Expandable:
+) -> None: ...
+
+
+@t.overload
+def expand_env_vars(
+    raw_value: str,
+    env: Mapping[str, str],
+    *,
+    if_missing: EnvVarMissingBehavior = EnvVarMissingBehavior.use_empty_str,
+    flat: bool = False,
+) -> str: ...
+
+
+@t.overload
+def expand_env_vars(
+    raw_value: list,
+    env: Mapping[str, str],
+    *,
+    if_missing: EnvVarMissingBehavior = EnvVarMissingBehavior.use_empty_str,
+    flat: bool = False,
+) -> list: ...
+
+
+@t.overload
+def expand_env_vars(
+    raw_value: Mapping,
+    env: Mapping[str, str],
+    *,
+    if_missing: EnvVarMissingBehavior = EnvVarMissingBehavior.use_empty_str,
+    flat: bool = False,
+) -> Mapping: ...
+
+
+def expand_env_vars(
+    raw_value: Expandable | None,
+    env: Mapping[str, str],
+    *,
+    if_missing: EnvVarMissingBehavior = EnvVarMissingBehavior.use_empty_str,
+    flat: bool = False,
+) -> Expandable | None:
     """Expand/interpolate provided env vars into a string or env mapping.
 
     By default, attempting to expand an env var which is not defined in the


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Improve type safety and typing annotations across core utilities, plugin services, and project configuration.

Enhancements:
- Refine the Expandable type and add overloads for env var expansion utilities to provide more precise return types.
- Update plugin- and project-related APIs to use the Canonical type and more accurate type annotations for plugin mappings and settings services.

Build:
- Adjust type-checker configuration by removing the dedicated module entry for the plugin settings service.