### PR TITLE
refactor: Bump Ruff to 0.16 and apply fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
           - "globals@17.7.0"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
     - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/docs/docs/contribute/style.md
+++ b/docs/docs/contribute/style.md
@@ -131,8 +131,8 @@ For new, deprecated, or experimental features, the relevant code path can be wra
 from meltano.core.project import Project
 from meltano.core.settings_service import FeatureFlags
 
-class ExistingClass:
 
+class ExistingClass:
     def __init__(self):
         self.project = Project.find()
 
@@ -147,7 +147,10 @@ class ExistingClass:
     # The same pattern can be used to deprecate existing behavior
     # Notice the "raise_error=False" in the feature_flag method call
     def existing_method_with_new_behavior(self):
-        with self.project.settings.feature_flag(FeatureFlags.NEW_BEHAVIOR, raise_error=False) as new_behavior:
+        with self.project.settings.feature_flag(
+            FeatureFlags.NEW_BEHAVIOR,
+            raise_error=False,
+        ) as new_behavior:
             if new_behavior:
                 print("Doing the new behavior...")
             else:

--- a/docs/docs/guide/custom-state-backend.md
+++ b/docs/docs/guide/custom-state-backend.md
@@ -75,7 +75,6 @@ class MyStateManager(StateStoreManager):
         if not self.password:
             raise MyStateManagerError("Password is required")
 
-
     def set(self, state: MeltanoState) -> None:
         # Implement the logic to store the state in your custom backend
         ...

--- a/docs/docs/tutorials/custom-extractor.md
+++ b/docs/docs/tutorials/custom-extractor.md
@@ -110,7 +110,6 @@ class Tapjsonplaceholder(Tap):
         """Return a list of discovered streams."""
 
         return [stream_class(tap=self) for stream_class in STREAM_TYPES]
-
 ```
 
 Then replace the content of `tap-jsonplaceholder/tap_jsonplaceholder/streams.py` with the content below:
@@ -118,14 +117,14 @@ Then replace the content of `tap-jsonplaceholder/tap_jsonplaceholder/streams.py`
 ```python
 """Stream type classes for tap-jsonplaceholder."""
 
-from singer_sdk import typing as th # JSON Schema typing helpers
+from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_jsonplaceholder.client import jsonplaceholderStream
 
 
 class CommentsStream(jsonplaceholderStream):
     primary_keys = ["id"]
