### PR TITLE
refactor: Remove the `meltano.__version__` variable in favor of `meltano.core.utils.get_meltano_version`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,7 @@ enable_error_code = [
   "exhaustive-match",
   "deprecated",
 ]
+explicit_package_bases = true
 incremental = true
 files = [
   "src/meltano/",
@@ -268,6 +269,7 @@ exclude = [
   "src/meltano/migrations/",
 ]
 local_partial_types = true
+mypy_path = ["src"]
 strict = false
 warn_redundant_casts = true
 warn_unreachable = true

--- a/src/meltano/__init__.py
+++ b/src/meltano/__init__.py
@@ -1,5 +1,0 @@
-"""Meltano."""  # noqa: I002
-
-import importlib.metadata
-
-__version__ = importlib.metadata.version("meltano")

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import click
 import structlog
 
-from meltano import __version__
 from meltano.cli.utils import InstrumentedGroup
 from meltano.core.error import EmptyMeltanoFileException, ProjectNotFound
 from meltano.core.logging import LEVELS, LogFormat, setup_logging
@@ -19,7 +18,11 @@ from meltano.core.project import PROJECT_ENVIRONMENT_ENV, Project
 from meltano.core.project_settings_service import ProjectSettingsService
 from meltano.core.tracking import Tracker
 from meltano.core.tracking.contexts import CliContext
-from meltano.core.utils import IncompatibleMeltanoVersionError, get_no_color_flag
+from meltano.core.utils import (
+    IncompatibleMeltanoVersionError,
+    get_meltano_version,
+    get_no_color_flag,
+)
 
 if sys.version_info >= (3, 12):
     from typing import override  # noqa: ICN003
@@ -135,7 +138,7 @@ def cli(
         setup_logging(project)
         logger.debug(
             "Meltano %s, Python %s, %s (%s)",
-            __version__,
+            get_meltano_version,
             platform.python_version(),
             platform.system(),
             platform.machine(),

--- a/src/meltano/cli/cli.py
+++ b/src/meltano/cli/cli.py
@@ -138,7 +138,7 @@ def cli(
         setup_logging(project)
         logger.debug(
             "Meltano %s, Python %s, %s (%s)",
-            get_meltano_version,
+            get_meltano_version(),
             platform.python_version(),
             platform.system(),
             platform.machine(),

--- a/src/meltano/core/tracking/contexts/environment.py
+++ b/src/meltano/core/tracking/contexts/environment.py
@@ -17,9 +17,14 @@ import psutil
 from snowplow_tracker import SelfDescribingJson
 from structlog.stdlib import get_logger
 
-import meltano
 from meltano.core.tracking.schemas import EnvironmentContextSchema
-from meltano.core.utils import get_boolean_env_var, hash_sha256, safe_hasattr, strtobool
+from meltano.core.utils import (
+    get_boolean_env_var,
+    get_meltano_version,
+    hash_sha256,
+    safe_hasattr,
+    strtobool,
+)
 
 from .base import new_context_uuid
 
@@ -91,7 +96,7 @@ class EnvironmentContext(SelfDescribingJson):
             {
                 "context_uuid": str(new_context_uuid()),
                 "parent_context_uuid": _get_parent_context_uuid_str(),
-                "meltano_version": meltano.__version__,
+                "meltano_version": get_meltano_version(),
                 "is_dev_build": not release_marker_path.is_file(),
                 "is_ci_environment": any(
                     get_boolean_env_var(marker) for marker in self.ci_markers

--- a/src/meltano/core/version_check.py
+++ b/src/meltano/core/version_check.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import importlib.metadata
 import json
 import os
 import sys
@@ -17,6 +16,7 @@ import structlog.stdlib
 from packaging.version import parse
 
 from meltano.core._packaging import editable_installation
+from meltano.core.utils import get_meltano_version
 
 if t.TYPE_CHECKING:
     from pathlib import Path
@@ -129,7 +129,7 @@ class VersionCheckService:
         if not self.should_check_version():
             return None
 
-        current_version = importlib.metadata.version("meltano")
+        current_version = get_meltano_version()
 
         # Skip check for development versions
         if self._is_development_version(current_version):

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -20,7 +20,7 @@ import responses
 import yaml
 from structlog.stdlib import get_logger
 
-import meltano
+import meltano.cli
 from asserts import assert_cli_runner
 from fixtures.utils import cd
 from meltano.cli import cli, handle_meltano_error
@@ -30,6 +30,7 @@ from meltano.core.error import EmptyMeltanoFileException, MeltanoError
 from meltano.core.logging.utils import setup_logging
 from meltano.core.project import PROJECT_ENVIRONMENT_ENV, PROJECT_READONLY_ENV, Project
 from meltano.core.project_settings_service import ProjectSettingsService
+from meltano.core.utils import get_meltano_version
 from meltano.core.version_check import PYPI_URL, VersionCheckResult
 
 if t.TYPE_CHECKING:
@@ -193,7 +194,7 @@ class TestCli:
     def test_version(self, cli_runner) -> None:
         cli_version = cli_runner.invoke(cli, ["--version"])
 
-        assert cli_version.output == f"meltano, version {meltano.__version__}\n"
+        assert cli_version.output == f"meltano, version {get_meltano_version()}\n"
 
     @pytest.mark.usefixtures("deactivate_project")
     def test_default_environment_is_activated(

--- a/tests/meltano/core/test_meltano_invoker.py
+++ b/tests/meltano/core/test_meltano_invoker.py
@@ -10,9 +10,9 @@ from unittest import mock
 
 import pytest
 
-import meltano
 from meltano.core.meltano_invoker import MELTANO_COMMAND, MeltanoInvoker
 from meltano.core.tracking.contexts import environment_context
+from meltano.core.utils import get_meltano_version
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -26,7 +26,7 @@ class TestMeltanoInvoker:
     def test_invoke(self, subject: MeltanoInvoker) -> None:
         process = subject.invoke(["--version"], stdout=subprocess.PIPE)
         assert process.returncode == 0
-        assert meltano.__version__ in str(process.stdout)
+        assert get_meltano_version() in str(process.stdout)
 
     def test_env(
         self,

--- a/tests/meltano/core/test_version_check.py
+++ b/tests/meltano/core/test_version_check.py
@@ -145,7 +145,7 @@ class TestVersionCheckService:
         responses.add(responses.GET, PYPI_URL, json=pypi_response, status=HTTPStatus.OK)
 
         with mock.patch(
-            "meltano.core.version_check.importlib.metadata.version",
+            "meltano.core.version_check.get_meltano_version",
             return_value="3.7.0",
         ):
             result = version_service.check_version()
@@ -181,7 +181,7 @@ class TestVersionCheckService:
         responses.add(responses.GET, PYPI_URL, json=pypi_response, status=HTTPStatus.OK)
 
         with mock.patch(
-            "meltano.core.version_check.importlib.metadata.version",
+            "meltano.core.version_check.get_meltano_version",
             return_value="invalid",
         ):
             result = version_service.check_version()
@@ -203,7 +203,7 @@ class TestVersionCheckService:
         responses.add(responses.GET, PYPI_URL, json=pypi_response, status=HTTPStatus.OK)
 
         with mock.patch(
-            "meltano.core.version_check.importlib.metadata.version",
+            "meltano.core.version_check.get_meltano_version",
             return_value="3.9.0",
         ):
             result = version_service.check_version()
@@ -231,7 +231,7 @@ class TestVersionCheckService:
     ):
         """Test version check skips development versions."""
         with mock.patch(
-            "meltano.core.version_check.importlib.metadata.version",
+            "meltano.core.version_check.get_meltano_version",
             return_value="0.0.0",
         ):
             result = version_service.check_version()
@@ -304,7 +304,7 @@ class TestVersionCheckService:
         responses.add(responses.GET, PYPI_URL, json=pypi_response, status=HTTPStatus.OK)
 
         with mock.patch(
-            "meltano.core.version_check.importlib.metadata.version",
+            "meltano.core.version_check.get_meltano_version",
             return_value="3.7.0",
         ):
             result1 = version_service.check_version()
@@ -316,7 +316,7 @@ class TestVersionCheckService:
 
         # Second check - should use cache
         with mock.patch(
-            "meltano.core.version_check.importlib.metadata.version",
+            "meltano.core.version_check.get_meltano_version",
             return_value="3.7.0",
         ):
             result2 = version_service.check_version()


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

Or folks can use [`importlib.metadata.version`](https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.version).

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Replace direct use of the package-level version with the core utils version helper across the codebase and tests, and adjust typing configuration to reflect the new structure.

Enhancements:
- Use meltano.core.utils.get_meltano_version as the single source of truth for Meltano version information throughout CLI, tracking, and version checking.
- Remove the top-level meltano __init__ module that exposed __version__, simplifying the package interface.

Build:
- Tighten mypy configuration by enabling explicit_package_bases and setting mypy_path to the src directory.

Tests:
- Update CLI, version check, and invoker tests to expect get_meltano_version usage instead of meltano.__version__ or direct importlib.metadata.version calls.