### PR TITLE
docs: Fix broken relative links on first page load

### DIFF
--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -7,6 +7,7 @@ import { useHistory, useLocation } from '@docusaurus/router';
 // against the current location, so the trailing slash makes sibling links
 // like `profiles#...` resolve to `accounts/profiles#...` on first load only.
 // Normalizing the runtime location makes first-load behave like SPA nav.
+// eslint-disable-next-line react/prop-types
 export default function Root({ children }) {
   const history = useHistory();
   const { pathname, search, hash } = useLocation();

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -16,7 +16,8 @@ export default function Root({ children }) {
     if (pathname.length > 1 && pathname.endsWith('/')) {
       history.replace({ pathname: pathname.replace(/\/+$/, ''), search, hash });
     }
-  }, [pathname, search, hash, history]);
+    // Run once on mount (first load); SPA navigation is already slashless.
+  }, []);
 
   return <>{children}</>;
 }

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { useHistory, useLocation } from '@docusaurus/router';
+import React, { useEffect } from "react";
+import { useHistory, useLocation } from "@docusaurus/router";
 
 // Netlify "Pretty URLs" serves pages at a trailing-slash URL on first load
 // (e.g. /resources/accounts/), while in-app navigation uses the slashless
@@ -12,8 +12,8 @@ export default function Root({ children }) {
   const { pathname, search, hash } = useLocation();
 
   useEffect(() => {
-    if (pathname.length > 1 && pathname.endsWith('/')) {
-      history.replace({ pathname: pathname.replace(/\/+$/, ''), search, hash });
+    if (pathname.length > 1 && pathname.endsWith("/")) {
+      history.replace({ pathname: pathname.replace(/\/+$/, ""), search, hash });
     }
   }, [pathname, search, hash, history]);
 

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -1,5 +1,5 @@
-import React, { useEffect } from "react";
-import { useHistory, useLocation } from "@docusaurus/router";
+import React, { useEffect } from 'react';
+import { useHistory, useLocation } from '@docusaurus/router';
 
 // Netlify "Pretty URLs" serves pages at a trailing-slash URL on first load
 // (e.g. /resources/accounts/), while in-app navigation uses the slashless
@@ -12,8 +12,8 @@ export default function Root({ children }) {
   const { pathname, search, hash } = useLocation();
 
   useEffect(() => {
-    if (pathname.length > 1 && pathname.endsWith("/")) {
-      history.replace({ pathname: pathname.replace(/\/+$/, ""), search, hash });
+    if (pathname.length > 1 && pathname.endsWith('/')) {
+      history.replace({ pathname: pathname.replace(/\/+$/, ''), search, hash });
     }
   }, [pathname, search, hash, history]);
 

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+import { useHistory, useLocation } from '@docusaurus/router';
+
+// Netlify "Pretty URLs" serves pages at a trailing-slash URL on first load
+// (e.g. /resources/accounts/), while in-app navigation uses the slashless
+// form (/resources/accounts). React Router resolves relative link clicks
+// against the current location, so the trailing slash makes sibling links
+// like `profiles#...` resolve to `accounts/profiles#...` on first load only.
+// Normalizing the runtime location makes first-load behave like SPA nav.
+export default function Root({ children }) {
+  const history = useHistory();
+  const { pathname, search, hash } = useLocation();
+
+  useEffect(() => {
+    if (pathname.length > 1 && pathname.endsWith('/')) {
+      history.replace({ pathname: pathname.replace(/\/+$/, ''), search, hash });
+    }
+  }, [pathname, search, hash, history]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Description

Netlify's "Pretty URLs" serves docs pages at a trailing-slash URL on first load (e.g. `/reference/cloud/api/resources/accounts/`), while in-app (SPA) navigation uses the slashless form (`/reference/cloud/api/resources/accounts`). React Router resolves relative link clicks against the current location, so on **first load only** a sibling link such as `profiles#set-the-working-account-for-a-profile` wrongly resolved to `.../accounts/profiles#...` instead of `.../profiles#...`. Clicking the same link after navigating in from another page worked correctly.

This swizzles `@theme/Root` to strip the trailing slash from the runtime location on load, so first-load navigation behaves identically to SPA navigation. It does not change what Netlify serves as canonical (no SEO/canonical impact) and requires no per-link edits or Netlify configuration changes.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* #10157

## Summary by Sourcery

Bug Fixes:
- Fix incorrect resolution of sibling relative links on first page load caused by Netlify trailing-slash URLs in the docs site.