### PR TITLE
feat: add refresh catalog flag to invoke

### DIFF
--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -21,8 +21,10 @@ from meltano.cli.utils import (
     propagate_stop_signals,
 )
 from meltano.core.db import project_engine
+from meltano.core.elt_context import ELTContextBuilder
 from meltano.core.error import AsyncSubprocessError
 from meltano.core.logging.utils import capture_subprocess_output
+from meltano.core.plugin import PluginType
 from meltano.core.plugin.error import PluginNotFoundError
 from meltano.core.plugin_install_service import PluginInstallReason
 from meltano.core.plugin_invoker import (
@@ -36,7 +38,6 @@ if t.TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from meltano.cli.params import InstallPlugins
-    from meltano.core.plugin import PluginType
     from meltano.core.plugin_invoker import PluginInvoker
     from meltano.core.project import Project
     from meltano.core.tracking import Tracker
@@ -75,6 +76,11 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
     is_flag=True,
     help="List the commands supported by the plugin.",
 )
+@click.option(
+    "--refresh-catalog",
+    is_flag=True,
+    help="Invalidates catalog cache and forces running discovery before this run.",
+)
 @click.argument("plugin_name", metavar="PLUGIN_NAME[:COMMAND_NAME]")
 @click.argument("plugin_args", nargs=-1, type=click.UNPROCESSED)
 @click.option(
@@ -95,6 +101,7 @@ async def invoke(
     plugin_type: PluginType | None,
     dump: str,
     list_commands: bool,
+    refresh_catalog: bool,
     plugin_name: str,
     plugin_args: tuple[str, ...],
     install_plugins: InstallPlugins,
@@ -138,7 +145,17 @@ async def invoke(
         reason=PluginInstallReason.AUTO,
     )
 
-    invoker = invoker_factory(project, plugin)
+    invoker_kwargs: dict[str, t.Any] = {}
+    if refresh_catalog and plugin.type is PluginType.EXTRACTORS:
+        invoker_kwargs["context"] = (
+            ELTContextBuilder(project)
+            .with_session(session)
+            .with_extractor(plugin.name)
+            .with_refresh_catalog(refresh_catalog=True)
+            .context()
+        )
+
+    invoker = invoker_factory(project, plugin, **invoker_kwargs)
     try:
         exit_code = await _invoke(
             invoker=invoker,

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -233,6 +233,28 @@ class TestCliInvoke:
             assert apply_catalog_rules.call_count == 2
             assert look_up_state.call_count == 2
 
+    def test_invoke_refresh_catalog_sets_extractor_context(
+        self,
+        cli_runner: CliRunner,
+        tap: ProjectPlugin,
+    ) -> None:
+        with patch("meltano.cli.invoke._invoke", new_callable=AsyncMock) as invoke_mock:
+            invoke_mock.return_value = 0
+
+            result = cli_runner.invoke(
+                cli,
+                ["invoke", "--refresh-catalog", tap.name],
+            )
+
+        assert result.exit_code == 0, (
+            f"exit code: {result.exit_code} - {result.exception}"
+        )
+        invoke_mock.assert_awaited_once()
+
+        invoker = invoke_mock.await_args.kwargs["invoker"]
+        assert invoker.context is not None
+        assert invoker.context.should_refresh_catalog()
+
     def test_invoke_dump_config(
         self,
         cli_runner: CliRunner,


### PR DESCRIPTION
## Description

Adds `--refresh-catalog` support to `meltano invoke` for extractor plugins.

`meltano invoke` creates a plugin invoker directly, so it did not previously attach an ELT context with `refresh_catalog=True`. This change reuses the existing `ELTContextBuilder` path for extractors when the flag is provided, allowing invoke runs to bypass the cached catalog and run discovery again.

I also added a focused CLI regression test that verifies `meltano invoke --refresh-catalog <tap>` passes an invoker context where `should_refresh_catalog()` is true.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [x] Yes: OpenAI Codex

Generated-by: OpenAI Codex following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Testing

Ran locally on Windows 11 with Python 3.14 via `uv`/`nox`.

- `uv run pytest tests/meltano/cli/test_invoke.py::TestCliInvoke::test_invoke_refresh_catalog_sets_extractor_context -q`
  - `1 passed in 2.54s`

- `uv run --script noxfile.py -s pre-commit -- run ruff-check --files src/meltano/cli/invoke.py tests/meltano/cli/test_invoke.py`
  - `ruff check Passed`

- `uv run --script noxfile.py -s pre-commit -- run ruff-format --files src/meltano/cli/invoke.py tests/meltano/cli/test_invoke.py`
  - `ruff format Passed`

- `uv run --script noxfile.py -s pytest-3.14 -- tests/meltano/cli/test_invoke.py`
  - `16 passed, 1 xfailed`
  - The xfail is the existing Windows marker for the containerized invoke test.

## Related Issues

* Closes #8858

## Summary by Sourcery

Add support for forcing catalog refresh when invoking extractor plugins via the CLI.

New Features:
- Add a --refresh-catalog flag to the meltano invoke command to bypass cached catalogs for extractor plugins and rerun discovery.

Tests:
- Add a CLI regression test verifying that meltano invoke --refresh-catalog sets an extractor invoker context with catalog refresh enabled.