### PR TITLE
feat: use .python-version for plugin Python default

### DIFF
--- a/docs/docs/reference/settings.mdx
+++ b/docs/docs/reference/settings.mdx
@@ -33,7 +33,7 @@ to list all available settings with their names, environment variables, and curr
 
 ### <a name="plugin-python"></a>`python`
 
-The python version to use for this plugin, specified as a path, or as the name of an executable to find within a directory in `$PATH`. You can set it at the time you add a plugin using [`meltano add --python <python>`](/reference/command-line-interface#add).
+The python version to use for this plugin, specified as a path, as the name of an executable to find within a directory in `$PATH`, or as a version number like `3.11`. You can set it at the time you add a plugin using [`meltano add --python <python>`](/reference/command-line-interface#add).
 
 If not specified, [the top-level `python` setting will be used](#project-python), or if it is not set, the python executable that was used to run Meltano will be used (within a separate virtual environment).
 
@@ -89,9 +89,9 @@ export MELTANO_DEFAULT_ENVIRONMENT=prod
 
 - [Environment variable](../guide/configuration#configuring-settings): `MELTANO_PYTHON`
 
-The python version to use for plugins, specified as a path, or as the name of an executable to find within a directory in `$PATH`.
+The python version to use for plugins, specified as a path, as the name of an executable to find within a directory in `$PATH`, or as a version number like `3.11`.
 
-If not specified, the python executable that was used to run Meltano will be used (within a separate virtual environment).
+If not specified, Meltano will use the first non-empty line from a project-level `.python-version` file when present. If neither the setting nor `.python-version` is present, the python executable that was used to run Meltano will be used (within a separate virtual environment).
 
 [This can be overridden on a per-plugin basis by setting the `python` property for the plugin.](#plugin-python)
 
@@ -106,6 +106,12 @@ python: /path/to/python3.10 # or just python3.10 if it's in your $PATH
 plugins:
   extractors: ...
   loaders: ...
+```
+
+Or commit a `.python-version` file at the project root:
+
+```text
+3.11
 ```
 
 ### <a name="send_anonymous_usage_stats"></a>`send_anonymous_usage_stats`

--- a/src/meltano/core/bundle/settings.yml
+++ b/src/meltano/core/bundle/settings.yml
@@ -44,7 +44,7 @@ settings:
   value: 104_857_600 # 100 MiB
   description: Size in bytes of the buffer between extractor and loader that stores Singer messages.
 - name: python
-  description: Python version to use for plugins, specified as a path or executable name. Can be overridden per-plugin.
+  description: Python version to use for plugins, specified as a path, executable name, or version number. If unset, Meltano will use a project-level `.python-version` file when present. Can be overridden per-plugin.
 - name: auto_install
   kind: boolean
   value: true

--- a/src/meltano/core/project_settings_service.py
+++ b/src/meltano/core/project_settings_service.py
@@ -28,6 +28,9 @@ if t.TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
+PYTHON_SETTING_NAME = "python"
+PYTHON_VERSION_FILENAME = ".python-version"
+
 
 class ProjectSettingsService(SettingsService):
     """Project Settings Service."""
@@ -167,3 +170,58 @@ class ProjectSettingsService(SettingsService):
             Processed configuration dict for presentation in `meltano config meltano`.
         """
         return nest_object(config)
+
+    def python_version_file_value(self) -> str | None:
+        """Read the project-level `.python-version` file, if present.
+
+        Returns:
+            The first non-empty, non-comment line from `.python-version`, or None.
+        """
+        python_version_file = self.project.root / PYTHON_VERSION_FILENAME
+        try:
+            contents = python_version_file.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+        for line in contents.splitlines():
+            value = line.strip()
+            if value and not value.startswith("#"):
+                return value
+
+        return None
+
+    @override
+    def get_with_metadata(
+        self,
+        name: str,
+        **kwargs: t.Any,
+    ) -> tuple[t.Any, dict[str, t.Any]]:
+        """Get a project setting with `.python-version` fallback support.
+
+        Args:
+            name: Setting name.
+            kwargs: Keyword arguments forwarded to the base settings service.
+
+        Returns:
+            A tuple of setting value and metadata.
+        """
+        value, metadata = super().get_with_metadata(name, **kwargs)
+        setting_def = kwargs.get("setting_def") or self.find_setting(name)
+        setting_name = setting_def.name if setting_def else name
+
+        if (
+            setting_name == PYTHON_SETTING_NAME
+            and value is None
+            and metadata["source"] is SettingValueStore.DEFAULT
+        ):
+            python_version = self.python_version_file_value()
+            if python_version:
+                value = python_version
+                metadata = {
+                    **metadata,
+                    "python_version_file": str(
+                        self.project.root / PYTHON_VERSION_FILENAME,
+                    ),
+                }
+
+        return value, metadata

--- a/src/meltano/schemas/meltano.schema.json
+++ b/src/meltano/schemas/meltano.schema.json
@@ -42,7 +42,7 @@
     },
     "python": {
       "type": "string",
-      "description": "The python version to use for plugins, specified as a path, as the name of an executable to find within a directory in $PATH, or as a version number (e.g. '3.11'). If not specified, the python executable that was used to run Meltano will be used (within a separate virtual environment). This can be overridden on a per-plugin basis by setting the `python` property for the plugin.",
+      "description": "The python version to use for plugins, specified as a path, as the name of an executable to find within a directory in $PATH, or as a version number (e.g. '3.11'). If not specified, Meltano will use a project-level `.python-version` file when present. If neither the setting nor `.python-version` is present, the python executable that was used to run Meltano will be used (within a separate virtual environment). This can be overridden on a per-plugin basis by setting the `python` property for the plugin.",
       "examples": [
         "/usr/bin/python3.10",
         "python",
@@ -415,7 +415,7 @@
           },
           "python": {
             "type": "string",
-            "description": "The python version to use for this plugin, specified as a path, as the name of an executable to find within a directory in $PATH, or as a version number (e.g. '3.11'). If not specified, the top-level `python` setting will be used, or if it is not set, the python executable that was used to run Meltano will be used (within a separate virtual environment).",
+            "description": "The python version to use for this plugin, specified as a path, as the name of an executable to find within a directory in $PATH, or as a version number (e.g. '3.11'). If not specified, the top-level `python` setting will be used, or if it is not set, Meltano will use a project-level `.python-version` file when present. If neither is present, the python executable that was used to run Meltano will be used (within a separate virtual environment).",
             "examples": [
               "/usr/bin/python3.10",
               "python",

--- a/tests/meltano/core/test_project_settings_service.py
+++ b/tests/meltano/core/test_project_settings_service.py
@@ -238,3 +238,63 @@ class TestProjectSettingsService:
 
         subject.env_override["DB_MAX_RETRIES_TEST"] = "7"
         assert subject.get(name) == 7
+
+    def test_python_version_file_used_as_python_default(
+        self,
+        project_function,
+    ) -> None:
+        subject = ProjectSettingsService(project_function)
+        subject.project.root.joinpath(".python-version").write_text(
+            "3.11.8\n",
+            encoding="utf-8",
+        )
+
+        assert subject.get_with_source("python") == (
+            "3.11.8",
+            SettingValueStore.DEFAULT,
+        )
+
+    def test_python_version_file_ignores_empty_and_comment_lines(
+        self,
+        project_function,
+    ) -> None:
+        subject = ProjectSettingsService(project_function)
+        subject.project.root.joinpath(".python-version").write_text(
+            "\n# Managed by pyenv\n3.12\n",
+            encoding="utf-8",
+        )
+
+        assert subject.get("python") == "3.12"
+
+    def test_python_version_file_does_not_override_python_setting(
+        self,
+        project_function,
+    ) -> None:
+        subject = ProjectSettingsService(project_function)
+        subject.project.root.joinpath(".python-version").write_text(
+            "3.11\n",
+            encoding="utf-8",
+        )
+        subject.set("python", "3.12", store=SettingValueStore.MELTANO_YML)
+
+        assert subject.get_with_source("python") == (
+            "3.12",
+            SettingValueStore.MELTANO_YML,
+        )
+
+    def test_python_version_file_does_not_override_environment(
+        self,
+        project_function,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        subject = ProjectSettingsService(project_function)
+        subject.project.root.joinpath(".python-version").write_text(
+            "3.11\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("MELTANO_PYTHON", "3.10")
+
+        assert subject.get_with_source("python") == (
+            "3.10",
+            SettingValueStore.ENV,
+        )


### PR DESCRIPTION
## Description

Adds project-level `.python-version` fallback support for the Meltano `python` setting used by plugin virtual environments.

- reads the first non-empty, non-comment line from `.python-version` when the top-level `python` setting is otherwise unset
- preserves existing precedence for `MELTANO_PYTHON`, `.env`, `meltano.yml`, and per-plugin `python`
- documents the fallback in settings docs, bundled settings metadata, and the JSON schema
- adds project settings tests for fallback and override behavior

## Checklist

- [X] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes - Codex

Generated-by: Codex following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Validation

- `git diff --check`
- `uv run pytest tests/meltano/core/test_project_settings_service.py`
- `uv run pytest tests/meltano/core/test_venv_service.py`
- `uv run --with "ruff>=0.15.14" ruff check src/meltano/core/project_settings_service.py tests/meltano/core/test_project_settings_service.py`
- `uv run ty check src/meltano/core/project_settings_service.py`

## Related Issues

* Closes #9851

## Summary by Sourcery

Add project-level `.python-version` support as a default for the top-level `python` setting used by plugin environments while preserving existing precedence rules.

New Features:
- Use the first non-empty, non-comment line from a project `.python-version` file as the default value for the project `python` setting when no other value is configured.

Enhancements:
- Extend settings metadata and JSON schema to describe `.python-version` fallback behavior for the `python` setting.

Documentation:
- Update settings reference docs to document `.python-version` fallback for the project `python` setting and clarify that version numbers like `3.11` are accepted.

Tests:
- Add project settings tests to cover `.python-version` fallback behavior and ensure it does not override explicit configuration or environment variables.