### PR TITLE
chore: Use Python 3.13 `Generator` generic type with default `SendType` and `ReturnType`

### DIFF
--- a/src/meltano/cli/elt.py
+++ b/src/meltano/cli/elt.py
@@ -33,6 +33,7 @@ from meltano.core.tracking.contexts import CliEvent, PluginsTrackingContext
 from meltano.core.utils import new_run_id, run_async
 
 if t.TYPE_CHECKING:
+    import sys
     import uuid
 
     from sqlalchemy.orm import Session
@@ -42,6 +43,11 @@ if t.TYPE_CHECKING:
     from meltano.core.plugin.base import PluginDefinition
     from meltano.core.project import Project
     from meltano.core.tracking import Tracker
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import AsyncGenerator
+    else:
+        from typing_extensions import AsyncGenerator
 
 DUMPABLES = {
     "catalog": (PluginType.EXTRACTORS, "catalog"),
@@ -492,7 +498,7 @@ async def _run_job(
 async def _redirect_output(
     log: structlog.stdlib.BoundLogger,
     output_logger: OutputLogger,
-) -> t.AsyncGenerator[None, None]:
+) -> AsyncGenerator[None]:
     meltano_stdout = output_logger.out(
         "meltano",
         log.bind(stdio="stdout", cmd_type="elt"),

--- a/src/meltano/core/behavior/addon.py
+++ b/src/meltano/core/behavior/addon.py
@@ -17,6 +17,11 @@ if t.TYPE_CHECKING:
     else:
         from importlib_metadata import EntryPoints
 
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 T = t.TypeVar("T")
 
 
@@ -40,7 +45,7 @@ class MeltanoAddon(t.Generic[T]):
         """
         return entry_points(group=self.entry_point_group)
 
-    def get_all(self) -> t.Generator[T, None, None]:
+    def get_all(self) -> Generator[T]:
         """Get all add-ons.
 
         Returns:

--- a/src/meltano/core/block/block_parser.py
+++ b/src/meltano/core/block/block_parser.py
@@ -19,8 +19,8 @@ from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.task_sets_service import TaskSetsService
 
 if t.TYPE_CHECKING:
+    import sys
     import uuid
-    from collections.abc import Generator
 
     import structlog
 
@@ -28,6 +28,11 @@ if t.TYPE_CHECKING:
     from meltano.core.block.singer import SingerBlock
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 def is_command_block(plugin: ProjectPlugin) -> bool:
@@ -190,7 +195,7 @@ class BlockParser:  # noqa: D101
     def find_blocks(
         self,
         offset: int = 0,
-    ) -> Generator[ExtractLoadBlocks | InvokerCommand, None, None]:
+    ) -> Generator[ExtractLoadBlocks | InvokerCommand]:
         """Find all blocks in the invocation.
 
         Args:

--- a/src/meltano/core/block/extract_load.py
+++ b/src/meltano/core/block/extract_load.py
@@ -28,8 +28,8 @@ from .future_utils import first_failed_future, handle_producer_line_length_limit
 from .singer import SingerBlock
 
 if t.TYPE_CHECKING:
+    import sys
     import uuid
-    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from sqlalchemy.orm import Session
@@ -39,6 +39,12 @@ if t.TYPE_CHECKING:
     from meltano.core.project import Project
 
     from .ioblock import IOBlock
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import AsyncGenerator
+    else:
+        from typing_extensions import AsyncGenerator
+
 
 logger = structlog.getLogger(__name__)
 
@@ -606,7 +612,7 @@ class ExtractLoadBlocks(BlockSet[SingerBlock]):
         return self.blocks[1:-1]
 
     @asynccontextmanager
-    async def _start_blocks(self) -> AsyncIterator[None]:
+    async def _start_blocks(self) -> AsyncGenerator[None]:
         """Start the blocks in the block set.
 
         Yields:

--- a/src/meltano/core/config_service.py
+++ b/src/meltano/core/config_service.py
@@ -14,10 +14,16 @@ from meltano.core.behavior.addon import MeltanoAddon
 from meltano.core.setting_definition import SettingDefinition
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
 
     from meltano.core.meltano_file import MeltanoFile
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -51,7 +57,7 @@ class ConfigService:
         return self.project.meltano
 
     @contextmanager
-    def update_meltano_yml(self) -> Generator[MeltanoFile, None, None]:
+    def update_meltano_yml(self) -> Generator[MeltanoFile]:
         """Update meltano.yml.
 
         This method is a context manager that will update meltano.yml with the

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -27,9 +27,14 @@ from meltano.core.sqlalchemy import (
 from meltano.core.utils import new_run_id
 
 if t.TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Generator
+    import sys
 
     from sqlalchemy.orm import Session
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import AsyncGenerator, Generator
+    else:
+        from typing_extensions import AsyncGenerator, Generator
 
 
 HEARTBEATLESS_JOB_VALID_HOURS = 24
@@ -261,7 +266,7 @@ class Job(SystemModel):
         return transition
 
     @asynccontextmanager
-    async def run(self, session: Session) -> AsyncGenerator[None, None]:
+    async def run(self, session: Session) -> AsyncGenerator[None]:
         """Run wrapped code in context of a job.
 
         Transitions state to RUNNING and SUCCESS/FAIL as appropriate and
@@ -375,7 +380,7 @@ class Job(SystemModel):
             await asyncio.sleep(1)
 
     @asynccontextmanager
-    async def _heartbeating(self, session: Session) -> AsyncGenerator[None, None]:
+    async def _heartbeating(self, session: Session) -> AsyncGenerator[None]:
         """Provide a context for heartbeating jobs.
 
         Args:
@@ -392,10 +397,7 @@ class Job(SystemModel):
                 await heartbeat_future
 
     @contextmanager
-    def _handling_sigterm(
-        self,
-        session: Session,  # noqa: ARG002
-    ) -> Generator[None, None, None]:
+    def _handling_sigterm(self, session: Session) -> Generator[None]:  # noqa: ARG002
         def handler(*_) -> t.NoReturn:
             sigterm_status = 143
             raise SystemExit(sigterm_status)

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -26,6 +26,11 @@ if t.TYPE_CHECKING:
 
     from structlog.types import Processor
 
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 install(suppress=[click])
 
 
@@ -68,7 +73,7 @@ class LoggingFeatures(t.TypedDict, total=False):
 # Convert boolean kwargs to LoggingFeatures enum.
 def _processors_from_kwargs(
     **features: Unpack[LoggingFeatures],
-) -> t.Generator[Processor, None, None]:
+) -> Generator[Processor]:
     if features.get("callsite_parameters", False):
         yield structlog.processors.CallsiteParameterAdder(
             parameters=(

--- a/src/meltano/core/manifest/contexts.py
+++ b/src/meltano/core/manifest/contexts.py
@@ -13,9 +13,16 @@ import typing as t
 from contextlib import contextmanager, suppress
 
 if t.TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    import sys
+    from collections.abc import Mapping
 
     from meltano.core.manifest.manifest import Manifest
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 _active_manifest: list[Manifest] = []
 
@@ -28,7 +35,7 @@ def _get_active_manifest() -> Manifest:
 
 
 @contextmanager
-def _manifest_context(manifest: Manifest) -> Iterator[None]:
+def _manifest_context(manifest: Manifest) -> Generator[None]:
     _active_manifest.append(manifest)
     try:
         yield
@@ -37,7 +44,7 @@ def _manifest_context(manifest: Manifest) -> Iterator[None]:
 
 
 @contextmanager
-def _env_context(env: Mapping[str, str]) -> Iterator[None]:
+def _env_context(env: Mapping[str, str]) -> Generator[None]:
     unique_keys = env.keys() - os.environ.keys()
     shared_keys = env.keys() & os.environ.keys()
     prev = {k: v for k, v in os.environ.items() if k in shared_keys}
@@ -53,7 +60,7 @@ def _env_context(env: Mapping[str, str]) -> Iterator[None]:
 
 
 @contextmanager
-def manifest_context(manifest: Manifest) -> Iterator[None]:
+def manifest_context(manifest: Manifest) -> Generator[None]:
     """Establish a context within which Meltano can run using a given manifest.
 
     All relevant general (i.e. excluding plugin-specific, schedule-specific,
@@ -74,7 +81,7 @@ def manifest_context(manifest: Manifest) -> Iterator[None]:
 
 
 @contextmanager
-def plugin_context(plugin_name: str) -> Iterator[None]:
+def plugin_context(plugin_name: str) -> Generator[None]:
     """Establish a context within which a plugin can be run.
 
     All relevant env vars for the specified plugin will be set in the process
@@ -107,7 +114,7 @@ def plugin_context(plugin_name: str) -> Iterator[None]:
 
 
 @contextmanager
-def schedule_context(schedule_name: str) -> Iterator[None]:
+def schedule_context(schedule_name: str) -> Generator[None]:
     """Establish a context within which a schedule can be run.
 
     All relevant env vars for the specified schedule will be set in the process
@@ -135,7 +142,7 @@ def schedule_context(schedule_name: str) -> Iterator[None]:
 
 
 @contextmanager
-def job_context(job_name: str) -> Iterator[None]:
+def job_context(job_name: str) -> Generator[None]:
     """Establish a context within which a job can be run.
 
     All relevant env vars for the specified job will be set in the process for

--- a/src/meltano/core/manifest/jsonschema.py
+++ b/src/meltano/core/manifest/jsonschema.py
@@ -6,7 +6,12 @@ import typing as t
 from contextlib import suppress
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 def meltano_config_env_locations(
@@ -44,7 +49,7 @@ class JsonschemaRefLocationParser:
         self,
         schema: dict[str, t.Any] | None = None,
         path: tuple[str, ...] = (),
-    ) -> Generator[str, None, None]:
+    ) -> Generator[str]:
         """Parse the jsonschema to find the locations of the target ref.
 
         Args:

--- a/src/meltano/core/plugin_invoker.py
+++ b/src/meltano/core/plugin_invoker.py
@@ -35,7 +35,6 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
     from pathlib import Path
 
     from sqlalchemy.orm import Session
@@ -48,6 +47,11 @@ if t.TYPE_CHECKING:
     from meltano.core.plugin.command import Command
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import AsyncGenerator
+    else:
+        from typing_extensions import AsyncGenerator
 
     class InvokerInitKwargs(t.TypedDict, total=False):
         """Keyword arguments for the Invoker constructor."""
@@ -275,7 +279,7 @@ class PluginInvoker:
             self._prepared = False
 
     @asynccontextmanager
-    async def prepared(self, session: Session) -> t.AsyncGenerator[None, None]:
+    async def prepared(self, session: Session) -> AsyncGenerator[None]:
         """Context manager that prepares plugin config.
 
         Args:
@@ -451,7 +455,7 @@ class PluginInvoker:
         env: dict[str, t.Any] | None = None,
         command: str | None = None,
         **kwargs: t.Any,
-    ) -> AsyncGenerator[tuple[list[str], dict[str, t.Any], dict[str, t.Any]], None]:
+    ) -> AsyncGenerator[tuple[list[str], dict[str, t.Any], dict[str, t.Any]]]:
         """Invoke a command.
 
         Args:

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -42,11 +42,14 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
-
     from meltano.core._types import StrPath
     from meltano.core.meltano_file import MeltanoFile as MeltanoFileTypeHint
     from meltano.core.plugin.base import PluginRef
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -59,7 +62,7 @@ PROJECT_SYS_DIR_ROOT_ENV = "MELTANO_SYS_DIR_ROOT"
 MELTANO_USER_AGENT_ENV = "MELTANO_USER_AGENT"
 
 
-def walk_parent_directories() -> Generator[Path, None, None]:
+def walk_parent_directories() -> Generator[Path]:
     """Yield each directory starting with the current up to the root.
 
     Yields:
@@ -321,7 +324,7 @@ class Project:
             return MeltanoFile.parse(self.project_files.load())
 
     @contextmanager
-    def meltano_update(self) -> Generator[MeltanoFileTypeHint, None, None]:
+    def meltano_update(self) -> Generator[MeltanoFileTypeHint]:
         """Yield the current meltano configuration.
 
         Update the meltanofile if the context ends gracefully.
@@ -406,7 +409,7 @@ class Project:
             self.refresh(environment=None)
 
     @contextmanager
-    def dotenv_update(self) -> Generator[Path, None, None]:
+    def dotenv_update(self) -> Generator[Path]:
         """Raise error if project is readonly.
 
         Used in context where .env files would be updated.

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -16,13 +16,18 @@ from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin_lock_service import PluginLockService
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
 
     from meltano.core.behavior.canonical import Canonical
     from meltano.core.environment import EnvironmentPluginConfig
     from meltano.core.plugin.base import BasePlugin
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -126,9 +131,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
         return self.project.config_service.current_meltano_yml.plugins
 
     @contextmanager
-    def update_plugins(
-        self,
-    ) -> Generator[Canonical, None, None]:
+    def update_plugins(self) -> Generator[Canonical]:
         """Update the current plugins.
 
         Yields:
@@ -437,11 +440,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
             for plugin_type in PluginType
         }
 
-    def plugins(
-        self,
-        *,
-        ensure_parent: bool = True,
-    ) -> Generator[ProjectPlugin, None, None]:
+    def plugins(self, *, ensure_parent: bool = True) -> Generator[ProjectPlugin]:
         """Return all plugins.
 
         Args:
@@ -625,10 +624,7 @@ class ProjectPluginsService:  # (too many methods, attributes)
         return source in self._prefer_source
 
     @contextmanager
-    def use_preferred_source(
-        self,
-        source: DefinitionSource,
-    ) -> Generator[None, None, None]:
+    def use_preferred_source(self, source: DefinitionSource) -> Generator[None]:
         """Prefer a source of definition.
 
         Args:

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -30,11 +30,17 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
+    from collections.abc import Iterable
 
     from meltano.core.project import Project
     from meltano.core.setting_definition import EnvVar, SettingDefinition
     from meltano.core.settings_store import SettingsStoreManager
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -679,7 +685,7 @@ class SettingsService(ABC):
         feature: str,
         *,
         raise_error: bool = True,
-    ) -> Generator[bool, None, None]:
+    ) -> Generator[bool]:
         """Gate code paths based on feature flags.
 
         Args:

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -33,13 +33,16 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
-
     from sqlalchemy.orm import Session
 
     from meltano.core.plugin.settings_service import PluginSettingsService
     from meltano.core.setting_definition import EnvVar, SettingDefinition
     from meltano.core.settings_service import SettingsService
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -904,7 +907,7 @@ class MeltanoEnvStoreManager(MeltanoYmlStoreManager):
 
     @override
     @contextmanager
-    def update_config(self) -> Generator[dict, None, None]:
+    def update_config(self) -> Generator[dict]:
         """Update Meltano Environment configuration.
 
         Yields:

