### PR TITLE
refactor: Apply missing `@override` decorators to first-party state backend implementations

### DIFF
--- a/src/meltano/core/state_store/azure/backend.py
+++ b/src/meltano/core/state_store/azure/backend.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from functools import cached_property
 
 from azure.storage.blob import BlobServiceClient
 
 from meltano.core.error import MeltanoError
-from meltano.core.state_store.filesystem import (
-    CloudStateStoreManager,
-)
+from meltano.core.state_store.filesystem import CloudStateStoreManager
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 
 class AZStorageStateStoreManager(CloudStateStoreManager):
@@ -50,6 +54,7 @@ class AZStorageStateStoreManager(CloudStateStoreManager):
         self.prefix = prefix or self.parsed.path
 
     @staticmethod
+    @override
     def is_file_not_found_error(err: Exception) -> bool:
         """Check if err is equivalent to file not being found.
 
@@ -94,6 +99,7 @@ class AZStorageStateStoreManager(CloudStateStoreManager):
             "Read https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string for more information.",  # noqa: E501
         )
 
+    @override
     def delete_file(self, file_path: str) -> None:
         """Delete the file/blob at the given path.
 
@@ -113,6 +119,7 @@ class AZStorageStateStoreManager(CloudStateStoreManager):
             if not self.is_file_not_found_error(e):
                 raise e  # noqa: TRY201
 
+    @override
     def list_all_files(
         self,
         *,
@@ -132,6 +139,7 @@ class AZStorageStateStoreManager(CloudStateStoreManager):
         ):
             yield blob.name
 
+    @override
     def copy_file(self, src: str, dst: str) -> None:
         """Copy a file from one location to another.
 

--- a/src/meltano/core/state_store/db.py
+++ b/src/meltano/core/state_store/db.py
@@ -70,6 +70,7 @@ class DBStateStoreManager(StateStoreManager):
         self.session.add(new_job_state)
         self.session.commit()
 
+    @override
     def get(self, state_id: str) -> MeltanoState | None:
         """Get the job state for the given state_id.
 

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -366,6 +366,7 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
     """State backend for local filesystem."""
 
     @property
+    @override
     def label(self) -> str:
         return "Local Filesystem"  # pragma: no cover
 
@@ -502,6 +503,7 @@ class _WindowsFilesystemStateStoreManager(_LocalFilesystemStateStoreManager):
     delimiter = "\\"
 
     @property
+    @override
     def label(self) -> str:
         return "Local Windows Filesystem"  # pragma: no cover
 

--- a/src/meltano/core/state_store/google/backend.py
+++ b/src/meltano/core/state_store/google/backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import typing as t
 import warnings
 from functools import cached_property
@@ -13,6 +14,11 @@ import google.cloud.storage
 import structlog.stdlib
 
 from meltano.core.state_store.filesystem import CloudStateStoreManager
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from collections.abc import Generator
@@ -81,6 +87,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
         self.application_credentials_json = application_credentials_json
 
     @staticmethod
+    @override
     def is_file_not_found_error(err: Exception) -> bool:
         """Check if err is equivalent to file not being found.
 
@@ -95,6 +102,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
         )
 
     @cached_property
+    @override
     def client(self) -> google.cloud.storage.Client:
         """Get an authenticated google.cloud.storage.Client.
 
@@ -123,6 +131,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
         return google.cloud.storage.Client()
 
     @property
+    @override
     def extra_transport_params(self) -> dict[str, t.Any]:
         """Extra transport params for ``smart_open.open``."""
         return {
@@ -131,6 +140,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
             },
         }
 
+    @override
     def delete_file(self, file_path: str) -> None:
         """Delete the file/blob at the given path.
 
@@ -150,6 +160,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
             else:
                 raise e  # noqa: TRY201
 
+    @override
     def list_all_files(self, *, with_prefix: bool = True) -> Generator[str, None, None]:
         """List all files in the backend.
 
@@ -166,6 +177,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
         ):
             yield blob.name
 
+    @override
     def copy_file(self, src: str, dst: str) -> None:
         """Copy a file from one location to another.
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Annotate first-party state store backend implementations and related methods with explicit override markers for better type checking and clarity.

Enhancements:
- Add conditional imports for typing.override or typing_extensions.override based on Python version.
- Mark cloud storage and filesystem state manager methods and properties as overrides of their base classes.
- Mark the database state store get method as an override of the base interface.