### PR TITLE
feat(cli): Allow `MELTANO_RUN_FORCE` environment variable to be used as an alternative `meltano run --force` flag

### DIFF
--- a/docs/docs/reference/command-line-interface.mdx
+++ b/docs/docs/reference/command-line-interface.mdx
@@ -1273,6 +1273,9 @@ meltano --environment=dev run --timeout 3600 tap-gitlab target-postgres
 # run a pipeline with timeout set via environment variable
 MELTANO_RUN_TIMEOUT=1800 meltano --environment=dev run tap-gitlab target-postgres
 
+# force a new run even if a pipeline with the same State ID is already running
+MELTANO_RUN_FORCE=1 meltano --environment=dev run tap-gitlab target-postgres
+
 # run a pipeline with state-id-suffix set via environment variable
 MELTANO_RUN_STATE_ID_SUFFIX=pipeline-alias meltano --environment=dev run tap-gitlab target-postgres
 

--- a/src/meltano/cli/run.py
+++ b/src/meltano/cli/run.py
@@ -84,6 +84,7 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
         "Force a new run even if a pipeline with the same State ID is already "
         "present. Applies to all pipelines."
     ),
+    envvar="MELTANO_RUN_FORCE",
     is_flag=True,
 )
 @click.option(


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #9542

## Summary by Sourcery

Document and enable the MELTANO_RUN_FORCE environment variable as an alternative way to trigger forced runs for the `meltano run` command.

Enhancements:
- Allow the `meltano run --force` option to be set via the MELTANO_RUN_FORCE environment variable.

Documentation:
- Add CLI reference documentation for using MELTANO_RUN_FORCE to force a new pipeline run via environment variable.