### PR TITLE
docs: added documentation for SurveyMonkey and Zendesk tap

### DIFF
--- a/docs/docs/connectors/tap-surveymonkey.mdx
+++ b/docs/docs/connectors/tap-surveymonkey.mdx
@@ -1,0 +1,87 @@
+---
+title: SurveyMonkey
+description: Sync your SurveyMonkey surveys, distribution data, and responses into your warehouse, already flattened into relational tables.
+---
+
+# SurveyMonkey
+
+SurveyMonkey is an online survey platform for creating and distributing surveys and collecting and analysing responses. Research, CX, HR, and marketing teams use this connector to bring survey definitions, distribution data, and individual responses into their warehouse for reporting and analysis, already flattened into relational tables, so you don't need warehouse-specific SQL to unnest nested survey or response data.
+
+## At a glance
+
+| Property | Value |
+|---|---|
+| **Authentication** | OAuth login (Connect with SurveyMonkey) |
+| **Sync type** | Mixed: some streams incremental, some full table |
+| **Streams** | Fixed list |
+| **Custom queries** | Not supported |
+
+## What you can sync
+
+This connector brings in your full survey program, both as raw nested objects and as pre-flattened relational tables:
+
+- Survey definitions (surveys, pages, questions, headings, answer choices, matrix sub-questions)
+- Distribution data (collectors and their recipients)
+- Responses, down to the individual answer
+- Address-book contacts and account survey categories
+
+## Prerequisites
+
+- **A SurveyMonkey account with access to the surveys you want to sync.** There's no manual credential to retrieve; you'll sign in directly in the setup step below. The authorising user must have access to the surveys you want to sync; connecting as a non-admin will only sync what that user can see.
+- **A paid SurveyMonkey plan, for full answer detail.** Full per-question answer detail (used by the `responses` and `response_answers` streams) requires a paid plan. On Basic plans, response answer detail is limited.
+
+## Setup
+
+### In SurveyMonkey
+
+1. No setup is needed in advance, just have an account (ideally an admin) with access to the surveys you want to sync.
+
+### In Meltano Cloud
+
+1. Add the SurveyMonkey data source.
+2. Click **Connect with SurveyMonkey** and sign in. You'll be redirected to SurveyMonkey's own authorisation page.
+3. Review and accept the requested permissions; you're redirected back and the connection completes automatically.
+4. Set a **Start Date**: the incremental bookmark for the `responses` stream (and its flattened `response_pages`/`response_answers` streams), so set it as far back as you need response history.
+5. If your account isn't hosted in the US, set **Region** to Europe (EU) or Canada (CA). Using the wrong region causes authentication or lookup failures; check with your SurveyMonkey account admin if you're not sure.
+
+## Settings
+
+| Field | Type | Required / Default | Description |
+|---|---|---|---|
+| `start_date` | string | required | An ISO-8601 date-time. The earliest response date to sync; used as the incremental bookmark for the `responses` stream |
+| `api_url` | string (options) | `https://api.surveymonkey.com/v3` | The SurveyMonkey data-residency region your account belongs to: United States, Europe (EU), or Canada (CA). Selecting the wrong region causes authentication or lookup failures |
+
+Sign-in and token management (OAuth authorisation, access and refresh tokens) are handled automatically by the **Connect with SurveyMonkey** flow and don't require manual configuration.
+
+## Available streams
+
+| Stream | Description |
+|---|---|
+| `surveys` | All surveys in the account |
+| `survey_details` | Full definition of each survey, including pages and questions |
+| `collectors` | Distribution channels (web links, email invitations) per survey |
+| `recipients` | Recipients of each collector (email-invite collectors only) |
+| `responses` | Individual survey responses, with per-question answers |
+| `survey_pages` | One row per survey page (flattened from `survey_details`) |
+| `questions` | One row per question (flattened from `survey_details`) |
+| `question_headings` | One row per question heading (flattened from `survey_details`) |
+| `question_options` | One row per answer choice (flattened from `survey_details`) |
+| `sub_questions` | One row per matrix subquestion/row (flattened from `survey_details`) |
+| `response_pages` | One row per answered page of a response (flattened from `responses`) |
+| `response_answers` | One row per individual answer (flattened from `responses`) |
+| `contacts` | Address-book contacts (requires the `contacts_read` scope) |
+| `survey_categories` | Survey categories available to the account |
+
+`responses`, `response_pages`, and `response_answers` sync incrementally on `date_modified`, bookmarked against your Start Date. Every other stream is full-table and re-syncs completely on each run.
+
+## Advanced configuration
+
+- **Backfilling response history.** To re-sync historical responses, lower the **Start Date** or reset the connection's sync state; either restarts the `responses`/`response_pages`/`response_answers` streams from that date.
+
+## A note on history
+
+These streams always reflect the *current state* of each record; they are not slowly-changing-dimension (SCD type-2) history tables. If you're migrating from a tool that provided full change history (e.g. Fivetran's `_history` tables) and need valid-from/valid-to versioning, that needs to be layered in your warehouse, for example with dbt snapshots. This can't be backfilled from before your first snapshot run, and needs a scheduled job to accrue over time.
+
+## Need help?
+
+If a stream or field you need isn't listed here, file it through the usual Meltano support channel.

