### PR TITLE
fix(core): Prevent include_paths from escaping project root (#10182)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - src/**
-      - integration/example-library/**
+      - integration/**
       - noxfile.py
       - pyproject.toml
       - uv.lock
@@ -16,7 +16,7 @@ on:
       - 'v*'
     paths:
       - src/**
-      - integration/example-library/**
+      - integration/**
       - noxfile.py
       - pyproject.toml
       - uv.lock

--- a/integration/meltano-run/validate.sh
+++ b/integration/meltano-run/validate.sh
@@ -10,7 +10,7 @@ LOG_FILE="./integration/example-library/meltano-run/integration-test.log"
 # test that meltano run saw dbt:test (set=1) as successfully completed
 grep "Block run completed            block_type=InvokerCommand.*err=None.*set_number=1.*success=True" $LOG_FILE
 # test that we see dbt:run output
-grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1 cmd_type=command.*name=dbt-postgres.*stdio=stderr" $LOG_FILE
+grep "Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 REUSED=0 TOTAL=1 cmd_type=command.*name=dbt-postgres.*stdio=stderr" $LOG_FILE
 
 # we could also run psql statements
 # check for the existence of files

--- a/src/meltano/core/project_files.py
+++ b/src/meltano/core/project_files.py
@@ -15,8 +15,15 @@ from meltano.core import yaml
 from meltano.core.utils import deep_merge
 
 if t.TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
     from pathlib import Path
+
+    # A path already proven (by `_validate_include_path`) to be a real file
+    # within the project root, or the project's own `meltano.yml`. This is
+    # the only place that boundary is enforced; `_write_file` trusts any
+    # `InProjectPath` it receives instead of re-checking it.
+    InProjectPath = t.NewType("InProjectPath", Path)
+    FilesContent: t.TypeAlias = dict[InProjectPath, CommentedMap]
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -51,9 +58,23 @@ class ProjectFiles:
             meltano_file_path: The path to the meltano.yml file.
         """
         self.root = root.resolve()
-        self._meltano_file_path = meltano_file_path.resolve()
-        self._plugin_file_map: dict[tuple[str, ...], str] = {}
-        self._raw_contents_map: dict[str, CommentedMap] = {}
+        # Trusted by construction: this is the project's own entry point,
+        # not a path derived from an `include_paths` pattern. Still verified
+        # here (rather than only asserted by the `InProjectPath` cast) so a
+        # caller that constructs `ProjectFiles` with a `meltano_file_path`
+        # outside `root` fails loudly instead of silently trusting it.
+        resolved_meltano_file_path = meltano_file_path.resolve()
+        try:
+            resolved_meltano_file_path.relative_to(self.root)
+        except ValueError as err:
+            msg = (
+                f"meltano_file_path '{meltano_file_path}' is not within "
+                f"the project root '{self.root}'."
+            )
+            raise InvalidIncludePathError(msg) from err
+        self._meltano_file_path = t.cast("InProjectPath", resolved_meltano_file_path)
+        self._plugin_file_map: dict[tuple[str, ...], InProjectPath] = {}
+        self._raw_contents_map: FilesContent = {}
         self._cached_loaded: CommentedMap | None = None
 
     @property
@@ -66,12 +87,8 @@ class ProjectFiles:
         return yaml.load(self._meltano_file_path)
 
     @property
-    def include_paths(self) -> list[Path]:
-        """Return list of paths derived from glob patterns defined in the meltanofile.
-
-        Returns:
-            List of paths derived from glob patterns defined in the meltanofile.
-        """
+    def include_paths(self) -> list[InProjectPath]:
+        """List of paths derived from glob patterns defined in the meltanofile."""
         include_path_patterns = self.meltano.get("include_paths", [])
         return self._resolve_include_paths(include_path_patterns)
 
@@ -83,7 +100,7 @@ class ProjectFiles:
         """
         prev_raw_contents_map = self._raw_contents_map.copy()
         self._raw_contents_map.clear()
-        self._raw_contents_map[str(self._meltano_file_path)] = self.meltano
+        self._raw_contents_map[self._meltano_file_path] = self.meltano
         included_file_contents = self._load_included_files()
 
         # If the exact same objects are loaded again, use the cached result:
@@ -119,24 +136,43 @@ class ProjectFiles:
         for file_path, contents in file_dicts.items():
             self._write_file(file_path, contents)
 
-        unused_files = [fl for fl in self.include_paths if str(fl) not in file_dicts]
+        unused_files = [fl for fl in self.include_paths if fl not in file_dicts]
         for unused_file_path in unused_files:
             self._write_file(unused_file_path, BLANK_SUBFILE)
         return meltano_config
 
-    def _is_valid_include_path(self, file_path: Path) -> None:
-        """Determine if given path is a valid `include_paths` file.
+    def _validate_include_path(self, file_path: Path) -> InProjectPath:
+        """Validate that a glob match is a real file within the project root.
+
+        This is the single point where paths derived from `include_paths`
+        patterns are checked before being trusted for reading or writing;
+        `_write_file` relies on every path it receives having passed here.
 
         Args:
-            file_path: The path to check.
+            file_path: The path to validate.
+
+        Returns:
+            The same path, now known to be a real file within the project root.
 
         Raises:
-            InvalidIncludePathError: If the included path is not a valid file.
+            InvalidIncludePathError: If the included path is not a valid file, or
+                if it resolves to a location outside the project root.
         """
-        if not (file_path.is_file() and file_path.exists()):
-            raise InvalidIncludePathError(f"Included path '{file_path}' not found.")  # noqa: EM102
+        if not file_path.is_file():
+            msg = f"Included path '{file_path}' is not a file."
+            raise InvalidIncludePathError(msg)
+        try:
+            file_path.resolve(strict=True).relative_to(self.root)
+        except ValueError as err:
+            root = self.root
+            msg = f"Included path '{file_path}' is outside the project root '{root}'."
+            raise InvalidIncludePathError(msg) from err
+        return t.cast("InProjectPath", file_path)
 
-    def _resolve_include_paths(self, include_path_patterns: list[str]) -> list[Path]:
+    def _resolve_include_paths(
+        self,
+        include_path_patterns: list[str],
+    ) -> list[InProjectPath]:
         """Return a list of paths from a list of glob pattern strings.
 
         Not including `meltano.yml` (even if it is matched by a pattern).
@@ -151,22 +187,21 @@ class ProjectFiles:
             InvalidIncludePathError: If a path is matched by a pattern but is
                 not a valid file.
         """
-        include_paths = []
+        include_paths: list[InProjectPath] = []
         for pattern in include_path_patterns:
             for path in self.root.glob(pattern):
+                if path == self._meltano_file_path:
+                    continue
                 try:
-                    self._is_valid_include_path(path)
+                    include_paths.append(self._validate_include_path(path))
                 except InvalidIncludePathError as err:
-                    logger.critical(f"Include path '{path}' is invalid: \n {err}")  # noqa: G004
-                    raise err
-                include_paths.append(path)
-            if self._meltano_file_path in include_paths:
-                include_paths.remove(self._meltano_file_path)
+                    logger.critical("Include path '%s' is invalid: \n %s", path, err)
+                    raise
 
         # Deduplicate entries
         return list(dict.fromkeys(include_paths))
 
-    def _add_to_index(self, key: tuple[str, ...], include_path: Path) -> None:
+    def _add_to_index(self, key: tuple[str, ...], include_path: InProjectPath) -> None:
         """Add a new key:path to the `_plugin_file_map`.
 
         Args:
@@ -180,16 +215,18 @@ class ProjectFiles:
             key_path_string = ":".join(key)
             existing_key_file_path = self._plugin_file_map.get(key)
             logger.critical(
-                f'Plugin with path "{key_path_string}" already added in '  # noqa: G004
-                f"file {existing_key_file_path}.",
+                "Plugin with path '%s' already added in file %s.",
+                key_path_string,
+                existing_key_file_path,
             )
-            raise Exception("Duplicate plugin name found.")  # noqa: EM101
+            msg = "Duplicate plugin name found"
+            raise Exception(msg)
 
-        self._plugin_file_map[key] = str(include_path)
+        self._plugin_file_map[key] = include_path
 
     def _index_file(
         self,
-        include_file_path: Path,
+        include_file_path: InProjectPath,
         include_file_contents: CommentedMap,
     ) -> None:
         """Populate map of plugins/schedules to their respective files.
@@ -238,45 +275,62 @@ class ProjectFiles:
             try:
                 contents: CommentedMap = yaml.load(path)
             except YAMLError as exc:  # noqa: PERF203
-                logger.critical(f"Error while parsing YAML file: {path} \n {exc}")  # noqa: G004
-                raise exc
+                logger.critical("Error while parsing YAML file: %s \n %s", path, exc)
+                raise
             else:
-                self._raw_contents_map[str(path)] = contents
+                self._raw_contents_map[path] = contents
                 # TODO: validate dict schema
                 # https://gitlab.com/meltano/meltano/-/issues/3029
                 self._index_file(include_file_path=path, include_file_contents=contents)
                 included_file_contents.append(contents)
         return included_file_contents
 
-    def _add_mapping_entry(self, file_dicts, file, key, value) -> None:  # noqa: ANN001
+    def _add_mapping_entry(
+        self,
+        file_dicts: FilesContent,
+        file: InProjectPath,
+        key: str,
+        value: Mapping[str, t.Any],
+    ) -> None:
         file_dict = file_dicts.setdefault(file, CommentedMap())
         entries = file_dict.setdefault(key, CommentedSeq())
         if value["name"] not in {scd["name"] for scd in entries}:
             entries.append(value)
 
-    def _add_sequence_entry(self, file_dicts, key, elements) -> None:  # noqa: ANN001
+    def _add_sequence_entry(
+        self,
+        file_dicts: FilesContent,
+        key: str,
+        elements: Iterable[Mapping[str, t.Any]],
+    ) -> None:
         for elem in elements:
             file_key = (key, elem["name"])
-            file = self._plugin_file_map.get(file_key, str(self._meltano_file_path))
+            file = self._plugin_file_map.get(file_key, self._meltano_file_path)
             self._add_mapping_entry(file_dicts, file, key, elem)
 
-    def _add_plugin(self, file_dicts, file, plugin_type, plugin) -> None:  # noqa: ANN001
+    def _add_plugin(
+        self,
+        file_dicts: FilesContent,
+        file: InProjectPath,
+        plugin_type: str,
+        plugin: dict,
+    ) -> None:
         file_dict = file_dicts.setdefault(file, CommentedMap())
         plugins_dict = file_dict.setdefault("plugins", CommentedMap())
         plugins = plugins_dict.setdefault(plugin_type, CommentedSeq())
         if plugin["name"] not in {plg["name"] for plg in plugins}:
             plugins.append(plugin)
 
-    def _add_plugins(self, file_dicts, all_plugins) -> None:  # noqa: ANN001
+    def _add_plugins(self, file_dicts: FilesContent, all_plugins: dict) -> None:
         for plugin_type, plugins in all_plugins.items():
             plugin_type = str(plugin_type)
             for plugin in plugins:
                 key = ("plugins", plugin_type, plugin.get("name"))
-                file = self._plugin_file_map.get(key, str(self._meltano_file_path))
+                file = self._plugin_file_map.get(key, self._meltano_file_path)
                 self._add_plugin(file_dicts, file, plugin_type, plugin)
 
-    def _split_config_dict(self, config: CommentedMap):  # noqa: ANN202
-        file_dicts: dict[str, CommentedMap] = {}
+    def _split_config_dict(self, config: CommentedMap) -> FilesContent:
+        file_dicts: FilesContent = {}
 
         # Fill in the top-level entries
         for key, value in config.items():
@@ -285,28 +339,32 @@ class ProjectFiles:
             elif key in MULTI_FILE_KEYS:
                 self._add_sequence_entry(file_dicts, key, value)
             else:
-                file = str(self._meltano_file_path)
+                file = self._meltano_file_path
                 file_dict = file_dicts.setdefault(file, CommentedMap())
                 file_dict[key] = value
 
         # Make sure that the top-level keys are in the same order as the original files
         sorted_file_dicts = self._restore_file_key_order(file_dicts)
 
+        # Ensure meltano.yml is always present, even if empty
+        if self._meltano_file_path not in sorted_file_dicts:
+            sorted_file_dicts[self._meltano_file_path] = CommentedMap()
+
         # Copy comments from the original config to the new config
-        config.copy_attributes(sorted_file_dicts[str(self._meltano_file_path)])
+        config.copy_attributes(sorted_file_dicts[self._meltano_file_path])
         self._copy_yaml_attributes(sorted_file_dicts)
         return sorted_file_dicts
 
-    def _restore_file_key_order(self, file_dicts: dict[str, CommentedMap]):  # noqa: ANN202
+    def _restore_file_key_order(self, file_dicts: FilesContent) -> FilesContent:
         """Restore the order of the keys in the meltano project files.
 
         Args:
             file_dicts: The dictionary mapping included files to their contents.
 
         Returns:
-            The file contents mapping with order preserved from the original files.∫
+            The file contents mapping with order preserved from the original files.
         """
-        sorted_file_dicts: dict[str, CommentedMap] = {}
+        sorted_file_dicts: FilesContent = {}
 
         for file, contents in self._raw_contents_map.items():
             if file not in file_dicts:
@@ -326,10 +384,7 @@ class ProjectFiles:
 
         return sorted_file_dicts
 
-    def _copy_yaml_attributes(
-        self,
-        file_dicts: dict[str, CommentedMap],
-    ) -> None:
+    def _copy_yaml_attributes(self, file_dicts: FilesContent) -> None:
         """Restore comments from top-level YAML entries in project files.
 
         For every file, use the top-level entries (e.g. "plugins") to copy the comments
@@ -366,8 +421,12 @@ class ProjectFiles:
             schedules = file_dict.get("schedules", CommentedSeq())
             original_schedules.copy_attributes(schedules)
 
-    def _write_file(self, file_path: str | os.PathLike[str], contents: Mapping) -> None:
-        dirname = os.path.dirname(file_path)  # noqa: PTH120
+    def _write_file(self, file_path: InProjectPath, contents: Mapping) -> None:
+        # No containment check here: file_path is only ever an InProjectPath,
+        # which is only ever produced by `_validate_include_path` (or is
+        # `self._meltano_file_path`, trusted by construction). See the
+        # `InProjectPath` definition above for the invariant this relies on.
+        dirname = file_path.parent
         fd, tmp_name = tempfile.mkstemp(dir=dirname, suffix=".tmp.yml")
         try:
             with os.fdopen(fd, "w") as tmp_file:

--- a/tests/meltano/core/test_project_files.py
+++ b/tests/meltano/core/test_project_files.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+import ruamel.yaml
 
 from fixtures.utils import cd
+from meltano.core.project_files import InvalidIncludePathError, ProjectFiles
 from meltano.core.utils import deep_merge
 
 
@@ -145,6 +147,109 @@ class TestProjectFiles:
             (project_files.root / "subconfig_2.yml"),
             (project_files.root / "subfolder" / "subconfig_1.yml"),
         ]
+
+    def test_meltano_file_path_outside_root_rejected(
+        self,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        base = tmp_path_factory.mktemp("meltano-file-path-outside-root")
+        root_dir = base / "root"
+        root_dir.mkdir()
+        outside_yml = base / "outside" / "meltano.yml"
+        outside_yml.parent.mkdir()
+        outside_yml.write_text("plugins: {}\n")
+
+        with pytest.raises(
+            InvalidIncludePathError,
+            match=r"is not within the project root",
+        ):
+            ProjectFiles(root=root_dir, meltano_file_path=outside_yml)
+
+    def test_include_not_yaml(self, tmp_path: Path) -> None:
+        include_yml = tmp_path / "inc.meltano.yml"
+        include_yml.write_text("}{")
+        root_yml = tmp_path / "meltano.yml"
+        root_yml.write_text("include_paths:\n  - ./**/*.meltano.yml\n")
+        project_files = ProjectFiles(root=root_yml.parent, meltano_file_path=root_yml)
+
+        with pytest.raises(ruamel.yaml.parser.ParserError):
+            project_files.load()
+
+    def test_include_path_self(self, tmp_path: Path) -> None:
+        root_yml = tmp_path / "meltano.yml"
+        root_yml.write_text("include_paths:\n  - ./**/meltano.yml\n")
+        project_files = ProjectFiles(root=root_yml.parent, meltano_file_path=root_yml)
+        assert not project_files.include_paths
+
+    def test_include_path_not_a_file(self, tmp_path: Path) -> None:
+        include_yml = tmp_path / "inc.meltano.yml"
+        include_yml.mkdir()
+        root_yml = tmp_path / "meltano.yml"
+        root_yml.write_text("include_paths:\n  - ./**/*.meltano.yml\n")
+        project_files = ProjectFiles(root=root_yml.parent, meltano_file_path=root_yml)
+
+        with pytest.raises(
+            InvalidIncludePathError,
+            match=r"Included path '.*inc\.meltano\.yml' is not a file",
+        ):
+            _ = project_files.include_paths
+
+    def test_include_paths_rejects_path_traversal(
+        self,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        base = tmp_path_factory.mktemp("traversal-test")
+        sibling_yml = base / "sibling" / "meltano.yml"
+        sibling_yml.parent.mkdir()
+        sibling_yml.write_text("plugins:\n  extractors:\n  - name: victim-tap\n")
+        original = sibling_yml.read_bytes()
+
+        contributed_dir = base / "contributed"
+        contributed_dir.mkdir()
+        (contributed_dir / "meltano.yml").write_text(
+            "include_paths:\n  - ../sibling/meltano.yml\n",
+        )
+
+        project_files = ProjectFiles(
+            root=contributed_dir,
+            meltano_file_path=contributed_dir / "meltano.yml",
+        )
+
+        with pytest.raises(InvalidIncludePathError):
+            _ = project_files.include_paths
+
+        with pytest.raises(InvalidIncludePathError):
+            project_files.load()
+
+        assert sibling_yml.read_bytes() == original
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="symlinks require elevated privileges on Windows",
+    )
+    def test_include_paths_rejects_symlink_traversal(
+        self,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        base = tmp_path_factory.mktemp("traversal-symlink-test")
+        sibling_yml = base / "sibling" / "meltano.yml"
+        sibling_yml.parent.mkdir()
+        sibling_yml.write_text("plugins: {}\n")
+
+        contributed_dir = base / "contributed"
+        contributed_dir.mkdir()
+        (contributed_dir / "meltano.yml").write_text(
+            "include_paths:\n  - ./escape.yml\n",
+        )
+        (contributed_dir / "escape.yml").symlink_to(sibling_yml)
+
+        project_files = ProjectFiles(
+            root=contributed_dir,
+            meltano_file_path=contributed_dir / "meltano.yml",
+        )
+
+        with pytest.raises(InvalidIncludePathError):
+            _ = project_files.include_paths
 
     @pytest.mark.order(5)
     def test_load(self, project_files) -> None:


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Enforce that meltano project and included config files stay within the project root and adjust integration test coverage and expectations accordingly.

Bug Fixes:
- Prevent include_paths glob patterns and the main meltano.yml path from resolving to files outside the project root, including via symlinks or non-file matches.

Enhancements:
- Introduce stronger typing and internal invariants around project file paths to ensure only validated in-project files are read and written.
- Ensure meltano.yml is always represented in the split configuration map, even when empty, and simplify error logging messages.

CI:
- Broaden integration test workflow path filters to run when changes occur anywhere under the integration directory.

Tests:
- Add tests covering invalid include_paths scenarios, path traversal and symlink traversal attempts, non-YAML includes, and project roots that mismatch meltano.yml locations.
- Update integration test validation script to reflect new dbt output format including REUSED in the summary.