--- a/src/meltano/core/state_store/azure/backend.py
+++ b/src/meltano/core/state_store/azure/backend.py
@@ -16,6 +16,12 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
+if t.TYPE_CHECKING:
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 class AZStorageStateStoreManager(CloudStateStoreManager):
     """State backend for Azure Blob Storage."""
@@ -118,11 +124,7 @@ class AZStorageStateStoreManager(CloudStateStoreManager):
                 raise e  # noqa: TRY201
 
     @override
-    def list_all_files(
-        self,
-        *,
-        with_prefix: bool = True,
-    ) -> t.Generator[str, None, None]:
+    def list_all_files(self, *, with_prefix: bool = True) -> Generator[str]:
         """List all files in the backend.
 
         Args:

--- a/src/meltano/core/state_store/base.py
+++ b/src/meltano/core/state_store/base.py
@@ -17,8 +17,13 @@ else:
 from meltano.core.utils import merge
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
+    from collections.abc import Iterable
     from types import TracebackType
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 class UnsupportedStateBackendURIError(Exception):
@@ -269,12 +274,7 @@ class StateStoreManager(ABC):
 
     @abstractmethod
     @contextmanager
-    def acquire_lock(
-        self,
-        state_id: str,
-        *,
-        retry_seconds: float,
-    ) -> Generator[None, None, None]:
+    def acquire_lock(self, state_id: str, *, retry_seconds: float) -> Generator[None]:
         """Acquire a naive lock for the given job's state.
 
         Args:

