### PR TITLE
fix(core): Avoid swallowing Pipelinewise plugin logs by setting the level for the root logger (#10104)

### DIFF
--- a/src/meltano/core/plugin/singer/base.py
+++ b/src/meltano/core/plugin/singer/base.py
@@ -181,6 +181,7 @@ class SingerPlugin(BasePlugin):
                 keys=default
 
                 [logger_root]
+                level={log_level}
                 handlers=console
 
                 [handler_console]


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

We were swallowing the pipelinewise plugin logs.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this
PR, please change below checkbox to `[X]` followed by the name of the
tool, uncomment the "Generated-by". See the agentic coding section of
the contribution guide for details:
https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding
guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Backport of https://github.com/meltano/meltano/pull/10105

## Summary by Sourcery

Bug Fixes:
- Fix missing Pipelinewise plugin log output by setting the root logger level in the default logging configuration.