### PR TITLE
refactor: Apply missing `@override` to the rest of the codebase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,7 @@ module = [
 ]
 
 [tool.ty.rules]
+missing-override-decorator = "error"
 unused-type-ignore-comment = "ignore"
 
 [tool.ty.src]

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -21,6 +21,11 @@ from meltano.core.tracking import Tracker
 from meltano.core.tracking.contexts import CliContext
 from meltano.core.utils import IncompatibleMeltanoVersionError, get_no_color_flag
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 logger = structlog.stdlib.get_logger(__name__)
 
 
@@ -33,7 +38,8 @@ class NoWindowsGlobbingGroup(InstrumentedGroup):
     typical Meltano commands fail, e.g. `meltano select tap-gitlab tags "*"`.
     """
 
-    def main(self, *args, **kwargs) -> t.Any:  # noqa: ANN002, ANN003, ANN401
+    @override
+    def main(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Invoke the Click CLI with Windows globbing disabled.
 
         Args:

--- a/src/meltano/cli/state.py
+++ b/src/meltano/cli/state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import json.decoder
 import re
+import sys
 import typing as t
 from datetime import datetime as dt
 from datetime import timezone as tz
@@ -21,6 +22,11 @@ from meltano.core.block.block_parser import BlockParser
 from meltano.core.db import project_engine
 from meltano.core.job import Payload
 from meltano.core.state_service import InvalidJobStateError, StateService
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -42,6 +48,7 @@ class MutuallyExclusiveOptionsError(Exception):
         super().__init__(*options)
         self.options = options
 
+    @override
     def __str__(self) -> str:
         """Represent the error as a string."""
         return f"Must provide exactly one of: {','.join(self.options)}"

--- a/src/meltano/cli/validate.py
+++ b/src/meltano/cli/validate.py
@@ -20,6 +20,11 @@ from meltano.core.plugin_install_service import PluginInstallReason
 from meltano.core.utils import run_async
 from meltano.core.validation_service import ValidationOutcome, ValidationsRunner
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from collections import abc
 
@@ -55,6 +60,7 @@ def write_sep_line(title: str, sepchar: str, **kwargs) -> None:  # noqa: ANN003
 class CommandLineRunner(ValidationsRunner):
     """Validator that runs in the CLI."""
 
+    @override
     async def run_test(self, name: str) -> int:
         """Run a test command.
 

--- a/src/meltano/core/block/singer.py
+++ b/src/meltano/core/block/singer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import asyncio.subprocess
+import sys
 import typing as t
 from contextlib import suppress
 
@@ -11,6 +12,11 @@ from meltano.core.block.ioblock import IOBlock
 from meltano.core.logging import capture_subprocess_output
 from meltano.core.plugin import PluginType
 from meltano.core.runner import RunnerError
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from asyncio.subprocess import Process
@@ -291,6 +297,7 @@ class SingerBlock(InvokerBase, IOBlock):
         self.plugin_args = plugin_args
 
     @property
+    @override
     def producer(self) -> bool:
         """Whether this plugin is a producer.
 
@@ -302,6 +309,7 @@ class SingerBlock(InvokerBase, IOBlock):
         return self.invoker.plugin.type in PRODUCERS
 
     @property
+    @override
     def consumer(self) -> bool:
         """Whether this plugin is a consumer.
 
@@ -313,6 +321,7 @@ class SingerBlock(InvokerBase, IOBlock):
         return self.invoker.plugin.type in CONSUMERS
 
     @property
+    @override
     def has_state(self) -> bool:
         """Whether this plugin has state.
 
@@ -321,6 +330,7 @@ class SingerBlock(InvokerBase, IOBlock):
         """
         return "state" in self.invoker.capabilities
 
+    @override
     async def start(self) -> None:
         """Start the SingerBlock by invoking the underlying plugin.
 
@@ -341,6 +351,7 @@ class SingerBlock(InvokerBase, IOBlock):
         except Exception as err:
             raise RunnerError(f"Cannot start plugin {self.string_id}: {err}") from err  # noqa: EM102, TRY003
 
+    @override
     async def stop(self, *, kill: bool = True) -> None:
         """Stop (kill) the underlying process and cancel output proxying.
 

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from enum import Enum
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from asyncio.streams import StreamReader
@@ -21,7 +27,8 @@ class ExitCode(int, Enum):  # noqa: D101
 class Error(Exception):
     """Base exception for ELT errors."""
 
-    def exit_code(self):  # noqa: ANN201, D102
+    def exit_code(self) -> ExitCode:
+        """Return the exit code for this error."""
         return ExitCode.FAIL
 
 
