### PR TITLE
refactor: Replace `metaclass=abc.ABCMeta` with `abc.ABC`

### DIFF
--- a/src/meltano/core/block/blockset.py
+++ b/src/meltano/core/block/blockset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing as t
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 if t.TYPE_CHECKING:
     from meltano.core.block.ioblock import IOBlock
@@ -24,7 +24,7 @@ class BlockSetValidationError(Exception):
         super().__init__(f"{message}: {error}")
 
 
-class BlockSet(t.Generic[_T], metaclass=ABCMeta):
+class BlockSet(ABC, t.Generic[_T]):
     """Currently the only complex block set is our `ExtractLoadBlocks` type.
 
     Theoretically, this is the bare minimum that we need to run and terminate

--- a/src/meltano/core/block/ioblock.py
+++ b/src/meltano/core/block/ioblock.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing as t
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 if t.TYPE_CHECKING:
     from asyncio import StreamWriter, Task
@@ -11,7 +11,7 @@ if t.TYPE_CHECKING:
     from meltano.core.logging.utils import SubprocessOutputWriter
 
 
-class IOBlock(metaclass=ABCMeta):
+class IOBlock(ABC):
     """A block that consumes, produces, or both (i.e. transforms) output.
 
     Underlying implementation could be subprocesses (e.g. Singer Plugins), or

--- a/src/meltano/core/block/plugin_command.py
+++ b/src/meltano/core/block/plugin_command.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import typing as t
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 import structlog
 
@@ -27,7 +27,7 @@ if t.TYPE_CHECKING:
 logger = structlog.getLogger(__name__)
 
 
-class PluginCommandBlock(metaclass=ABCMeta):
+class PluginCommandBlock(ABC):
     """Basic PluginCommand interface specification."""
 
     string_id: str

--- a/src/meltano/core/plugin_repository.py
+++ b/src/meltano/core/plugin_repository.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing as t
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 from meltano.core.plugin.factory import base_plugin_factory
 
@@ -12,7 +12,7 @@ if t.TYPE_CHECKING:
     from meltano.core.plugin.project_plugin import ProjectPlugin
 
 
-class PluginRepository(metaclass=ABCMeta):
+class PluginRepository(ABC):
     """A generic plugin definition repository."""
 
     @abstractmethod

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -7,7 +7,7 @@ import os
 import sys
 import typing as t
 import warnings
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
 import structlog
@@ -81,7 +81,7 @@ class FeatureNotAllowedException(Exception):
         return f"{self.feature} not enabled."
 
 
-class SettingsService(metaclass=ABCMeta):
+class SettingsService(ABC):
     """Abstract base class for managing settings."""
 
     LOGGING = False

--- a/src/meltano/core/validation_service.py
+++ b/src/meltano/core/validation_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 import sys
 import typing as t
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 from meltano.core.plugin import PluginType
 from meltano.core.plugin_invoker import invoker_factory
@@ -51,7 +51,7 @@ class ValidationOutcome(StrEnum):
         return cls.SUCCESS if exit_code == EXIT_CODE_OK else cls.FAILURE
 
 
-class ValidationsRunner(metaclass=ABCMeta):
+class ValidationsRunner(ABC):
     """Class to collect all validations defined for a plugin."""
 
     def __init__(


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enhancements:
- Update several core abstract classes to subclass abc.ABC rather than specifying metaclass=abc.ABCMeta for improved clarity and modern style.