### PR TITLE
test: Add configurable uv CLI with optional --preview for venv ops

### DIFF
--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -22,6 +22,7 @@ import structlog
 from meltano.core.error import AsyncSubprocessError
 
 if t.TYPE_CHECKING:
+    import os
     from collections.abc import Iterable, Sequence
     from pathlib import Path
 
@@ -242,7 +243,11 @@ async def _extract_stderr(_) -> None:  # ruff:ignore[unused-async]
     return None  # pragma: no cover
 
 
-async def exec_async(*args, extract_stderr=_extract_stderr, **kwargs) -> Process:  # noqa: ANN001, ANN002, ANN003
+async def exec_async(
+    *args: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+    extract_stderr: StdErrExtractor = _extract_stderr,
+    **kwargs: t.Any,
+) -> Process:
     """Run an executable asynchronously in a subprocess.
 
     Args:
@@ -410,8 +415,8 @@ class PipPackageManager(PackageManager):
 class UvPackageManager(PackageManager):
     """Package manager using ``uv pip``."""
 
-    uv: str
-    """Path to the `uv` executable."""
+    cli: tuple[str, ...]
+    """Base uv CLI arguments, e.g. ``uv --quiet``."""
 
     @override
     async def install(
@@ -424,7 +429,7 @@ class UvPackageManager(PackageManager):
         env: dict[str, str | None] | None = None,
     ) -> Process:
         return await exec_async(
-            self.uv,
+            *self.cli,
             "pip",
             "install",
             f"--python={python}",
@@ -436,7 +441,7 @@ class UvPackageManager(PackageManager):
     @override
     async def uninstall(self, package: str, *, python: str) -> Process:
         return await exec_async(
-            self.uv,
+            *self.cli,
             "pip",
             "uninstall",
             f"--python={python}",
@@ -446,7 +451,7 @@ class UvPackageManager(PackageManager):
     @override
     async def list_installed(self, *args: str, python: str) -> list[dict[str, t.Any]]:
         proc = await exec_async(
-            self.uv,
+            *self.cli,
             "pip",
             "list",
             "--quiet",
@@ -559,7 +564,7 @@ class VirtualEnvService:
             self.name,
         )
 
-        async def extract_stderr(proc: Process):  # noqa: ANN202
+        async def extract_stderr(proc: Process) -> str:
             return (await t.cast("asyncio.StreamReader", proc.stdout).read()).decode(
                 "utf-8",
                 errors="replace",
@@ -872,21 +877,23 @@ class VirtualenvBackend(VenvBackend):
 class UvBackend(VenvBackend):
     """Manages virtual environments using `uv`."""
 
-    def __init__(self, *args: t.Any, **kwargs: t.Any):
+    def __init__(self, *args: t.Any, preview: bool = False, **kwargs: t.Any):
         """Initialize the `UvBackend`.
 
         Args:
             args: Positional arguments for the VenvBackend.
+            preview: Run uv with the ``--preview`` flag.
             kwargs: Keyword arguments for the VenvBackend.
         """
         super().__init__(*args, **kwargs)
         self.uv = find_uv()
+        self._cli = (self.uv, "--preview") if preview else (self.uv,)
         logger.debug("Using uv executable at %s", self.uv)
 
     @cached_property
     def package_manager(self) -> UvPackageManager:
         """The uv-based package manager for this virtual environment."""
-        return UvPackageManager(uv=self.uv)
+        return UvPackageManager(cli=self._cli)
 
     @override
     async def create_venv(
@@ -904,7 +911,7 @@ class UvBackend(VenvBackend):
             The Python process creating the virtual environment.
         """
         return await exec_async(
-            self.uv,
+            *self._cli,
             "venv",
             "--clear",
             f"--python={self.venv.python_path}",

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -99,13 +99,15 @@ class TestVirtualEnvService:
         venv: VirtualEnv,
         log_path: Path,
     ) -> VirtualEnvService:
-        backend_name = request.param
-        backend_class = UvBackend if backend_name == "uv" else VirtualenvBackend
+        if request.param == "uv":
+            backend = UvBackend(venv=venv, log_path=log_path, preview=True)
+        else:
+            backend = VirtualenvBackend(venv=venv, log_path=log_path)
         return VirtualEnvService(
             project=project,
             namespace="namespace",
             name="name",
-            backend=backend_class(venv=venv, log_path=log_path),
+            backend=backend,
         )
 
     def test_clean_run_files(


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Make uv-based virtual environment operations configurable and add optional preview mode support.

New Features:
- Allow configuring the uv CLI arguments used for virtual environment and package management operations, including an optional --preview flag.

Enhancements:
- Refine the asynchronous subprocess execution helper with more precise typing and stderr extraction.
- Update tests to exercise the uv backend using the preview-enabled CLI configuration.