### PR TITLE
fix: Correctly propagate SIGTERM to plugin subprocesses

### DIFF
--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import sys
@@ -111,6 +112,13 @@ def _run_cli() -> None:
                 f"The requested action could not be completed: {err}",  # noqa: EM102
             ) from None
         except KeyboardInterrupt:
+            raise
+        except asyncio.CancelledError:
+            from meltano.core.job.job import SIGTERM_EXIT_CODE, sigterm_received
+
+            if sigterm_received():
+                msg = "The process was terminated"
+                raise CliError(msg, exit_code=SIGTERM_EXIT_CODE) from None
             raise
         except MeltanoError as err:
             handle_meltano_error(err)

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -407,6 +407,11 @@ class Job(SystemModel):
 
     @contextmanager
     def _handling_sigterm(self, session: Session) -> Generator[None]:  # noqa: ARG002
+        # A new run should only report SIGTERMs delivered during that run, so
+        # clear any stale flag from a previous run in this process
+        global _sigterm_received
+        _sigterm_received = False
+
         def cancel_task() -> None:
             # Cancel the task running the job so termination flows through the
             # same cancellation path as SIGINT, giving plugin subprocesses the

--- a/src/meltano/core/job/job.py
+++ b/src/meltano/core/job/job.py
@@ -40,6 +40,15 @@ if t.TYPE_CHECKING:
 HEARTBEATLESS_JOB_VALID_HOURS = 24
 HEARTBEAT_VALID_MINUTES = 5
 
+SIGTERM_EXIT_CODE = 143  # 128 + SIGTERM's signal number (15)
+
+_sigterm_received = False
+
+
+def sigterm_received() -> bool:
+    """Whether a SIGTERM was received while a job was running."""
+    return _sigterm_received
+
 
 class InconsistentStateError(Error):
     """Occur upon a wrong operation for the current state."""
@@ -398,19 +407,58 @@ class Job(SystemModel):
 
     @contextmanager
     def _handling_sigterm(self, session: Session) -> Generator[None]:  # noqa: ARG002
-        def handler(*_) -> t.NoReturn:
-            sigterm_status = 143
-            raise SystemExit(sigterm_status)
+        def cancel_task() -> None:
+            # Cancel the task running the job so termination flows through the
+            # same cancellation path as SIGINT, giving plugin subprocesses the
+            # chance to finish their graceful shutdown before the process
+            # exits: https://github.com/meltano/meltano/issues/9981
+            global _sigterm_received
+            _sigterm_received = True
+            self._terminated_by_sigterm = True
+            if task is not None:  # pragma: no branch
+                task.cancel()
 
-        original_termination_handler = signal.signal(signal.SIGTERM, handler)
+        def handler(*_) -> t.NoReturn:
+            global _sigterm_received
+            _sigterm_received = True
+            self._terminated_by_sigterm = True
+            raise SystemExit(SIGTERM_EXIT_CODE)
+
+        loop: asyncio.AbstractEventLoop | None = None
+        task: asyncio.Task | None = None
+        with suppress(RuntimeError):
+            loop = asyncio.get_running_loop()
+            task = asyncio.current_task()
+
+        added_loop_handler = False
+        if loop is not None and task is not None:
+            # Not available on Windows, where we fall back to the
+            # `signal.signal` handler below
+            with suppress(NotImplementedError):
+                loop.add_signal_handler(signal.SIGTERM, cancel_task)
+                added_loop_handler = True
+
+        original_termination_handler = (
+            None if added_loop_handler else signal.signal(signal.SIGTERM, handler)
+        )
 
         try:
             yield
         finally:
-            signal.signal(signal.SIGTERM, original_termination_handler)
+            if added_loop_handler and loop is not None:
+                loop.remove_signal_handler(signal.SIGTERM)
+            else:
+                signal.signal(signal.SIGTERM, original_termination_handler)
 
     def _error_message(self, err: BaseException) -> str:
         if isinstance(err, SystemExit):
+            return "The process was terminated"
+
+        if isinstance(err, asyncio.CancelledError) and getattr(
+            self,
+            "_terminated_by_sigterm",
+            False,
+        ):
             return "The process was terminated"
 
         if isinstance(err, KeyboardInterrupt | asyncio.CancelledError):

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import platform
 import re