-    path = '/comments'
+    path = "/comments"
     name = "comments"
     schema = th.PropertiesList(
         th.Property("postId", th.IntegerType),

--- a/docs/docs/tutorials/jupyter.md
+++ b/docs/docs/tutorials/jupyter.md
@@ -103,7 +103,6 @@ PG_PORT = os.getenv("PG_PORT", default=None)
 PG_DB = os.getenv("PG_DB", default=None)
 PG_USER = os.getenv("PG_USER", default=None)
 PG_PWD = os.getenv("PG_PWD", default=None)
-
 ```
 
 ### 4. Execute notebooks via nbconvert or papermill

--- a/integration/example-library/ruff.toml
+++ b/integration/example-library/ruff.toml
@@ -3,5 +3,5 @@ extend = "../../pyproject.toml"
 [lint]
 extend-ignore = [
     "ANN",   # type annotations
-    "T201",  # print function
+    "print",  # print function
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,16 +338,18 @@ build-backend = "hatchling.build"
 
 [tool.ruff]
 line-length = 88
-required-version = ">=0.15.14"
+required-version = ">=0.16.0"
 
 [tool.ruff.lint]
 future-annotations = true
+preview = true
 ignore = [
-  "N818",   # Allow Exceptions to have suffix 'Exception' rather than 'Error'
-  "S310",   # Allow `urllib.open`
-  "S603",   # Allow `subprocess.run(..., shell=False)`
-  "COM812", # Handled by the Ruff formatter
-  "ISC001", # Handled by the Ruff formatter
+  "error-suffix-on-exception-name",   # Allow Exceptions to have suffix 'Exception' rather than 'Error'
+  "suspicious-url-open-usage",   # Allow `urllib.open`
+  "subprocess-without-shell-equals-true",   # Allow `subprocess.run(..., shell=False)`
+  "missing-trailing-comma", # Handled by the Ruff formatter
+  "single-line-implicit-string-concatenation", # Handled by the Ruff formatter
+  "noqa-comments",
 ]
 select = [
   "A",     # flake8-builtins
@@ -399,23 +401,27 @@ select = [
   "YTT",   # flake8-2020
 ]
 unfixable = [
-  "ERA001", # Don't remove commented-out code
+  "commented-out-code", # Don't remove commented-out code
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "src/meltano/**/__init__.py" = [
-  "F401", # Permit unused imports in `__init__.py` files
+  "unused-import", # Permit unused imports in `__init__.py` files
 ]
 "tests/**" = [
   "ANN",
   "D1",
-  "S101",    # Allow 'assert' in tests
+  "assert",    # Allow 'assert' in tests
   "INP",     # Don't require __init__.py files in tests directories
-  "LOG015",  # Allow `logging.<level>` in tests
+  "root-logger-call",  # Allow `logging.<level>` in tests
+  "fallible-context-manager",
+  "suspicious-subprocess-import",
+  "unused-async",
+  "non-empty-init-module",
 ]
 "src/meltano/migrations/versions/*" = [
-  "D103",
-  "INP001",
+  "undocumented-public-function",
+  "implicit-namespace-package",
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/src/meltano/cli/__init__.py
+++ b/src/meltano/cli/__init__.py
@@ -1,5 +1,7 @@
 """Main entry point for the meltano CLI."""
 
+# ruff: file-ignore[non-empty-init-module]
+
 from __future__ import annotations
 
 import asyncio

--- a/src/meltano/core/behavior/hookable.py
+++ b/src/meltano/core/behavior/hookable.py
@@ -92,7 +92,7 @@ class HookObject(metaclass=Hookable):
             self._triggering_hooks.add(hook_name)
             await self.__class__.trigger(self, f"before_{hook_name}", *args, **kwargs)
 
-        yield
+        yield  # ruff:ignore[fallible-context-manager]
 
         if not already_triggering:
             await self.__class__.trigger(self, f"after_{hook_name}", *args, **kwargs)

--- a/src/meltano/core/bundle/__init__.py
+++ b/src/meltano/core/bundle/__init__.py
@@ -1,5 +1,7 @@
 """Bundled yaml files."""
 
+# ruff: file-ignore[non-empty-init-module]
+
 from __future__ import annotations
 
 import importlib.resources

--- a/src/meltano/core/logging/formatters.py
+++ b/src/meltano/core/logging/formatters.py
@@ -74,7 +74,7 @@ class LoggingFeatures(t.TypedDict, total=False):
 def _processors_from_kwargs(
     **features: Unpack[LoggingFeatures],
 ) -> Generator[Processor]:
-    if features.get("callsite_parameters", False):
+    if features.get("callsite_parameters"):
         yield structlog.processors.CallsiteParameterAdder(
             parameters=(
                 structlog.processors.CallsiteParameter.PATHNAME,
@@ -84,7 +84,7 @@ def _processors_from_kwargs(
             ),
         )
 
-    if features.get("dict_tracebacks", False):
+    if features.get("dict_tracebacks"):
         show_locals = features.get("show_locals", False)
         yield structlog.processors.ExceptionRenderer(
             structlog.tracebacks.ExceptionDictTransformer(show_locals=show_locals),

--- a/src/meltano/core/meltano_invoker.py
+++ b/src/meltano/core/meltano_invoker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import platform
-import subprocess
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import sys
 import typing as t
 from pathlib import Path

--- a/src/meltano/core/plugin/airflow.py
+++ b/src/meltano/core/plugin/airflow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import configparser
 import os
-import subprocess
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import typing as t
 from contextlib import suppress
 

--- a/src/meltano/core/plugin/dbt/base.py
+++ b/src/meltano/core/plugin/dbt/base.py
@@ -50,7 +50,7 @@ class DbtPlugin(BasePlugin):
     invoker_class = DbtInvoker
 
 
-async def install_dbt_plugin(
+async def install_dbt_plugin(  # ruff:ignore[unused-async]
     *,
     project: Project,
     plugin: ProjectPlugin,

--- a/src/meltano/core/plugin/singer/catalog.py
+++ b/src/meltano/core/plugin/singer/catalog.py
@@ -793,8 +793,7 @@ class ListSelectedExecutor(CatalogExecutor):
         if metadata.get(INCLUSION_KEY) == SelectionType.UNSUPPORTED:
             return SelectionType.UNSUPPORTED
         if metadata.get(SELECTED_KEY) is True or (
-            metadata.get(SELECTED_KEY) is None
-            and metadata.get(SELECTED_BY_DEFAULT_KEY, False)
+            metadata.get(SELECTED_KEY) is None and metadata.get(SELECTED_BY_DEFAULT_KEY)
         ):
             return SelectionType.SELECTED
         return SelectionType.EXCLUDED

--- a/src/meltano/core/plugin/superset.py
+++ b/src/meltano/core/plugin/superset.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import subprocess
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import sys
 import typing as t
 from contextlib import suppress

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -343,7 +343,7 @@ class Project:
 
         with self._meltano_rw_lock.write_lock(), self._meltano_interprocess_lock:
             meltano_config = MeltanoFile.parse(self.project_files.load())
-            yield meltano_config
+            yield meltano_config  # ruff:ignore[fallible-context-manager]
             try:
                 self.project_files.update(meltano_config.canonical())  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
             except Exception as err:  # pragma: no cover
@@ -423,7 +423,7 @@ class Project:
         if self.readonly:
             raise ProjectReadonly
 
-        yield self.dotenv
+        yield self.dotenv  # ruff:ignore[fallible-context-manager]
         self.refresh()
 
     @deprecated(

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -635,5 +635,5 @@ class ProjectPluginsService:  # (too many methods, attributes)
         """
         previous = self._prefer_source
         self._prefer_source = source
-        yield
+        yield  # ruff:ignore[fallible-context-manager]
         self._prefer_source = previous

--- a/src/meltano/core/runner/__init__.py
+++ b/src/meltano/core/runner/__init__.py
@@ -1,4 +1,6 @@
-from __future__ import annotations  # noqa: D104
+# ruff: file-ignore[non-empty-init-module]  # ruff:ignore[undocumented-public-package]
+
+from __future__ import annotations
 
 
 class RunnerError(Exception):  # noqa: D101

--- a/src/meltano/core/runner/singer.py
+++ b/src/meltano/core/runner/singer.py
@@ -2,7 +2,7 @@ from __future__ import annotations  # noqa: D100
 
 import asyncio
 import asyncio.subprocess
-import subprocess
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import sys
 import typing as t
 

--- a/src/meltano/core/settings_service.py
+++ b/src/meltano/core/settings_service.py
@@ -345,7 +345,7 @@ class SettingsService(ABC):
             f"{FEATURE_FLAG_PREFIX}.{FeatureFlags.STRICT_ENV_VAR_MODE}",
             cast_value=True,
         )
-        if expand_env_vars and metadata.get("expandable", False):
+        if expand_env_vars and metadata.get("expandable"):
             metadata["expandable"] = False
             expanded_value = do_expand_env_vars(
                 value,
@@ -394,7 +394,7 @@ class SettingsService(ABC):
 
             # Only cast if the setting is not expandable,
             # since we can't cast e.g. $PORT to an integer
-            if not metadata.get("expandable", False):
+            if not metadata.get("expandable"):
                 cast_value = setting_def.cast_value(value)
                 if cast_value != value:
                     metadata["uncast_value"] = value

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -776,7 +776,7 @@ class MeltanoYmlStoreManager(SettingsStoreManager):
             StoreNotSupportedError: if the project is in read-only mode.
         """
         config = deepcopy(self.settings_service.meltano_yml_config)
-        yield config
+        yield config  # ruff:ignore[fallible-context-manager]
 
         try:
             self.settings_service.update_meltano_yml_config(config)
@@ -847,7 +847,7 @@ class MeltanoEnvStoreManager(MeltanoYmlStoreManager):
             StoreNotSupportedError: if the project is in read-only mode.
         """
         config = deepcopy(self.settings_service.environment_config)
-        yield config
+        yield config  # ruff:ignore[fallible-context-manager]
 
         try:
             self.settings_service.update_meltano_environment_config(config)

--- a/src/meltano/core/state_store/__init__.py
+++ b/src/meltano/core/state_store/__init__.py
@@ -1,5 +1,7 @@
 """State backends."""
 
+# ruff: file-ignore[non-empty-init-module]
+
 from __future__ import annotations
 
 import sys

--- a/src/meltano/core/upgrade_service.py
+++ b/src/meltano/core/upgrade_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import pathlib
-import subprocess
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import sys
 import typing as t
 

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -1,5 +1,7 @@
 """Defines helpers for the core codebase."""
 
+# ruff: file-ignore[non-empty-init-module]
+
 from __future__ import annotations
 
 import asyncio
@@ -440,7 +442,7 @@ def noop(*_args, **_kwargs) -> None:  # noqa: D103
     pass
 
 
-async def async_noop(*_args, **_kwargs) -> bool:  # noqa: D103
+async def async_noop(*_args, **_kwargs) -> bool:  # noqa: D103  # ruff:ignore[unused-async]
     return True
 
 

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -9,7 +9,7 @@ import json
 import platform
 import shlex
 import shutil
-import subprocess
+import subprocess  # ruff:ignore[suspicious-subprocess-import]
 import sys
 import typing as t
 from asyncio.subprocess import Process
@@ -238,7 +238,7 @@ class VirtualEnv:
         return any(checks())
 
 
-async def _extract_stderr(_) -> None:
+async def _extract_stderr(_) -> None:  # ruff:ignore[unused-async]
     return None  # pragma: no cover
 
 

--- a/src/meltano/core/version_check.py
+++ b/src/meltano/core/version_check.py
@@ -120,7 +120,7 @@ class VersionCheckService:
             response.raise_for_status()
             data = response.json()
             return data["info"]["version"]
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.debug("Failed to fetch latest version from PyPI", exc_info=True)
             return None
 
@@ -184,6 +184,6 @@ class VersionCheckService:
         """Check if a newer version of Meltano is available."""
         try:
             return self._check_version()
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.debug("Failed to check version", exc_info=True)
             return None

--- a/src/meltano/migrations/__init__.py
+++ b/src/meltano/migrations/__init__.py
@@ -1,4 +1,6 @@
-from __future__ import annotations  # noqa: D104
+# ruff: file-ignore[non-empty-init-module]  # ruff:ignore[undocumented-public-package]
+
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/tests/meltano/core/plugin/singer/test_catalog.py
+++ b/tests/meltano/core/plugin/singer/test_catalog.py
@@ -862,7 +862,7 @@ class TestLegacyCatalogSelectVisitor:
 
         metadatas = [
             (stream["tap_stream_id"], metadata)
-            for _, stream in streams.items()
+            for _, stream in streams.items()  # ruff:ignore[incorrect-dict-iterator]
             for metadata in stream["metadata"]
         ]
 
@@ -1402,14 +1402,14 @@ class TestCatalogSelectVisitor(TestLegacyCatalogSelectVisitor):
     def test_select_filter_preserves_existing_property_selections(self) -> None:
         """Test that select_filter operates at stream level and preserves property selections made by select."""  # noqa: E501
         # This conceptual test shows the intended behavior:
-        # 1. select: ["users.name", "users.email", "orders.*"] selects properties  # noqa: E501
+        # 1. select: ["users.name", "users.email", "orders.*"] selects properties
         # 2. select_filter: ["users"] then filters to only include the users stream
         # 3. Result should be users stream with only name,email properties (select chose)  # noqa: E501
 
         # This is demonstrated in the existing test_apply_catalog_rules_select_filter
         # where _select: ["one.one", "three.three", "five.*"] sets property selections
         # and _select_filter: ["three"] filters to only the three stream
-        # resulting in {"three": {"one", "three"}} - preserving original selection  # noqa: E501
+        # resulting in {"three": {"one", "three"}} - preserving original selection
 
         # The behavior is already tested in test_tap.py, this test documents the intent
         select_rules = select_metadata_rules(["users.name", "users.email"])

--- a/tests/meltano/core/test_yaml.py
+++ b/tests/meltano/core/test_yaml.py
@@ -123,7 +123,7 @@ settings:
 
     # Verify content
     assert "decimal_setting" in data1["settings"]
-    assert data1["settings"]["decimal_setting"] == 123.45
+    assert data1["settings"]["decimal_setting"] == 123.45  # ruff:ignore[float-equality-comparison]
 
 
 def test_decimal_representer_function() -> None:


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

- https://github.com/astral-sh/ruff/releases/tag/0.16.0
- https://astral.sh/blog/ruff-v0.16.0

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Upgrade Ruff tooling to v0.16 and align lint configuration, code annotations, and docs with the new rules and behavior.

Enhancements:
- Refresh Ruff lint configuration to use new rule names, expand per-file ignores, and add file-level and inline Ruff directives across the codebase.
- Adjust minor code and documentation formatting to satisfy updated Ruff style and lint requirements.

Build:
- Update Ruff version constraint in pyproject and pre-commit hook to require Ruff 0.16 and enable preview features.

Documentation:
- Update contributor and tutorial documentation examples to match current Ruff-driven style conventions.

Tests:
- Adapt test code comments and assertions to comply with updated Ruff linting while preserving test behavior.