--- a/src/meltano/core/state_store/db.py
+++ b/src/meltano/core/state_store/db.py
@@ -18,9 +18,14 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterable, Iterator
+    from collections.abc import Iterable, Iterator
 
     from sqlalchemy.orm import Session
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 class DBStateStoreManager(StateStoreManager):
@@ -194,7 +199,7 @@ class DBStateStoreManager(StateStoreManager):
         state_id: str,
         *,
         retry_seconds: float = 1,
-    ) -> Generator[None, None, None]:
+    ) -> Generator[None]:
         """Acquire a naive lock for the given job's state.
 
         For DBStateStoreManager, the db manages transactions.

--- a/src/meltano/core/state_store/filesystem.py
+++ b/src/meltano/core/state_store/filesystem.py
@@ -32,7 +32,13 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterable, Iterator
+    from collections.abc import Iterable
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -112,7 +118,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
         return self.join_path(self.uri.removesuffix(self.state_dir), path)
 
     @contextmanager
-    def get_reader(self, path: str) -> Iterator[t.TextIO]:
+    def get_reader(self, path: str) -> Generator[t.TextIO]:
         """Get reader for given path.
 
         Args:
@@ -131,7 +137,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
             yield reader
 
     @contextmanager
-    def get_writer(self, path: str) -> Iterator[t.TextIO]:
+    def get_writer(self, path: str) -> Generator[t.TextIO]:
         """Get writer for given path.
 
         Args:
@@ -266,12 +272,7 @@ class BaseFilesystemStateStoreManager(StateStoreManager):
 
     @override
     @contextmanager
-    def acquire_lock(
-        self,
-        state_id: str,
-        *,
-        retry_seconds: float,
-    ) -> Generator[None, None, None]:
+    def acquire_lock(self, state_id: str, *, retry_seconds: float) -> Generator[None]:
         """Context manager for locking state_id during reads and writes.
 
         Args:
