### PR TITLE
fix: Update changelog page and fix pagination on Getting started page.

### DIFF
--- a/docs/cloud-changelog/2026-07-31-cloud-changelog.mdx
+++ b/docs/cloud-changelog/2026-07-31-cloud-changelog.mdx
@@ -1,0 +1,21 @@
+---
+slug: 2026-07-31-cloud-changelog
+title: Workspace Secrets Hidden From Non-Admins & Pipeline Reliability Fixes
+date: 2026-07-31
+---
+
+Pipeline-level secrets are now hidden from non-admin workspace members. This release also fixes pipelines getting stuck in running status, along with reliability fixes for tap-mysql, target-postgres, tap-auth0, target-snowflake and target-clickhouse.
+
+{/* truncate */}
+
+## Features
+
+- **Workspace secrets are now properly hidden from members:** Pipeline-level secrets (like tap credentials) are encrypted and redacted for non-admin workspace members, so only admins can see the real values.
+
+## Fixes
+
+- **Bumped target-snowflake to v0.17.8-5:** Resolved flakiness that could affect pipeline runs, so your Snowflake syncs are more reliable.
+- **Bumped tap-auth0 to v0.6.1:** Corrected the schema types for latitude/longitude fields so they come through properly instead of being miscast.
+- **Bumped tap-mysql to v1.5.3 and target-postgres to v0.2.2:** Date-typed columns are now handled more reliably.
+- **Bumped target-clickhouse to v0.4.0:** Enables processing of Arrow-formatted data.
+- **Fixed pipelines getting stuck in running status:** Runs no longer hang indefinitely and now complete as expected.

--- a/docs/docs/getting-started/which-meltano.mdx
+++ b/docs/docs/getting-started/which-meltano.mdx
@@ -2,7 +2,7 @@
 title: Which Meltano Is Right for You?
 description: Compare Meltano Open and Meltano Cloud — choose the right product for your team's needs.
 sidebar_position: 0
-pagination_next: meltano-cloud/cloud-overview
+pagination_next: meltano-cloud/index
 ---
 
 import Link from '@docusaurus/Link';


### PR DESCRIPTION
## Description

- Fixed "Which Meltano is right for you?" page redirect
`docs/docs/getting-started/which-meltano.mdx` - updated the `pagination_next` frontmatter so the page's "Next" link now goes to Meltano Cloud's index page (`meltano-cloud/index`) instead of the generic Cloud "Overview" page (`meltano-cloud/cloud-overview`).

- Adds the 2026-07-31 Meltano Cloud changelog entry for latest release.


## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update documentation for Meltano Cloud by correcting getting started pagination and adding the latest changelog entry.

Bug Fixes:
- Fix the "Which Meltano Is Right for You?" getting started page so its next-page link correctly routes to the Meltano Cloud index.

Documentation:
- Add the 2026-07-31 Meltano Cloud changelog page describing workspace secret visibility changes and pipeline reliability fixes.