### PR TITLE
refactor: Remove dev-only setting resolution debug logs

### DIFF
--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -10,8 +10,6 @@ import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
-import structlog
-
 from meltano.core.setting_definition import SettingKind
 from meltano.core.settings_store import SettingValueStore
 from meltano.core.utils import EnvVarMissingBehavior, flatten
@@ -40,9 +38,6 @@ if t.TYPE_CHECKING:
         from collections.abc import Generator
     else:
         from typing_extensions import Generator
-
-
-logger = structlog.stdlib.get_logger(__name__)
 
 
 # sentinel value to use to prevent leaking sensitive data
@@ -90,7 +85,6 @@ class FeatureNotAllowedException(Exception):
 class SettingsService(ABC):
     """Abstract base class for managing settings."""
 
-    LOGGING = False
     supports_environments = True
 
     def __init__(
@@ -324,8 +318,6 @@ class SettingsService(ABC):
         if setting_def:
             name = setting_def.name
 
-        self.log(f"Getting setting '{name}'")
-
         metadata: dict[str, t.Any] = {
             "name": name,
             "source": source,
@@ -414,8 +406,6 @@ class SettingsService(ABC):
                 metadata["redacted"] = True
                 value = redacted_value
 
-        self.log(f"Got setting {name!r} with metadata: {metadata}")
-
         if setting_def is None and metadata["source"] is SettingValueStore.DEFAULT:
             warnings.warn(
                 (
@@ -478,8 +468,6 @@ class SettingsService(ABC):
         Returns:
             the new value and metadata for the setting
         """
-        self.log(f"Setting setting '{path}'")
-
         if isinstance(path, str):
             path = [path]
 
@@ -521,7 +509,6 @@ class SettingsService(ABC):
             ),
         )
 
-        self.log(f"Set setting {name!r} with metadata: {metadata}")
         return value, metadata
 
     def set(self, *args: t.Any, **kwargs: t.Any) -> t.Any:  # noqa: ANN401
@@ -554,24 +541,19 @@ class SettingsService(ABC):
         Returns:
             the metadata for the setting
         """
-        self.log(f"Unsetting setting '{path}'")
-
         if isinstance(path, str):
             path = [path]
 
         name = ".".join(path)
         setting_def = self.find_setting(name)
 
-        metadata = {
+        return {
             "name": name,
             "path": path,
             "store": store,
             "setting": setting_def,
             **store.manager(self, **kwargs).unset(name, path, setting_def=setting_def),
         }
-
-        self.log(f"Unset setting {name!r} with metadata: {metadata}")
-        return metadata
 
     def reset(
         self,
@@ -588,9 +570,7 @@ class SettingsService(ABC):
         Returns:
             the metadata for the setting
         """
-        metadata = {"store": store, **store.manager(self, **kwargs).reset()}
-        self.log(f"Reset settings with metadata: {metadata}")
-        return metadata
+        return {"store": store, **store.manager(self, **kwargs).reset()}
 
     def definitions(self, *, extras: bool | None = None) -> Iterable[SettingDefinition]:
         """Return setting definitions along with extras.
@@ -669,15 +649,6 @@ class SettingsService(ABC):
             environment variable for given setting
         """
         return self.setting_env_vars(setting_def)[0].key
-
-    def log(self, message: str) -> None:
-        """Log the given message.
-
-        Args:
-            message: the message to log
-        """
-        if self.LOGGING:
-            logger.debug(message)
 
     @contextmanager
     def feature_flag(

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -326,14 +326,6 @@ class SettingsStoreManager(ABC):
                 instruction=instruction,
             )
 
-    def log(self, message: str) -> None:
-        """Log method.
-
-        Args:
-            message: message to log.
-        """
-        self.settings_service.log(message)
-
 
 class ConfigOverrideStoreManager(SettingsStoreManager):
     """Config override store manager."""
@@ -360,7 +352,6 @@ class ConfigOverrideStoreManager(SettingsStoreManager):
         """
         try:
             value = self.settings_service.config_override[name]
-            self.log(f"Read key '{name}' from config override: {value!r}")
             return value, {}  # noqa: TRY300
         except KeyError:
             return None, {}
@@ -449,32 +440,6 @@ class EnvStoreManager(BaseEnvStoreManager):
         """Values from the calling terminals environment."""
         return self.settings_service.env
 
-    @override
-    def get(
-        self,
-        name: str,
-        setting_def: SettingDefinition | None = None,
-        *,
-        cast_value: bool = False,
-    ) -> tuple[str | None, dict]:
-        """Get value by name from the .env file.
-
-        Args:
-            name: Setting name.
-            setting_def: SettingDefinition instance.
-            cast_value: Whether to cast the value according to `setting_def`.
-
-        Returns:
-            A tuple the got value and a dictionary containing metadata.
-        """
-        value, metadata = super().get(name, setting_def, cast_value=cast_value)
-
-        if value is not None:
-            env_key = metadata["env_var"]
-            self.log(f"Read key '{env_key}' from the environment: {value!r}")
-
-        return value, metadata
-
 
 class DotEnvStoreManager(BaseEnvStoreManager):
     """.env file store manager."""
@@ -517,32 +482,6 @@ class DotEnvStoreManager(BaseEnvStoreManager):
         return self._env
 
     @override
-    def get(
-        self,
-        name: str,
-        setting_def: SettingDefinition | None = None,
-        *,
-        cast_value: bool = False,
-    ) -> tuple[str | None, dict]:
-        """Get value by name from the .env file.
-
-        Args:
-            name: Setting name.
-            setting_def: SettingDefinition instance.
-            cast_value: Whether to cast the value according to `setting_def`.
-
-        Returns:
-            A tuple the got value and a dictionary containing metadata.
-        """
-        value, metadata = super().get(name, setting_def, cast_value=cast_value)
-
-        if value is not None:
-            env_key = metadata["env_var"]
-            self.log(f"Read key '{env_key}' from `.env`: {value!r}")
-
-        return value, metadata
-
-    @override
     def set(self, name: str, path: list[str], value, setting_def=None):  # noqa: ANN001, ANN201
         """Set value by name in the .env file.
 
@@ -573,13 +512,11 @@ class DotEnvStoreManager(BaseEnvStoreManager):
             if dotenv_file.exists():
                 for key in other_keys:
                     dotenv.unset_key(dotenv_file, key)
-                    self.log(f"Unset key '{key}' in `.env`")
             else:
                 dotenv_file.touch()
 
             dotenv.set_key(dotenv_file, primary_key, setting_def.stringify_value(value))
 
-        self.log(f"Set key '{primary_key}' in `.env`: {value!r}")
         return {"env_var": primary_key}
 
     @override
@@ -618,7 +555,6 @@ class DotEnvStoreManager(BaseEnvStoreManager):
 
             for key in env_keys:
                 dotenv.unset_key(dotenv_file, key)
-                self.log(f"Unset key '{key}' in `.env`")
 
         return {}
 
@@ -717,7 +653,6 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
             except KeyError:
                 continue
 
-            self.log(f"Read key '{key}' from `meltano.yml`: {value!r}")
             vals_with_metadata.append((value, {"key": key, "expandable": True}))
 
         if len(vals_with_metadata) > 1 and not reduce(
@@ -769,14 +704,11 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         with self.update_config() as config:
             for key in keys_to_unset:
                 config.pop(key, None)
-                self.log(f"Popped key '{key}' in `meltano.yml`")
 
             for path_to_unset in paths_to_unset:
                 pop_at_path(config, path_to_unset, None)
-                self.log(f"Popped path '{path_to_unset}' in `meltano.yml`")
 
             set_at_path(config, path, value)
-            self.log(f"Set path '{path}' in `meltano.yml`: {value!r}")
 
         return {}
 
@@ -806,14 +738,11 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
         with self.update_config() as config:
             for key in keys_to_unset:
                 config.pop(key, None)
-                self.log(f"Popped key '{key}' in `meltano.yml`")
 
             for path_to_unset in paths_to_unset:
                 pop_at_path(config, path_to_unset, None)
-                self.log(f"Popped path '{path_to_unset}' in `meltano.yml`")
 
             pop_at_path(config, path, None)
-            self.log(f"Popped path '{path}' in `meltano.yml`")
 
         return {}
 
@@ -1010,7 +939,6 @@ class DbStoreManager(SettingsStoreManager):
                     .value
                 )
 
-            self.log(f"Read key '{name}' from system database: {value!r}")
             return value, {}  # noqa: TRY300
         except (sqlalchemy.exc.NoResultFound, KeyError):
             return None, {}
@@ -1045,7 +973,6 @@ class DbStoreManager(SettingsStoreManager):
 
         self._all_settings = None
 
-        self.log(f"Set key '{name}' in system database: {value!r}")
         return {}
 
     @override
@@ -1073,7 +1000,6 @@ class DbStoreManager(SettingsStoreManager):
 
         self._all_settings = None
 
-        self.log(f"Deleted key '{name}' from system database")
         return {}
 
     @override
@@ -1161,7 +1087,6 @@ class InheritedStoreManager(SettingsStoreManager):
         if value is None or metadata["source"] is SettingValueStore.DEFAULT:
             return None, {}
 
-        self.log(f"Read key '{name}' from inherited: {value!r}")
         return value, {
             "inherited_source": metadata["source"],
             "expandable": metadata.get("expandable", False),
@@ -1230,7 +1155,6 @@ class DefaultStoreManager(SettingsStoreManager):
         if setting_def:
             value = setting_def.value
             if value is not None:
-                self.log(f"Read key '{name}' from default: {value!r}")
                 return value, {"expandable": True}
         # As default is lowest in our order of precedence, we want it to always return
         # a value, even if it is None.


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

These were gated by `SettingService.LOGGING`, which the end user had no control of, so they were really only there to help maintainers debug settings resolution. There are arguably better ways to debug, so removing them makes sense.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Simplify settings management by removing development-only debug logging from settings stores and service.

Enhancements:
- Remove the settings service logging flag, logger usage, and helper methods tied to debug logging.
- Clean up debug log statements related to reading, setting, and unsetting configuration values across environment, dotenv, YAML, and database stores.

## Summary by Sourcery

Remove development-only debug logging from settings management to simplify configuration handling and avoid unused logging paths.

Enhancements:
- Delete the settings service logging flag, logger, and helper methods used exclusively for internal debug logging.
- Remove debug log statements from environment, dotenv, YAML, and database settings stores to streamline settings operations.