@@ -602,7 +603,7 @@ class CloudStateStoreManager(BaseFilesystemStateStoreManager):
         return self.join_path(self.uri.removesuffix(self.prefix), path)
 
     @abstractmethod
-    def list_all_files(self, *, with_prefix: bool = True) -> Iterator[str]:
+    def list_all_files(self, *, with_prefix: bool = True) -> Iterable[str]:
         """List all files in the backend.
 
         Args:

--- a/src/meltano/core/state_store/google/backend.py
+++ b/src/meltano/core/state_store/google/backend.py
@@ -20,7 +20,11 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -156,7 +160,7 @@ class GCSStateStoreManager(CloudStateStoreManager):
                 raise e  # noqa: TRY201
 
     @override
-    def list_all_files(self, *, with_prefix: bool = True) -> Generator[str, None, None]:
+    def list_all_files(self, *, with_prefix: bool = True) -> Generator[str]:
         """List all files in the backend.
 
         Args:

--- a/src/meltano/core/state_store/s3/backend.py
+++ b/src/meltano/core/state_store/s3/backend.py
@@ -20,11 +20,16 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
+    from collections.abc import Iterable
 
     from mypy_boto3_s3 import S3Client
 
     from meltano.core.state_store.base import MeltanoState
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 class S3StateStoreManager(CloudStateStoreManager):
@@ -153,7 +158,7 @@ class S3StateStoreManager(CloudStateStoreManager):
         )
 
     @override