@@ -47,6 +54,7 @@ class MeltanoError(Error):
         self.instruction = instruction
         super().__init__(reason, instruction, *args, **kwargs)
 
+    @override
     def __str__(self) -> str:
         """Return a string representation of the error.
 
@@ -63,7 +71,8 @@ class MeltanoError(Error):
 class ExtractError(Error):
     """Error in the extraction process, like API errors."""
 
-    def exit_code(self):  # noqa: ANN201, D102
+    @override
+    def exit_code(self) -> ExitCode:
         return ExitCode.NO_RETRY
 
 

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from http import HTTPStatus
 
@@ -18,6 +19,11 @@ from meltano.core.plugin import PluginDefinition, PluginRef, PluginType, Variant
 from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.factory import base_plugin_factory
 from meltano.core.plugin_repository import PluginRepository
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from meltano.core.plugin import BasePlugin
@@ -220,6 +226,7 @@ class MeltanoHubService(PluginRepository):
         except requests.exceptions.ConnectionError as connection_err:
             raise HubConnectionError from connection_err
 
+    @override
     def find_definition(
         self,
         plugin_type: PluginType,
@@ -275,6 +282,7 @@ class MeltanoHubService(PluginRepository):
             is_default_variant=variant_name == plugin.default_variant,
         )
 
+    @override
     def find_base_plugin(
         self,
         plugin_type: PluginType,

--- a/src/meltano/core/job_state.py
+++ b/src/meltano/core/job_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from datetime import datetime
 
@@ -11,6 +12,11 @@ from meltano.core.job import JobFinder, Payload
 from meltano.core.models import SystemModel
 from meltano.core.sqlalchemy import StateType  # noqa: TC001
 from meltano.core.utils import merge
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -35,6 +41,7 @@ class JobState(SystemModel):
     partial_state: Mapped[t.Optional[StateType]]  # noqa: UP045
     completed_state: Mapped[t.Optional[StateType]]  # noqa: UP045
 
+    @override
     def __eq__(self, other: object) -> bool:
         """Check equality with another JobState.
 

--- a/src/meltano/core/locked_definition_service.py
+++ b/src/meltano/core/locked_definition_service.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 
 from meltano.core.plugin.factory import base_plugin_factory
 from meltano.core.plugin_lock_service import PluginLockService
 from meltano.core.plugin_repository import PluginRepository
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from meltano.core.plugin import BasePlugin, PluginDefinition, PluginType
@@ -25,6 +31,7 @@ class LockedDefinitionService(PluginRepository):
         self.project = project
         self.lock_service = PluginLockService(project)
 
+    @override
     def find_definition(
         self,
         plugin_type: PluginType,
@@ -50,6 +57,7 @@ class LockedDefinitionService(PluginRepository):
             variant_name=variant_name,
         )
 
+    @override
     def find_base_plugin(
         self,
         plugin_type: PluginType,

--- a/src/meltano/core/logging/parsers.py
+++ b/src/meltano/core/logging/parsers.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 import typing as t
 from abc import ABC, abstractmethod
 
 from .models import ParsedLogRecord, PluginException
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 logger = logging.getLogger(__name__)  # noqa: TID251
 
@@ -41,6 +47,7 @@ class SingerSDKLogParser(LogParser):
         "message",
     }
 
+    @override
     def parse(self, line: str) -> ParsedLogRecord | None:
         """Parse Singer SDK JSON log line.
 
@@ -90,6 +97,7 @@ class SingerSDKLogParser(LogParser):
 class PassthroughLogParser(LogParser):
     """Fallback parser that passes through unparsed lines."""
 
+    @override
     def parse(self, line: str) -> ParsedLogRecord | None:
         """Return line as-is with minimal structure.
 

--- a/src/meltano/core/logging/renderers.py
+++ b/src/meltano/core/logging/renderers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 from dataclasses import dataclass
 from io import StringIO
@@ -17,6 +18,11 @@ from rich.traceback import PathHighlighter
 
 from meltano.core.logging.models import PluginException
 from meltano.core.plugin_install_service import PluginInstallState
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from collections.abc import MutableMapping
@@ -341,6 +347,7 @@ class MeltanoConsoleRenderer(structlog.dev.ConsoleRenderer):  # noqa: TID251
         """Render the name to a string."""
         return name or self.DEFAULT_PLUGIN_NAME
 
