### PR TITLE
fix: Updated the docs overview cards with open and cloud details

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -104,6 +104,13 @@ const config = {
             'aria-label': 'Tutorials',
           },
           {
+            to: '/reference',
+            label: 'Reference',
+            position: 'left',
+            className: 'header-reference-link',
+            'aria-label': 'Reference',
+          },
+          {
             to: '/changelog',
             label: 'Changelog',
             position: 'left',

--- a/docs/src/components/homepage/Features.js
+++ b/docs/src/components/homepage/Features.js
@@ -1,37 +1,34 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './features.module.scss';
 import Link from '@docusaurus/Link';
 
+const openEdition = {
+  Svg: require('@site/static/img/homepage/open.svg').default,
+  name: 'Open',
+  desc: 'The open-source, self-hosted foundation of Meltano. Own every part of your data infrastructure, on your own servers, free forever. Best for teams with DevOps capacity who want full control with zero vendor dependency.',
+  features: [
+    { text: 'You host and manage everything on your own servers', type: 'base' },
+    { text: 'Access to 600+ built-in connectors', type: 'base' },
+    { text: 'Free, you pay only for your own infra', type: 'base' },
+  ],
+  cta: { title: 'Get Started', url: '/getting-started/meltano-at-a-glance' },
+};
+
+const cloudEdition = {
+  Svg: require('@site/static/img/homepage/cloud.svg').default,
+  name: 'Cloud',
+  desc: 'A fully managed hosted service built on top of Meltano Open. Pipelines, workspaces, secrets, and monitoring are all handled for you. No infrastructure to provision, patch, or maintain. Best for data teams who want to move fast without managing the plumbing.',
+  features: [
+    { text: 'Meltano hosts, scales, and maintains everything for you', type: 'base' },
+    { text: 'Access to 600+ built-in and custom connectors', type: 'base' },
+    { text: 'Paid plans based on compute hours', type: 'base' },
+    { text: 'Built-in pipeline monitoring and alerts', type: 'base' },
+  ],
+  cta: { title: 'Get Started', url: '/getting-started/cloud-overview' },
+};
+
 const FeatureList = [
-  {
-    title: 'Open',
-    Svg: require('@site/static/img/homepage/open.svg').default,
-    description: (
-      <>
-        Open source (MIT). The core Singer-based ELT engine. Bring your own
-        orchestration, storage, and infrastructure. Fully self-managed.
-      </>
-    ),
-    link: {
-      title: 'Get Started',
-      url: '/getting-started/meltano-at-a-glance',
-    },
-  },
-  {
-    title: 'Cloud',
-    Svg: require('@site/static/img/homepage/cloud.svg').default,
-    description: (
-      <>
-        Fully managed hosted service. Hosted pipelines, workspaces, secrets, and
-        monitoring. No infrastructure to run. Connect with us, get access and
-        start moving data in minutes.{' '}
-      </>
-    ),
-    link: {
-      title: 'Get Started',
-      url: '/getting-started/cloud-overview',
-    },
-  },
   {
     title: 'Reference',
     Svg: require('@site/static/img/homepage/book-open.svg').default,
@@ -41,10 +38,7 @@ const FeatureList = [
         plugin definition syntax, and more.
       </>
     ),
-    link: {
-      title: 'View Reference',
-      url: '/reference',
-    },
+    link: { title: 'View Reference', url: '/reference' },
   },
   {
     title: 'Meltano Hub',
@@ -55,11 +49,7 @@ const FeatureList = [
         ecosystem.
       </>
     ),
-    link: {
-      title: 'Go to Hub',
-      url: 'https://hub.meltano.com',
-      target: '_blank',
-    },
+    link: { title: 'Go to Hub', url: 'https://hub.meltano.com', target: '_blank' },
   },
   {
     title: 'SDK',
@@ -70,11 +60,7 @@ const FeatureList = [
         destination.
       </>
     ),
-    link: {
-      title: 'Go to SDK',
-      url: 'https://sdk.meltano.com',
-      target: '_blank',
-    },
+    link: { title: 'Go to SDK', url: 'https://sdk.meltano.com', target: '_blank' },
   },
   {
     title: 'SDK in Action',
@@ -85,13 +71,56 @@ const FeatureList = [
         on GitHub: Meltano Labs.
       </>
     ),
-    link: {
-      title: 'View Examples',
-      url: 'https://github.com/meltanolabs/',
-      target: '_blank',
-    },
+    link: { title: 'View Examples', url: 'https://github.com/meltanolabs/', target: '_blank' },
   },
 ];
+
+// Each direct child maps to one subgrid row: header / desc / metric / features / cta
+function EditionCard({ Svg, name, desc, metric, metricLabel, chip, features, cta }) {
+  return (
+    <div className="edition-card">
+      <div className={styles.header}>
+        <Svg className={styles.featureSvg} role="img" />
+        <h4 className="text-2xl font-semibold ms-2">{name}</h4>
+      </div>
+
+      <p className="p2">{desc}</p>
+
+      <ul className="edition-features">
+        {features.map((f, i) => (
+          <li key={i} className="edition-features__item">
+            {f.type === 'add'
+              ? <span className="edition-features__add">+</span>
+              : <span className="edition-features__check">✓</span>
+            }
+            {f.text}
+          </li>
+        ))}
+      </ul>
+
+      <Link to={cta.url} className="btn main-btn">
+        {cta.title}
+      </Link>
+    </div>
+  );
+}
+
+EditionCard.propTypes = {
+  Svg: PropTypes.elementType.isRequired,
+  name: PropTypes.string.isRequired,
+  desc: PropTypes.string.isRequired,
+  metric: PropTypes.string,
+  metricLabel: PropTypes.string,
+  chip: PropTypes.string,
+  features: PropTypes.arrayOf(PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+  })).isRequired,
+  cta: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+};
 
 // eslint-disable-next-line react/prop-types
 function Feature({ Svg, title, description, link }) {
@@ -117,7 +146,11 @@ export default function HomepageFeatures() {
   return (
     <section className="md:my-20">
       <div className="container relative">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="edition-grid">
+          <EditionCard {...openEdition} />
+          <EditionCard {...cloudEdition} />
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
           {FeatureList.map((props, idx) => (
             <Feature key={idx} {...props} />
           ))}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -831,6 +831,15 @@ main {
   background-position: center center;
 }
 
+.header-reference-link::before {
+  background: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEwIDUuMDM1MDFDOC42MjYzNCAzLjgwMjgxIDYuODQ1MzMgMy4xMjI0NiA1IDMuMTI1MDFDNC4xMjMzMyAzLjEyNTAxIDMuMjgxNjcgMy4yNzUwMSAyLjUgMy41NTE2N1YxNS40MjY3QzMuMzAzMDIgMTUuMTQzNCA0LjE0ODQ3IDE0Ljk5OTEgNSAxNUM2LjkyMDgzIDE1IDguNjczMzMgMTUuNzIyNSAxMCAxNi45MU0xMCA1LjAzNTAxQzExLjM3MzYgMy44MDI3NCAxMy4xNTQ3IDMuMTIyMzggMTUgMy4xMjUwMUMxNS44NzY3IDMuMTI1MDEgMTYuNzE4MyAzLjI3NTAxIDE3LjUgMy41NTE2N1YxNS40MjY3QzE2LjY5NyAxNS4xNDM0IDE1Ljg1MTUgMTQuOTk5MSAxNSAxNUMxMy4xNTQ3IDE0Ljk5NzUgMTEuMzczNyAxNS42Nzc4IDEwIDE2LjkxTTEwIDUuMDM1MDFWMTYuOTEiIHN0cm9rZT0iIzNBNjRGQSIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4K") no-repeat;
+  content: "";
+  display: flex;
+  height: 24px;
+  width: 26px;
+  background-position: center center;
+}
+
 .header-docs-link::before {
   background: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEwIDUuMDM1MDFDOC42MjYzNCAzLjgwMjgxIDYuODQ1MzMgMy4xMjI0NiA1IDMuMTI1MDFDNC4xMjMzMyAzLjEyNTAxIDMuMjgxNjcgMy4yNzUwMSAyLjUgMy41NTE2N1YxNS40MjY3QzMuMzAzMDIgMTUuMTQzNCA0LjE0ODQ3IDE0Ljk5OTEgNSAxNUM2LjkyMDgzIDE1IDguNjczMzMgMTUuNzIyNSAxMCAxNi45MU0xMCA1LjAzNTAxQzExLjM3MzYgMy44MDI3NCAxMy4xNTQ3IDMuMTIyMzggMTUgMy4xMjUwMUMxNS44NzY3IDMuMTI1MDEgMTYuNzE4MyAzLjI3NTAxIDE3LjUgMy41NTE2N1YxNS40MjY3QzE2LjY5NyAxNS4xNDM0IDE1Ljg1MTUgMTQuOTk5MSAxNSAxNUMxMy4xNTQ3IDE0Ljk5NzUgMTEuMzczNyAxNS42Nzc4IDEwIDE2LjkxTTEwIDUuMDM1MDFWMTYuOTEiIHN0cm9rZT0iIzNBNjRGQSIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4K") no-repeat;
   content: "";
@@ -861,6 +870,15 @@ main {
 
 [data-theme='dark'] .header-tutorials-link::before {
   background: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0LjY2MDggMi43NjgxNEMxNS41Nzc1IDIuODc0OCAxNi4yNSAzLjY2NTY0IDE2LjI1IDQuNTg4OTdWMTcuNDk5OEwxMCAxNC4zNzQ4TDMuNzUgMTcuNDk5OFY0LjU4ODk3QzMuNzUgMy42NjU2NCA0LjQyMTY3IDIuODc0OCA1LjMzOTE3IDIuNzY4MTRDOC40MzU5OSAyLjQwODY3IDExLjU2NCAyLjQwODY3IDE0LjY2MDggMi43NjgxNFoiIHN0cm9rZT0iIzE4QzNGQSIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4K") no-repeat;
+  content: "";
+  display: flex;
+  height: 24px;
+  width: 26px;
+  background-position: center center;
+}
+
+[data-theme='dark'] .header-reference-link::before {
+  background: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEwIDUuMDM1MDFDOC42MjYzNCAzLjgwMjgxIDYuODQ1MzMgMy4xMjI0NiA1IDMuMTI1MDFDNC4xMjMzMyAzLjEyNTAxIDMuMjgxNjcgMy4yNzUwMSAyLjUgMy41NTE2N1YxNS40MjY3QzMuMzAzMDIgMTUuMTQzNCA0LjE0ODQ3IDE0Ljk5OTEgNSAxNUM2LjkyMDgzIDE1IDguNjczMzMgMTUuNzIyNSAxMCAxNi45MU0xMCA1LjAzNTAxQzExLjM3MzYgMy44MDI3NCAxMy4xNTQ3IDMuMTIyMzggMTUgMy4xMjUwMUMxNS44NzY3IDMuMTI1MDEgMTYuNzE4MyAzLjI3NTAxIDE3LjUgMy41NTE2N1YxNS40MjY3QzE2LjY5NyAxNS4xNDM0IDE1Ljg1MTUgMTQuOTk5MSAxNSAxNUMxMy4xNTQ3IDE0Ljk5NzUgMTEuMzczNyAxNS42Nzc4IDEwIDE2LjkxTTEwIDUuMDM1MDFWMTYuOTEiIHN0cm9rZT0iIzE4QzNGQSIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4K") no-repeat;
   content: "";
   display: flex;
   height: 24px;
@@ -1573,4 +1591,151 @@ article {
   font-size: 14px;
   font-weight: 600;
   color: var(--meltano-blue) !important;
+}
+
+/* Homepage edition cards (Open / Cloud) */
+
+/* Subgrid container: 5 named row tracks so every section aligns across both cards */
+.edition-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto auto 1fr auto;
+  column-gap: 16px;
+  row-gap: 20px;
+  margin-bottom: 16px;
+}
+
+@media (max-width: 1024px) {
+  .edition-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: none;
+    row-gap: 16px;
+  }
+  .edition-card {
+    display: flex !important;
+    flex-direction: column;
+    gap: 16px;
+  }
+}
+
+.edition-card {
+  display: grid;
+  grid-row: span 5;
+  grid-template-rows: subgrid;
+  align-content: start;
+  border-radius: 5px;
+  padding: 30px;
+  border: 1px solid rgba(8, 2, 22, 0.15);
+  background: rgba(255, 255, 255, 0.7);
+  position: relative;
+  z-index: 3;
+}
+
+[data-theme='dark'] .edition-card {
+  border-color: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.edition-card::before {
+  content: "";
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.5;
+  background-image: url(/img/homepage/bg-ellipse.svg);
+  background-size: cover;
+  background-repeat: no-repeat;
+  pointer-events: none;
+}
+
+.edition-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.edition-metric__number {
+  font-size: 36px;
+  font-weight: 800;
+  line-height: 1.1;
+  color: var(--markdown-h-color);
+}
+
+.edition-metric__label {
+  font-size: 13px;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 4px;
+}
+
+.edition-chip {
+  display: inline-block;
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 2px 10px;
+  border-radius: 20px;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-700);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  width: fit-content;
+}
+
+.edition-chip--highlight {
+  background: rgba(153, 206, 85, 0.2);
+  color: #3d6a12;
+  border-color: rgba(153, 206, 85, 0.5);
+}
+
+[data-theme='dark'] .edition-chip--highlight {
+  color: var(--meltano-green);
+  background: rgba(153, 206, 85, 0.1);
+}
+
+.edition-features {
+  list-style: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding-top: 14px !important;
+}
+
+[data-theme='dark'] .edition-features {
+  border-top-color: rgba(255, 255, 255, 0.1);
+}
+
+.edition-features__item {
+  font-size: 13.5px;
+  line-height: 1.45;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  color: var(--ifm-color-emphasis-800) !important;
+}
+
+.edition-features__check {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-500);
+  margin-top: 1px;
+}
+
+.edition-features__add {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--meltano-blue);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
 }


### PR DESCRIPTION
## Description

Updates the homepage Open and Cloud edition cards with refreshed positioning copy and simplified feature lists.

Open edition

New description: frames Open as the self-hosted, open-source foundation — zero vendor dependency, free forever
Feature list trimmed to 3 focused items: self-hosting, 600+ connectors, free infra

Cloud edition

New description: positions Cloud as the fully managed layer built on top of Meltano Open — no infrastructure to provision or maintain
Feature list updated to 4 items: managed hosting, 600+ and custom connectors, compute-hour billing, built-in monitoring
Also includes supporting CSS and docusaurus config tweaks for the edition card layout.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Revise the homepage to highlight distinct Open and Cloud edition cards with updated positioning copy and feature lists, and add a dedicated Reference nav link and icon styling.

New Features:
- Introduce dedicated Open and Cloud edition cards on the docs homepage with tailored descriptions, feature highlights, and calls to action.
- Add a Reference item to the main docs navigation with a custom header icon style.

Enhancements:
- Update homepage feature grid layout to accommodate edition cards above the existing resources.
- Add CSS for edition card layout, feature list styling, and header reference link icons in light and dark themes.