-    def list_all_files(self, *, with_prefix: bool = True) -> Generator[str, None, None]:
+    def list_all_files(self, *, with_prefix: bool = True) -> Generator[str]:
         """List all files in the backend.
 
         Args:

--- a/src/meltano/core/task_sets.py
+++ b/src/meltano/core/task_sets.py
@@ -15,7 +15,13 @@ from meltano.core.behavior import NameEq
 from meltano.core.behavior.canonical import Canonical
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 logger = structlog.getLogger(__name__)
 
@@ -50,7 +56,7 @@ class InvalidTasksError(Exception):
         super().__init__(f"Job '{name}' has invalid tasks. {message}")
 
 
-def _flat_split(items: Iterable | str) -> Generator[str, None, None]:
+def _flat_split(items: Iterable | str) -> Generator[str]:
     for el in items:
         if isinstance(el, Iterable) and not isinstance(el, str):
             yield from _flat_split(el)

--- a/src/meltano/core/tracking/tracker.py
+++ b/src/meltano/core/tracking/tracker.py
@@ -12,6 +12,7 @@ import uuid
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from enum import Enum, auto
+from functools import cached_property
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -33,7 +34,8 @@ from meltano.core.tracking.schemas import (
 from meltano.core.utils import format_exception, uuid7
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Mapping
+    import sys
+    from collections.abc import Mapping
     from pathlib import Path
 
     from meltano.core.project import Project
@@ -43,7 +45,11 @@ if t.TYPE_CHECKING:
         ProjectContext,
     )
 
-from functools import cached_property
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 URL_REGEX = (
     r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
@@ -296,10 +302,7 @@ class Tracker:  # - too many (public) methods
         self._contexts = (*self._contexts, *extra_contexts)
 
     @contextmanager
-    def with_contexts(
-        self,
-        *extra_contexts: SelfDescribingJson,
-    ) -> Generator[Tracker, None, None]:
+    def with_contexts(self, *extra_contexts: SelfDescribingJson) -> Generator[Tracker]:
         """Context manager within which the `Tracker` has additional Snowplow contexts.
 
         Args:

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -22,11 +22,16 @@ import structlog
 from meltano.core.error import AsyncSubprocessError
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator, Iterable, Sequence
+    from collections.abc import Iterable, Sequence
     from pathlib import Path
 
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 if sys.version_info >= (3, 11):
     from typing import Self  # noqa: ICN003
