### PR TITLE
refactor: Apply missing `@override` decorators to `meltano.core.plugin`

### DIFF
--- a/src/meltano/core/plugin/command.py
+++ b/src/meltano/core/plugin/command.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import shlex
+import sys
 import typing as t
 
 from meltano.core.behavior.canonical import Canonical
 from meltano.core.container.container_spec import ContainerSpec
 from meltano.core.error import Error
 from meltano.core.utils import expand_env_vars
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from collections.abc import Mapping
@@ -87,6 +93,7 @@ class Command(Canonical):
         return expanded
 
     @classmethod
+    @override
     def as_canonical(cls, target):  # noqa: ANN001, ANN206
         """Serialize the target command.
 
@@ -105,6 +112,7 @@ class Command(Canonical):
         return canonical
 
     @classmethod
+    @override
     def parse(cls, obj: str | dict) -> Command:
         """Deserialize data into a Command.
 

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from pathlib import Path
 
@@ -15,6 +16,11 @@ from meltano.core.plugin_invoker import PluginInvoker
 from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.transform_add_service import TransformAddService
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.plugin_install_service import PluginInstaller
@@ -26,7 +32,8 @@ logger = structlog.stdlib.get_logger(__name__)
 class DbtInvoker(PluginInvoker):
     """dbt plugin invoker."""
 
-    def Popen_options(self):  # noqa: ANN201, N802
+    @override
+    def Popen_options(self) -> dict[str, t.Any]:
         """Get options for `subprocess.Popen`.
 
         Returns:
@@ -115,6 +122,7 @@ class DbtTransformPlugin(BasePlugin):
         super().__init__(*args, **kwargs)
         self.installer: PluginInstaller = install_dbt_plugin
 
+    @override
     def is_invokable(self) -> bool:
         """Return whether the plugin is invokable.
 

--- a/src/meltano/core/plugin/error.py
+++ b/src/meltano/core/plugin/error.py
@@ -1,10 +1,16 @@
 from __future__ import annotations  # noqa: D100
 
 import inspect
+import sys
 
 from meltano.core.plugin.base import PluginDefinition
 
 from . import PluginRef
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 
 class PluginNotFoundError(Exception):
@@ -18,7 +24,8 @@ class PluginNotFoundError(Exception):
             self.plugin_type = "plugin"
             self.plugin_name = plugin_or_name
 
-    def __str__(self) -> str:  # noqa: D105
+    @override
+    def __str__(self) -> str:
         return (
             f"{self.plugin_type.capitalize()} '{self.plugin_name}' is not "
             "known to Meltano"
@@ -32,7 +39,8 @@ class PluginNotSupportedError(Exception):
         """Construct a PluginNotSupportedError instance."""
         self.plugin = plugin
 
-    def __str__(self) -> str:  # noqa: D105
+    @override
+    def __str__(self) -> str:
         return (
             "Operation not supported for "
             f"{self.plugin.type.descriptor} '{self.plugin.name}'"
@@ -67,5 +75,6 @@ class InvalidPluginDefinitionError(Exception):
         else:
             self.reason = "incorrect format"
 
-    def __str__(self) -> str:  # noqa: D105
+    @override
+    def __str__(self) -> str:
         return f"Plugin definition is invalid: {self.reason}"

--- a/src/meltano/core/plugin/file.py
+++ b/src/meltano/core/plugin/file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 
 import structlog
@@ -12,6 +13,11 @@ from meltano.core.plugin.settings_service import PluginSettingsService
 from meltano.core.plugin_install_service import PluginInstallReason
 from meltano.core.setting_definition import SettingDefinition, SettingKind
 from meltano.core.venv_service import VirtualEnv
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from os import PathLike
@@ -39,6 +45,7 @@ class FilePlugin(BasePlugin):
         ),
     ]
 
+    @override
     def is_invokable(self) -> bool:
         """Return whether the plugin is invokable.
 
@@ -47,6 +54,7 @@ class FilePlugin(BasePlugin):
         """
         return False
 
+    @override
     def should_add_to_file(self) -> bool:
         """Return whether the plugin should be added to `meltano.yml`.
 

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from functools import cached_property
 
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.settings_service import FeatureFlags, SettingsService
 from meltano.core.utils import EnvVarMissingBehavior, expand_env_vars
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from meltano.core.environment import EnvironmentPluginConfig
@@ -100,6 +106,7 @@ class PluginSettingsService(SettingsService):
         self.env_override.update(environment_plugin_env)
 
     @property
+    @override
     def project_settings_service(self) -> SettingsService:
         """Get the settings service for the active project.
 
@@ -109,6 +116,7 @@ class PluginSettingsService(SettingsService):
         return self.project.settings
 
     @property
+    @override
     def label(self) -> str:
         """Get the label for this plugin.
 
@@ -118,6 +126,7 @@ class PluginSettingsService(SettingsService):
         return f"{self.plugin.type.descriptor} '{self.plugin.name}'"
 
     @property
+    @override
     def docs_url(self) -> str:
         """Get the documentation URL for this plugin.
 
@@ -126,6 +135,7 @@ class PluginSettingsService(SettingsService):
         """
         return self.plugin.docs
 
+    @override
     def setting_env_vars(
         self,
         setting_def: SettingDefinition,
@@ -148,6 +158,7 @@ class PluginSettingsService(SettingsService):
         )
 
     @property
+    @override
     def db_namespace(self):  # noqa: ANN201
         """Return namespace for setting value records in system database.
 
