### PR TITLE
fix: Docs content updated for Getting Started, removed Meltano Community f…

### DIFF
--- a/docs/docs/getting-started/cloud-quickstart.mdx
+++ b/docs/docs/getting-started/cloud-quickstart.mdx
@@ -53,5 +53,5 @@ Get from zero to a running pipeline in five steps. No infrastructure setup requi
 </div>
 
 :::tip You're live
-Once your first run succeeds you can set a schedule, configure external log streaming (DataDog, CloudWatch, Grafana), and add alerting — all from the Cloud UI.
+Once your first run succeeds you can set a schedule, configure external log streaming (DataDog), and add alerting — all from the Cloud UI.
 :::

--- a/docs/docs/getting-started/which-meltano.mdx
+++ b/docs/docs/getting-started/which-meltano.mdx
@@ -1,177 +1,52 @@
 ---
-title: Which Meltano is right for me?
-description: Compare Meltano Open, Meltano Community, and Meltano Cloud — choose the right product for your team size, support requirements, and operational preferences.
+title: Which Meltano Is Right for You?
+description: Compare Meltano Open and Meltano Cloud — choose the right product for your team's needs.
 sidebar_position: 0
 ---
 
 import Link from '@docusaurus/Link';
 
-Meltano is one platform — open at the core, with hosted and managed tiers layered on top. Pick your starting point below and the docs will guide you from there.
-
 <div className="wm-chooser">
-  <Link to="/getting-started/cloud-quickstart" className="wm-card wm-card--cloud">
+  <div className="wm-card wm-card--cloud">
     <div className="wm-card__icon">☁️</div>
     <div className="wm-card__header">
       <span className="wm-card__title">Meltano Cloud</span>
       <span className="wm-badge wm-badge--cloud">Fully managed</span>
     </div>
-    <p className="wm-card__desc">Hosted pipelines, workspaces, secrets, and monitoring. No infrastructure to run. Sign up and start moving data in minutes.</p>
-    <span className="wm-card__cta">Get started with Cloud →</span>
-  </Link>
+    <p className="wm-card__desc">Fully managed hosted service. Hosted pipelines, workspaces, secrets, and monitoring. No infrastructure to run. <a href="https://meltano.com/contact">Connect with us</a>, get access and start moving data in minutes.</p>
+  </div>
 
-  <Link to="/getting-started/installation" className="wm-card wm-card--community">
-    <div className="wm-card__icon">👥</div>
-    <div className="wm-card__header">
-      <span className="wm-card__title">Meltano Community</span>
-      <span className="wm-badge wm-badge--community">Self-hosted</span>
-    </div>
-    <p className="wm-card__desc">The full-featured open-source edition. Run locally or on your own infra. Includes the CLI, the Hub, and community plugins.</p>
-    <span className="wm-card__cta">Install Community →</span>
-  </Link>
-
-  <Link to="/getting-started/meltano-at-a-glance" className="wm-card wm-card--open">
+  <div className="wm-card wm-card--open">
     <div className="wm-card__icon">🔄</div>
     <div className="wm-card__header">
       <span className="wm-card__title">Meltano Open</span>
-      <span className="wm-badge wm-badge--open">Open source</span>
+      <span className="wm-badge wm-badge--open">Open source (MIT)</span>
     </div>
-    <p className="wm-card__desc">The core Singer-based ELT engine. Bring your own orchestration, storage, and infra. MIT licensed and fully self-managed.</p>
-    <span className="wm-card__cta">Self-host Meltano Open →</span>
-  </Link>
+    <p className="wm-card__desc">The core Singer-based ELT engine. Bring your own orchestration, storage, and infrastructure. Fully self-managed.</p>
+  </div>
 </div>
 
 ---
 
-## Meltano Open
+## Feature Comparison
 
-Full open-source Meltano on your own infrastructure with complete ownership and flexibility.
-
-### Includes
-
-- Declarative, code-first pipelines
-- Git-native change management
-- 600+ connectors
-- Documentation
-- Complete ownership of infrastructure
-- Self-managed deployments
-- Open-source extensibility
-
-### Best suited for
-
-- Developers
-- Small engineering teams
-- Organizations preferring self-hosting
-- Teams wanting full infrastructure control
+| Features | Open | Cloud |
+|---|---|---|
+| Connectors | 600+ connectors | 600+ and custom connectors |
+| Pipeline hours | Self managed, Not applicable | Unlimited |
+| Users | Only you | Unlimited |
+| Setup | Well documented, self-setup | Easy, stress-free and managed setup |
+| Account management | — | Dedicated |
+| Engineer on demand / mo | — | Starting from 8hrs/mo |
+| Build with agents | ✅ | ✅ |
+| Reverse ETL connections | ✅ | ✅ |
+| API | — | ✅ |
+| Workspaces | — | ✅ |
+| Direct engineer Slack access | — | ✅ |
+| Enterprise grade security | — | ✅ |
+| AI Data Engineer Agent | — | ✅ |
 
 ---
 