@@ -222,7 +227,7 @@ class VirtualEnv:
         """
 
         # A generator is used to perform the checks lazily
-        def checks() -> Generator[bool, None, None]:
+        def checks() -> Generator[bool]:
             # The Python installation used to create this venv no longer exists
             yield not self.exec_path("python").exists()
             # The fingerprint of the venv does not match the pip install args

--- a/tests/benchmarks/test_state_backend_benchmarks.py
+++ b/tests/benchmarks/test_state_backend_benchmarks.py
@@ -22,10 +22,15 @@ from meltano.core.state_store.filesystem import (
 )
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
     from pathlib import Path
 
     from pytest_codspeed import BenchmarkFixture
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 def on_windows() -> bool:

--- a/tests/fixtures/core.py
+++ b/tests/fixtures/core.py
@@ -39,11 +39,18 @@ from meltano.core.task_sets_service import TaskSetsService
 from meltano.core.utils import merge
 
 if t.TYPE_CHECKING:
-    from collections.abc import Callable, Generator
+    import sys
+    from collections.abc import Callable
 
     from requests.adapters import BaseAdapter
 
     from meltano.core.plugin.project_plugin import ProjectPlugin
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 current_dir = Path(__file__).parent
 
@@ -2090,7 +2097,7 @@ def job_logging_service(project):
 
 
 @contextmanager
-def project_directory(project_init_service) -> Generator[Project, None, None]:
+def project_directory(project_init_service) -> Generator[Project]:
     project = project_init_service.init()
     logging.debug(f"Created new project at {project.root}")  # noqa: G004
 
@@ -2275,7 +2282,7 @@ def state_ids_with_jobs(
     state_ids: StateIds,
     job_args: JobArgs,
     payloads: Payloads,
-    mock_time: t.Generator[datetime.datetime, None, None],
+    mock_time: Generator[datetime.datetime],
 ) -> dict[str, list[Job]]:
     jobs = {
         state_ids.single_incomplete_state_id: [

--- a/tests/fixtures/db/__init__.py
+++ b/tests/fixtures/db/__init__.py
@@ -12,9 +12,14 @@ from sqlalchemy.orm import close_all_sessions, sessionmaker
 from sqlalchemy.pool import NullPool
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
 
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/fixtures/docker/snowplow.py
+++ b/tests/fixtures/docker/snowplow.py
@@ -12,9 +12,14 @@ from urllib3.util.retry import Retry
 from meltano.core.project_settings_service import ProjectSettingsService
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
 
     from pytest_docker.plugin import Services
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 logger = logging.getLogger(__name__)  # noqa: TID251
 
@@ -64,9 +69,7 @@ class SnowplowMicro:
 
 
 @pytest.fixture(scope="session")
-def snowplow_session(
-    request: pytest.FixtureRequest,
-) -> Generator[SnowplowMicro | None, None, None]:
+def snowplow_session(request: pytest.FixtureRequest) -> Generator[SnowplowMicro | None]:
     """Start a Snowplow Micro Docker container, then yield a `SnowplowMicro` instance.
 
     The environment variable `$MELTANO_SNOWPLOW_COLLECTOR_ENDPOINTS` is set to
