### PR TITLE
fix(core): Output more detailed errors when requests to the Hub API fail

### DIFF
--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -274,7 +274,11 @@ class MeltanoHubService(PluginRepository):
         response = self._get(url)
 
         if response.status_code >= HTTPStatus.BAD_REQUEST:
-            raise HubConnectionError(response.reason)
+            reason = (
+                f"{response.reason or 'Unknown reason'} ({response.status_code}): "
+                "can not retrieve plugin"
+            )
+            raise HubConnectionError(reason)
 
         return PluginDefinition(
             **response.json(),
@@ -329,15 +333,15 @@ class MeltanoHubService(PluginRepository):
         url = self.plugin_type_endpoint(plugin_type)
         response = self._get(url)
 
-        if (
-            HTTPStatus.BAD_REQUEST
-            <= response.status_code
-            < HTTPStatus.TOO_MANY_REQUESTS
-        ):
+        if response.status_code == HTTPStatus.NOT_FOUND:
             raise HubPluginTypeNotFoundError(plugin_type)
 
-        if HTTPStatus.INTERNAL_SERVER_ERROR <= response.status_code < 600:
-            raise HubConnectionError(response.reason)
+        if response.status_code >= HTTPStatus.BAD_REQUEST:
+            reason = (
+                f"{response.reason or 'Unknown reason'} ({response.status_code}): "
+                f"can not retrieve plugins of type '{plugin_type.singular}'"
+            )
+            raise HubConnectionError(reason)
 
         plugins: dict[str, dict[str, t.Any]] = response.json()
         return {

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -126,17 +126,11 @@ class TestMeltanoHubService:
         assert project.hub_service.session.headers["Authorization"] == "Bearer s3cr3t"
 
     def test_server_error(self, project: Project) -> None:
-        with pytest.raises(
-            HubConnectionError,
-            match=r"Internal Server Error",
-        ) as exc_info:
+        with pytest.raises(HubConnectionError, match=r"Internal Server Error \(500\)"):
             project.hub_service.find_definition(
                 PluginType.EXTRACTORS,
                 "this-returns-500",
             )
-
-        assert isinstance(exc_info.value, HubConnectionError)
-        assert str(exc_info.value) == "Internal Server Error."
 
     def test_request_headers(self, project: Project) -> None:
         with mock.patch("click.get_current_context") as get_context:
@@ -214,11 +208,13 @@ class TestMeltanoHubService:
                 "send",
                 side_effect=requests.exceptions.ConnectionError,
             ),
-            pytest.raises(HubConnectionError) as exc_info,
+            pytest.raises(
+                HubConnectionError,
+                match=r"Could not connect to Meltano Hub\.",
+            ) as exc_info,
         ):
             project.hub_service._get(project.hub_service.hub_api_url)
 
-        assert str(exc_info.value) == "Could not connect to Meltano Hub."
         assert isinstance(exc_info.value.__cause__, requests.exceptions.ConnectionError)
 
     def test_plugin_type_not_found_error(self, project: Project) -> None:
@@ -227,11 +223,23 @@ class TestMeltanoHubService:
 
         with (
             mock.patch.object(project.hub_service, "_get", return_value=mock_response),
-            pytest.raises(HubPluginTypeNotFoundError) as exc_info,
+            pytest.raises(
+                HubPluginTypeNotFoundError,
+                match="is not supported in Meltano Hub",
+            ),
         ):
             project.hub_service.get_plugins_of_type(PluginType.EXTRACTORS)
 
-        assert "is not supported in Meltano Hub" in str(exc_info.value)
+    def test_plugin_type_auth_error(self, project: Project) -> None:
+        mock_response = Response()
+        mock_response.status_code = HTTPStatus.UNAUTHORIZED
+        mock_response.reason = "Unauthorized"
+
+        with (
+            mock.patch.object(project.hub_service, "_get", return_value=mock_response),
+            pytest.raises(HubConnectionError, match=r"Unauthorized \(401\)"),
+        ):
+            project.hub_service.get_plugins_of_type(PluginType.EXTRACTORS)
 
     def test_server_error_on_index(self, project: Project) -> None:
         mock_response = Response()
@@ -240,6 +248,6 @@ class TestMeltanoHubService:
 
         with (
             mock.patch.object(project.hub_service, "_get", return_value=mock_response),
-            pytest.raises(HubConnectionError, match="Internal Server Error"),
+            pytest.raises(HubConnectionError, match=r"Internal Server Error \(500\)"),
         ):
             project.hub_service.get_plugins_of_type(PluginType.EXTRACTORS)

--- a/tests/meltano/core/hub/test_meltano_hub_service.py
+++ b/tests/meltano/core/hub/test_meltano_hub_service.py
@@ -126,7 +126,10 @@ class TestMeltanoHubService:
         assert project.hub_service.session.headers["Authorization"] == "Bearer s3cr3t"
 
     def test_server_error(self, project: Project) -> None:
-        with pytest.raises(HubConnectionError, match=r"Internal Server Error \(500\)"):
+        with pytest.raises(
+            HubConnectionError,
+            match=r"Internal Server Error \(500\): can not retrieve plugin",
+        ):
             project.hub_service.find_definition(
                 PluginType.EXTRACTORS,
                 "this-returns-500",
@@ -237,7 +240,10 @@ class TestMeltanoHubService:
 
         with (
             mock.patch.object(project.hub_service, "_get", return_value=mock_response),
-            pytest.raises(HubConnectionError, match=r"Unauthorized \(401\)"),
+            pytest.raises(
+                HubConnectionError,
+                match=r"Unauthorized \(401\): can not retrieve plugins of type",
+            ),
         ):
             project.hub_service.get_plugins_of_type(PluginType.EXTRACTORS)
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Follows from https://github.com/meltano/meltano/pull/10007

## Summary by Sourcery

Improve error reporting and handling for failed Meltano Hub API requests.

Bug Fixes:
- Include HTTP status code and clearer context in errors raised when plugin definition retrieval fails.
- Raise detailed connection errors for plugin type retrieval failures instead of generic messages.
- Treat 404 responses for plugin type lookups as unsupported plugin types while surfacing other client/server errors as Hub connection issues.

Tests:
- Update Hub service tests to assert richer error messages and specific patterns for connection and server errors.
- Add coverage for unauthorized plugin type access returning detailed Hub connection errors.