### PR TITLE
fix: Ensure stdlib logging `extra` values are added to the object when the JSON log formatter is used

### DIFF
--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -330,8 +330,8 @@ def json_formatter(
             dict_tracebacks=dict_tracebacks,
             show_locals=show_locals,
         ),
-        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         structlog.stdlib.ExtraAdder(),
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         *preset_processors,
         structlog.processors.JSONRenderer(),
     )

--- a/tests/meltano/core/logging/test_formatters.py
+++ b/tests/meltano/core/logging/test_formatters.py
@@ -91,7 +91,7 @@ class TestLogFormatters:
 
     @pytest.fixture
     def record(self):
-        return logging.LogRecord(
+        rec = logging.LogRecord(
             name="test",
             level=logging.INFO,
             pathname="/path/to/my_module.py",
@@ -101,6 +101,9 @@ class TestLogFormatters:
             exc_info=None,
             func="my_func",
         )
+        rec.__dict__["extra_int"] = 1
+        rec.__dict__["extra_str"] = "foo"
+        return rec
 
     @pytest.fixture
     def record_with_exception(self, exc_info: ExcInfo, tmp_path: Path):
@@ -176,16 +179,22 @@ class TestLogFormatters:
         output = formatter.format(record)
         assert "foo=bar" not in output
         assert "baz=qux" not in output
+        assert "extra_int=1" not in output
+        assert "extra_str=foo" not in output
 
-        formatter = formatters.console_log_formatter(include_keys=["foo"])
+        formatter = formatters.console_log_formatter(include_keys=["foo", "extra_int"])
         output = formatter.format(record)
         assert "foo=bar" in output
         assert "baz=qux" not in output
+        assert "extra_int=1" in output
+        assert "extra_str=foo" not in output
 
         formatter = formatters.console_log_formatter(all_keys=True)
         output = formatter.format(record)
         assert "foo=bar" in output
         assert "baz=qux" in output
+        assert "extra_int=1" in output
+        assert "extra_str=foo" in output
 
     def test_key_value_formatter(self, record):
         formatter = formatters.key_value_formatter()
@@ -199,6 +208,13 @@ class TestLogFormatters:
         assert "lineno=1" in output
         assert "func_name='my_func'" in output
         assert f"process={os.getpid()}" in output
+
+    def test_json_formatter_extra(self, record) -> None:
+        formatter = formatters.json_formatter()
+        output = formatter.format(record)
+        message_dict = json.loads(output)
+        assert message_dict["extra_int"] == 1
+        assert message_dict["extra_str"] == "foo"
 
     def test_json_formatter_callsite_parameters(self, record):
         formatter = formatters.json_formatter(callsite_parameters=True)


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA, we were removing those values by having the structlog processors in the wrong order.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Ensure stdlib logging `extra` values are preserved in JSON-formatted logs and covered by tests.

Bug Fixes:
- Fix JSON log formatter to include stdlib logging `extra` fields in the rendered output.

Tests:
- Extend logging formatter tests to cover stdlib `extra` fields for console and JSON formatters.