@@ -7,6 +8,7 @@ import shutil
 import subprocess
 import typing as t
 import uuid
+import warnings
 from http import HTTPStatus
 from pathlib import Path
 from time import perf_counter_ns
@@ -298,6 +300,66 @@ class TestCli:
         exception = MeltanoError(reason="This failed", instruction="Try again")
         with pytest.raises(CliError, match=r"This failed. Try again."):
             handle_meltano_error(exception)
+
+    def test_sigterm_cancellation_exits_143(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("meltano.core.job.job._sigterm_received", True)
+
+        with (
+            mock.patch("meltano.cli.cli", side_effect=asyncio.CancelledError),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            meltano.cli._run_cli()
+
+        assert exc_info.value.code == 143
+
+    def test_cancellation_without_sigterm_propagates(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("meltano.core.job.job._sigterm_received", False)
+
+        with (
+            mock.patch("meltano.cli.cli", side_effect=asyncio.CancelledError),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            meltano.cli._run_cli()
+
+    @pytest.mark.parametrize(
+        ("raised", "expected_exit_code"),
+        (
+            pytest.param(None, 0, id="success"),
+            pytest.param(SystemExit(143), 143, id="sigterm"),
+            pytest.param(SystemExit(None), 0, id="none-code"),
+            pytest.param(SystemExit("boom"), 1, id="string-code"),
+            pytest.param(RuntimeError("boom"), 1, id="other-error"),
+        ),
+    )
+    def test_main_records_exit_code(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        raised: BaseException | None,
+        expected_exit_code: int,
+    ) -> None:
+        monkeypatch.setattr(
+            meltano.cli,
+            "_run_cli",
+            mock.Mock(side_effect=raised),
+        )
+        monkeypatch.setattr(meltano.cli, "exit_event_tracker", None)
+        # keep `main`'s global logging/warnings tweaks out of the test session
+        monkeypatch.setattr("logging.captureWarnings", mock.Mock())
+
+        with warnings.catch_warnings():
+            if raised is None:
+                meltano.cli.main()
+            else:
+                with pytest.raises(type(raised)):
+                    meltano.cli.main()
+
+        assert meltano.cli.exit_code == expected_exit_code
 
     @pytest.mark.usefixtures("pushd")
     def test_cwd_option(

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -6,6 +6,7 @@ import signal
 import typing as t
 import uuid
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 import pytest
 
@@ -14,6 +15,7 @@ from meltano.core.job.job import (
     HEARTBEATLESS_JOB_VALID_HOURS,
     Job,
     State,
+    sigterm_received,
 )
 
 if t.TYPE_CHECKING:
@@ -125,21 +127,97 @@ class TestJob:
         assert subject.payload["error"] == "The process was interrupted"
 
     @pytest.mark.asyncio
-    async def test_run_terminated(self, session) -> None:
+    async def test_run_terminated(
+        self,
+        session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         if platform.system() == "Windows":
             pytest.xfail(
                 "Fails on Windows: https://github.com/meltano/meltano/issues/2842",
             )
+        monkeypatch.setattr("meltano.core.job.job._sigterm_received", False)
         subject = self.sample_job({"original_state": 1}).save(session)
+        cleanup_completed = False
 
-        with pytest.raises(SystemExit):
+        # SIGTERM must cancel the task running the job rather than abort it
+        # immediately, so in-flight work (e.g. plugin graceful shutdown) can
+        # complete: https://github.com/meltano/meltano/issues/9981
+        async def run_job() -> None:
+            nonlocal cleanup_completed
             async with subject.run(session):
-                signal.raise_signal(signal.SIGTERM)
+                try:
+                    signal.raise_signal(signal.SIGTERM)
+                    await asyncio.sleep(30)
+                except asyncio.CancelledError:
+                    cleanup_completed = True
+                    raise
 
+        with pytest.raises(asyncio.CancelledError):
+            await run_job()
+
+        assert cleanup_completed
+        assert sigterm_received()
         assert subject.state is State.FAIL
         assert subject.ended_at is not None
         assert subject.payload["original_state"] == 1
         assert subject.payload["error"] == "The process was terminated"
+
+    @pytest.mark.asyncio
+    async def test_run_terminated_signal_handler_fallback(
+        self,
+        session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without loop signal handlers (e.g. Windows), SIGTERM exits directly."""
+        if platform.system() == "Windows":
+            pytest.xfail(
+                "Fails on Windows: https://github.com/meltano/meltano/issues/2842",
+            )
+        monkeypatch.setattr("meltano.core.job.job._sigterm_received", False)
+        subject = self.sample_job({"original_state": 1}).save(session)
+        loop = asyncio.get_running_loop()
+
+        async def run_job() -> None:
+            async with subject.run(session):
+                signal.raise_signal(signal.SIGTERM)
+
+        with (
+            mock.patch.object(
+                type(loop),
+                "add_signal_handler",
+                side_effect=NotImplementedError,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            await run_job()
+
+        assert exc_info.value.code == 143
+        assert sigterm_received()
+        assert subject.state is State.FAIL
+        assert subject.payload["error"] == "The process was terminated"
+
+    def test_handling_sigterm_without_event_loop(
+        self,
+        session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Outside a running loop, SIGTERM falls back to a direct exit."""
+        if platform.system() == "Windows":
+            pytest.xfail(
+                "Fails on Windows: https://github.com/meltano/meltano/issues/2842",
+            )
+        monkeypatch.setattr("meltano.core.job.job._sigterm_received", False)
+        subject = self.sample_job()
+
+        with (
+            pytest.raises(SystemExit) as exc_info,
+            subject._handling_sigterm(session),
+        ):
+            signal.raise_signal(signal.SIGTERM)
+
+        assert exc_info.value.code == 143
+        assert sigterm_received()
 
     def test_run_id(self, session) -> None:
         job = Job()

--- a/tests/meltano/core/job/test_job.py
+++ b/tests/meltano/core/job/test_job.py
@@ -219,6 +219,22 @@ class TestJob:
         assert exc_info.value.code == 143
         assert sigterm_received()
 
+    @pytest.mark.asyncio
+    async def test_sigterm_flag_reset_on_new_run(
+        self,
+        session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stale SIGTERM flag from a previous run must not leak into the next."""
+        monkeypatch.setattr("meltano.core.job.job._sigterm_received", True)
+        subject = self.sample_job({"original_state": 1}).save(session)
+
+        async with subject.run(session):
+            pass
+
+        assert not sigterm_received()
+        assert subject.state is State.SUCCESS
+
     def test_run_id(self, session) -> None:
         job = Job()
         run_id = job.run_id


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude Code (Fable)](https://www.anthropic.com/claude/fable) following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* https://github.com/meltano/sdk/pull/3698
* Closes https://github.com/meltano/meltano/pull/9981
* Supersedes https://github.com/meltano/meltano/pull/9986

## Summary by Sourcery

Handle SIGTERM in async jobs so plugin subprocesses can complete graceful shutdown and propagate correct exit codes to the CLI.

Bug Fixes:
- Ensure SIGTERM cancels running job tasks instead of exiting immediately so subprocess cleanup can complete.
- Return a consistent SIGTERM-derived exit code from job termination and surface it through the CLI when applicable.

Enhancements:
- Expose a helper to query whether a SIGTERM was received during job execution.
- Align error messaging for SIGTERM-triggered cancellations with other termination scenarios.

Tests:
- Extend job termination tests to cover async SIGTERM handling, task cancellation, and SIGTERM tracking state.

## Summary by Sourcery

Improve SIGTERM handling so async jobs and the CLI propagate graceful termination and consistent exit codes while allowing plugin subprocess cleanup to complete.

New Features:
- Expose a helper to query whether a SIGTERM was received during job execution.

Bug Fixes:
- Ensure SIGTERM cancels the running job task instead of exiting immediately so plugin subprocesses can complete graceful shutdown.
- Propagate a consistent SIGTERM-derived exit code (143) from job termination through the CLI when applicable.
- Align error messaging for SIGTERM-triggered cancellations with other termination scenarios.

Tests:
- Extend job and CLI tests to cover async SIGTERM handling, task cancellation behaviour, SIGTERM tracking state, and exit code recording.