### PR TITLE
chore: Document `uv run python -m pytest` as the preferred way to run tests outside of a Nox session

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,4 +61,4 @@ jobs:
       uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
       with:
         mode: walltime
-        run: uv run pytest tests/benchmarks/ --codspeed -p no:randomly
+        run: uv run python -m pytest tests/benchmarks/ --codspeed -p no:randomly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ### Testing
 
-- Run specific test: `uv run pytest tests/path/to/test.py::test_function`
+- Run specific test: `uv run python -m pytest tests/path/to/test.py::test_function`
 - Run all tests: `nox -t test` or `nox -s pytest`
 - Run a subset of tests on a single Python version: `nox -p 3.14 -s pytest -- tests/meltano/core/state_store`
 - Run with specific backend: `PYTEST_BACKEND=postgresql nox -s pytest`

--- a/docs/docs/contribute/agentic-coding.md
+++ b/docs/docs/contribute/agentic-coding.md
@@ -41,7 +41,7 @@ Before opening a pull request, whether the code was written by you, an agent, or
 2. **Run the relevant tests**
 
    ```bash
-   uv run pytest tests/path/to/test.py
+   uv run python -m pytest tests/path/to/test.py
    ```
 
 3. **Review the diff yourself** - agents can introduce subtle issues such as


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

This is because calling via `python` will also add the current directory to `sys.path` and allow imports from `tests.fixtures` to work correctly.

https://docs.pytest.org/en/stable/how-to/usage.html#calling-pytest-through-python-m-pytest

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Standardize guidance on running pytest via `uv run python -m pytest` instead of `uv run pytest` across CI and contributor docs.

CI:
- Update benchmark workflow to invoke tests with `uv run python -m pytest` for correct import behavior.

Documentation:
- Refresh agent and contributor testing instructions to recommend `uv run python -m pytest` as the preferred way to run tests outside Nox.