### PR TITLE
docs: Add Microsoft SQL Server Store guides to sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -46,6 +46,7 @@ const sidebars = {
           link: { type: 'doc', id: 'meltano-cloud/connect-a-store/index' },
           items: [
             { type: 'doc', id: 'meltano-cloud/connect-a-store/snowflake-guides' },
+            { type: 'doc', id: 'meltano-cloud/connect-a-store/microsoft-sql-server-guides' },
             //{ type: 'doc', id: 'meltano-cloud/stores/bigquery' },
           ],
         },


### PR DESCRIPTION
## Description

Follow-on to #10123

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

## Related Issues

* Closes #XXXX
* Ref MEL-492

## Summary by Sourcery

Documentation:
- Include the Microsoft SQL Server store guide in the Meltano Cloud "Connect a store" sidebar section.