-## Meltano Community
+Not sure which to choose? Jump into our [Slack community's #general channel](https://meltano.com/slack) or [connect with us](https://meltano.com/contact) and we will be happy to help.
 
-Open source paired with priority support, bug fixes, and direct access to the Meltano engineering team.
-
-### Includes everything in Meltano Open, plus
-
-- Community of 5,500+ users
-- Plugin Hub access
-- Technical advisory
-- Code review
-- Private office hours
-- Priority guidance from Meltano experts
-- Faster issue resolution and support
-
-### Best suited for
-
-- Growing teams
-- Teams needing implementation guidance
-- Organizations wanting engineering collaboration
-- Users seeking dedicated support while remaining self-hosted
-
----
-
-## Meltano Cloud
-
-> Recommended for teams looking for a fully managed, enterprise-ready data platform.
-
-Fully managed runtime with the same code and connectors, while handling deployment, scheduling, monitoring, and scaling for you.
-
-### Includes everything in Meltano Community, plus
-
-- Proactive data quality alerting
-- Managed scheduling & orchestration
-- Self-serve tenant workspaces
-- Hosted secrets vault
-- External logging (DataDog, CloudWatch)
-- Search & AI features
-- Enterprise-grade security (SSO available)
-- Private Slack support channel
-- Priority support with SLA
-- Implementation support
-- Managed deployment & onboarding
-- Managed infrastructure & scaling
-- Operational reliability and monitoring
-
-### Best suited for
-
-- Enterprise organizations
-- Teams requiring managed infrastructure
-- Businesses needing SLA-backed support
-- Companies prioritizing security & scalability
-- Organizations wanting reduced operational overhead
-
----
-
-## Side-by-side comparison
-
-| Capability | Meltano Open | Meltano Community | Meltano Cloud |
-|---|---|---|---|
-| Open-source Meltano | ✓ | ✓ | ✓ |
-| Self-hosted | ✓ | ✓ | Managed |
-| Declarative pipelines | ✓ | ✓ | ✓ |
-| Git-native workflows | ✓ | ✓ | ✓ |
-| 600+ connectors | ✓ | ✓ | ✓ |
-| Documentation | ✓ | ✓ | ✓ |
-| Plugin Hub access | — | ✓ | ✓ |
-| Community access | — | ✓ | ✓ |
-| Technical advisory | — | ✓ | ✓ |
-| Code review | — | ✓ | ✓ |
-| Private office hours | — | ✓ | ✓ |
-| Managed scheduling & orchestration | — | — | ✓ |
-| Workspaces & teams | — | — | ✓ |
-| Hosted secrets vault | — | — | ✓ |
-| Data quality alerting | — | — | ✓ |
-| External logging (DataDog, CloudWatch) | — | — | ✓ |
-| Search & AI features | — | — | ✓ |
-| Enterprise-grade security | — | — | ✓ |
-| SSO | — | — | Enterprise |
-| Private Slack support | — | — | ✓ |
-| SLA-backed support | — | — | ✓ |
-| Implementation support | — | — | ✓ |
-| Managed onboarding | — | — | ✓ |
-| Managed scaling | — | — | ✓ |
-
----
-
-## Which plan should you choose?
-
-### Choose Meltano Open if
-
-- You want full control over infrastructure
-- Your team is comfortable managing deployments
-- You prefer open-source flexibility
-
-### Choose Meltano Community if
-
-- You need expert support and technical guidance
-- Your team wants faster troubleshooting and collaboration
-- You still prefer managing infrastructure internally
-
-### Choose Meltano Cloud if
-
-- You want a fully managed platform
-- Your organization requires enterprise support & security
-- Your team wants to reduce operational overhead
-- Reliability, monitoring, and scaling are business-critical
-
----
-
-Not sure? Jump into [Slack #general](https://meltano.com/slack) and ask — the community is happy to help you choose.

--- a/docs/docs/getting-started/which-meltano.mdx
+++ b/docs/docs/getting-started/which-meltano.mdx
@@ -49,4 +49,3 @@ import Link from '@docusaurus/Link';
 ---
 
 Not sure which to choose? Jump into our [Slack community's #general channel](https://meltano.com/slack) or [connect with us](https://meltano.com/contact) and we will be happy to help.
-

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -25,7 +25,7 @@ const sidebars = {
         {
           type: 'doc',
           id: 'getting-started/which-meltano',
-          label: 'Which Meltano is right for me?',
+          label: 'Which Meltano is right for you?',
         },
         // MELTANO CLOUD
         {
@@ -44,38 +44,6 @@ const sidebars = {
           id: 'getting-started/cloud-quickstart',
           label: 'Quickstart',
           customProps: { badgeType: 'cloud', icon: 'bell' },
-        },
-        // MELTANO COMMUNITY
-        {
-          type: 'html',
-          value: 'MELTANO COMMUNITY',
-          className: 'sidebar-section-label',
-        },
-        {
-          type: 'doc',
-          id: 'getting-started/community-overview',
-          label: 'Overview',
-          customProps: { badgeType: 'community', icon: 'connect' },
-        },
-        {
-          type: 'doc',
-          id: 'getting-started/installation',
-          customProps: { badgeType: 'community', icon: 'download' },
-        },
-        {
-          type: 'doc',
-          id: 'getting-started/part1',
-          customProps: { icon: 'connect' },
-        },
-        {
-          type: 'doc',
-          id: 'getting-started/part2',
-          customProps: { icon: 'database' },
-        },
-        {
-          type: 'doc',
-          id: 'getting-started/part3',
-          customProps: { icon: 'process' },
         },
         // MELTANO OPEN
         {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -136,7 +136,7 @@ h2 {
   font-weight: 700;
   font-size: 56px;
   line-height: 110%;
-  text-align: center;
+  text-align: left;
   letter-spacing: -0.02em;
   margin: 0;
 }


### PR DESCRIPTION
…rom navbar

## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update getting started documentation to focus on Meltano Open and Meltano Cloud and remove references to the deprecated Meltano Community offering.

Documentation:
- Revise the "Which Meltano" getting started page to compare only Meltano Open and Meltano Cloud, adding an updated feature comparison table and guidance links.
- Remove Meltano Community items from the navigation sidebar and adjust labels and headings for consistency and clarity.
- Clarify Cloud quickstart guidance regarding external log streaming options.
- Adjust global docs heading styling to left-align main page titles.