### PR TITLE
feat(cli): Add --refresh-catalog option to `meltano invoke`

### DIFF
--- a/docs/docs/reference/command-line-interface.mdx
+++ b/docs/docs/reference/command-line-interface.mdx
@@ -1001,6 +1001,8 @@ Dumping the config and catalog of a plugin may reveal sensitive values in your t
 ```bash
 meltano invoke --dump=config <plugin>
 meltano invoke --dump=catalog <plugin>
+meltano invoke --refresh-catalog <plugin>
+meltano invoke --refresh-catalog --dump=catalog <plugin>
 ```
 
 By default, `meltano invoke` will attempt to install the plugin before invoking it. Use `--no-install` to skip this behavior:
@@ -1008,6 +1010,8 @@ By default, `meltano invoke` will attempt to install the plugin before invoking 
 ```bash
 meltano invoke --no-install <plugin>
 ```
+
+Use `--refresh-catalog` with Singer extractors to ignore any existing cached catalog and run discovery before invoking the tap in sync mode or dumping the catalog.
 
 Like any standard output, the dumped content can be [redirected](<https://en.wikipedia.org/wiki/Redirection_(computing)>) to a file using `>`, e.g. `meltano invoke --dump=catalog <plugin> > state.json`.
 

--- a/src/meltano/cli/invoke.py
+++ b/src/meltano/cli/invoke.py
@@ -71,6 +71,11 @@ install, no_install, only_install = get_install_options(include_only_install=Tru
     help="Dump content of specified file to disk.",
 )
 @click.option(
+    "--refresh-catalog",
+    is_flag=True,
+    help="Invalidates catalog cache and forces running discovery before invoke.",
+)
+@click.option(
     "--list-commands",
     is_flag=True,
     help="List the commands supported by the plugin.",
@@ -94,6 +99,7 @@ async def invoke(
     *,
     plugin_type: PluginType | None,
     dump: str,
+    refresh_catalog: bool,
     list_commands: bool,
     plugin_name: str,
     plugin_args: tuple[str, ...],
@@ -145,6 +151,7 @@ async def invoke(
             plugin_args=plugin_args,
             session=session,
             dump=dump,
+            refresh_catalog=refresh_catalog,
             command_name=command_name,
             containers=containers,
             print_var=print_var,
@@ -215,12 +222,16 @@ async def _invoke(  # noqa: ANN202
     plugin_args: tuple[str, ...],
     session: Session,
     dump: str,
+    refresh_catalog: bool,
     command_name: str | None,
     containers: bool,
     print_var: tuple[str, ...],
 ):
     if command_name is not None:
         command = invoker.find_command(command_name)
+
+    if refresh_catalog:
+        invoker.settings_service.config_override["_use_cached_catalog"] = False
 
     try:
         async with invoker.prepared(session):

--- a/tests/meltano/cli/test_invoke.py
+++ b/tests/meltano/cli/test_invoke.py
@@ -4,6 +4,7 @@ import json
 import logging
 import platform
 import typing as t
+from contextlib import asynccontextmanager
 from unittest import mock
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -11,7 +12,7 @@ import pytest
 import structlog
 
 from meltano.cli import cli
-from meltano.cli.invoke import _LogOutputHandler
+from meltano.cli.invoke import _invoke, _LogOutputHandler
 from meltano.core.plugin import PluginType
 from meltano.core.plugin.singer import SingerTap
 from meltano.core.plugin_install_service import PluginInstallReason
@@ -194,6 +195,71 @@ class TestCliInvoke:
 
         basic = cli_runner.invoke(cli, ["invoke", "utility-mock"])
         assert basic.exit_code == 2
+
+    def test_invoke_refresh_catalog_option(
+        self,
+        cli_runner: CliRunner,
+        tap: ProjectPlugin,
+    ) -> None:
+        with patch(
+            "meltano.cli.invoke._invoke", new=AsyncMock(return_value=0)
+        ) as invoke:
+            result = cli_runner.invoke(cli, ["invoke", "--refresh-catalog", tap.name])
+
+        assert result.exit_code == 0, (
+            f"exit code: {result.exit_code} - {result.exception}"
+        )
+        invoke.assert_awaited_once()
+        assert invoke.call_args.kwargs["refresh_catalog"] is True
+
+    @pytest.mark.parametrize(
+        ("invoke_kwargs", "expected_config_override"),
+        (
+            pytest.param({"refresh_catalog": False}, {}, id="default"),
+            pytest.param(
+                {"refresh_catalog": True},
+                {"_use_cached_catalog": False},
+                id="refresh-catalog",
+            ),
+        ),
+    )
+    @pytest.mark.asyncio
+    async def test_invoke_refresh_catalog_cache_override(
+        self,
+        invoke_kwargs: dict[str, bool],
+        expected_config_override: dict[str, bool],
+    ) -> None:
+        session = Mock()
+        settings_service = Mock()
+        settings_service.config_override = {}
+
+        invoker = Mock()
+        invoker.settings_service = settings_service
+        invoker.dump = AsyncMock(return_value="{}")
+
+        @asynccontextmanager
+        async def prepared(session_arg: object) -> t.AsyncIterator[None]:
+            assert session_arg is session
+            assert settings_service.config_override == expected_config_override
+            yield
+
+        invoker.prepared = prepared
+
+        exit_code = await _invoke(
+            invoker=invoker,
+            plugin_args=(),
+            session=session,
+            dump="catalog",
+            refresh_catalog=invoke_kwargs["refresh_catalog"],
+            command_name=None,
+            containers=False,
+            print_var=(),
+        )
+
+        assert exit_code == 0
+        assert settings_service.config_override == expected_config_override
+        invoker.dump.assert_awaited_once_with("catalog")
+        session.close.assert_called_once()
 
     def test_invoke_triggers(
         self,


### PR DESCRIPTION
## Summary

Closes #8858.

Adds `--refresh-catalog` to `meltano invoke`.

This allows:

```bash
meltano invoke --refresh-catalog <tap>
meltano invoke --refresh-catalog --dump catalog <tap>
```

to ignore any existing cached catalog and run discovery before invoking a Singer tap in sync mode or dumping the catalog.

## Implementation

This avoids introducing an `ELTContext` into `meltano invoke`.

Instead, it follows the existing `SelectService` approach and sets:

```python
invoker.settings_service.config_override["_use_cached_catalog"] = False
```

before `invoker.prepared(session)` runs.

## Tests

Added focused tests for:

- CLI wiring of `--refresh-catalog` into `_invoke`
- setting `_use_cached_catalog=False` before `invoker.prepared(session)`
- existing invoke trigger behaviour

Local checks run:

```bash
uv run pytest tests/meltano/cli/test_invoke.py::TestCliInvoke::test_invoke_refresh_catalog_option -q
uv run pytest tests/meltano/cli/test_invoke.py::TestCliInvoke::test_invoke_refresh_catalog_cache_override -q
uv run pytest tests/meltano/cli/test_invoke.py::TestCliInvoke::test_invoke_triggers -q
uv run --with ruff ruff check src/meltano/cli/invoke.py tests/meltano/cli/test_invoke.py
uv run --with ruff ruff format --check src/meltano/cli/invoke.py tests/meltano/cli/test_invoke.py
git diff --check
```

Docs updated in the CLI reference.

## Summary by Sourcery

Introduce a refresh-catalog option to meltano invoke that allows users to invalidate cached catalogs and rerun discovery before tap execution or catalog dumping, with corresponding CLI, internal handling, tests, and documentation updates.

New Features:
- Add a --refresh-catalog flag to meltano invoke to force catalog discovery before invoking Singer taps or dumping catalogs.

Enhancements:
- Wire the new refresh-catalog option through the CLI to the internal _invoke helper, updating invoker configuration to bypass cached catalogs when requested.

Documentation:
- Update CLI reference documentation to describe the new --refresh-catalog usage and its interaction with catalog dumping.

Tests:
- Add CLI and async invoke tests to validate refresh-catalog flag wiring, catalog cache override behavior, and existing invoke trigger behavior remain intact.