### PR TITLE
refactor: Unify log configurations between formatters available in `logging.yaml` and the default preset configs (`colored`, `json`, etc.)

### DIFF
--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -156,12 +156,16 @@ def default_config(
 
     match log_format:
         case LogFormat.colored:
-            no_color = get_no_color_flag() or not sys.stderr.isatty()
-            formatter_config = {
-                "()": console_log_formatter,
-                "colors": not no_color,
-                "max_frames": max_frames,
-            }
+            colors = sys.stderr.isatty() and not get_no_color_flag()
+            # Pre-build now so terminal detection runs before any stream capture
+            # (e.g. Click's CliRunner replaces sys.stdout with StringIO on entry,
+            # causing structlog's get_default_column_styles to see a non-tty and
+            # return plain styles even when colors=True).
+            colored_formatter = console_log_formatter(
+                colors=colors,
+                max_frames=max_frames,
+            )
+            formatter_config = {"()": lambda: colored_formatter}
         case LogFormat.uncolored:
             formatter_config = {
                 "()": console_log_formatter,

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -153,6 +153,7 @@ def default_config(
     numeric_level = parse_log_level(log_level.lower())
     log_level = log_level.upper()
     max_frames = _FRAMES_DEBUG if log_level == "DEBUG" else _FRAMES_DEFAULT
+    formatter_config: dict[str, t.Any]
 
     match log_format:
         case LogFormat.colored:

--- a/src/meltano/core/logging/utils.py
+++ b/src/meltano/core/logging/utils.py
@@ -15,12 +15,13 @@ import structlog
 import yaml
 
 from meltano.core.logging.formatters import (
+    console_log_formatter,
     get_default_foreign_pre_chain,
-    rich_exception_formatter_factory,
+    json_formatter,
+    key_value_formatter,
+    plain_formatter,
 )
 from meltano.core.utils import get_no_color_flag
-
-from .renderers import MeltanoConsoleRenderer
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -118,7 +119,7 @@ def parse_log_level(log_level: str) -> int:
     return LEVELS.get(log_level, LEVELS[DEFAULT_LEVEL])
 
 
-def read_config(config_file: os.PathLike[str] | None = None) -> dict | None:
+def read_config(config_file: Path | None = None) -> dict | None:
     """Read a logging config yaml from disk.
 
     Args:
@@ -128,7 +129,7 @@ def read_config(config_file: os.PathLike[str] | None = None) -> dict | None:
         dict: parsed yaml config
     """
     if config_file and os.path.exists(config_file):  # noqa: PTH110
-        with open(config_file) as cf:  # noqa: PTH123
+        with config_file.open() as cf:
             return yaml.safe_load(cf.read())
     else:
         return None
@@ -152,76 +153,30 @@ def default_config(
     numeric_level = parse_log_level(log_level.lower())
     log_level = log_level.upper()
     max_frames = _FRAMES_DEBUG if log_level == "DEBUG" else _FRAMES_DEFAULT
-    foreign_pre_chain = get_default_foreign_pre_chain()
 
     match log_format:
         case LogFormat.colored:
             no_color = get_no_color_flag() or not sys.stderr.isatty()
-
-            if no_color:
-                formatter = rich_exception_formatter_factory(
-                    no_color=True,
-                    max_frames=max_frames,
-                )
-            else:
-                formatter = rich_exception_formatter_factory(
-                    color_system="truecolor",
-                    max_frames=max_frames,
-                )
             formatter_config = {
-                "()": structlog.stdlib.ProcessorFormatter,
-                "processor": MeltanoConsoleRenderer(
-                    colors=not no_color,
-                    exception_formatter=formatter,
-                ),
-                "foreign_pre_chain": foreign_pre_chain,
-            }
-
-        case LogFormat.json:
-            formatter_config = {
-                "()": structlog.stdlib.ProcessorFormatter,
-                "processors": [
-                    structlog.processors.dict_tracebacks,
-                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                    structlog.processors.JSONRenderer(),
-                ],
-                "foreign_pre_chain": foreign_pre_chain,
-            }
-        case LogFormat.key_value:
-            formatter_config = {
-                "()": structlog.stdlib.ProcessorFormatter,
-                "processor": structlog.processors.KeyValueRenderer(
-                    key_order=["timestamp", "level", "event", "logger"],
-                ),
-                "foreign_pre_chain": foreign_pre_chain,
+                "()": console_log_formatter,
+                "colors": not no_color,
+                "max_frames": max_frames,
             }
         case LogFormat.uncolored:
             formatter_config = {
-                "()": structlog.stdlib.ProcessorFormatter,
-                "processor": MeltanoConsoleRenderer(
-                    colors=False,
-                    exception_formatter=rich_exception_formatter_factory(
-                        no_color=True,
-                        max_frames=max_frames,
-                    ),
-                ),
-                "foreign_pre_chain": foreign_pre_chain,
+                "()": console_log_formatter,
+                "colors": False,
+                "max_frames": max_frames,
+            }
+        case LogFormat.json:
+            formatter_config = {"()": json_formatter}
+        case LogFormat.key_value:
+            formatter_config = {
+                "()": key_value_formatter,
+                "key_order": ["timestamp", "level", "event", "logger"],
             }
         case LogFormat.plain:
-            formatter_config = {
-                "()": structlog.stdlib.ProcessorFormatter,
-                "processors": [
-                    structlog.stdlib.filter_by_level,
-                    structlog.stdlib.add_logger_name,
-                    structlog.stdlib.add_log_level,
-                    structlog.stdlib.PositionalArgumentsFormatter(),
-                    structlog.processors.StackInfoRenderer(),
-                    structlog.processors.format_exc_info,
-                    structlog.processors.UnicodeDecoder(),
-                    lambda _logger, _name, event_dict: event_dict["event"],
-                ],
-                "foreign_pre_chain": foreign_pre_chain,
-            }
+            formatter_config = {"()": plain_formatter}
         case _:  # pragma: no cover
             t.assert_never(log_format)
 
@@ -272,7 +227,7 @@ def default_config(
 def setup_logging(
     project: Project | None = None,
     log_level: str = DEFAULT_LEVEL,
-    log_config: os.PathLike[str] | None = None,
+    log_config: os.PathLike[str] | str | None = None,
     log_format: LogFormat = LogFormat.colored,
 ) -> None:
     """Configure logging for a meltano project.

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -1409,10 +1409,7 @@ class TestCliRunScratchpadOne:
             result = cli_runner.invoke(cli, args)
             ansi_color_escape = re.compile(r"\x1b\[[0-9;]+m")
             match = ansi_color_escape.search(result.stderr)
-            if colors:
-                assert match
-            else:
-                assert not match
+            assert (colors and match is not None) or (not colors and match is None)
 
     @pytest.mark.backend("sqlite")
     @pytest.mark.usefixtures(

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -28,7 +28,9 @@ if t.TYPE_CHECKING:
 
 
 class MockIOBlock(IOBlock):
-    string_id = "mock-io-block"
+    @property
+    def string_id(self):
+        return "mock-io-block"
 
 
 @pytest.fixture(scope="class")

--- a/tests/meltano/cli/test_run.py
+++ b/tests/meltano/cli/test_run.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock
 import pytest
 
 from meltano.cli import cli
-from meltano.core.block.ioblock import IOBlock
 from meltano.core.logging.job_logging_service import MissingJobLogException
 from meltano.core.logging.utils import default_config
 from meltano.core.plugin import PluginType
@@ -25,12 +24,6 @@ if t.TYPE_CHECKING:
     from fixtures.cli import MeltanoCliRunner
     from meltano.core.logging.job_logging_service import JobLoggingService
     from meltano.core.project import Project
-
-
-class MockIOBlock(IOBlock):
-    @property
-    def string_id(self):
-        return "mock-io-block"
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Unify default logging formatter configuration with the formatters exposed in `logging.yaml`, and align logging utility types with `pathlib.Path` usage.

Enhancements:
- Route colored, uncolored, JSON, key-value, and plain log formats through shared formatter factory helpers to keep preset and `logging.yaml` configurations consistent.
- Update logging config file handling to use `pathlib.Path`-based APIs and accept both path-like and string values for the `log_config` parameter.