### PR TITLE
chore: connectors page fixed along with general fixes and improvement

### DIFF
--- a/docs/docs/connectors/index.mdx
+++ b/docs/docs/connectors/index.mdx
@@ -8,7 +8,9 @@ import ConnectorSearch from '@site/src/components/ConnectorSearch';
 
 # All connectors
 
-Explore Meltano Cloud's growing library of managed connectors for building your data pipelines.
+<div className="tier-banner tier-banner--yellow">
+  In-depth documentation for our most-used connectors, more added regularly. Don't see the one you need? It may already be supported. <a href="https://meltano.com/connectors?tab=cloud">Check the full list</a>.
+</div>
 
 Meltano Cloud connectors move data in one of two directions: extractors pull data out of a source, and loaders push it into a destination. Search or filter below to find the one you need, then click through for setup instructions, configuration options, streams, and more.
 

--- a/docs/docs/connectors/tap-rakutenadvertising.mdx
+++ b/docs/docs/connectors/tap-rakutenadvertising.mdx
@@ -9,8 +9,6 @@ import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
 
 <ConnectorTypeBadge type="extractor" block />
 
-`tap-rakutenadvertising` (meltanolabs variant)
-
 Rakuten Advertising is an affiliate marketing platform that connects advertisers with publishers to drive sales through performance-based partnerships.
 
 This tap extracts data from multiple Rakuten Advertising APIs, organized into three groups:

--- a/docs/docs/connectors/tap-spreadsheets-imap.mdx
+++ b/docs/docs/connectors/tap-spreadsheets-imap.mdx
@@ -9,8 +9,6 @@ import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
 
 <ConnectorTypeBadge type="extractor" block />
 
-`tap-spreadsheets-imap` (matatika variant)
-
 Spreadsheets IMAP syncs spreadsheet data from attachments in an IMAP mailbox. The tap connects to an IMAP mailbox, discovers email attachments based on the configured table definitions, and extracts data from supported spreadsheet and structured file formats.
 
 ## At a glance

--- a/docs/docs/connectors/tap-weatherapi.mdx
+++ b/docs/docs/connectors/tap-weatherapi.mdx
@@ -9,8 +9,6 @@ import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
 
 <ConnectorTypeBadge type="extractor" block />
 
-`tap-weatherapi` (meltanolabs variant)
-
 WeatherAPI is a weather data provider offering current conditions, forecasts, and historical weather data for locations worldwide. It supports queries by city name, US ZIP code, UK postcode, latitude/longitude pairs, IP address, and more.
 
 The `tap-weatherapi` extractor connects to the WeatherAPI REST API to sync weather data for one or more configured locations into your data warehouse.

--- a/docs/docs/getting-started/which-meltano.mdx
+++ b/docs/docs/getting-started/which-meltano.mdx
@@ -2,7 +2,7 @@
 title: Which Meltano Is Right for You?
 description: Compare Meltano Open and Meltano Cloud — choose the right product for your team's needs.
 sidebar_position: 0
-pagination_next: meltano-cloud/cloud-overview
+pagination_next: meltano-cloud/index
 ---
 
 import Link from '@docusaurus/Link';

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1784,6 +1784,15 @@ article {
   background: rgba(153, 206, 85, 0.14);
 }
 
+.tier-banner--yellow {
+  border-left-color: var(--meltano-yellow);
+  background: rgba(251, 204, 84, 0.08);
+}
+
+[data-theme='dark'] .tier-banner--yellow {
+  background: rgba(251, 204, 84, 0.14);
+}
+
 /* Getting Started — card grid */
 .gs-card-grid {
   display: grid;


### PR DESCRIPTION
## Description

- Fixed "Which Meltano is right for you" page's Next button to link to the Meltano Cloud landing page instead of the Overview sub-page
- Removed the tap-x (variant) line from the Rakuten Advertising, Spreadsheets (IMAP), and Weather API connector docs
- Replaced the intro sentence on the connectors page with a new yellow info ribbon pointing users to the full connector list at meltano.com

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update connectors documentation and navigation to improve clarity and direct users to the full connector list and Meltano Cloud landing page.

Enhancements:
- Introduce a reusable yellow tier banner style for highlighted informational content in the docs.

Documentation:
- Add a yellow info banner to the connectors index page pointing users to the full Meltano Cloud connector list.
- Remove variant-specific tap descriptions from the Rakuten Advertising, Spreadsheets IMAP, and Weather API connector docs.
- Change the "Which Meltano Is Right for You" page next link to go to the Meltano Cloud landing page instead of the overview sub-page.