### PR TITLE
feat(cli): Process exception notes in Singer SDK structured logs

### DIFF
--- a/src/meltano/core/logging/models.py
+++ b/src/meltano/core/logging/models.py
@@ -51,6 +51,8 @@ class PluginException:
     cause: PluginException | None = None
     #: The context of the exception.
     context: PluginException | None = None
+    #: The optional exception notes (Python 3.11+)
+    notes: list[str] | None = None
 
     @classmethod
     def from_dict(cls, data: dict) -> PluginException:
@@ -80,6 +82,7 @@ class PluginException:
             traceback=exc_traceback,
             cause=exc_cause,
             context=exc_context,
+            notes=data.get("notes"),
         )
 
     def to_dict(self) -> dict:
@@ -104,6 +107,8 @@ class PluginException:
             result["cause"] = self.cause.to_dict()
         if self.context:
             result["context"] = self.context.to_dict()
+        if self.notes:
+            result["notes"] = self.notes
         return result
 
     def __structlog__(self) -> dict:

--- a/src/meltano/core/logging/renderers.py
+++ b/src/meltano/core/logging/renderers.py
@@ -142,6 +142,12 @@ class PluginErrorFormatter:
             )
             yield self.render_exception(exc.context)
 
+        # Add exception notes
+        if exc.notes:
+            yield ""
+            for note in exc.notes:
+                yield Text(note)
+
     def format(
         self,
         sio: t.TextIO,

--- a/tests/meltano/core/logging/test_renderers.py
+++ b/tests/meltano/core/logging/test_renderers.py
@@ -62,6 +62,10 @@ def exception() -> PluginException:
                 line="raise CustomException('Custom exception message') from err",
             ),
         ],
+        notes=[
+            "Note 1",
+            "Note 2",
+        ],
     )
 
 
@@ -127,6 +131,9 @@ def expected_exception_output() -> str:
         During handling of the above exception, another exception occurred:
 
         ValueError: An invalid value was provided
+
+        Note 1
+        Note 2
     """)
 
 

--- a/tests/meltano/core/logging/test_renderers.py
+++ b/tests/meltano/core/logging/test_renderers.py
@@ -187,6 +187,7 @@ class TestPluginException:
             type="CustomException",
             module="my_package.my_module",
             message="Custom exception message",
+            notes=["First note", "Second note"],
         )
         processor = structlog.processors.JSONRenderer()
         logger = structlog.get_logger()


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

Docs: [Enriching Exceptions with Notes](https://docs.python.org/3/tutorial/errors.html#enriching-exceptions-with-notes)

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* https://github.com/meltano/sdk/pull/3666

## Summary by Sourcery

Handle and surface Python exception notes in Meltano's structured and human-readable logging for plugin exceptions.

New Features:
- Include optional exception notes on plugin exceptions in the PluginException model and its dict/structlog representations.

Enhancements:
- Render exception notes in CLI exception output alongside existing traceback and context information.

Tests:
- Expand logging renderer tests to cover exception notes in both text rendering and structlog JSON output.