### PR TITLE
chore: Add `uv-audit` and `uv-sync` pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ ci:
   autofix_prs: true
   autoupdate_commit_msg: "chore: pre-commit autoupdate"
   autoupdate_schedule: monthly
+  skip:
+    - uv-audit
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -78,6 +80,8 @@ repos:
     rev: 0.11.26
     hooks:
       - id: uv-lock
+      - id: uv-sync
+      - id: uv-audit
 
   - repo: https://github.com/crate-ci/typos
     rev: v1.48.0


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

astral.sh/blog/uv-audit

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Build:
- Enable uv-audit and uv-sync hooks in the pre-commit configuration to run alongside uv-lock.

## Summary by Sourcery

Build:
- Add uv-audit and uv-sync hooks to the existing uv-pre-commit configuration.