### PR TITLE
chore: Stop redirecting away from the DataML and Cloud API reference pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ setup.py
 # Ruff
 .ruff_cache/
 test-project/
+
+# Netlify
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -386,12 +386,6 @@
   force = true
 
 [[redirects]]
-  from = "*/docs/how-to-guides/manage-workspaces/"
-  to = "/meltano-cloud/managing-a-workspace"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "*/docs/how-to-guides/import-data/"
   to = "/meltano-cloud/importing-data"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,10 +24,9 @@
   force = true
 
 [[redirects]]
-  from = "*/docs/api/resources/members"
-  to = "/reference/cloud/api/resources/members"
+  from = "/docs/api/*"
+  to = "/reference/cloud/api/:splat"
   status = 301
-  force = true
 
 [[redirects]]
   from = "*/docs/cli/fetch"
@@ -39,36 +38,6 @@
 [[redirects]]
   from = "*/docs/how-to-guides/import-data/adding-a-custom-data-source"
   to = "/meltano-cloud/importing-data#adding-a-custom-data-source"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "*/docs/api/postman-collection"
-  to = "/reference/cloud/api/postman-collection"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "*/docs/api/errors"
-  to = "/reference/cloud/api/errors"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "*/docs/api/resources/deployments"
-  to = "/reference/cloud/api/resources/deployments"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "*/docs/api/"
-  to = "/reference/cloud/api"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "*/docs/api/resources/resources"
-  to = "/reference/cloud/api/resources/resources"
   status = 301
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,26 +18,8 @@
   force = true
 
 [[redirects]]
-  from = "*/docs/dataml/workspaceml/invitations/"
-  to = "/reference/cloud/dataml/workspaceml/invitations"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "*/docs/how-to-guides/import-data/create-a-data-import-pipeline"
   to = "/meltano-cloud/importing-data#create-a-data-import-pipeline"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "*/docs/dataml/"
-  to = "/reference/cloud/dataml"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "*/docs/dataml/pipelineml/custom-scripts"
-  to = "/reference/cloud/dataml/pipelineml/custom-scripts"
   status = 301
   force = true
 
@@ -53,12 +35,6 @@
   status = 301
   force = true
   # no relevant content found on meltano
-
-[[redirects]]
-  from = "*/docs/dataml/meltanoyml/"
-  to = "/concepts/project#meltano-yml-project-file"
-  status = 301
-  force = true
 
 [[redirects]]
   from = "*/docs/how-to-guides/import-data/adding-a-custom-data-source"
@@ -580,7 +556,6 @@
   status = 301
   force = true
 
-
 [[redirects]]
   from = "*/overview"
   to = "/meltano-cloud/cloud-overview"
@@ -607,12 +582,6 @@
   force = true
 
 [[redirects]]
-  from = "*/dataml/pipelineml/environment"
-  to = "/getting-started/which-meltano"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "*/library"
   to = "/getting-started/which-meltano"
   status = 301
@@ -625,10 +594,14 @@
   force = true
 
 [[redirects]]
-  from = "*/dataml/*"
-  to = "/getting-started/which-meltano"
+  from = "/docs/dataml/*"
+  to = "/reference/cloud/dataml/:splat"
   status = 301
-  force = true
+
+[[redirects]]
+  from = "/reference/cloud/dataml/meltanoyml"
+  to = "/concepts/project#meltano-yml-project-file"
+  status = 301
 
 [[redirects]]
   from = "*/how-to-guides/analyze-data/fetch-data-into-a-jupyter-notebook"

--- a/netlify.toml
+++ b/netlify.toml
@@ -380,10 +380,9 @@
   force = true
 
 [[redirects]]
-  from = "*/docs/how-to-guides/manage-workspaces/"
-  to = "/meltano-cloud/managing-a-workspace"
+  from = "/docs/how-to-guides/manage-workspaces/*"
+  to = "/meltano-cloud/managing-a-workspace#:splat"
   status = 301
-  force = true
 
 [[redirects]]
   from = "*/docs/how-to-guides/import-data/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -129,13 +129,6 @@
   # no relevant content found on meltano
 
 [[redirects]]
-  from = "*/visualisation/"
-  to = "https://meltano.com"
-  status = 301
-  force = true
-  # no relevant content found on meltano
-
-[[redirects]]
   from = "*/technology-cloud/"
   to = "https://meltano.com"
   status = 301
@@ -261,13 +254,6 @@
   to = "https://meltano.com/about"
   status = 301
   force = true
-
-[[redirects]]
-  from = "*/news/"
-  to = "https://meltano.com"
-  status = 301
-  force = true
-  # no relevant content found on meltano
 
 [[redirects]]
   from = "*/wp-content/uploads/2023/10/The-Ultimate-Guide-to-Modern-DataOps.pdf"


### PR DESCRIPTION
## Description

16 reference pages redirected away instead of opening: the whole `/reference/cloud/dataml/` tree went to Which Meltano, and `/reference/cloud/api/resources/news` went to the marketing site. Broken since `c139d24b2` on 7 August 2026.

Netlify matches `from` against the request path alone, so a pattern that opens with a splat also matches the parent segments of a real page. `*/dataml/*` bound its splat to `/reference/cloud` and claimed `/reference/cloud/dataml/pipelineml`, and `force = true` made it beat the page that lives there. `*/visualisation/` and `*/news/` did the same to one page each.

### Changes

* `/docs/dataml/*` -> `/reference/cloud/dataml/:splat` replaces `*/dataml/*` and three named rules. Anchored, so it cannot reach into the reference tree. `meltanoyml` has no counterpart and keeps its own rule.
* `/docs/api/*` -> `/reference/cloud/api/:splat` replaces six named rules. The legacy Cloud API tree is an exact 29-page mirror.
* `/docs/how-to-guides/manage-workspaces/*` -> `/meltano-cloud/managing-a-workspace#:splat`. The four legacy sub-pages became sections of that page, so the splat carries the sub-page name into the anchor. A duplicate rule is removed.
* `*/visualisation/` and `*/news/` are removed. Both pointed at the meltano.com home page, and matatika.com routes those paths to the marketing site, so neither served live traffic.
* `.gitignore` ignores the local Netlify directory.

### Verification

All 902 built pages were resolved through the full redirect chain: **16 taken over by a redirect before, 0 after**. Across 238 archived legacy documentation URLs, no path that resolved before regressed, and 22 legacy Cloud API paths that returned 404 now reach a page.

Two deliberate 404s: `docs.meltano.com/visualisation/` and `/news/`, per the bullet above. Legacy `/dataml/...` links without the `/docs` prefix still 404, because matatika.com strips that prefix; tracked separately.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Code following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes MEL-622

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
