### PR TITLE
fix: Stop emitting null `plugin_exception` and `stream_name` keys for every single log

### DIFF
--- a/src/meltano/core/logging/models.py
+++ b/src/meltano/core/logging/models.py
@@ -15,6 +15,7 @@ class ParsedLogRecord:
     extra: dict[str, t.Any]
     timestamp: str | None = None
     logger_name: str | None = None
+    stream_name: str | None = None
     exception: PluginException | None = None
 
 

--- a/src/meltano/core/logging/output_logger.py
+++ b/src/meltano/core/logging/output_logger.py
@@ -302,19 +302,17 @@ class Out:
             )
         ):
             # Use the parsed record's level and extra fields
-            extra = {"name": self.name, **parsed_record.extra}
-
-            # If we have a logger name from the parsed record, include it
-            if parsed_record.logger_name:
-                extra["plugin_logger"] = parsed_record.logger_name
+            extra = {
+                **parsed_record.extra,
+                "name": self.name,
+                "plugin_logger": parsed_record.logger_name,
+                "stream_name": parsed_record.stream_name,
+                "plugin_exception": parsed_record.exception,
+            }
+            extra = {k: v for k, v in extra.items() if v is not None}
 
             # Log with the parsed level and structured data
-            self.logger.log(
-                parsed_record.level,
-                parsed_record.message,
-                plugin_exception=parsed_record.exception,
-                **extra,
-            )
+            self.logger.log(parsed_record.level, parsed_record.message, **extra)
             return
 
         # Fallback to original behavior for unparsable lines

--- a/src/meltano/core/logging/parsers.py
+++ b/src/meltano/core/logging/parsers.py
@@ -43,7 +43,6 @@ class SingerSDKLogParser(LogParser):
         "ts",
         "thread_name",
         "app_name",
-        "stream_name",
         "message",
     }
 
@@ -76,6 +75,7 @@ class SingerSDKLogParser(LogParser):
             level_name = data.pop("level")
             level = logging._nameToLevel.get(level_name.upper(), logging.INFO)
             logger_name = data.pop("logger_name")
+            stream_name = data.pop("stream_name", None)
             timestamp = data.pop("ts")
             message = data.pop("message")
             exception = data.pop("exception", None)
@@ -87,6 +87,7 @@ class SingerSDKLogParser(LogParser):
                 extra={**data, **extra},
                 timestamp=str(timestamp) if timestamp else None,
                 logger_name=logger_name,
+                stream_name=stream_name,
                 exception=PluginException.from_dict(exception) if exception else None,
             )
 

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -13,7 +13,7 @@ import pytest
 import structlog
 from structlog.testing import LogCapture
 
-from meltano.core.logging.models import ParsedLogRecord
+from meltano.core.logging.models import ParsedLogRecord, PluginException, TracebackFrame
 from meltano.core.logging.output_logger import Out, OutputLogger
 
 if t.TYPE_CHECKING:
@@ -340,6 +340,68 @@ class TestOutputLogger:
         assert entry["log_level"] == "info"
         assert entry["name"] == "test_singer"
         assert entry["record_count"] == 100
+        assert "plugin_exception" not in entry
+
+    def test_writeline_with_singer_sdk_exception(
+        self,
+        subject: OutputLogger,
+        log_output: LogCapture,
+    ) -> None:
+        """Test writeline method with Singer SDK parser configured."""
+        # Create an Out instance with singer-sdk parser
+        out = subject.out("test_singer", log_parser="singer-sdk")
+
+        # Singer SDK structured log line
+        singer_log = json.dumps(
+            {
+                "level": "info",
+                "pid": 12345,
+                "logger_name": "tap_example.streams",
+                "ts": 1703097600.123456,
+                "thread_name": "MainThread",
+                "app_name": "tap-example",
+                "stream_name": "users",
+                "message": "Processing records",
+                "exception": {
+                    "type": "ValueError",
+                    "module": "builtins",
+                    "message": "Test exception",
+                    "traceback": [
+                        {
+                            "filename": "/path/to/file.py",
+                            "function": "my_function",
+                            "lineno": 140,
+                            "line": "        raise ValueError(msg)\n",
+                        }
+                    ],
+                },
+                "extra": {
+                    "record_count": 100,
+                },
+            },
+        )
+
+        out.writeline(singer_log)
+
+        # Verify the log was parsed and structured correctly
+        assert len(log_output.entries) == 1
+        entry = log_output.entries[0]
+
+        assert entry["plugin_exception"] == PluginException(
+            type="ValueError",
+            module="builtins",
+            message="Test exception",
+            traceback=[
+                TracebackFrame(
+                    filename="/path/to/file.py",
+                    function="my_function",
+                    lineno=140,
+                    line="        raise ValueError(msg)\n",
+                )
+            ],
+            cause=None,
+            context=None,
+        )
 
     def test_writeline_with_parser_error_log(
         self,

--- a/tests/meltano/core/logging/test_parsers.py
+++ b/tests/meltano/core/logging/test_parsers.py
@@ -100,12 +100,12 @@ class TestSingerSDKLogParser:
         assert result.level == logging.INFO
         assert result.message == "Processing records"
         assert result.logger_name == "tap_example.streams"
+        assert result.stream_name == "users"
         assert result.timestamp == "1703097600.123456"
         assert result.extra == {
             "pid": 12345,
             "thread_name": "MainThread",
             "app_name": "tap-example",
-            "stream_name": "users",
             "custom_field": "custom_value",
         }
 
@@ -551,7 +551,6 @@ class TestLogParserIntegration:
             "pid": 12345,
             "thread_name": "MainThread",
             "app_name": "tap-example",
-            "stream_name": None,
             "phase": "discovery",
         }
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Adjust structured logging of Singer SDK output to avoid emitting null fields and expose parsed stream metadata and exceptions more cleanly.

Bug Fixes:
- Stop including null `plugin_exception` and `stream_name` fields on every structured log entry when no value is present.

Enhancements:
- Capture `stream_name` and plugin exception details as first-class fields on parsed Singer SDK log records and propagate them via logger extras.

Tests:
- Extend Singer SDK log parsing tests to cover `stream_name` extraction and add coverage for logging structured plugin exceptions through `OutputLogger`.