### PR TITLE
fix(core): Avoid swallowing Pipelinewise plugin logs by setting the level for the root logger

### DIFF
--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -184,8 +184,6 @@ class SingerPlugin(BasePlugin):
                 [logger_root]
                 level={log_level}
                 handlers=console
-                formatter=default
-                propagate=0
 
                 [handler_console]
                 class=StreamHandler

--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -182,7 +182,10 @@ class SingerPlugin(BasePlugin):
                 keys=default
 
                 [logger_root]
+                level={log_level}
                 handlers=console
+                formatter=default
+                propagate=0
 
                 [handler_console]
                 class=StreamHandler


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

We were swallowing the pipelinewise plugin logs.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Bug Fixes:
- Set the root logger level, formatter, and propagation settings in the Singer plugin logging hook so Pipelinewise plugin logs are emitted correctly.

## Summary by Sourcery

Bug Fixes:
- Configure the root logger level, formatter, and propagation in the Singer plugin logging hook so Pipelinewise plugin logs are emitted correctly.