### PR TITLE
chore: document DataML artifact deployment behaviour

### DIFF
--- a/docs/docs/reference/cloud/dataml/index.md
+++ b/docs/docs/reference/cloud/dataml/index.md
@@ -9,3 +9,97 @@ import DocCardList from '@theme/DocCardList';
 Examples and reference documentation for **Data Management Language** **(DataML)** artifacts.
 
 <DocCardList />
+
+## Deploy WorkspaceML
+[WorkspaceML](/reference/cloud/dataml/workspaceml) configures the workspace you deploy to, rather than a resource within it. A deploy *merges* `workspace.yml` into the existing workspace: the provided properties are updated and those omitted are left unchanged - nothing resets to a default. The workspace name is set from the `name` property. `app_properties` are recomputed from the file, so removed keys are dropped.
+
+## Deploy workspace artifacts
+Every other DataML artifact backs a corresponding [resource](/reference/cloud/api/resources) that is created, updated or deleted by [deploying a workspace](/reference/cloud/api/resources/deployments).
+
+A [create](#create), [update](#update) or [delete](#delete) operates on the resource that the artifact is matched to by `name` (`alias` for a dataset) unique within the workspace. This identifier is derived from the artifact filepath, minus the extension (pipeline names are additionally slugified).
+
+### Create
+When an artifact does not yet match a resource, deploying the workspace creates the corresponding resource from the artifact.
+
+### Update
+When an artifact matches a resource, deploying the workspace updates the corresponding resource from the artifact.
+
+In general, a property is applied as a *replacement*: a value you provide overwrites the existing one, and a property you omit resets to its default (`null` or empty collection).
+
+For example, given the following existing [pipeline resource](/reference/cloud/api/resources/pipelines#pipeline)
+```json
+{
+    "dataComponents": ["tap-github", "target-snowflake"],
+    "script": "echo 'Hello world!'",
+    "timeout": 3600
+}
+```
+
+backed by the following [PipelineML](/reference/cloud/dataml/pipelineml) artifact
+
+```yml
+data_components:
+- tap-github
+- target-snowflake
+timeout: 3600
+```
+
+when deploying the workspace, the `script` is unset and the pipeline assumes default behaviour at runtime:
+```json
+{
+    "dataComponents": ["tap-github", "target-snowflake"],
+    "timeout": 3600
+}
+```
+
+A property holding a schemaless object, such as pipeline `properties`, is instead applied as a *merge*: because the object can hold any number of keys, the artifact updates only those provided and leaves the rest unchanged.
+
+For example, given the following existing pipeline resource
+```json
+{
+    "properties": {
+        "username": "example_user",
+        "password": "***",
+        "start_date": "2026-01-01"
+    }
+}
+```
+
+backed by the following PipelineML artifact
+
+```yml
+properties:
+  username: another_example_user
+  start_date: 2026-01-01
+```
+
+when deploying the workspace, only the provided keys of `properties` are updated:
+```json
+{
+    "properties": {
+        "username": "another_example_user",
+        "password": "***",
+        "start_date": "2026-01-01"
+    }
+}
+```
+
+An explicit `null` mapping can also be used to unset a key within a schemaless object:
+
+```yml
+properties:
+  username: another_example_user
+  start_date: null
+```
+
+```json
+{
+    "properties": {
+        "username": "another_example_user",
+        "password": "***"
+    }
+}
+```
+
+### Delete
+When an artifact that previously matched a resource has its filepath modified or is deleted, deploying the workspace deletes the corresponding resource. Modifying the filepath will also [create](#create) a new resource under the new identifier.

--- a/docs/docs/reference/cloud/dataml/pipelineml/index.md
+++ b/docs/docs/reference/cloud/dataml/pipelineml/index.md
@@ -39,7 +39,7 @@ Path | JSON Type | Description
 `version`         | `string`   | The version identifies this artifact type.
 `data_components` | `string[]` | The meltano.yml data component name.
 `actions`         | `string[]` | The Meltano tasks that will be run as defined in your meltano.yml or Plugins.
-`inline_script`   | `string`   | Custom [Bash](https://www.gnu.org/software/bash/) script.  Overrides actions if supplied.
+`script`          | `string`   | Custom [Bash](https://www.gnu.org/software/bash/) script.  Overrides actions if supplied.
 `timeout`         | `number`   | A timeout value in seconds that prevents pipelines from running for too long. A pipeline running longer that the timeout setting is automatically stopped.
 `max_retries`      | `number`  | The maximum number of retries to attempt for a job ending with `ERROR`
 `properties`      | `object`      | A map of properties, with Data Component name and setting as the key and the value e.g. `data-component-name.setting=value`, that configures the pipeline environment.


### PR DESCRIPTION
## Description

The DataML reference now documents what a deploy does to a workspace and the resources its artifacts back — behaviour a reader previously could not infer from the artifact formats alone.

The DataML index gains two deployment sections:

- **Deploy WorkspaceML** — a deploy merges `workspace.yml` into the workspace you deploy to: a property you set is updated, one you omit is left unchanged, the workspace `name` comes from the file's `name` property, and `app_properties` are recomputed so removed keys are dropped.
- **Deploy workspace artifacts** — every other artifact backs a resource matched by `name` (`alias` for a dataset) derived from the artifact's filepath, minus the extension. It covers create, update and delete, and the update semantics: a property is applied as a replacement (an omitted property resets to its default), while a schemaless object such as pipeline `properties` is merged so only the provided keys change. Worked PipelineML examples show the replacement and merge cases, including an explicit `null` to unset a key.

This also corrects the PipelineML reference, which named the custom-script key `inline_script` instead of `script`.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document DataML workspace deployment behavior and correct the PipelineML custom-script field name.

Enhancements:
- Document how deploying DataML artifacts creates, updates, merges, and deletes their corresponding workspace resources, including replacement and schemaless-property merge semantics with examples.
- Document WorkspaceML deployment behavior, including workspace property merging and app property recomputation.

Documentation:
- Correct the PipelineML reference to use the `script` key for custom scripts.
