### PR TITLE
chore: Clean up property docstrings

### DIFF
--- a/src/meltano/cli/interactive/config.py
+++ b/src/meltano/cli/interactive/config.py
@@ -92,7 +92,7 @@ class InteractiveConfig:
 
     @property
     def configurable_settings(self):  # noqa: ANN201
-        """Return settings available for interactive configuration."""
+        """Settings available for interactive configuration."""
         return self.settings.config_with_metadata(
             session=self.session,
             extras=self.extras,
@@ -101,7 +101,7 @@ class InteractiveConfig:
 
     @property
     def setting_choices(self) -> list[tuple[str, str, str]]:
-        """Return simplified setting choices, for easy printing."""
+        """Simplified setting choices, for easy printing."""
         setting_choices: list[tuple[str, str, str]] = []
         for index, (name, config_metadata) in enumerate(
             self.configurable_settings.items(),

--- a/src/meltano/core/behavior/canonical.py
+++ b/src/meltano/core/behavior/canonical.py
@@ -238,11 +238,7 @@ class Canonical(metaclass=AnnotationsMeta):  # (too many methods)
 
     @property
     def attrs(self) -> CommentedMap:
-        """Return the attributes of the current instance.
-
-        Returns:
-            Attributes of the current instance.
-        """
+        """The attributes of the current instance."""
         return self._dict
 
     def is_attr_set(self, attr):  # noqa: ANN001, ANN201

--- a/src/meltano/core/block/block_parser.py
+++ b/src/meltano/core/block/block_parser.py
@@ -157,11 +157,7 @@ class BlockParser:  # noqa: D101
 
     @property
     def plugins(self) -> list[ProjectPlugin]:
-        """Return the list of plugins in the block.
-
-        Returns:
-            A list of ProjectPlugin.
-        """
+        """The list of plugins in the block."""
         return self._plugins
 
     def _expand_jobs(self, blocks: list[str], task_sets: TaskSetsService) -> list[str]:

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -301,11 +301,7 @@ class ELBContextBuilder:
 
     @property
     def elt_run_dir(self) -> Path | None:
-        """Get the run directory for the current job.
-
-        Returns:
-            The run directory for the current job.
-        """
+        """The run directory for the current job."""
         if self._job:  # pragma: no cover
             return self.project.dirs.job(self._job.job_name, str(self._job.run_id))
 
@@ -388,10 +384,7 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
 
     @property
     def state_service(self) -> StateService:
-        """Get StateService for managing state for this BlockSet.
-
-        Returns:
-            A StateService using this BlockSet's context's session
+        """StateService for managing state for this BlockSet.
 
         Raises:
             BlockSetHasNoStateError: if no Block in this BlockSet has state capability
@@ -558,11 +551,7 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
 
     @property
     def process_futures(self) -> list[asyncio.Task]:
-        """Return the futures of the blocks subprocess calls.
-
-        Returns:
-            The list of all process futures.
-        """
+        """The futures of the blocks subprocess calls."""
         if self._process_futures is None:
             self._process_futures = [block.process_future for block in self.blocks]
         return self._process_futures

--- a/src/meltano/core/block/ioblock.py
+++ b/src/meltano/core/block/ioblock.py
@@ -21,13 +21,10 @@ class IOBlock(metaclass=ABCMeta):
     @property
     @abstractmethod
     def stdin(self) -> StreamWriter | None:
-        """Get the `StreamWriter` that should be used for writes, if any.
+        """The `StreamWriter` that should be used for writes, if any.
 
         Raises:
             NotImplementedError
-
-        Returns:
-            StreamWriter
         """
         raise NotImplementedError
 
@@ -46,7 +43,7 @@ class IOBlock(metaclass=ABCMeta):
     @property
     @abstractmethod
     def string_id(self) -> str:
-        """Return a string identifier for this block."""
+        """A string identifier for this block."""
         raise NotImplementedError
 
     @property

--- a/src/meltano/core/block/plugin_command.py
+++ b/src/meltano/core/block/plugin_command.py
@@ -45,7 +45,7 @@ class PluginCommandBlock(metaclass=ABCMeta):
     @property
     @abstractmethod
     def command(self) -> str | None:
-        """Get the plugin command to use when invoking the plugin (if any)."""
+        """The plugin command to use when invoking the plugin (if any)."""
         raise NotImplementedError
 
     @abstractmethod
@@ -109,11 +109,7 @@ class InvokerCommand(InvokerBase, PluginCommandBlock):
 
     @property
     def command_args(self) -> str | None:
-        """Get the command args to use when invoking the plugin.
-
-        Returns:
-            The command args if any.
-        """
+        """The command args to use when invoking the plugin."""
         return self._command_args
 
     async def _start(self) -> None:

--- a/src/meltano/core/block/singer.py
+++ b/src/meltano/core/block/singer.py
@@ -74,11 +74,7 @@ class InvokerBase:
 
     @property
     def process_handle(self) -> Process:
-        """Get the process handle for the underlying plugin.
-
-        Returns:
-            The process handle for the underlying plugin.
-        """
+        """The process handle for the underlying plugin."""
         if self._process_handle is None:
             msg = f"Process is not running for {self.string_id}"
             raise ProcessNotRunningError(msg)
@@ -87,20 +83,12 @@ class InvokerBase:
 
     @property
     def command(self) -> str | None:
-        """Get the command to use when invoking the plugin.
-
-        Returns:
-            The command to use when invoking the plugin.
-        """
+        """The command to use when invoking the plugin."""
         return self._command
 
     @property
     def string_id(self) -> str:
-        """Return a string identifier for this block.
-
-        Returns:
-            A string identifier for this block.
-        """
+        """A string identifier for this block."""
         return self.invoker.plugin.name
 
     @property
@@ -189,22 +177,14 @@ class InvokerBase:
 
     @property
     def process_future(self) -> asyncio.Task:
-        """Return the future of the underlying process wait() call.
-
-        Returns:
-            The future of the underlying process wait() calls.
-        """
+        """The future of the underlying process wait() call."""
         if self._process_future is None:
             self._process_future = asyncio.ensure_future(self.process_handle.wait())
         return self._process_future
 
     @property
     def stdin(self) -> asyncio.StreamWriter | None:
-        """Return stdin of the underlying process.
-
-        Returns:
-            The stdin of the underlying process.
-        """
+        """Stream: stdin of the underlying process."""
         return self.process_handle.stdin
 
     async def close_stdin(self) -> None:

--- a/src/meltano/core/config_service.py
+++ b/src/meltano/core/config_service.py
@@ -37,11 +37,7 @@ class ConfigService:
 
     @cached_property
     def settings(self) -> list[SettingDefinition]:
-        """Return the project settings.
-
-        Returns:
-            The project settings.
-        """
+        """Project settings."""
         with bundle.root.joinpath("settings.yml").open() as settings_yaml:
             content = yaml.safe_load(settings_yaml)
 
@@ -51,11 +47,7 @@ class ConfigService:
 
     @cached_property
     def current_meltano_yml(self) -> MeltanoFile:
-        """Return the current `meltano.yml` contents.
-
-        Returns:
-            The contents of `meltano.yml`.
-        """
+        """Current `meltano.yml` contents."""
         return self.project.meltano
 
     @contextmanager
@@ -89,11 +81,7 @@ class ConfigService:
 
     @property
     def current_config(self):  # noqa: ANN201
-        """Return the current configuration.
-
-        Returns:
-            The current configuration.
-        """
+        """Current configuration."""
         return self.current_meltano_yml.extras
 
     def update_config(self, config: dict[str, t.Any]) -> None:
@@ -107,9 +95,5 @@ class ConfigService:
 
     @property
     def env(self) -> dict[str, str]:
-        """Return the top-level env vars from meltano.yml.
-
-        Returns:
-            A dictionary of (unexpanded) environment variables.
-        """
+        """Top-level (unexpanded) env vars from meltano.yml."""
         return self.current_meltano_yml.env

--- a/src/meltano/core/elt_context.py
+++ b/src/meltano/core/elt_context.py
@@ -78,11 +78,7 @@ class PluginContext(t.NamedTuple):
 
     @property
     def env(self) -> dict[str, str]:
-        """Get complete plugin environment dict.
-
-        Returns:
-            Complete plugin environment dict.
-        """
+        """Complete plugin environment dict."""
         return {**self.plugin.info_env, **self.config_env()}
 
 
@@ -154,11 +150,7 @@ class ELTContext(ELContextProtocol):
 
     @property
     def elt_run_dir(self) -> Path | None:
-        """Get the ELT run directory.
-
-        Returns:
-            The job dir, if a Job is provided, else None.
-        """
+        """ELT run directory."""
         if self.job:
             return self.project.dirs.job(self.job.job_name, str(self.job.run_id))
 

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -73,7 +73,7 @@ class EnvironmentPluginConfig(PluginRef):
 
     @property
     def extra_config(self):  # noqa: ANN201
-        """Get extra config from the Meltano environment, like `select` and `schema`.
+        """Extra config from the Meltano environment, like `select` and `schema`.
 
         Returns:
             Extra config.
@@ -82,7 +82,7 @@ class EnvironmentPluginConfig(PluginRef):
 
     @property
     def config_with_extras(self) -> dict[str, t.Any]:
-        """Get plugin configuration values from the Meltano environment.
+        """Plugin configuration values from the Meltano environment.
 
         Returns:
             Plugin configuration with extra values.

--- a/src/meltano/core/error.py
+++ b/src/meltano/core/error.py
@@ -92,7 +92,7 @@ class AsyncSubprocessError(Exception):
 
     @property
     async def stderr(self) -> str | None:
-        """Return the output of the process to stderr."""
+        """The output of the process to stderr."""
         if not self._stderr:
             return None
         if not isinstance(self._stderr, str):

--- a/src/meltano/core/hub/client.py
+++ b/src/meltano/core/hub/client.py
@@ -132,23 +132,15 @@ class MeltanoHubService(PluginRepository):
 
     @property
     def hub_api_url(self) -> str:
-        """Return the URL of the Hub API.
-
-        Returns:
-            The URL of the Hub API.
-        """
+        """The URL of the Hub API."""
         hub_api_root = self.project.settings.get("hub_api_root")
         hub_url = self.project.settings.get("hub_url")
 
         return hub_api_root or f"{hub_url}/meltano/api/v1"
 
     @property
-    def hub_url_auth(self) -> str:
-        """Return the `hub_url_auth` setting.
-
-        Returns:
-            The `hub_url_auth` setting.
-        """
+    def hub_url_auth(self) -> str | None:
+        """The `hub_url_auth` setting."""
         return self.project.settings.get("hub_url_auth")
 
     def plugin_type_endpoint(self, plugin_type: PluginType) -> str:

--- a/src/meltano/core/hub/schema.py
+++ b/src/meltano/core/hub/schema.py
@@ -17,11 +17,7 @@ class IndexedPlugin:
 
     @property
     def variant_labels(self) -> list[str]:
-        """Return a list of variant labels.
-
-        Returns:
-            A list of variant labels.
-        """
+        """List of variant labels."""
         variants = deepcopy(self.variants)
         default_variant = variants.pop(self.default_variant)
         return [

--- a/src/meltano/core/manifest/manifest.py
+++ b/src/meltano/core/manifest/manifest.py
@@ -152,7 +152,7 @@ class Manifest:
 
     @cached_property
     def _schema_validator(self) -> jsonschema.protocols.Validator:
-        """Return a cached validator for the manifest schema.
+        """A cached validator for the manifest schema.
 
         The validator class is automatically determined from the schema's
         $schema field using jsonschema.validators.validator_for().

--- a/src/meltano/core/plugin/airflow.py
+++ b/src/meltano/core/plugin/airflow.py
@@ -49,11 +49,7 @@ class Airflow(BasePlugin):
 
     @property
     def config_files(self) -> dict[str, str]:
-        """Return the configuration files required by the plugin.
-
-        Returns:
-            Dictionary of config file identifiers and filenames
-        """
+        """Configuration files required by the plugin."""
         return {"config": "airflow.cfg"}
 
     def process_config(self, flat_config: dict[str, str]) -> dict[str, dict[str, str]]:

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -86,11 +86,7 @@ class PluginType(YAMLEnum):
 
     @property
     def descriptor(self) -> str:
-        """Return the descriptor of the plugin type.
-
-        Returns:
-            The descriptor of the plugin type.
-        """
+        """Descriptor of the plugin type."""
         return "file bundle" if self is self.__class__.FILES else self.singular
 
     @property
@@ -208,20 +204,12 @@ class PluginRef(Canonical):
 
     @property
     def type(self) -> PluginType:
-        """Return the type of the plugin.
-
-        Returns:
-            The type of the plugin.
-        """
+        """The type of the plugin."""
         return self._type
 
     @property
     def plugin_dir_name(self) -> str:
-        """Return the plugin directory name.
-
-        Returns:
-            The plugin directory name.
-        """
+        """The plugin directory name."""
         return self.name
 
     def __eq__(self, other: PluginRef) -> bool:
@@ -480,11 +468,7 @@ class PluginDefinition(PluginRef):
 
     @property
     def variant_labels(self):  # noqa: ANN201
-        """Return labels for supported variants.
-
-        Returns:
-            The labels for the supported variants.
-        """
+        """Labels for supported variants."""
         return ", ".join([self.variant_label(variant) for variant in self.variants])
 
     @classmethod
@@ -589,47 +573,27 @@ class BasePlugin(HookObject):
 
     @property
     def variant(self) -> str:
-        """Return the variant name.
-
-        Returns:
-            The variant name.
-        """
+        """The variant name."""
         return self._variant.name
 
     @property
     def executable(self) -> str:
-        """Return the plugin executable.
-
-        Returns:
-            The executable name.
-        """
+        """The plugin executable."""
         return self._variant.executable or self._plugin_def.name
 
     @property
     def extras(self):  # noqa: ANN201
-        """Return the plugin extras.
-
-        Returns:
-            The extras.
-        """
+        """Plugin extras."""
         return {**self._plugin_def.extras, **self._variant.extras}
 
     @property
     def all_commands(self):  # noqa: ANN201
-        """Return a dictionary of supported commands.
-
-        Returns:
-            A dictionary of supported commands.
-        """
+        """A dictionary of supported commands."""
         return self._variant.commands
 
     @property
     def test_commands(self) -> dict[str, Command]:
-        """Return a the test command for this plugin.
-
-        Returns:
-            The test command for this plugin.
-        """
+        """Dictionary of test commands for this plugin."""
         return {
             name: command
             for name, command in self.all_commands.items()
@@ -638,20 +602,12 @@ class BasePlugin(HookObject):
 
     @property
     def all_settings(self):  # noqa: ANN201
-        """Return a list of settings.
-
-        Returns:
-            A list of settings.
-        """
+        """The full list of settings for this plugin."""
         return self._variant.settings
 
     @property
     def extra_settings(self):  # noqa: ANN201
-        """Return the extra settings for this plugin.
-
-        Returns:
-            The extra settings for this plugin.
-        """
+        """The extra settings for this plugin."""
         defaults = {f"_{name}": value for name, value in self.extras.items()}
 
         existing_settings = []
@@ -677,11 +633,7 @@ class BasePlugin(HookObject):
 
     @property
     def all_requires(self):  # noqa: ANN201
-        """Return a list of requires.
-
-        Returns:
-            A list of requires.
-        """
+        """A list of transitive plugin requirements."""
         return self._variant.requires
 
     def env_prefixes(
@@ -761,20 +713,12 @@ class BasePlugin(HookObject):
 
     @property
     def config_files(self) -> dict[str, str]:
-        """Return a list of stubbed files created for this plugin.
-
-        Returns:
-            A list of stubbed files created for this plugin.
-        """
+        """A list of stubbed files created for this plugin."""
         return {}
 
     @property
     def output_files(self) -> dict[str, str]:
-        """Return a list of stubbed files created for this plugin.
-
-        Returns:
-            A list of stubbed files created for this plugin.
-        """
+        """A list of stubbed files created for this plugin."""
         return {}
 
     def process_config(self, config: dict) -> dict:
@@ -790,11 +734,7 @@ class BasePlugin(HookObject):
 
     @property
     def definition(self) -> PluginDefinition:
-        """Return the plugin definition.
-
-        Returns:
-            The plugin definition.
-        """
+        """The plugin definition."""
         return self._plugin_def
 
 

--- a/src/meltano/core/plugin/project_plugin.py
+++ b/src/meltano/core/plugin/project_plugin.py
@@ -227,11 +227,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def parent(self) -> ProjectPlugin | BasePlugin | None:
-        """Plugins parent.
-
-        Returns:
-            Parent ProjectPlugin instance, or None if no parent.
-        """
+        """Plugins parent or None if no parent."""
         return self._parent
 
     @parent.setter
@@ -248,49 +244,33 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def is_variant_set(self) -> bool:
-        """Check if variant is set explicitly.
-
-        Returns:
-            'True' if variant is set explicitly.
-        """
+        """Whether variant is set explicitly."""
         return self.is_attr_set(self.VARIANT_ATTR)
 
     @property
     def info(self) -> PluginInfo:
-        """Plugin info dict.
-
-        Returns:
-            Dictionary of plugin info (name, namespace and variant)
-        """
+        """Dictionary of plugin info (name, namespace and variant)."""
         return {"name": self.name, "namespace": self.namespace, "variant": self.variant}
 
     @property
     def info_env(self) -> dict[str, str]:
-        """Plugin environment info.
-
-        Returns:
-            Dictionary of plugin info formatted as Meltano environment variables.
-        """
+        """Dictionary of plugin info formatted as Meltano environment variables."""
         # MELTANO_EXTRACTOR_...
         return flatten({"meltano": {self.type.singular: self.info}}, "env_var")
 
     @property
     def all_commands(self) -> dict[str, Command]:
-        """Return all commands for this plugin.
+        """Dictionary of supported commands.
 
-        Returns:
-            Dictionary of supported commands, including those inherited from
-            the parent plugin.
+        Includes commands inherited from the parent plugin.
         """
         return {**(self._parent.all_commands if self._parent else {}), **self.commands}
 
     @property
     def test_commands(self) -> dict[str, Command]:
-        """Return the test commands for this plugin.
+        """Dictionary of supported test commands.
 
-        Returns:
-            Dictionary of supported test commands, including those inherited
-            from the parent plugin.
+        Includes commands inherited from the parent plugin.
         """
         return {
             name: command
@@ -300,11 +280,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def supported_commands(self) -> list[str]:
-        """Return supported command names.
-
-        Returns:
-            All defined command names for the plugin.
-        """
+        """All defined command names for the plugin."""
         return list(self.all_commands.keys())
 
     def env_prefixes(self, *, for_writing: bool = False) -> list[str]:
@@ -327,20 +303,12 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def extra_config(self) -> dict[str, t.Any]:
-        """Return plugin extra config.
-
-        Returns:
-            Dictionary of extra config.
-        """
+        """Dictionary of extra config."""
         return {f"_{key}": value for key, value in self.extras.items()}
 
     @property
     def config_with_extras(self) -> dict[str, t.Any]:
-        """Return config with extras.
-
-        Returns:
-            Complete config dictionary, including config extras.
-        """
+        """Complete config dictionary, including config extras."""
         return {**self.config, **self.extra_config}
 
     @config_with_extras.setter
@@ -356,11 +324,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def all_settings(self) -> list[SettingDefinition]:
-        """Return all settings for this plugin.
-
-        Returns:
-            List of settings, including those inherited from the parent plugin.
-        """
+        """List of settings, including those inherited from the parent plugin."""
         # New setting definitions override old ones
         new_setting_names = {setting.name for setting in self.settings}
         existing_settings = (
@@ -381,10 +345,9 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def extra_settings(self) -> list[SettingDefinition]:
-        """Return extra settings.
+        """A list of extra `SettingDefinition` objects.
 
-        Returns:
-            A list of extra SettingDefinitions, including those defined by the parent.
+        Includes settings defined by the parent.
         """
         existing_settings = self._parent.extra_settings if self._parent else []
         return [
@@ -394,11 +357,7 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def settings_with_extras(self) -> list[SettingDefinition]:
-        """Return all settings.
-
-        Returns:
-            A complete list of SettingDefinitions, including extras.
-        """
+        """A complete list of `SettingDefinition` objects, including extras."""
         return [*self.all_settings, *self.extra_settings]
 
     def is_custom(self) -> bool:
@@ -411,23 +370,15 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def is_shadowing(self) -> bool:
-        """Return whether this plugin is shadowing a base plugin with the same name.
-
-        Returns:
-            'True' if this plugin is shadowing a base plugin with the same name.
-        """
+        """Whether this plugin is shadowing a base plugin with the same name."""
         return not self.inherit_from
 
     @property
     def plugin_dir_name(self) -> str:
-        """Return the plugin directory name this plugin should use.
+        """Plugin directory name this plugin should use.
 
         This directory is where the plugin's Python virtual environment will be
         created, among other things.
-
-        Returns:
-            The name of this plugins parent if both pip urls are the same, else
-            this plugins name.
         """
         if not self.inherit_from:
             return self.name
@@ -465,21 +416,12 @@ class ProjectPlugin(PluginRef):  # too many attrs and methods
 
     @property
     def all_requires(self) -> dict[PluginType, list]:
-        """Return all requires for this plugin.
-
-        Returns:
-            List of supported requires, including those inherited from the
-            parent plugin.
-        """
+        """All transitive requirements for this plugin."""
         return self.get_requirements(plugin_types=None)
 
     @property
     def requirements(self) -> list[ProjectPlugin]:
-        """Return the requirements for this plugin.
-
-        Returns:
-            A list of requirements for this plugin.
-        """
+        """Requirements for this plugin."""
         return [
             ProjectPlugin(plugin_type=plugin_type, name=dep.name, variant=dep.variant)
             for plugin_type, deps in self.all_requires.items()

--- a/src/meltano/core/plugin/settings_service.py
+++ b/src/meltano/core/plugin/settings_service.py
@@ -108,31 +108,19 @@ class PluginSettingsService(SettingsService):
     @property
     @override
     def project_settings_service(self) -> SettingsService:
-        """Get the settings service for the active project.
-
-        Returns:
-            A project settings service for the active project.
-        """
+        """Settings service for the active project."""
         return self.project.settings
 
     @property
     @override
     def label(self) -> str:
-        """Get the label for this plugin.
-
-        Returns:
-            The label for this plugin.
-        """
+        """Label for this plugin."""
         return f"{self.plugin.type.descriptor} '{self.plugin.name}'"
 
     @property
     @override
     def docs_url(self) -> str:
-        """Get the documentation URL for this plugin.
-
-        Returns:
-            The documentation URL for this plugin.
-        """
+        """Documentation URL for this plugin."""
         return self.plugin.docs
 
     @override
@@ -160,22 +148,14 @@ class PluginSettingsService(SettingsService):
     @property
     @override
     def db_namespace(self):  # noqa: ANN201
-        """Return namespace for setting value records in system database.
-
-        Returns:
-            Namespace for setting value records in system database.
-        """
+        """Namespace for setting value records in system database."""
         # "default" is included for legacy reasons
         return f"{self.plugin.type}.{self.plugin.name}.default"
 
     @property
     @override
     def setting_definitions(self) -> list[SettingDefinition]:
-        """Return definitions of supported settings.
-
-        Returns:
-            A list of setting definitions.
-        """
+        """Definitions of supported settings."""
         settings = self.plugin.settings_with_extras
 
         if self.environment_plugin_config is not None:
@@ -188,20 +168,12 @@ class PluginSettingsService(SettingsService):
     @property
     @override
     def meltano_yml_config(self):  # noqa: ANN201
-        """Return current configuration in `meltano.yml`.
-
-        Returns:
-            Current configuration in `meltano.yml`.
-        """
+        """Current configuration in `meltano.yml`."""
         return self.plugin.config_with_extras
 
     @property
     def environment_config(self):  # noqa: ANN201
-        """Return current environment configuration in `meltano.yml`.
-
-        Returns:
-            Current environment configuration in `meltano.yml`.
-        """
+        """Current environment configuration in `meltano.yml`."""
         if self.environment_plugin_config:
             return self.environment_plugin_config.config_with_extras
         return {}
@@ -231,11 +203,7 @@ class PluginSettingsService(SettingsService):
 
     @cached_property
     def inherited_settings_service(self) -> PluginSettingsService | None:
-        """Return settings service to inherit configuration from.
-
-        Returns:
-            Settings service to inherit configuration from.
-        """
+        """Settings service to inherit configuration from."""
         return (
             type(self)(
                 self.project,

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -758,7 +758,7 @@ class ListSelectedExecutor(CatalogExecutor):
 
     @property
     def selected_properties(self) -> dict[str, set[str]]:
-        """Get selected streams and properties."""
+        """Selected streams and properties."""
         # we don't want to mutate the visitor result
         properties = self.properties.copy()
 

--- a/src/meltano/core/plugin/singer/mapper.py
+++ b/src/meltano/core/plugin/singer/mapper.py
@@ -58,7 +58,7 @@ class SingerMapper(SingerPlugin):
     @property
     @override
     def config_files(self) -> dict[str, str]:
-        """Return the configuration files required by the plugin."""
+        """Configuration files required by the plugin."""
         return {
             "config": f"mapper.{self.instance_uuid}.config.json",
             "singer_sdk_logging": "mapper.singer_sdk_logging.json",

--- a/src/meltano/core/plugin/singer/tap.py
+++ b/src/meltano/core/plugin/singer/tap.py
@@ -206,7 +206,7 @@ class SingerTap(SingerPlugin):
     @property
     @override
     def config_files(self):  # noqa: ANN201
-        """Get the configuration files for this tap."""
+        """Configuration files for this tap."""
         return {
             "config": f"tap.{self.instance_uuid}.config.json",
             "catalog": "tap.properties.json",
@@ -219,7 +219,7 @@ class SingerTap(SingerPlugin):
     @property
     @override
     def output_files(self):  # noqa: ANN201
-        """Get the output files for this tap."""
+        """Output files for this tap."""
         return {"output": "tap.out"}
 
     @hook("before_invoke")

--- a/src/meltano/core/plugin/singer/target.py
+++ b/src/meltano/core/plugin/singer/target.py
@@ -137,11 +137,7 @@ class SingerTarget(SingerPlugin):
     @property
     @override
     def config_files(self) -> dict[str, str]:
-        """Get config files for this target.
-
-        Returns:
-            The config_files for this target.
-        """
+        """Config files for this target."""
         return {
             "config": f"target.{self.instance_uuid}.config.json",
             "singer_sdk_logging": "target.singer_sdk_logging.json",
@@ -151,11 +147,7 @@ class SingerTarget(SingerPlugin):
     @property
     @override
     def output_files(self) -> dict[str, str]:
-        """Get output files for this target.
-
-        Returns:
-            The output files for this target.
-        """
+        """Output files for this target."""
         return {"state": "new_state.json"}
 
     @hook("before_invoke")

--- a/src/meltano/core/plugin/superset.py
+++ b/src/meltano/core/plugin/superset.py
@@ -62,11 +62,7 @@ class Superset(BasePlugin):
     @property
     @override
     def config_files(self) -> dict[str, str]:
-        """Return the configuration files required by the plugin.
-
-        Returns:
-            Dictionary of config file identifiers and filenames
-        """
+        """Configuration files required by the plugin."""
         return {"config": "superset_config.py"}
 
     @hook("before_configure")

--- a/src/meltano/core/plugin_install_service.py
+++ b/src/meltano/core/plugin_install_service.py
@@ -185,11 +185,7 @@ class PluginInstallService:
 
     @cached_property
     def parallelism(self) -> int:
-        """Return the number of parallel installation processes to use.
-
-        Returns:
-            The number of parallel installation processes to use.
-        """
+        """Number of parallel installation processes to use."""
         if self._parallelism is None:
             return cpu_count()
         if self._parallelism < 1:

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -225,22 +225,15 @@ class PluginInvoker:
 
     @property
     def capabilities(self) -> frozenset[str]:
-        """Get plugin immutable capabilities.
+        """Plugin immutable capabilities.
 
         Makes sure the capabilities are immutable from the `PluginInvoker` interface.
-
-        Returns:
-            The set of plugin capabilities.
         """
         return frozenset(self.plugin.capabilities)
 
     @property
     def files(self) -> dict[str, Path]:
-        """Get all config and output files of the plugin.
-
-        Returns:
-            A mapping of file IDs to file names.
-        """
+        """A mapping of file IDs to file names."""
         plugin_files = {**self.plugin.config_files, **self.plugin.output_files}
         return {
             _key: self.plugin_config_service.run_dir.joinpath(filename)
@@ -541,11 +534,11 @@ class PluginInvoker:
             args: Command line invocation arguments.
             kwargs: Command line invocation keyword arguments.
 
-        Raises:
-            ValueError: If the command doesn't declare a container spec.
-
         Returns:
             The container run exit code.
+
+        Raises:
+            ValueError: If the command doesn't declare a container spec.
         """
         command_config = self.find_command(plugin_command)
 
@@ -629,20 +622,12 @@ class PluginInvoker:
 
     @property
     def stdout_logger(self) -> BoundLogger:
-        """Get the logger for the plugin stdout.
-
-        Returns:
-            The logger for the plugin stdout.
-        """
+        """The logger for the plugin stdout."""
         return self.get_logger("stdout", "structlog")
 
     @property
     def stderr_logger(self) -> BoundLogger:
-        """Get the logger for the plugin stderr.
-
-        Returns:
-            The logger for the plugin stderr.
-        """
+        """The logger for the plugin stderr."""
         return self.get_logger("stderr", "structlog")
 
     def get_log_parser(self) -> str | None:

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -138,56 +138,32 @@ class Project:
 
     @cached_property
     def config_service(self) -> ConfigService:
-        """Get the project config service.
-
-        Returns:
-            A `ConfigService` instance for this project.
-        """
+        """A `ConfigService` instance for this project."""
         return ConfigService(self)
 
     @cached_property
     def project_files(self) -> ProjectFiles:
-        """Return a singleton `ProjectFiles` file manager instance.
-
-        Returns:
-            `ProjectFiles` file manager.
-        """
+        """`ProjectFiles` file manager."""
         return ProjectFiles(root=self.root, meltano_file_path=self.meltanofile)
 
     @cached_property
     def settings(self) -> ProjectSettingsService:
-        """Get the project settings.
-
-        Returns:
-            A `ProjectSettingsService` instance for this project.
-        """
+        """A `ProjectSettingsService` instance for this project."""
         return ProjectSettingsService(self)
 
     @cached_property
     def plugins(self) -> ProjectPluginsService:
-        """Get the project plugins.
-
-        Returns:
-            A `ProjectPluginsService` instance for this project.
-        """
+        """A `ProjectPluginsService` instance for this project."""
         return ProjectPluginsService(self)
 
     @cached_property
     def hub_service(self) -> MeltanoHubService:
-        """Get the Meltano Hub service.
-
-        Returns:
-            A `MeltanoHubService` instance for this project.
-        """
+        """A `MeltanoHubService` instance for this project."""
         return MeltanoHubService(self)
 
     @cached_property
     def dirs(self) -> ProjectDirsService:
-        """Get the project directories service.
-
-        Returns:
-            A `ProjectDirsService` instance for this project.
-        """
+        """A `ProjectDirsService` instance for this project."""
         return ProjectDirsService.from_project(self)
 
     @cached_property
@@ -196,20 +172,12 @@ class Project:
 
     @property
     def user_agent(self) -> str:
-        """Get the user agent for this project.
-
-        Returns:
-            the user agent string for this project
-        """
+        """The user-agent for this project."""
         return f"Meltano/{get_meltano_version()}"
 
     @property
     def env(self) -> dict[str, str]:
-        """Get environment variables for this project.
-
-        Returns:
-            dict of environment variables and values for this project.
-        """
+        """Environment variables for this project."""
         environment_name = self.environment.name if self.environment else ""
         return {
             PROJECT_ROOT_ENV: str(self.root),
@@ -280,11 +248,7 @@ class Project:
 
     @property
     def file_version(self) -> int:
-        """Get the version of Meltano found in this project's meltano.yml.
-
-        Returns:
-            the Project's meltano version
-        """
+        """The version of Meltano found in this project's meltano.yml."""
         return self.meltano.version
 
     @classmethod
@@ -342,13 +306,10 @@ class Project:
 
     @property
     def meltano(self) -> MeltanoFileTypeHint:
-        """Return a copy of the current meltano config.
+        """A copy of the current meltano config.
 
         Raises:
             EmptyMeltanoFileException: The `meltano.yml` file is empty.
-
-        Returns:
-            The current meltano config.
         """
         from meltano.core.meltano_file import MeltanoFile
 
@@ -405,20 +366,12 @@ class Project:
 
     @property
     def meltanofile(self) -> Path:
-        """Get the path to this project's meltano.yml.
-
-        Returns:
-            the path to this project meltano.yml
-        """
+        """Path to this project's meltano.yml."""
         return self.root.joinpath("meltano.yml")
 
     @property
     def dotenv(self) -> Path:
-        """Get the path to this project's .env file.
-
-        Returns:
-            the path to this project's .env file
-        """
+        """Path to this project's .env file."""
         if self.dotenv_file:
             return (
                 self.dotenv_file
@@ -429,10 +382,9 @@ class Project:
 
     @cached_property
     def dotenv_env(self) -> dict[str, str]:
-        """Get values from this project's .env file.
+        """Values from this project's .env file.
 
-        Returns:
-            Values found in this project's .env file, with None values filtered out.
+        With None values filtered out.
         """
         return {k: v for k, v in dotenv_values(self.dotenv).items() if v is not None}
 

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -58,20 +58,12 @@ class ProjectFiles:
 
     @property
     def meltano(self) -> CommentedMap:
-        """Return the contents of this project's `meltano.yml`.
-
-        Returns:
-            The contents of this projects `meltano.yml`.
-        """
+        """Contents of this project's `meltano.yml`."""
         return yaml.load(self._meltano_file_path)
 
     @property
     def include_paths(self) -> list[Path]:
-        """Return list of paths derived from glob patterns defined in the meltanofile.
-
-        Returns:
-            List of paths derived from glob patterns defined in the meltanofile.
-        """
+        """List of paths derived from glob patterns defined in the meltanofile."""
         include_path_patterns = self.meltano.get("include_paths", [])
         return self._resolve_include_paths(include_path_patterns)
 

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -122,11 +122,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
 
     @cached_property
     def current_plugins(self) -> Canonical:
-        """Return the current plugins.
-
-        Returns:
-            The current plugins.
-        """
+        """Current plugins."""
         return self.project.config_service.current_meltano_yml.plugins
 
     @contextmanager
@@ -175,14 +171,14 @@ class ProjectPluginsService:  # (too many methods, attributes)
                 and it is the same variant. Note: Updates are only allowed for
                 plugins with matching variants to prevent configuration conflicts.
 
+        Returns:
+            The added plugin and flags indicating the operation result.
+
         Raises:
             PluginAlreadyAddedException: If the plugin is already added and either:
                 - `update=False` (default behavior)
                 - `update=True` but the new plugin has a different variant than
                   the existing plugin (prevents accidental variant changes)
-
-        Returns:
-            The added plugin and flags indicating the operation result.
         """
         # FIXME: `should_add_to_file` is a method from `BasePlugin`, which is
         #        not a subclass of `ProjectPlugin`. I've left this call to it

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -120,7 +120,7 @@ class ProjectSettingsService(SettingsService):
     @property
     @override
     def label(self) -> str:
-        """Project abel."""
+        """Project label."""
         return "Meltano"
 
     @property

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -83,12 +83,9 @@ class ProjectSettingsService(SettingsService):
     @property
     @override
     def project_settings_service(self) -> Self:
-        """Get the settings service for this project.
+        """Settings service for this project.
 
         For ProjectSettingsService, just returns self.
-
-        Returns:
-            self
         """
         return self
 
@@ -123,51 +120,31 @@ class ProjectSettingsService(SettingsService):
     @property
     @override
     def label(self) -> str:
-        """Return label.
-
-        Returns:
-            Project label.
-        """
+        """Project abel."""
         return "Meltano"
 
     @property
     @override
     def docs_url(self) -> str:
-        """Return docs URL.
-
-        Returns:
-            URL for Meltano doc site.
-        """
+        """URL for Meltano doc site."""
         return "https://docs.meltano.com/reference/settings"
 
     @property
     @override
     def db_namespace(self) -> str:
-        """Return namespace for setting value records in system database.
-
-        Returns:
-            Namespace for setting value records in system database.
-        """
+        """Namespace for setting value records in system database."""
         return "meltano"
 
     @property
     @override
     def setting_definitions(self) -> list[SettingDefinition]:
-        """Return definitions of supported settings.
-
-        Returns:
-            A list of defined settings.
-        """
+        """Definitions of supported settings."""
         return self.project.config_service.settings
 
     @property
     @override
     def meltano_yml_config(self) -> dict[str, t.Any]:
-        """Return current configuration in `meltano.yml`.
-
-        Returns:
-            Current configuration in `meltano.yml`.
-        """
+        """Current configuration in `meltano.yml`."""
         return self.project.config_service.current_config
 
     @override

--- a/src/meltano/core/schedule.py
+++ b/src/meltano/core/schedule.py
@@ -233,11 +233,7 @@ class Schedule(NameEq, Canonical):
 
     @property
     def cron_interval(self) -> str | None:
-        """Return the explicit cron interval expression for a cron alias.
-
-        Returns:
-            The cron expression.
-        """
+        """Explicit cron interval expression for a cron alias."""
         return (
             CRON_INTERVALS.get(self.interval, self.interval) if self.interval else None
         )
@@ -273,12 +269,9 @@ class ELTSchedule(Schedule):
 
     @property
     def elt_args(self) -> list[str]:
-        """Return the list of arguments to pass to the elt command.
+        """List of arguments to pass to the elt command.
 
         Only valid if the schedule is an elt schedule.
-
-        Returns:
-            The list of arguments to pass to the elt command.
 
         Raises:
             NotImplementedError: If the schedule is a job.

--- a/src/meltano/core/select_service.py
+++ b/src/meltano/core/select_service.py
@@ -33,12 +33,12 @@ class SelectService:  # noqa: D101
 
     @property
     def extractor(self) -> ProjectPlugin:
-        """Retrieve extractor ProjectPlugin object."""
+        """Extractor ProjectPlugin object."""
         return self._extractor
 
     @property
     def current_select(self) -> list[str]:
-        """Get the current select patterns.
+        """Current select patterns.
 
         Returns:
             The current select pattern.

--- a/src/meltano/core/setting_definition.py
+++ b/src/meltano/core/setting_definition.py
@@ -88,11 +88,7 @@ class EnvVar:
 
     @property
     def definition(self) -> str:
-        """Return env var definition.
-
-        Returns:
-            Env var definition.
-        """
+        """Env var definition."""
         prefix = "!" if self.negated else ""
         return f"{prefix}{self.key}"
 
@@ -188,11 +184,7 @@ class SettingKind(YAMLEnum):
 
     @cached_property
     def is_sensitive(self) -> bool:
-        """Return whether the setting kind is sensitive.
-
-        Returns:
-            True if the setting kind is sensitive.
-        """
+        """Whether the setting kind is sensitive."""
         return self in {
             SettingKind.PASSWORD,
             SettingKind.OAUTH,
@@ -392,31 +384,20 @@ class SettingDefinition(NameEq, Canonical):
 
     @property
     def is_extra(self) -> bool:
-        """Return whether setting is a config extra.
+        """Whether setting is a config extra.
 
         See https://docs.meltano.com/reference/command-line-interface#how-to-use-plugin-extras
-
-        Returns:
-            True if setting is a config extra.
         """
         return self.name.startswith("_")
 
     @property
     def is_custom(self) -> bool:
-        """Return whether the setting is custom, i.e. user-defined in `meltano.yml`.
-
-        Returns:
-            True if the setting is custom (user defined).
-        """
+        """Whether the setting is custom, i.e. user-defined in `meltano.yml`."""
         return self._custom
 
     @property
     def is_redacted(self) -> bool:
-        """Return whether the setting value is redacted.
-
-        Returns:
-            True if setting value is redacted.
-        """
+        """Whether the setting value is redacted."""
         return self.sensitive
 
     def env_vars(
@@ -476,11 +457,11 @@ class SettingDefinition(NameEq, Canonical):
             expected_type: The Python type class of the expected type. Used to
                 ensure that the parsed value is of the expected type.
 
-        Raises:
-            parse_error: Parsing failed, or the parsed value had an unexpected type.
-
         Returns:
             The parsed value.
+
+        Raises:
+            parse_error: Parsing failed, or the parsed value had an unexpected type.
         """
         parse_error = ValueError(
             f"Failed to parse JSON {expected_type_name} from string: {unparsed!r}",

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -55,11 +55,7 @@ class FeatureFlags(StrEnum):
 
     @property
     def setting_name(self) -> str:
-        """Return the setting name for this feature flag.
-
-        Returns:
-            The setting name for this feature flag.
-        """
+        """Setting name for this feature flag."""
         return f"{FEATURE_FLAG_PREFIX}.{self.value}"
 
 
@@ -116,58 +112,42 @@ class SettingsService(metaclass=ABCMeta):
     @property
     @abstractmethod
     def label(self) -> str:
-        """Return label.
-
-        Returns:
-            Label for the settings service.
-        """
+        """Label for the settings service."""
 
     @property
     @abstractmethod
     def docs_url(self) -> str:
-        """Return docs URL.
-
-        Returns:
-            URL for Meltano doc site.
-        """
+        """Docs URL."""
 
     @property
     @abstractmethod
     def project_settings_service(self) -> SettingsService:
-        """Get a project settings service.
-
-        Returns:
-            A ProjectSettingsService
-        """
+        """Project settings service."""
 
     @property
     def env_prefixes(self) -> list[str]:
-        """Return prefixes for setting environment variables.
-
-        Returns:
-            prefixes for settings environment variables
-        """
+        """Prefixes for setting environment variables."""
         return ["meltano"]
 
     @property
     @abstractmethod
     def db_namespace(self) -> str:
-        """Return namespace for setting value records in system database."""
+        """Namespace for setting value records in system database."""
 
     @property
     @abstractmethod
     def setting_definitions(self) -> list[SettingDefinition]:
-        """Return definitions of supported settings."""
+        """Definitions of supported settings."""
 
     @property
     def inherited_settings_service(self) -> Self | None:
-        """Return settings service to inherit configuration from."""
+        """Settings service to inherit configuration from."""
         return None
 
     @property
     @abstractmethod
     def meltano_yml_config(self) -> dict:
-        """Return current configuration in `meltano.yml`."""
+        """Current configuration in `meltano.yml`."""
 
     @abstractmethod
     def update_meltano_yml_config(self, config: dict) -> None:
@@ -197,11 +177,7 @@ class SettingsService(metaclass=ABCMeta):
 
     @property
     def env(self) -> dict[str, str]:
-        """Return the environment as a dict.
-
-        Returns:
-            the environment as a dict.
-        """
+        """Environment as a dict."""
         return {**os.environ, **self.env_override}
 
     def config_with_metadata(

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -173,11 +173,7 @@ class SettingValueStore(StrEnum):
 
     @property
     def manager(self: Self) -> type[SettingsStoreManager]:
-        """Return store manager for this store.
-
-        Returns:
-            SettingsStoreManager for this store.
-        """
+        """Store manager for this store."""
         # ordering here is not significant, other than being consistent with
         # the order of precedence.
         managers: dict[str, type[SettingsStoreManager]] = {
@@ -195,20 +191,12 @@ class SettingValueStore(StrEnum):
 
     @property
     def label(self) -> str:
-        """Return printable label.
-
-        Returns:
-            Printable label.
-        """
+        """Printable label."""
         return self.manager.label
 
     @property
     def writable(self) -> bool:
-        """Return if this store is writable.
-
-        Returns:
-            True if store is writable.
-        """
+        """Whether this store is writable."""
         return self.manager.writable
 
     def overrides(self, source: SettingValueStore) -> bool:
@@ -399,15 +387,15 @@ class BaseEnvStoreManager(SettingsStoreManager):
             setting_def: SettingDefinition instance.
             cast_value: Whether to cast the value according to `setting_def`.
 
+        Returns:
+            A tuple the got value and a dictionary containing metadata.
+
         Raises:
             StoreNotSupportedError: if setting_def not passed.
             ConflictingSettingValueException: if multiple conflicting values for the
                 same setting are provided.
             MultipleEnvVarsSetException: if multiple environment variables are set for
                 the same setting.
-
-        Returns:
-            A tuple the got value and a dictionary containing metadata.
         """
         if not setting_def:
             reason = "Can not retrieve unknown setting from environment variables"
@@ -456,11 +444,7 @@ class EnvStoreManager(BaseEnvStoreManager):
     @property
     @override
     def env(self) -> dict[str, str]:
-        """Return values from the calling terminals environment.
-
-        Returns:
-            Values found in the calling terminals environment.
-        """
+        """Values from the calling terminals environment."""
         return self.settings_service.env
 
     @override
@@ -525,11 +509,7 @@ class DotEnvStoreManager(BaseEnvStoreManager):
     @property
     @override
     def env(self) -> dict[str, str]:
-        """Return values from the .env file.
-
-        Returns:
-            A dictionary of values found in the .env file.
-        """
+        """Dictionary of values from the .env file."""
         if self._env is None:
             self._env = self.project.dotenv_env
         return self._env
@@ -570,11 +550,11 @@ class DotEnvStoreManager(BaseEnvStoreManager):
             value: New value to set.
             setting_def: SettingDefinition.
 
-        Raises:
-            StoreNotSupportedError: if setting_def not provided.
-
         Returns:
             An empty dictionary.
+
+        Raises:
+            StoreNotSupportedError: if setting_def not provided.
         """
         if not setting_def:
             reason = f"Unknown setting '{name}' can not be set in `.env`"
@@ -848,11 +828,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
 
     @property
     def flat_config(self) -> dict:
-        """Get dictionary of flattened configuration.
-
-        Returns:
-            A dictionary of flattened configuration.
-        """
+        """Dictionary of flattened configuration."""
         if self._flat_config is None:
             self._flat_config = self.settings_service.flat_meltano_yml_config
         return self._flat_config
@@ -901,11 +877,7 @@ class MeltanoEnvStoreManager(MeltanoYmlStoreManager):
     @property
     @override
     def flat_config(self) -> dict[str, t.Any]:
-        """Get dictionary of flattened configuration.
-
-        Returns:
-            A dictionary of flattened configuration.
-        """
+        """Dictionary of flattened configuration."""
         # TODO: Remove this cast when we have a better way to get the settings service
         # type or when we figure how the settings service type should be narrowed
         # per-manager.
@@ -1117,20 +1089,12 @@ class DbStoreManager(SettingsStoreManager):
 
     @property
     def namespace(self) -> str:
-        """Return the current SettingService namespace.
-
-        Returns:
-            The current SettingService namespace
-        """
+        """Current SettingService namespace."""
         return self.settings_service.db_namespace
 
     @property
     def all_settings(self) -> dict[str, str | None]:
-        """Fetch all settings from the system database for this namespace that are enabled.
-
-        Returns:
-            A dictionary of Setting models.
-        """  # noqa: E501
+        """All settings from the system database for this namespace that are enabled."""
         if self._all_settings is None:
             self._all_settings = {
                 setting.name: setting.value
@@ -1202,11 +1166,7 @@ class InheritedStoreManager(SettingsStoreManager):
 
     @property
     def inherited_settings_service(self) -> SettingsService:
-        """Return settings service to inherit configuration from.
-
-        Returns:
-            A SettingsService to inherit configuration from.
-        """
+        """Settings service to inherit configuration from."""
         service = self.settings_service.inherited_settings_service
         if service is None:
             msg = "Inherited settings service is missing"
@@ -1216,11 +1176,7 @@ class InheritedStoreManager(SettingsStoreManager):
 
     @property
     def config_with_metadata(self) -> dict:
-        """Return all inherited config and metadata.
-
-        Returns:
-            A dictionary containing config and metadata.
-        """
+        """All inherited config and metadata."""
         if self._config_with_metadata is None:
             self._config_with_metadata = (
                 self.inherited_settings_service.config_with_metadata(**self._kwargs)
@@ -1315,22 +1271,14 @@ class AutoStoreManager(SettingsStoreManager):
 
     @property
     def sources(self) -> list[SettingValueStore]:
-        """Return a list of readable SettingValueStore.
-
-        Returns:
-            A list of readable SettingValueStore
-        """
+        """A list of readable SettingValueStore."""
         sources = SettingValueStore.readables()
         sources.remove(SettingValueStore.AUTO)
         return sources
 
     @property
     def stores(self) -> list[SettingValueStore]:
-        """Return a list of writable SettingValueStore.
-
-        Returns:
-            A list of writable SettingValueStore
-        """
+        """A list of writable SettingValueStore."""
         stores = SettingValueStore.writables()
         stores.remove(SettingValueStore.AUTO)
         return stores

--- a/src/meltano/core/state_service.py
+++ b/src/meltano/core/state_service.py
@@ -105,11 +105,11 @@ class StateService:
         Args:
             job: either an existing Job to modify state for, or a state_id
 
-        Raises:
-            TypeError: if job is not of type Job or str
-
         Returns:
             A new job with given state_id, or the given Job
+
+        Raises:
+            TypeError: if job is not of type Job or str
         """
         if isinstance(job, str):
             now = datetime.datetime.now(datetime.timezone.utc)

--- a/src/meltano/core/state_store/azure/backend.py
+++ b/src/meltano/core/state_store/azure/backend.py
@@ -73,10 +73,7 @@ class AZStorageStateStoreManager(CloudStateStoreManager):
 
     @cached_property
     def client(self) -> BlobServiceClient:
-        """Get an authenticated azure.storage.blob.BlobServiceClient.
-
-        Returns:
-            An authenticated azure.storage.blob.BlobServiceClient
+        """Authenticated azure.storage.blob.BlobServiceClient.
 
         Raises:
             MeltanoError: If connection string is not provided.

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -172,7 +172,7 @@ class StateStoreManager(ABC):
     @property
     @abstractmethod
     def label(self) -> str:
-        """Get the label for the StateStoreManager."""
+        """Label for the StateStoreManager."""
         ...
 
     @abstractmethod

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -161,7 +161,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
     @property
     @abstractmethod
     def client(self) -> t.Any:  # noqa: ANN401
-        """Get a client for performing fs operations.
+        """Client for performing fs operations.
 
         Used for cloud backends, particularly in deleting and listing blobs.
         """
@@ -170,7 +170,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
     @property
     @abstractmethod
     def state_dir(self) -> str:
-        """Get the path (either filepath or prefix) that state should be stored at."""
+        """Path (either filepath or prefix) that state should be stored at."""
         ...
 
     def get_path(self, state_id: str, filename: str | None = None) -> str:
@@ -397,7 +397,7 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
     @property
     @override
     def client(self) -> None:
-        """Get a client for performing fs operations.
+        """Client for performing fs operations.
 
         Returns:
             None
@@ -407,7 +407,7 @@ class _LocalFilesystemStateStoreManager(BaseFilesystemStateStoreManager):
     @property
     @override
     def state_dir(self) -> str:
-        """Get the path that state should be stored at.
+        """Path that state should be stored at.
 
         Returns:
             The relevant path
@@ -587,11 +587,7 @@ class CloudStateStoreManager(BaseFilesystemStateStoreManager):
     @property
     @override
     def state_dir(self) -> str:
-        """Get the prefix that state should be stored at.
-
-        Returns:
-            The relevant prefix
-        """
+        """Prefix where state should be stored at."""
         return self.prefix.lstrip(self.delimiter).rstrip(self.delimiter)
 
     @override

--- a/src/meltano/core/state_store/google/backend.py
+++ b/src/meltano/core/state_store/google/backend.py
@@ -104,11 +104,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
     @cached_property
     @override
     def client(self) -> google.cloud.storage.Client:
-        """Get an authenticated google.cloud.storage.Client.
-
-        Returns:
-            A google.cloud.storage.Client.
-        """
+        """Authenticated google.cloud.storage.Client."""
         if self.application_credentials_json:
             # Parse JSON string and create client from service account info
             try:

--- a/src/meltano/core/state_store/s3/backend.py
+++ b/src/meltano/core/state_store/s3/backend.py
@@ -94,10 +94,7 @@ class S3StateStoreManager(CloudStateStoreManager):
     @cached_property
     @override
     def client(self) -> S3Client:
-        """Get an authenticated boto3.Client.
-
-        Returns:
-            A boto3.Client.
+        """An authenticated boto3.Client.
 
         Raises:
             InvalidStateBackendConfigurationException: when configured AWS

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -107,11 +107,7 @@ class EnvironmentContext(SelfDescribingJson):
 
     @cached_property
     def system_info(self) -> dict[str, t.Any]:
-        """Get system information.
-
-        Returns:
-            A dictionary containing system information.
-        """
+        """A dictionary containing system information."""
         try:
             freedesktop_data = platform.freedesktop_os_release()
         except Exception:  # noqa: BLE001

--- a/src/meltano/core/tracking/contexts/project.py
+++ b/src/meltano/core/tracking/contexts/project.py
@@ -68,13 +68,10 @@ class ProjectContext(SelfDescribingJson):
 
     @property
     def environment_name(self) -> str | None:
-        """Get the name of the active environment.
+        """Name of the active environment.
 
-        Only the hash of this value is reported to Snowplow.
-
-        Returns:
-            The name of the active environment, or `None` if there is no active
-            environment.
+        `None` if there is no active environment. Only the hash of this value is
+        reported to Snowplow.
         """
         return self._environment_name
 

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -221,11 +221,7 @@ class Tracker:  # - too many (public) methods
 
     @property
     def contexts(self) -> tuple[SelfDescribingJson]:
-        """Get the contexts that will accompany events fired by this tracker.
-
-        Returns:
-            The contexts that will accompany events fired by this tracker.
-        """
+        """Contexts that will accompany events fired by this tracker."""
         from meltano.core.tracking.contexts import ExceptionContext
 
         # The `ExceptionContext` is re-created every time this is accessed
@@ -432,11 +428,7 @@ class Tracker:  # - too many (public) methods
 
     @property
     def analytics_json_path(self) -> Path:
-        """Return path to the 'analytics.json' file.
-
-        Returns:
-            Path to 'analytics.json' file.
-        """
+        """Path to the 'analytics.json' file."""
         return self.project.dirs.meltano().joinpath("analytics.json")
 
     def load_saved_telemetry_settings(self) -> TelemetrySettings:

--- a/src/meltano/core/user_config.py
+++ b/src/meltano/core/user_config.py
@@ -156,6 +156,7 @@ class UserConfigService:
 
     @property
     def yaml(self) -> YamlSettings:
+        """YAML formatting settings as a YamlSettings object."""
         """A dictionary of YAML formatting settings."""
         return self.config.yaml
 

--- a/src/meltano/core/user_config.py
+++ b/src/meltano/core/user_config.py
@@ -157,7 +157,6 @@ class UserConfigService:
     @property
     def yaml(self) -> YamlSettings:
         """YAML formatting settings as a YamlSettings object."""
-        """A dictionary of YAML formatting settings."""
         return self.config.yaml
 
 

--- a/src/meltano/core/user_config.py
+++ b/src/meltano/core/user_config.py
@@ -46,7 +46,7 @@ class YamlSettings:
 
     @property
     def indent(self) -> int:
-        """Get the indentation level."""
+        """Indentation level."""
         if self._indent < 1:
             logger.warning(
                 "Invalid YAML indentation level, using default",
@@ -57,7 +57,7 @@ class YamlSettings:
 
     @property
     def block_seq_indent(self) -> int:
-        """Get the block sequence indentation level."""
+        """Block sequence indentation level."""
         if self._block_seq_indent < 0:
             logger.warning(
                 "Invalid YAML block sequence indentation level, using default",
@@ -68,7 +68,7 @@ class YamlSettings:
 
     @property
     def sequence_dash_offset(self) -> int:
-        """Get the sequence dash offset."""
+        """Sequence dash offset."""
         if self._sequence_dash_offset is None:
             self._sequence_dash_offset = max(0, self.indent - 2)
         return self._sequence_dash_offset
@@ -120,7 +120,7 @@ class UserConfigService:
 
     @property
     def config_path(self) -> Path:
-        """Get the path to the configuration file."""
+        """Path to the configuration file."""
         if self._config_path is None:
             config_dir = platformdirs.user_config_path("meltano")
             self._config_path = config_dir / "config.yml"
@@ -128,7 +128,7 @@ class UserConfigService:
 
     @property
     def config(self) -> UserConfig:
-        """Get the configuration data.
+        """Configuration data.
 
         Returns:
             The configuration data as a dictionary.
@@ -156,11 +156,7 @@ class UserConfigService:
 
     @property
     def yaml(self) -> YamlSettings:
-        """Get all YAML formatting settings.
-
-        Returns:
-            A dictionary of YAML formatting settings.
-        """
+        """A dictionary of YAML formatting settings."""
         return self.config.yaml
 
 

--- a/src/meltano/core/validation_service.py
+++ b/src/meltano/core/validation_service.py
@@ -35,11 +35,7 @@ class ValidationOutcome(StrEnum):
 
     @property
     def color(self) -> str:
-        """Return terminal color for this outcome.
-
-        Returns:
-            The string name of a color for this outcome.
-        """
+        """Terminal color for this outcome."""
         return "green" if self == ValidationOutcome.SUCCESS else "red"
 
     @classmethod
@@ -74,11 +70,7 @@ class ValidationsRunner(metaclass=ABCMeta):
 
     @property
     def plugin_name(self) -> str:
-        """Get underlying plugin name.
-
-        Returns:
-            The name of the plugin to run.
-        """
+        """Underlying plugin name to run."""
         return self.invoker.plugin.name
 
     def select_test(self, name: str) -> None:

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -105,13 +105,10 @@ class VirtualEnv:
 
     @cached_property
     def lib_dir(self) -> Path:
-        """Return the lib directory of the virtual environment.
+        """The lib directory of the virtual environment.
 
         Raises:
             MeltanoError: The current system is not supported.
-
-        Returns:
-            The lib directory of the virtual environment.
         """
         if self._system == "Windows":
             return self.root / "Lib"
@@ -120,13 +117,10 @@ class VirtualEnv:
 
     @cached_property
     def bin_dir(self) -> Path:
-        """Return the bin directory of the virtual environment.
+        """The bin directory of the virtual environment.
 
         Raises:
             MeltanoError: The current system is not supported.
-
-        Returns:
-            The bin directory of the virtual environment.
         """
         if self._system == "Windows":
             return self.root / "Scripts"
@@ -135,13 +129,10 @@ class VirtualEnv:
 
     @cached_property
     def site_packages_dir(self) -> Path:
-        """Return the site-packages directory of the virtual environment.
+        """The site-packages directory of the virtual environment.
 
         Raises:
             MeltanoError: The current system is not supported.
-
-        Returns:
-            The site-packages directory of the virtual environment.
         """
         if self._system == "Windows":
             return self.lib_dir / "site-packages"
@@ -154,11 +145,7 @@ class VirtualEnv:
 
     @cached_property
     def python_version_tuple(self) -> tuple[int, int, int]:
-        """Return the Python version tuple of the virtual environment.
-
-        Returns:
-            The Python version tuple of the virtual environment.
-        """
+        """The Python version tuple of the virtual environment."""
         if self.python_path == sys.executable:
             return sys.version_info[:3]
 
@@ -259,11 +246,11 @@ async def exec_async(*args, extract_stderr=_extract_stderr, **kwargs) -> Process
             and returns its error string or `None`.
         kwargs: Keyword arguments for `asyncio.create_subprocess_exec`.
 
-    Raises:
-        AsyncSubprocessError: The command failed.
-
     Returns:
         The subprocess.
+
+    Raises:
+        AsyncSubprocessError: The command failed.
     """
     run = await asyncio.create_subprocess_exec(
         *args,
@@ -555,11 +542,11 @@ class VirtualEnvService:
     async def create(self) -> Process:
         """Create a new virtual environment.
 
-        Raises:
-            AsyncSubprocessError: The virtual environment could not be created.
-
         Returns:
             The Python process creating the virtual environment.
+
+        Raises:
+            AsyncSubprocessError: The virtual environment could not be created.
         """
         logger.debug(
             "Creating virtual environment for '%s/%s'",
@@ -598,11 +585,11 @@ class VirtualEnvService:
             force: Whether to ignore the Python version required by plugins.
             env: Environment variables to pass to the subprocess.
 
-        Raises:
-            AsyncSubprocessError: The command failed.
-
         Returns:
             The process running `pip install` with the provided args.
+
+        Raises:
+            AsyncSubprocessError: The command failed.
         """
         if clean:
             await self.create()
@@ -816,11 +803,11 @@ class VirtualenvBackend(VenvBackend):
         Args:
             env: Environment variables to pass to the subprocess.
 
-        Raises:
-            AsyncSubprocessError: Failed to upgrade pip to the latest version.
-
         Returns:
             The process running `pip install --upgrade ...`.
+
+        Raises:
+            AsyncSubprocessError: Failed to upgrade pip to the latest version.
         """
         return await self.install_pip_args(("--upgrade", "pip"), env=env)
 


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Simplify and standardize docstrings for many core properties and accessors across plugins, settings, environment, state, tracking, and related services.

Enhancements:
- Condense property and accessor docstrings to concise, descriptive one-liners without changing behavior or signatures.
- Align return/raises sections for several methods to improve consistency and readability of API documentation.