@@ -102,7 +105,7 @@ def snowplow_session(
 def snowplow_optional(
     snowplow_session: SnowplowMicro | None,
     monkeypatch,
-) -> Generator[SnowplowMicro | None, None, None]:
+) -> Generator[SnowplowMicro | None]:
     """Provide a clean `SnowplowMicro` instance.
 
     This fixture resets the `SnowplowMicro` instance, and enables the

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -12,11 +12,16 @@ from meltano.core.project import Project
 from meltano.core.project_init_service import ProjectInitService
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 @contextmanager
-def cd(path: Path) -> Generator[Path, None, None]:
+def cd(path: Path) -> Generator[Path]:
     prev_dir = Path.cwd()
     os.chdir(path)
     try:
@@ -26,11 +31,7 @@ def cd(path: Path) -> Generator[Path, None, None]:
 
 
 @contextmanager
-def tmp_project(
-    name: str,
-    source: Path,
-    compatible_copy_tree,
-) -> Generator[Project, None, None]:
+def tmp_project(name: str, source: Path, compatible_copy_tree) -> Generator[Project]:
     project_init_service = ProjectInitService(name)
     blank_project = project_init_service.init()
     logging.debug(f"Created new project at {blank_project.root}")  # noqa: G004

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -31,8 +31,15 @@ from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.version_check import PYPI_URL, VersionCheckResult
 
 if t.TYPE_CHECKING:
+    import sys
+
     from fixtures.cli import MeltanoCliRunner
     from meltano.core.project_init_service import ProjectInitService
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 
@@ -75,7 +82,7 @@ class TestCli:
         self,
         tmp_path: Path,
         project_init_service: ProjectInitService,
-    ) -> t.Generator[Project, None, None]:
+    ) -> Generator[Project]:
         os.chdir(tmp_path)
         project = project_init_service.init(activate=False)
         Project._default = None

--- a/tests/meltano/core/block/test_extract_load.py
+++ b/tests/meltano/core/block/test_extract_load.py
@@ -32,8 +32,15 @@ from meltano.core.runner import RunnerError
 from meltano.core.runner.singer import SingerRunner
 
 if t.TYPE_CHECKING:
+    import sys
+
     from meltano.core.plugin.project_plugin import ProjectPlugin
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 TEST_STATE_ID = "test_job"
 MOCK_STATE_MESSAGE = json.dumps({"type": "STATE"})
@@ -183,7 +190,7 @@ class TestExtractLoadBlocks:
             logger.setLevel(orig)
 
     @pytest.fixture
-    def log(self, tmp_path: Path) -> t.Generator[t.IO[str], None, None]:
+    def log(self, tmp_path: Path) -> Generator[t.IO[str]]:
         with tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path) as file:
             yield file
 

--- a/tests/meltano/core/block/test_singer.py
+++ b/tests/meltano/core/block/test_singer.py
@@ -15,12 +15,18 @@ from meltano.core.job import Job
 from meltano.core.logging import OutputLogger
 
 if t.TYPE_CHECKING:
+    import sys
     from pathlib import Path
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 class TestSingerBlocks:
     @pytest.fixture
-    def log(self, tmp_path: Path) -> t.Generator[t.IO[str], None, None]:
+    def log(self, tmp_path: Path) -> Generator[t.IO[str]]:
         with tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path) as file:
             yield file
 

--- a/tests/meltano/core/logging/test_output_logger.py
+++ b/tests/meltano/core/logging/test_output_logger.py
@@ -17,8 +17,12 @@ from meltano.core.logging.models import ParsedLogRecord
 from meltano.core.logging.output_logger import Out, OutputLogger
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
     from pathlib import Path
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 def assert_lines(output, *lines) -> None:
@@ -28,7 +32,7 @@ def assert_lines(output, *lines) -> None:
 
 class TestOutputLogger:
     @pytest.fixture
-    def log(self, tmp_path: Path) -> t.Generator[t.IO[str], None, None]:
+    def log(self, tmp_path: Path) -> Generator[t.IO[str]]:
         with tempfile.NamedTemporaryFile(mode="w+", dir=tmp_path) as file:
             yield file
 
@@ -57,10 +61,7 @@ class TestOutputLogger:
         return LogCapture()
 
     @pytest.fixture(autouse=True)
-    def fixture_configure_structlog(
-        self,
-        log_output: LogCapture,
-    ) -> Generator[None, None, None]:
+    def fixture_configure_structlog(self, log_output: LogCapture) -> Generator[None]:
         original_config = structlog.get_config()
         structlog.configure(
             processors=[log_output],
@@ -73,10 +74,7 @@ class TestOutputLogger:
             structlog.configure(**original_config)
 
     @pytest.fixture(name="redirect_handler")
-    def redirect_handler(
-        self,
-        subject: OutputLogger,
-    ) -> Generator[logging.Handler, None, None]:
+    def redirect_handler(self, subject: OutputLogger) -> Generator[logging.Handler]:
         formatter = structlog.stdlib.ProcessorFormatter(
             # use a json renderer so output is easier to verify
             processor=structlog.processors.JSONRenderer(),

--- a/tests/meltano/core/plugin/test_plugin_settings.py
+++ b/tests/meltano/core/plugin/test_plugin_settings.py
@@ -26,13 +26,18 @@ from meltano.core.settings_store import (
 from meltano.core.utils import EnvironmentVariableNotSetError
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
 
     from sqlalchemy.orm import Session
 
     from meltano.core.environment import Environment
     from meltano.core.plugin.settings_service import PluginSettingsService
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
     class PluginSettingsServiceFactory(t.Protocol):
         def __call__(
@@ -88,7 +93,7 @@ def subject(tap, plugin_settings_service_factory) -> PluginSettingsService:
 
 
 @pytest.fixture
-def environment(project: Project) -> Generator[Environment | None, None, None]:
+def environment(project: Project) -> Generator[Environment | None]:
     project.activate_environment("dev")
     try:
         yield project.environment

--- a/tests/meltano/core/state_store/test_filesystem.py
+++ b/tests/meltano/core/state_store/test_filesystem.py
@@ -36,9 +36,14 @@ from meltano.core.state_store.google.backend import GCSStateStoreManager
 from meltano.core.state_store.s3.backend import S3StateStoreManager
 
 if t.TYPE_CHECKING:
-    from collections.abc import Iterator
+    import sys
 
     import faker
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 def on_windows() -> bool:
@@ -477,7 +482,7 @@ class TestS3StateStoreManager:
         monkeypatch.delenv("AWS_PROFILE", raising=False)
 
     @contextmanager
-    def stubber(self) -> Iterator[Stubber]:
+    def stubber(self) -> Generator[Stubber]:
         with patch(
             "meltano.core.state_store.s3.backend.S3StateStoreManager.client",
             new_callable=PropertyMock,

--- a/tests/meltano/core/test_migration_service.py
+++ b/tests/meltano/core/test_migration_service.py
@@ -10,10 +10,16 @@ from sqlalchemy import create_engine
 from meltano.core.migration_service import MigrationError, MigrationService
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
     from pathlib import Path
 
     from sqlalchemy import Engine
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
+
 
 MIGRATION_TEMPLATE = """
 revision = {revision}
