### PR TITLE
fix: fixes and improvements to Meltano cloud index page and Connector docs page

### DIFF
--- a/docs/docs/connectors/tap-rakutenadvertising.mdx
+++ b/docs/docs/connectors/tap-rakutenadvertising.mdx
@@ -9,8 +9,6 @@ import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
 
 <ConnectorTypeBadge type="extractor" block />
 
-`tap-rakutenadvertising` (meltanolabs variant)
-
 Rakuten Advertising is an affiliate marketing platform that connects advertisers with publishers to drive sales through performance-based partnerships.
 
 This tap extracts data from multiple Rakuten Advertising APIs, organized into three groups:

--- a/docs/docs/connectors/tap-spreadsheets-imap.mdx
+++ b/docs/docs/connectors/tap-spreadsheets-imap.mdx
@@ -9,8 +9,6 @@ import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
 
 <ConnectorTypeBadge type="extractor" block />
 
-`tap-spreadsheets-imap` (matatika variant)
-
 Spreadsheets IMAP syncs spreadsheet data from attachments in an IMAP mailbox. The tap connects to an IMAP mailbox, discovers email attachments based on the configured table definitions, and extracts data from supported spreadsheet and structured file formats.
 
 ## At a glance

--- a/docs/docs/connectors/tap-weatherapi.mdx
+++ b/docs/docs/connectors/tap-weatherapi.mdx
@@ -9,8 +9,6 @@ import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
 
 <ConnectorTypeBadge type="extractor" block />
 
-`tap-weatherapi` (meltanolabs variant)
-
 WeatherAPI is a weather data provider offering current conditions, forecasts, and historical weather data for locations worldwide. It supports queries by city name, US ZIP code, UK postcode, latitude/longitude pairs, IP address, and more.
 
 The `tap-weatherapi` extractor connects to the WeatherAPI REST API to sync weather data for one or more configured locations into your data warehouse.

--- a/docs/docs/getting-started/which-meltano.mdx
+++ b/docs/docs/getting-started/which-meltano.mdx
@@ -2,7 +2,7 @@
 title: Which Meltano Is Right for You?
 description: Compare Meltano Open and Meltano Cloud — choose the right product for your team's needs.
 sidebar_position: 0
-pagination_next: meltano-cloud/cloud-overview
+pagination_next: meltano-cloud/index
 ---
 
 import Link from '@docusaurus/Link';


### PR DESCRIPTION
## Description

-  Redirect to Meltano Cloud's Index page from "Which Meltano is right for you" page inside Platform section on Meltano Documentation
-  Remove unnecessary extra headers from Cloud Docs page- Rakuten, IMAP and Weather API.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update Meltano documentation to improve Cloud product navigation and clean up connector pages.

Documentation:
- Redirect the "Which Meltano Is Right for You" getting-started page to the Meltano Cloud index page in pagination navigation.
- Remove redundant variant name headers from the Rakuten Advertising, Spreadsheets IMAP, and WeatherAPI connector documentation pages.