### PR TITLE
refactor: Raise more consistent errors when a schedule, environment or plugin variant is not found

### DIFF
--- a/docs/docs/contribute/errors.md
+++ b/docs/docs/contribute/errors.md
@@ -17,17 +17,14 @@ The `meltano.core.error.MeltanoError` initializer takes in a `reason` argument, 
 from meltano.core.error import MeltanoError
 
 
-class ScheduleDoesNotExistError(MeltanoError):
-    """Occurs when a schedule does not exist."""
+class StoreNotSupportedError(MeltanoError):
+    """Error raised when write actions are performed on a Store that is not writable."""
 
-    def __init__(self, name: str):
-        """Initialize the exception.
-
-        Args:
-            name: The name of the schedule that does not exist.
-        """
-        super().__init__(
-            reason=f"Schedule '{name}' does not exist",
-            instruction="Use `meltano schedule add` to add a schedule",
-        )
+    def __init__(
+        self,
+        reason: str | Exception = "Store is not supported",
+        **kwds: t.Any,
+    ) -> None:
+        """Instantiate the error."""
+        super().__init__(reason, **kwds)
 ```

--- a/src/meltano/core/behavior/name_eq.py
+++ b/src/meltano/core/behavior/name_eq.py
@@ -1,9 +1,33 @@
-from __future__ import annotations  # noqa: D100
+"""Mixin for objects that have a name attribute and can be compared by name."""
+
+from __future__ import annotations
+
+import sys
+import typing as t
+
+if sys.version_info >= (3, 11):
+    from typing import Self  # noqa: ICN003
+else:
+    from typing_extensions import Self
+
+if t.TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
-class NameEq:  # noqa: D101
-    def __eq__(self, other):  # noqa: ANN001, ANN204, D105
-        return self is other or self.name == other.name
+class NameEq:
+    """Mixin for objects that have a name attribute and can be compared by name."""
 
-    def __hash__(self):  # noqa: ANN204, D105
+    name: str
+
+    def __eq__(self, value: object, /) -> bool:
+        """Compare two NameEq objects for equality."""
+        return isinstance(value, NameEq) and (self is value or self.name == value.name)
+
+    def __hash__(self) -> int:
+        """Return the hash of the named object."""
         return hash(self.name)
+
+    @classmethod
+    def find_by_name(cls, xs: Iterable[Self], name: str) -> Self | None:
+        """Find a NameEq object by its name."""
+        return next((x for x in xs if x.name == name), None)

--- a/src/meltano/core/environment.py
+++ b/src/meltano/core/environment.py
@@ -213,8 +213,8 @@ class Environment(NameEq, Canonical):
                 for env in objects
                 if getattr(env, "name", env["name"]) == name
             )
-        except StopIteration as stop:
-            raise NotFound(name, cls) from stop
+        except StopIteration:
+            raise NotFound(name, obj_type=cls) from None
 
     def get_plugin_config(
         self,

--- a/src/meltano/core/environment_service.py
+++ b/src/meltano/core/environment_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing as t
 
 from meltano.core.environment import Environment
-from meltano.core.utils import find_named
+from meltano.core.utils import NotFound
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -85,15 +85,16 @@ class EnvironmentService:
 
         Returns:
             The name of the removed Environment.
+
+        Raises:
+            NotFound: If no environment with the given name exists.
         """
         with self.project.meltano_update() as meltano:
-            environment = find_named(
-                self.list_environments(),
-                name,
-                obj_type=Environment,
-            )
+            env = Environment.find_by_name(meltano.environments, name)
+            if not env:
+                raise NotFound(name, obj_type=Environment) from None
 
             # find the schedules plugin config
-            meltano.environments.remove(environment)
+            meltano.environments.remove(env)
 
         return name

--- a/src/meltano/core/plugin/base.py
+++ b/src/meltano/core/plugin/base.py
@@ -17,7 +17,6 @@ from meltano.core.constants import STATE_ID_COMPONENT_DELIMITER
 from meltano.core.plugin.command import Command
 from meltano.core.plugin.requirements import PluginRequirement
 from meltano.core.setting_definition import SettingDefinition, SettingKind, YAMLEnum
-from meltano.core.utils import NotFound, find_named
 
 if t.TYPE_CHECKING:
     from pathlib import Path
@@ -417,10 +416,9 @@ class PluginDefinition(PluginRef):
         Raises:
             VariantNotFoundError: If the variant is not found.
         """
-        try:
-            return find_named(self.variants, variant_name)
-        except NotFound as err:
-            raise VariantNotFoundError(self, variant_name) from err
+        if variant := Variant.find_by_name(self.variants, variant_name):
+            return variant
+        raise VariantNotFoundError(self, variant_name)
 
     def find_variant(self, variant_or_name: str | Variant | None = None) -> Variant:
         """Find the variant with the given name or variant.

--- a/src/meltano/core/schedule_service.py
+++ b/src/meltano/core/schedule_service.py
@@ -18,7 +18,7 @@ from meltano.core.schedule import (
     is_valid_cron,
 )
 from meltano.core.task_sets_service import TaskSetsService
-from meltano.core.utils import NotFound, find_named
+from meltano.core.utils import NotFound
 
 if t.TYPE_CHECKING:
     import subprocess
@@ -39,40 +39,6 @@ class ScheduleAlreadyExistsError(MeltanoError):
         """
         self.schedule = schedule
         super().__init__(reason=f"Schedule '{self.schedule.name}' already exists")
-
-
-class ScheduleDoesNotExistError(MeltanoError):
-    """A schedule does not exist."""
-
-    def __init__(self, name: str):
-        """Initialize the exception.
-
-        Args:
-            name: The name of the schedule that does not exist.
-
-        """
-        self.name = name
-
-        super().__init__(
-            reason=f"Schedule '{name}' does not exist",
-            instruction="Use `meltano schedule add` to add a schedule",
-        )
-
-
-class ScheduleNotFoundError(MeltanoError):
-    """A schedule for a namespace cannot be found."""
-
-    def __init__(self, namespace: str):
-        """Initialize the exception.
-
-        Args:
-            namespace: The namespace that had no associated schedules.
-        """
-        self.namespace = namespace
-
-        reason = f"No schedule found for namespace {self.namespace}"
-        instruction = "Use `meltano schedule add` to add a schedule"
-        super().__init__(reason, instruction)
 
 
 class BadCronError(MeltanoError):
@@ -199,14 +165,12 @@ class ScheduleService:
             The name of the schedule.
 
         Raises:
-            ScheduleDoesNotExistError: If the schedule does not exist.
+            NotFound: If the schedule does not exist.
         """
         with self.project.meltano_update() as meltano:
-            try:
-                # guard if it doesn't exist
-                schedule = find_named(self.schedules(), name)
-            except NotFound as ex:
-                raise ScheduleDoesNotExistError(name) from ex
+            schedule = Schedule.find_by_name(meltano.schedules, name)
+            if not schedule:
+                raise NotFound(name, obj_type=Schedule) from None
 
             # find the schedules plugin config
             meltano.schedules.remove(schedule)
@@ -220,13 +184,13 @@ class ScheduleService:
             schedule: The schedule to update.
 
         Raises:
-            ScheduleDoesNotExistError: If the schedule doesn't exist.
+            NotFound: If the schedule doesn't exist.
         """
         with self.project.meltano_update() as meltano:
             try:
                 idx = meltano.schedules.index(schedule)
             except ValueError:
-                raise ScheduleDoesNotExistError(schedule.name) from None
+                raise NotFound(schedule.name, obj_type=Schedule) from None
             else:
                 meltano.schedules[idx] = schedule
 
@@ -244,7 +208,7 @@ class ScheduleService:
             The schedule
 
         Raises:
-            ScheduleNotFoundError: If no schedule is found.
+            NotFound: If no schedule is found.
         """
         try:
             extractor = self.project.plugins.find_plugin_by_namespace(
@@ -259,7 +223,7 @@ class ScheduleService:
                 and schedule.extractor == extractor.name
             )
         except (PluginNotFoundError, StopIteration) as err:
-            raise ScheduleNotFoundError(namespace) from err
+            raise NotFound(namespace, obj_type=Schedule) from err
 
     def schedules(self) -> list[Schedule]:
         """Return all schedules in the project.
@@ -279,9 +243,12 @@ class ScheduleService:
             Schedule: the schedule with the given name
 
         Raises:
-            ScheduleNotFoundError: if the schedule does not exist
+            NotFound: if the schedule does not exist
         """
-        return find_named(self.schedules(), name)
+        if schedule := Schedule.find_by_name(self.schedules(), name):
+            return schedule
+
+        raise NotFound(name, obj_type=Schedule)
 
     def run(
         self,

--- a/src/meltano/core/settings_store.py
+++ b/src/meltano/core/settings_store.py
@@ -106,7 +106,7 @@ class StoreNotSupportedError(MeltanoError):
         **kwds: t.Any,
     ) -> None:
         """Instantiate the error."""
-        return super().__init__(reason, **kwds)
+        super().__init__(reason, **kwds)
 
 
 def cast_setting_value(

--- a/src/meltano/core/utils/__init__.py
+++ b/src/meltano/core/utils/__init__.py
@@ -92,20 +92,22 @@ REGEX_ISO8601 = (
 )
 
 
-class NotFound(Exception):
+class NotFound(MeltanoError):
     """An element is not found."""
 
-    def __init__(self, name, obj_type=None) -> None:  # noqa: ANN001
+    def __init__(self, name: str, *, obj_type: type | None = None) -> None:
         """Create a new exception.
 
         Args:
             name: the name of the element that is not found
             obj_type: the type of element
         """
-        if obj_type is None:
-            super().__init__(f"{name} was not found.")
-        else:
-            super().__init__(f"{obj_type.__name__} '{name}' was not found.")
+        msg = (
+            f"{name} was not found"
+            if obj_type is None
+            else f"{obj_type.__name__} '{name}' was not found"
+        )
+        super().__init__(msg)
 
 
 class IncompatibleMeltanoVersionError(Exception):
@@ -448,33 +450,6 @@ async def async_noop(*_args, **_kwargs) -> bool:  # noqa: D103  # ruff:ignore[un
 
 def truthy(val: str) -> bool:  # noqa: D103
     return str(val).lower() in TRUTHY
-
-
-class _GetItemProtocol(t.Protocol):
-    def __getitem__(self, key: str) -> str: ...
-
-
-_G = t.TypeVar("_G", bound=_GetItemProtocol)
-
-
-def find_named(xs: Iterable[_G], name: str, obj_type: type | None = None) -> _G:
-    """Find an object by its 'name' key.
-
-    Args:
-        xs: Some iterable of objects against which that name should be matched.
-        name: Used to match against the input objects.
-        obj_type: Object type used for generating the exception message.
-
-    Returns:
-        The first item matched, if any. Otherwise raises an exception.
-
-    Raises:
-        NotFound: If an object with the given name was not found.
-    """
-    try:
-        return next(x for x in xs if x["name"] == name)
-    except StopIteration as stop:
-        raise NotFound(name, obj_type) from stop
 
 
 P = t.ParamSpec("P")

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -188,7 +188,7 @@ class TestCli:
             assert results[source].exit_code
             assert (
                 results[source].exception.args[0]
-                == f"Environment {name!r} was not found."
+                == f"Environment {name!r} was not found"
             )
 
     def test_version(self, cli_runner) -> None:

--- a/tests/meltano/core/plugin/test_plugin.py
+++ b/tests/meltano/core/plugin/test_plugin.py
@@ -4,11 +4,16 @@ import typing as t
 
 import pytest
 
-from meltano.core.plugin import BasePlugin, PluginDefinition, PluginType, Variant
+from meltano.core.plugin import (
+    BasePlugin,
+    PluginDefinition,
+    PluginType,
+    Variant,
+    VariantNotFoundError,
+)
 from meltano.core.plugin.project_plugin import CyclicInheritanceError, ProjectPlugin
 from meltano.core.plugin.requirements import PluginRequirement
 from meltano.core.setting_definition import SettingDefinition, SettingKind
-from meltano.core.utils import find_named
 
 if t.TYPE_CHECKING:
     from meltano.core.project import Project
@@ -172,6 +177,9 @@ class TestPluginDefinition:
 
         assert plugin_def.find_variant(plugin_def.variants[1]).name == "singer-io"
 
+        with pytest.raises(VariantNotFoundError):
+            plugin_def.find_variant("foo")
+
     def test_variant_labels(self) -> None:
         plugin_def = PluginDefinition(PluginType.EXTRACTORS, **self.ATTRS["variants"])
 
@@ -240,21 +248,21 @@ class TestBasePlugin:
         settings = subject.extra_settings
 
         # Known, overwritten in plugin/variant definition
-        foo_setting = find_named(settings, "_foo")
+        foo_setting = SettingDefinition.find_by_name(settings, "_foo")
         assert foo_setting
         assert foo_setting.sensitive
         assert foo_setting.value == "bar"
         assert not foo_setting.is_custom
 
         # Known, not overwritten
-        bar_setting = find_named(settings, "_bar")
+        bar_setting = SettingDefinition.find_by_name(settings, "_bar")
         assert bar_setting
         assert bar_setting.kind == SettingKind.INTEGER
         assert bar_setting.value == 0
         assert not bar_setting.is_custom
 
         # Unknown, set in plugin/variant definition
-        baz_setting = find_named(settings, "_baz")
+        baz_setting = SettingDefinition.find_by_name(settings, "_baz")
         assert baz_setting
         assert baz_setting.kind is None
         assert baz_setting.value == "qux"

--- a/tests/meltano/core/test_schedule_service.py
+++ b/tests/meltano/core/test_schedule_service.py
@@ -9,12 +9,7 @@ from meltano.core.plugin import PluginType
 from meltano.core.plugin.project_plugin import ProjectPlugin
 from meltano.core.project_plugins_service import PluginAlreadyAddedException
 from meltano.core.schedule import ELTSchedule, JobSchedule, is_valid_cron
-from meltano.core.schedule_service import (
-    BadCronError,
-    ScheduleAlreadyExistsError,
-    ScheduleDoesNotExistError,
-    ScheduleNotFoundError,
-)
+from meltano.core.schedule_service import BadCronError, ScheduleAlreadyExistsError
 from meltano.core.utils import NotFound
 
 if t.TYPE_CHECKING:
@@ -165,7 +160,7 @@ class TestScheduleService:
         assert excinfo.value.reason == "Invalid Cron expression or alias: 'bad_cron'"
         assert excinfo.value.instruction == "Please use a valid cron expression"
 
-    def test_remove_schedule(self, subject) -> None:
+    def test_remove_schedule(self, subject: ScheduleService) -> None:
         schedules = list(subject.schedules())
         schedules_count = len(schedules)
 
@@ -181,10 +176,10 @@ class TestScheduleService:
         assert target_schedule not in schedules
 
         # schedule name must exist to be removed
-        with pytest.raises(ScheduleDoesNotExistError):
+        with pytest.raises(NotFound):
             subject.remove_schedule(target_name)
 
-    def test_schedule_update(self, subject) -> None:
+    def test_schedule_update(self, subject: ScheduleService) -> None:
         schedule = subject.schedules()[0]
 
         yearly_intervals = sum(sbj.interval == "@yearly" for sbj in subject.schedules())
@@ -206,7 +201,7 @@ class TestScheduleService:
 
         # it must exists
         schedule.name = "llamasareverynice"
-        with pytest.raises(ScheduleDoesNotExistError):
+        with pytest.raises(NotFound):
             subject.update_schedule(schedule)
 
     def test_run_elt_schedule(self, subject, tap, target) -> None:
@@ -307,10 +302,10 @@ class TestScheduleService:
         assert isinstance(found_schedule, ELTSchedule)
         assert found_schedule.extractor == custom_tap.name
 
-    def test_find_namespace_schedule_not_found(self, subject) -> None:
-        with pytest.raises(ScheduleNotFoundError):
+    def test_find_namespace_schedule_not_found(self, subject: ScheduleService) -> None:
+        with pytest.raises(NotFound):
             subject.find_namespace_schedule("no-such-namespace")
 
-    def test_find_schedule_not_found(self, subject) -> None:
+    def test_find_schedule_not_found(self, subject: ScheduleService) -> None:
         with pytest.raises(NotFound):
             subject.find_schedule("no-such-schedule")


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Unify not-found error handling across schedules, environments, and plugin variants by using a shared NotFound/MeltanoError pattern and name-based lookup helpers.

New Features:
- Add NameEq.find_by_name helper for name-based lookup on mixin-based objects.

Bug Fixes:
- Raise consistent NotFound errors when schedules, environments, and plugin variants are missing instead of custom schedule-specific exceptions.

Enhancements:
- Make NotFound a MeltanoError with standardized messages for missing objects.
- Refine equality and hashing semantics for NameEq objects and add typing improvements.
- Improve Environment.find and environment removal behavior to use the shared NotFound error semantics.
- Update plugin variant and extra settings lookup to use typed find_by_name helpers instead of the generic find_named utility.

Documentation:
- Update error documentation to show a StoreNotSupportedError example instead of the removed ScheduleDoesNotExistError.

Tests:
- Adjust schedule, environment, and plugin tests to assert the new NotFound and VariantNotFoundError behaviors and to use type-annotated ScheduleService in tests.