--- a/docs/docs/connectors/tap-zendesk.mdx
+++ b/docs/docs/connectors/tap-zendesk.mdx
@@ -1,0 +1,263 @@
+---
+title: Zendesk
+description: Sync your Zendesk Support tickets, agents, and Help Center content into your warehouse.
+---
+
+# Zendesk
+
+Zendesk Support is a customer service platform that helps businesses manage customer interactions across email, chat, phone, and social media, backed by a self-service Help Center for knowledge base articles and community discussions. Support, CX, and operations teams use this connector to bring ticket, agent, and customer data into their warehouse for reporting and analysis.
+
+## At a glance
+
+| Property | Value |
+|---|---|
+| **Authentication** | API key / token |
+| **Sync type** | Mixed: some streams incremental, some full table |
+| **Streams** | Fixed list |
+| **Custom queries** | Not supported |
+
+## What you can sync
+
+This connector brings in your full support operations dataset, plus your public-facing knowledge base:
+
+- Core ticketing data (tickets, users, organisations, and their relationships)
+- Support operations configuration (groups, macros, triggers, automations, SLA policies, custom roles and fields)
+- Customer experience signals (satisfaction ratings, ticket metrics)
+- Help Center content (articles, categories, sections, community posts and topics)
+
+## Prerequisites
+
+- **A Zendesk account with API token access.** The connector authenticates as one of your agents using an API token, not a full sign-in flow.
+- **Your Zendesk subdomain and agent email address.** These are needed alongside the API token to authenticate.
+- **An API token, generated in Zendesk.** See the setup steps below.
+
+## Setup
+
+### In Zendesk
+
+1. Go to **Admin Center → Apps and integrations → Zendesk API**.
+2. Enable API token access if it isn't already, and generate a new token.
+3. Note your subdomain (the `mycompany` in `mycompany.zendesk.com`) and the agent email address you'll authenticate with.
+
+### In Meltano Cloud
+
+1. Add the Zendesk data source.
+2. Enter your **Subdomain**, **Email**, and the **API Token** you generated above.
+3. Set a **Start Date** for how far back to sync ticket, user, and metric-event history.
+
+## Settings
+
+| Field | Type | Required / Default | Description |
+|---|---|---|---|
+| `subdomain` | string | required | Your Zendesk subdomain. If your Zendesk URL is `https://mycompany.zendesk.com`, your subdomain is `mycompany` |
+| `email` | string | required when using API token auth | Zendesk agent email address, set together with `api_token` |
+| `api_token` | string | required when using API token auth | Zendesk API token, generated in **Admin Center → Apps and integrations → Zendesk API → API token** |
+| `start_date` | string | required | An ISO-8601 date-time. Earliest record date to sync |
+
+## Available streams
+
+**Incremental streams** (bookmark carried between syncs):
+
+| Stream | Replication key | Description |
+|---|---|---|
+| `tickets` | `updated_at` | Support tickets |
+| `users` | `updated_at` | Agents, admins, end-users |
+| `organizations` | `updated_at` | Organisations linked to users and tickets |
+| `ticket_metric_events` | `time` | Metric milestone events (reply time, wait time) |
+
+**Full-table streams** (re-synced completely on every run):
+
+| Stream | Description |
+|---|---|
+| `automations` | Time-based automation rules |
+| `brands` | Brand configurations (multi-brand setups) |
+| `custom_roles` | Custom agent roles |
+| `group_memberships` | Agent-to-group memberships |
+| `groups` | Agent groups |
+| `macros` | Macros for bulk-updating tickets |
+| `organization_fields` | Custom fields defined on organisations |
+| `organization_memberships` | User-to-organisation memberships |
+| `satisfaction_ratings` | CSAT ratings submitted by end-users |
+| `schedules` | Business hours schedules |
+| `sla_policies` | SLA policy definitions |
+| `tags` | Tag vocabulary with usage counts |
+| `ticket_fields` | Ticket field definitions (system and custom) |
+| `ticket_forms` | Ticket form definitions (Enterprise plans; skipped gracefully if unavailable) |
+| `ticket_metrics` | Per-ticket SLA and timing metrics |
+| `triggers` | Event-based automation triggers |
+| `user_fields` | Custom user field definitions |
+| `user_identities` | Email, phone, and social accounts per user (child of `users`) |
+| `views` | Shared and personal ticket views |
+
+**Help Center streams** (skipped gracefully if Guide isn't enabled on your account):
+
+| Stream | Description |
+|---|---|
+| `articles` | Knowledge base articles |
+| `categories` | Top-level Help Center categories |
+| `posts` | Community posts |
+| `sections` | Sections within categories |
+| `topics` | Community discussion topics |
+
+### Field reference (key streams)
+
+#### `tickets`
+
+| Field | Description |
+|---|---|
+| `id` | Unique ticket identifier |
+| `type` | Ticket type (problem, incident, question, task) |
+| `subject` | Ticket subject |
+| `description` | First comment body |
+| `priority` | Ticket priority (urgent, high, normal, low) |
+| `status` | Ticket status (new, open, pending, hold, solved, closed) |
+| `recipient` | Email address the ticket was sent to |
+| `requester_id` | ID of the requester |
+| `submitter_id` | ID of the submitter |
+| `assignee_id` | ID of the assigned agent |
+| `organization_id` | ID of the requester's organisation |
+| `group_id` | ID of the assigned group |
+| `collaborator_ids` | IDs of collaborators |
+| `follower_ids` | IDs of followers |
+| `has_incidents` | Whether this ticket has incident links |
+| `is_public` | Whether comments are public |
+| `due_at` | Due date for task tickets |
+| `tags` | Tags applied to the ticket |
+| `custom_fields` | Custom field values |
+| `satisfaction_rating` | CSAT rating (id, score, comment) |
+| `brand_id` | Brand the ticket belongs to |
+| `created_at` | Ticket creation timestamp |
+| `updated_at` | Last modification timestamp (replication key) |
+| `via` | Channel the ticket was created through |
+
+#### `users`
+
+| Field | Description |
+|---|---|
+| `id` | Unique user identifier |
+| `name` | Full name |
+| `email` | Primary email address |
+| `role` | Role (end-user, agent, admin) |
+| `organization_id` | Primary organisation ID |
+| `verified` | Whether the user is verified |
+| `active` | Whether the user is active |
+| `suspended` | Whether the user is suspended |
+| `tags` | Tags |
+| `last_login_at` | Last login timestamp |
+| `custom_role_id` | Custom role ID for agents |
+| `created_at` | Account creation timestamp |
+| `updated_at` | Last modification timestamp (replication key) |
+
+#### `organizations`
+
+| Field | Description |
+|---|---|
+| `id` | Unique organisation identifier |
+| `name` | Organisation name |
+| `shared_tickets` | Whether tickets are shared within the organisation |
+| `shared_comments` | Whether comments are shared within the organisation |
+| `domain_names` | Domains associated with the organisation |
+| `group_id` | Default group ID |
+| `tags` | Tags |
+| `custom_fields` | Custom field values |
+| `created_at` | Creation timestamp |
+| `updated_at` | Last modification timestamp (replication key) |
+
+#### `groups` / `group_memberships`
+
+| Field | Description |
+|---|---|
+| `id` | Unique identifier |
+| `name` | Group name (`groups` only) |
+| `user_id` | Agent user ID (`group_memberships` only) |
+| `group_id` | Group ID (`group_memberships` only) |
+| `default` | Whether this is the (agent's) default group |
+| `created_at` / `updated_at` | Timestamps |
+
+#### `macros` / `triggers`
+
+| Field | Description |
+|---|---|
+| `id` | Unique identifier |
+| `title` | Macro/trigger title |
+| `active` | Whether it's active |
+| `conditions` | Trigger only: conditions that activate it |
+| `actions` | Actions applied (field, value) |
+| `restriction` | Macro only: visibility restriction |
+| `created_at` / `updated_at` | Timestamps |
+
+#### `organization_fields` / `custom_roles`
+
+| Field | Description |
+|---|---|
+| `id` | Unique identifier |
+| `key` | Field key used in API calls (`organization_fields` only) |
+| `name` | Role name (`custom_roles` only) |
+| `type` | Field type (`organization_fields` only) |
+| `title` / `description` | Display text |
+| `configuration` | Permission configuration (`custom_roles` only) |
+| `team_member_count` | Number of agents with this role (`custom_roles` only) |
+| `created_at` / `updated_at` | Timestamps |
+
+#### `organization_memberships`
+
+| Field | Description |
+|---|---|
+| `id` | Unique membership identifier |
+| `user_id` | User ID |
+| `organization_id` | Organisation ID |
+| `default` | Whether this is the user's default organisation |
+| `created_at` / `updated_at` | Timestamps |
+
+#### `satisfaction_ratings`
+
+| Field | Description |
+|---|---|
+| `id` | Unique rating identifier |
+| `ticket_id` | Associated ticket ID |
+| `score` | Rating score (good, bad, offered) |
+| `reason` | Reason for the rating |
+| `comment` | Customer comment |
+| `created_at` / `updated_at` | Timestamps |
+
+#### `schedules` / `sla_policies`
+
+| Field | Description |
+|---|---|
+| `id` | Unique identifier |
+| `name` / `title` | Display name |
+| `intervals` | Business hour intervals (`schedules` only) |
+| `filter` | Conditions that activate the policy (`sla_policies` only) |
+| `policy_metrics` | Metric definitions: priority, metric, target (`sla_policies` only) |
+| `created_at` / `updated_at` | Timestamps |
+
+#### `user_identities`
+
+Child stream of `users`: each user's email addresses, phone numbers, and social accounts.
+
+| Field | Description |
+|---|---|
+| `id` | Unique identity identifier |
+| `user_id` | Parent user ID |
+| `type` | Identity type (email, twitter, facebook, google, phone_number, etc.) |
+| `value` | Identity value |
+| `verified` | Whether the identity is verified |
+| `primary` | Whether this is the primary identity |
+
+#### Help Center: `categories` / `sections` / `posts`
+
+| Field | Description |
+|---|---|
+| `id` | Unique identifier |
+| `name` / `title` | Display name |
+| `description` / `details` | Body text |
+| `position` | Display position |
+| `locale` | Current locale |
+| `parent_section_id` / `category_id` / `section_id` | Parent references |
+| `author_id` | Post author (`posts` only) |
+| `status` | Post status: planned, not_planned, completed, published (`posts` only) |
+| `created_at` / `updated_at` | Timestamps |
+
+## Need help?
+
+If a stream or field you need isn't listed here, file it through the usual Meltano support channel.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -19,6 +19,8 @@ const sidebars = {
     { type: 'doc', id: 'connectors/index', label: 'All connectors' },
     { type: 'doc', id: 'connectors/tap-spreadsheets-outlook', label: 'Outlook' },
     { type: 'doc', id: 'connectors/tap-spreadsheets-sharepoint', label: 'SharePoint' },
+    { type: 'doc', id: 'connectors/tap-zendesk', label: 'Zendesk' },
+    { type: 'doc', id: 'connectors/tap-surveymonkey', label: 'SurveyMonkey' },
   ],
   platformSidebar: [
     {

--- a/docs/src/components/ConnectorSearch.jsx
+++ b/docs/src/components/ConnectorSearch.jsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 const CONNECTORS = [
   { label: 'Outlook', href: '/connectors/tap-spreadsheets-outlook' },
   { label: 'SharePoint', href: '/connectors/tap-spreadsheets-sharepoint' },
+  { label: 'Zendesk', href: '/connectors/tap-zendesk' },
+  { label: 'SurveyMonkey', href: '/connectors/tap-surveymonkey' },
 ];
 
 export default function ConnectorSearch() {


### PR DESCRIPTION
## Description

Added documentation for tap-zendesk
Added documentation for tap-surveymonkey

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Add Zendesk and SurveyMonkey connector documentation and extend Meltano Cloud changelog and navigation UX.

Enhancements:
- Revamp the changelog experience with Cloud/Open tabs, per-release pages, back links, animations, and blog item styling tweaks.
- Update connectors catalog copy and search, and add Zendesk and SurveyMonkey entries to navigation and search.
- Adjust site styling for links, connector cards, sidebar hover behaviour, navbar logo, blog post metadata, and GitHub/Slack hover icons for a more consistent look.

Build:
- Configure a dedicated Docusaurus blog instance for Meltano Cloud changelog content and update navigation and redirects to point Changelog and quickstart flows to Cloud-focused pages.

Documentation:
- Add detailed user-facing setup and stream reference documentation pages for the Zendesk and SurveyMonkey taps.
- Extend Outlook and SharePoint connector docs with structured settings tables and clearer wording.
- Introduce a Meltano Cloud docs index page linking key Cloud guides.