+    @override
     def __call__(
         self,
         logger: WrappedLogger,

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -22,12 +22,17 @@ from meltano.core.utils import get_no_color_flag
 
 from .renderers import MeltanoConsoleRenderer
 
-logger = structlog.getLogger(__name__)
-
 if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
     from backports.strenum import StrEnum
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
+logger = structlog.getLogger(__name__)
 
 
 if t.TYPE_CHECKING:
@@ -47,6 +52,7 @@ class SafeStreamHandler(logging.StreamHandler):
     instructions on opting in via a custom ``logging.yaml`` config.
     """
 
+    @override
     def emit(self, record: logging.LogRecord) -> None:
         """Emit a record, falling back to backslashreplace on encode errors."""
         stream = self.stream

--- a/src/meltano/core/meltano_file.py
+++ b/src/meltano/core/meltano_file.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import sys
 import typing as t
 import warnings
 
@@ -12,6 +13,11 @@ from meltano.core.plugin import PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.schedule import ELTSchedule, JobSchedule
 from meltano.core.task_sets import TaskSets
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -136,6 +142,7 @@ class MeltanoFile(Canonical):
                 result.append(ELTSchedule(**schedule))
         return result
 
+    @override
     def __iter__(self):  # noqa: ANN204
         """Return an iterator over the attributes.
 

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -29,6 +29,11 @@ else:
     from backports.strenum import StrEnum
     from typing_extensions import Unpack
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from collections.abc import AsyncGenerator
     from pathlib import Path
@@ -123,6 +128,7 @@ class UnknownCommandError(InvokerError):
         self.plugin = plugin
         self.command = command
 
+    @override
     def __str__(self) -> str:
         """Return error message.
 

--- a/src/meltano/core/plugin_location_remove.py
+++ b/src/meltano/core/plugin_location_remove.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import sys
 import typing as t
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -15,6 +16,11 @@ from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin.settings_service import PluginSettingsService
 
 from .settings_store import SettingValueStore
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from meltano.core.plugin.project_plugin import ProjectPlugin
@@ -92,6 +98,7 @@ class DbRemoveManager(PluginLocationRemoveManager):
         self.plugins_settings_service = PluginSettingsService(project, plugin)
         self.session = project_engine(project)[1]
 
+    @override
     def remove(self) -> None:
         """Remove the plugin's settings from the system db `plugin_settings` table.
 
@@ -125,6 +132,7 @@ class MeltanoYmlRemoveManager(PluginLocationRemoveManager):
         super().__init__(plugin, str(project.meltanofile.relative_to(project.root)))
         self.project = project
 
+    @override
     def remove(self) -> None:
         """Remove the plugin from `meltano.yml`."""
         try:
@@ -159,6 +167,7 @@ class LockedDefinitionRemoveManager(PluginLocationRemoveManager):
 
         self.paths = list(lockfile_dir.glob(glob_expr))
 
+    @override
     def remove(self) -> None:
         """Remove the plugin from `plugins/`."""
         if not self.paths:
@@ -190,6 +199,7 @@ class InstallationRemoveManager(PluginLocationRemoveManager):
         super().__init__(plugin, str(path.parent.relative_to(project.root)))
         self.path = path
 
+    @override
     def remove(self) -> None:
         """Remove the plugin installation from `.meltano`."""
         if not self.path.exists():

--- a/src/meltano/core/plugin_test_service.py
+++ b/src/meltano/core/plugin_test_service.py
@@ -6,6 +6,7 @@ import asyncio
 import asyncio.subprocess
 import json
 import json.decoder
+import sys
 import typing as t
 from abc import ABC, abstractmethod
 
@@ -13,6 +14,11 @@ import structlog
 
 from meltano.core.plugin.base import PluginType
 from meltano.core.plugin.error import PluginNotSupportedError
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from meltano.core.plugin_invoker import PluginInvoker
@@ -70,6 +76,7 @@ class PluginTestService(ABC):
 class ExtractorTestService(PluginTestService):
     """Handle extractor test operations."""
 
+    @override
     async def validate(self, **kwargs: t.Any) -> tuple[bool, str | None]:
         """Validate extractor configuration.
 
@@ -122,6 +129,7 @@ class ExtractorTestService(PluginTestService):
 class LoaderTestService(PluginTestService):
     """Handle loader test operations."""
 
+    @override
     async def validate(self, **kwargs: t.Any) -> tuple[bool, str | None]:
         """Validate loader configuration by sending test Singer messages.
 

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -36,6 +36,11 @@ from meltano.core.utils import (
     truthy,
 )
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from collections.abc import Generator
 
@@ -651,6 +656,7 @@ class Project:
             make_dirs=make_dirs,
         )
 
