### PR TITLE
fix(core): Ensure project `.env` files are created with 0600 permissions

### DIFF
--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -513,7 +513,8 @@ class DotEnvStoreManager(BaseEnvStoreManager):
                 for key in other_keys:
                     dotenv.unset_key(dotenv_file, key)
             else:
-                dotenv_file.touch()
+                # `.env` holds secrets; don't create it world-readable
+                dotenv_file.touch(mode=0o600)
 
             dotenv.set_key(dotenv_file, primary_key, setting_def.stringify_value(value))
 

--- a/tests/meltano/core/test_settings_store.py
+++ b/tests/meltano/core/test_settings_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import platform
+import stat
 import typing as t
 from contextlib import contextmanager
 from unittest import mock
@@ -675,6 +677,22 @@ class TestDotEnvStoreManager:
     def test_unset_undefined_setting_failure(self, subject: DotEnvStoreManager) -> None:
         with pytest.raises(StoreNotSupportedError, match="Unknown setting"):
             subject.unset("undefined", [], setting_def=None)
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="File modes are not enforced on Windows",
+    )
+    def test_dotenv_created_with_owner_only_permissions(
+        self,
+        subject: DotEnvStoreManager,
+        project,
+    ) -> None:
+        project.dotenv.unlink(missing_ok=True)
+        setting_def = subject.settings_service.find_setting("password")
+
+        subject.set("password", ["password"], "s3cret-value", setting_def)
+
+        assert stat.S_IMODE(project.dotenv.stat().st_mode) == 0o600
 
     def test_reset_readonly_project_failure(
         self,


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude Code](https://claude.com/product/claude-code) following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Ensure project `.env` files are created with secure, owner-only permissions when settings are written.

Bug Fixes:
- Prevent newly created `.env` files from defaulting to world-readable permissions by explicitly setting owner-only mode.

Tests:
- Add a platform-aware test verifying `.env` files are created with 0600 permissions, skipping enforcement on Windows.

## Summary by Sourcery

Ensure `.env` files created by the settings store are restricted to owner-only permissions to protect secrets.

Bug Fixes:
- Prevent newly created `.env` files from being world-readable by setting their file mode to owner read/write only.

Tests:
- Add a non-Windows test verifying that created `.env` files have owner-only (0o600) permissions.