### PR TITLE
chore: Update changelog after backport releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
 
+## v4.2.1 (2026-06-16)
+
+### 🐛 Fixes
+
+- [#10106](https://github.com/meltano/meltano/issues/10106) Avoid swallowing PipelineWise plugin logs by setting the level for the root logger (#10104)
+
 ## v4.2.0 (2026-04-10)
 
 ### ✨ New

--- a/changelogs/v3.md
+++ b/changelogs/v3.md
@@ -1,5 +1,11 @@
 # CHANGELOG 3.x
 
+## v3.9.4 (2026-06-16)
+
+### 🐛 Fixes
+
+- [#10105](https://github.com/meltano/meltano/issues/10105) Avoid swallowing PipelineWise plugin logs by setting the level for the root logger (#10104)
+
 ## v3.9.3 (2026-04-13)
 
 ### 📦 Packaging changes


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update changelog files to document recent backport releases that fix PipelineWise plugin log handling.

Bug Fixes:
- Document the fix that prevents swallowing PipelineWise plugin logs by adjusting the root logger level for v4.2.1 and v3.9.4 releases.

Documentation:
- Add v4.2.1 entry to the main changelog and v3.9.4 entry to the 3.x changelog describing the PipelineWise logging fix.