### PR TITLE
test: Replace `click.testing.CliRunner.isolated_filesystem()` with `monkeypatch.chdir` pytest fixture

### DIFF
--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -15,6 +15,7 @@ from time import perf_counter_ns
 from unittest import mock
 
 import click
+import click.testing
 import pytest
 import responses
 import yaml
@@ -647,20 +648,22 @@ class TestCliColors:
     )
     def test_no_color(
         self,
-        cli_runner,
-        env,
-        log_config,
-        cli_colors_expected,
-        log_colors_expected,
-        tmp_path,
-        monkeypatch,
+        cli_runner: click.testing.CliRunner,
+        env: dict[str, str],
+        log_config: dict[str, t.Any],
+        cli_colors_expected: bool,  # ruff: ignore[boolean-type-hint-positional-argument]
+        log_colors_expected: bool,  # ruff: ignore[boolean-type-hint-positional-argument]
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.delenv("NO_COLOR", raising=False)
         monkeypatch.delenv("FORCE_COLOR", raising=False)
         styled_text = click.style(self.TEST_TEXT, fg="red")
+        project_path = tmp_path / "project"
+        project_path.mkdir()
 
         if log_config:
-            log_config_path = tmp_path / "logging.yml"
+            log_config_path = project_path / "logging.yml"
             log_config_path.write_text(yaml.dump(log_config))
         else:
             log_config_path = None
@@ -676,12 +679,16 @@ class TestCliColors:
 
         expected_text = styled_text if cli_colors_expected else self.TEST_TEXT
 
-        with cli_runner.isolated_filesystem():
-            result = cli_runner.invoke(cli, ["dummy"], color=True, env=env)
-            assert result.exit_code == 0, result.exception
-            assert result.stdout.strip() == expected_text
-            assert bool(ANSI_RE.findall(result.stderr)) is log_colors_expected
-            assert result.exception is None
+        result = cli_runner.invoke(
+            cli,
+            ["--cwd", str(project_path), "dummy"],
+            color=True,
+            env=env,
+        )
+        assert result.exit_code == 0, result.exception
+        assert result.stdout.strip() == expected_text
+        assert bool(ANSI_RE.findall(result.stderr)) is log_colors_expected
+        assert result.exception is None
 
 
 class TestLargeConfigProject:

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -651,7 +651,7 @@ class TestCliColors:
         *,
         cli_runner: click.testing.CliRunner,
         env: dict[str, str],
-        log_config: dict[str, t.Any],
+        log_config: dict[str, t.Any] | None,
         cli_colors_expected: bool,
         log_colors_expected: bool,
         tmp_path: Path,

--- a/tests/meltano/cli/test_cli.py
+++ b/tests/meltano/cli/test_cli.py
@@ -648,11 +648,12 @@ class TestCliColors:
     )
     def test_no_color(
         self,
+        *,
         cli_runner: click.testing.CliRunner,
         env: dict[str, str],
         log_config: dict[str, t.Any],
-        cli_colors_expected: bool,  # ruff: ignore[boolean-type-hint-positional-argument]
-        log_colors_expected: bool,  # ruff: ignore[boolean-type-hint-positional-argument]
+        cli_colors_expected: bool,
+        log_colors_expected: bool,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -679,12 +680,8 @@ class TestCliColors:
 
         expected_text = styled_text if cli_colors_expected else self.TEST_TEXT
 
-        result = cli_runner.invoke(
-            cli,
-            ["--cwd", str(project_path), "dummy"],
-            color=True,
-            env=env,
-        )
+        monkeypatch.chdir(project_path)
+        result = cli_runner.invoke(cli, ["dummy"], color=True, env=env)
         assert result.exit_code == 0, result.exception
         assert result.stdout.strip() == expected_text
         assert bool(ANSI_RE.findall(result.stderr)) is log_colors_expected


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Update the CLI color test to manage its temporary working directory through pytest.

Enhancements:
- Modernize the CLI color test to use pytest’s working-directory fixture instead of Click’s isolated filesystem context.

Tests:
- Improve the CLI color test with explicit type annotations and a dedicated temporary project directory.