@@ -158,6 +169,7 @@ class PluginSettingsService(SettingsService):
         return f"{self.plugin.type}.{self.plugin.name}.default"
 
     @property
+    @override
     def setting_definitions(self) -> list[SettingDefinition]:
         """Return definitions of supported settings.
 
@@ -174,6 +186,7 @@ class PluginSettingsService(SettingsService):
         return settings
 
     @property
+    @override
     def meltano_yml_config(self):  # noqa: ANN201
         """Return current configuration in `meltano.yml`.
 
@@ -193,6 +206,7 @@ class PluginSettingsService(SettingsService):
             return self.environment_plugin_config.config_with_extras
         return {}
 
+    @override
     def update_meltano_yml_config(self, config: dict) -> None:
         """Update configuration in `meltano.yml`.
 
@@ -232,6 +246,7 @@ class PluginSettingsService(SettingsService):
             else None
         )
 
+    @override
     def process_config(self, config: dict[str, t.Any]) -> dict[str, t.Any]:
         """Process configuration dictionary to be passed to plugin.
 

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -91,6 +91,7 @@ class SingerPlugin(BasePlugin):
         _pop_non_leaf_keys(processed_config)
         return processed_config
 
+    @override
     def exec_env(self, plugin_invoker: PluginInvoker) -> dict[str, str]:
         """Get the environment variables for this tap.
 

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -352,7 +352,8 @@ class SelectionType(StrEnum):
         """
         return self not in {SelectionType.EXCLUDED, SelectionType.UNSUPPORTED}
 
-    def __add__(self, other: object) -> SelectionType:  # ty:ignore[invalid-method-override]
+    @override
+    def __add__(self, other: object) -> SelectionType:
         """Combine two selection types.
 
         Args:

--- a/src/meltano/core/plugin/singer/mapper.py
+++ b/src/meltano/core/plugin/singer/mapper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 
 import anyio
@@ -12,6 +13,11 @@ from meltano.core.setting_definition import SettingDefinition, SettingKind, json
 from meltano.core.utils import expand_env_vars
 
 from . import PluginType, SingerPlugin
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from pathlib import Path
@@ -44,11 +50,13 @@ class SingerMapper(SingerPlugin):
         ),
     ]
 
+    @override
     def exec_args(self, plugin_invoker: PluginInvoker) -> list[str | Path]:
         """Return the arguments to be passed to the plugin's executable."""
         return ["--config", plugin_invoker.files["config"]]
 
     @property
+    @override
     def config_files(self) -> dict[str, str]:
         """Return the configuration files required by the plugin."""
         return {

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -35,6 +35,11 @@ from .catalog import (
     select_metadata_rules,
 )
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from pathlib import Path
 
@@ -161,6 +166,7 @@ class SingerTap(SingerPlugin):
         ),
     ]
 
+    @override
     def exec_args(self, plugin_invoker):  # noqa: ANN001, ANN201
         """Return the arguments list with the complete runtime paths.
 
@@ -198,6 +204,7 @@ class SingerTap(SingerPlugin):
         return args
 
     @property
+    @override
     def config_files(self):  # noqa: ANN201
         """Get the configuration files for this tap."""
         return {
@@ -210,6 +217,7 @@ class SingerTap(SingerPlugin):
         }
 
     @property
+    @override
     def output_files(self):  # noqa: ANN201
         """Get the output files for this tap."""
         return {"output": "tap.out"}

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import typing as t
 from datetime import datetime, timezone
 
@@ -18,6 +19,11 @@ from meltano.core.state_service import (
 )
 
 from . import PluginType, SingerPlugin
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from pathlib import Path
@@ -116,6 +122,7 @@ class SingerTarget(SingerPlugin):
         SettingDefinition(name="_dialect", value="$MELTANO_LOADER_NAMESPACE"),
     ]
 
+    @override
     def exec_args(self, plugin_invoker: PluginInvoker) -> list[str | Path]:
         """Get command-line args to pass to the plugin.
 
@@ -128,6 +135,7 @@ class SingerTarget(SingerPlugin):
         return ["--config", plugin_invoker.files["config"]]
 
     @property
+    @override
     def config_files(self) -> dict[str, str]:
         """Get config files for this target.
 
@@ -141,6 +149,7 @@ class SingerTarget(SingerPlugin):
         }
 
     @property
+    @override
     def output_files(self) -> dict[str, str]:
         """Get output files for this target.
 

--- a/src/meltano/core/plugin/superset.py
+++ b/src/meltano/core/plugin/superset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import typing as t
 from contextlib import suppress
 
@@ -17,6 +18,11 @@ from meltano.core.setting_definition import SettingDefinition
 
 from . import BasePlugin, PluginType
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
@@ -26,6 +32,7 @@ logger = structlog.getLogger(__name__)
 class SupersetInvoker(PluginInvoker):
     """Invoker that prepares env for Superset."""
 
+    @override
     def env(self) -> dict[str, str]:
         """Environment variables for Superset.
 
@@ -53,6 +60,7 @@ class Superset(BasePlugin):
     ]
 
     @property
+    @override
     def config_files(self) -> dict[str, str]:
         """Return the configuration files required by the plugin.
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Annotate plugin-related classes and methods with explicit override decorators for improved type safety and clarity.

Enhancements:
- Add conditional imports for typing.override / typing_extensions.override based on Python version.
- Mark plugin error __str__ methods, settings service properties and methods, and various Singer, dbt, Superset, file, and command plugin hooks as overrides of base implementations.
- Align method signatures where necessary to correctly satisfy overridden interfaces (e.g. Popen_options, __add__).