+    @override
     def __eq__(self, other: object) -> bool:
         """Project equivalence check.
 
@@ -662,6 +668,7 @@ class Project:
         """
         return self.root == getattr(other, "root", object())
 
+    @override
     def __hash__(self) -> int:
         """Project hash.
 
@@ -670,6 +677,7 @@ class Project:
         """
         return self.root.__hash__()
 
+    @override
     def __repr__(self) -> str:
         """Project representation.
 

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -17,6 +17,11 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
     from meltano.core.setting_definition import SettingDefinition
@@ -76,6 +81,7 @@ class ProjectSettingsService(SettingsService):
             )
 
     @property
+    @override
     def project_settings_service(self) -> Self:
         """Get the settings service for this project.
 
@@ -115,6 +121,7 @@ class ProjectSettingsService(SettingsService):
                 logger.debug("Restored 'project_id' from 'analytics.json'")
 
     @property
+    @override
     def label(self) -> str:
         """Return label.
 
@@ -124,6 +131,7 @@ class ProjectSettingsService(SettingsService):
         return "Meltano"
 
     @property
+    @override
     def docs_url(self) -> str:
         """Return docs URL.
 
@@ -133,6 +141,7 @@ class ProjectSettingsService(SettingsService):
         return "https://docs.meltano.com/reference/settings"
 
     @property
+    @override
     def db_namespace(self) -> str:
         """Return namespace for setting value records in system database.
 
@@ -142,6 +151,7 @@ class ProjectSettingsService(SettingsService):
         return "meltano"
 
     @property
+    @override
     def setting_definitions(self) -> list[SettingDefinition]:
         """Return definitions of supported settings.
 
@@ -151,6 +161,7 @@ class ProjectSettingsService(SettingsService):
         return self.project.config_service.settings
 
     @property
+    @override
     def meltano_yml_config(self) -> dict[str, t.Any]:
         """Return current configuration in `meltano.yml`.
 
@@ -159,6 +170,7 @@ class ProjectSettingsService(SettingsService):
         """
         return self.project.config_service.current_config
 
+    @override
     def update_meltano_yml_config(self, config: dict[str, t.Any]) -> None:
         """Update configuration in `meltano.yml`.
 
@@ -167,6 +179,7 @@ class ProjectSettingsService(SettingsService):
         """
         self.project.config_service.update_config(config)
 
+    @override
     def process_config(self, config: dict[str, t.Any]) -> dict[str, t.Any]:
         """Process configuration dict for presentation in `meltano config meltano`.
 

--- a/src/meltano/core/setting.py
+++ b/src/meltano/core/setting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # noqa: D100
 
+import sys
 import typing as t
 
 from sqlalchemy import types
@@ -8,6 +9,11 @@ from sqlalchemy.orm import Mapped, mapped_column
 from meltano.core.sqlalchemy import StrPK  # noqa: TC001
 
 from .models import SystemModel
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 
 class Setting(SystemModel):  # noqa: D101
@@ -24,6 +30,7 @@ class Setting(SystemModel):  # noqa: D101
     value: Mapped[t.Optional[str]] = mapped_column(types.PickleType)  # noqa: UP045
     enabled: Mapped[bool] = mapped_column(default=False)
 
-    def __repr__(self) -> str:  # noqa: D105
+    @override
+    def __repr__(self) -> str:
         enabled_marker = "E" if self.enabled else ""
         return f"<({self.namespace}) {self.name}={self.value} {enabled_marker}>"

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -319,6 +319,7 @@ class SettingDefinition(NameEq, Canonical):
 
         self._verbatim.add("value")
 
+    @override
     def __repr__(self) -> str:
         """Return string representation.
 

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -24,6 +24,11 @@ else:
     from backports.strenum import StrEnum
     from typing_extensions import Self
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from collections.abc import Generator, Iterable
 
@@ -70,6 +75,7 @@ class FeatureNotAllowedException(Exception):
         super().__init__(feature)
         self.feature = feature
 
+    @override
     def __str__(self) -> str:
         """Represent the error as a string.
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Add explicit override annotations and type hints across the codebase to enforce interface contracts and improve type checking.

Enhancements:
- Annotate overriding methods and dunder implementations with @override throughout core, CLI, logging, hub, and plugin services.
- Tighten type hints for several methods, including exit codes and CLI entrypoints, to better align with their actual behavior.

Build:
- Configure type-checking rules to treat missing override decorators as errors in the ty configuration.