@@ -61,7 +67,7 @@ def _generate_migrations(
 
 class TestMigrationService:
     @pytest.fixture
-    def engine(self) -> Generator[Engine, None, None]:
+    def engine(self) -> Generator[Engine]:
         engine = create_engine("sqlite:///:memory:")
         try:
             yield engine

--- a/tests/meltano/core/test_plugin_remove_service.py
+++ b/tests/meltano/core/test_plugin_remove_service.py
@@ -14,9 +14,14 @@ from sqlalchemy.exc import OperationalError
 from meltano.core.plugin_remove_service import PluginRemoveService
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
 
     from meltano.core.plugin_location_remove import PluginLocationRemoveManager
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 class TestPluginRemoveService:
@@ -25,7 +30,7 @@ class TestPluginRemoveService:
         return PluginRemoveService(project)
 
     @pytest.fixture
-    def add(self, subject: PluginRemoveService) -> Generator[None, None, None]:
+    def add(self, subject: PluginRemoveService) -> Generator[None]:
         with subject.project.meltanofile.open("r") as meltano_yml:
             original = yaml.safe_load(meltano_yml)
 
@@ -59,7 +64,7 @@ class TestPluginRemoveService:
             meltano_yml.write(yaml.dump(original))
 
     @pytest.fixture
-    def no_plugins(self, subject: PluginRemoveService) -> Generator[None, None, None]:
+    def no_plugins(self, subject: PluginRemoveService) -> Generator[None]:
         with subject.project.meltanofile.open("r") as meltano_yml:
             original = yaml.safe_load(meltano_yml)
 
@@ -72,7 +77,7 @@ class TestPluginRemoveService:
             meltano_yml.write(yaml.dump(original))
 
     @pytest.fixture
-    def install(self, subject: PluginRemoveService) -> Generator[None, None, None]:
+    def install(self, subject: PluginRemoveService) -> Generator[None]:
         tap_gitlab_installation = subject.project.dirs.meltano().joinpath(
             "extractors",
             "tap-gitlab",
@@ -88,7 +93,7 @@ class TestPluginRemoveService:
         shutil.rmtree(target_csv_installation, ignore_errors=True)
 
     @pytest.fixture
-    def lock(self, subject: PluginRemoveService) -> Generator[None, None, None]:
+    def lock(self, subject: PluginRemoveService) -> Generator[None]:
         tap_gitlab_lockfile = subject.project.dirs.plugin_lock_path(
             "extractors",
             "tap-gitlab",

--- a/tests/meltano/core/test_sqlalchemy.py
+++ b/tests/meltano/core/test_sqlalchemy.py
@@ -9,12 +9,17 @@ import sqlalchemy as sa
 from meltano.core.sqlalchemy import DateTimeUTC
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 class TestSQLAlchemyModels:
     @pytest.fixture
-    def engine(self) -> Generator[sa.Engine, None, None]:
+    def engine(self) -> Generator[sa.Engine]:
         engine = sa.create_engine("sqlite:///:memory:")
         try:
             yield engine

--- a/tests/meltano/core/tracking/test_tracker.py
+++ b/tests/meltano/core/tracking/test_tracker.py
@@ -21,12 +21,17 @@ from meltano.core.tracking.tracker import TelemetrySettings, Tracker, new_client
 from meltano.core.utils import hash_sha256, new_project_id
 
 if t.TYPE_CHECKING:
-    from collections.abc import Generator
+    import sys
 
     from snowplow_tracker import SelfDescribing
 
     from fixtures.docker import SnowplowMicro
     from meltano.core.project import Project
+
+    if sys.version_info >= (3, 13):
+        from collections.abc import Generator
+    else:
+        from typing_extensions import Generator
 
 
 def load_analytics_json(project: Project) -> dict[str, t.Any]:
@@ -46,7 +51,7 @@ def check_analytics_json(project: Project) -> None:
 
 
 @contextmanager
-def delete_analytics_json(project: Project) -> Generator[None, None, None]:
+def delete_analytics_json(project: Project) -> Generator[None]:
     (project.dirs.meltano() / "analytics.json").unlink(missing_ok=True)
     try:
         yield


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

- https://docs.python.org/3.13/library/typing.html#annotating-generators-and-coroutines
- [PEP 696 – Type Defaults for Type Parameters](https://peps.python.org/pep-0696/)

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Adopt Python 3.13-compatible Generator and AsyncGenerator type annotations across core modules and tests, using collections.abc with typing_extensions fallbacks, and simplify generator signatures to rely on default Send/Return type parameters.

Enhancements:
- Standardize generator and async generator type hints to use the Python 3.13 Generator/AsyncGenerator generics with default Send/Return types throughout the codebase.
- Introduce conditional imports that prefer collections.abc.Generator/AsyncGenerator on Python 3.13+ and fall back to typing_extensions for earlier versions.
- Align several contextmanager and fixture return annotations from Iterator/AsyncIterator to Generator/AsyncGenerator and adjust some APIs to return Iterable where appropriate (e.g., list_all_files).