### PR TITLE
fix: add documentation for few connectors on connectors page

### DIFF
--- a/docs/docs/connectors/tap-aptem.mdx
+++ b/docs/docs/connectors/tap-aptem.mdx
@@ -1,0 +1,111 @@
+---
+title: Aptem
+description: Sync learner enrollment, program delivery, compliance, and assessment data from Aptem's OData API.
+---
+
+import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
+
+# Aptem
+
+<ConnectorTypeBadge type="extractor" block />
+
+Aptem is an end-to-end apprenticeship and vocational training management platform used by training providers and employers to manage learner enrollment, programme delivery, progress tracking, compliance, and end-point assessment.
+
+## At a glance
+
+| Property | Value |
+|---|---|
+| **Authentication** | API Token |
+| **API** | Aptem OData API |
+| **Stream discovery** | Dynamic, from the Aptem OData service `$metadata` document |
+| **Replication** | Incremental for streams with a known replication key; full-table for the rest |
+
+## What you can sync
+
+This tap discovers streams dynamically from the Aptem OData service `$metadata` document, so the exact set of streams reflects the entities and related collections exposed by your tenant. Additional related collections embedded within these entities are also discovered and extracted as their own streams.
+
+The following streams are recognised by the tap:
+
+- `AimWorkPlacements`
+- `ApprenticeshipFinancialRecords`
+- `AptemCognitiveAssessments`
+- `AwardingBodyQualifications`
+- `AwardingBodyQualificationsAssessmentHistory`
+- `ComplianceDocuments`
+- `ComponentDueDateChanges`
+- `CrmActivities`
+- `DestinationProgressions`
+- `EmployerGroups`
+- `EPAErrors`
+- `Episodes`
+- `Groups`
+- `HoursRecords`
+- `IlrAims`
+- `IlrLearner`
+- `Jobs`
+- `LearnerEmployment`
+- `LearningPlanComponents`
+- `LearningPlanEvidences`
+- `LearningPlanEvidenceWithActivityData`
+- `MaximumProgrammeDataFields`
+- `Messages`
+- `Milestones`
+- `Notes`
+- `OnboardingResponses`
+- `OrganizationContacts`
+- `Organizations`
+- `ReviewResponses`
+- `Reviews`
+- `Tasks`
+- `Trackers`
+- `Users`
+- `UserGroups`
+- `WithdrawalReasons`
+
+## Prerequisites
+
+To connect to Aptem, you will need:
+
+- An **API token** for the Aptem OData API.
+- Your Aptem **tenant name**, which is used to build the API base URL.
+
+## Setup
+
+In Meltano Cloud:
+
+1. Enter your Aptem API token.
+2. Enter your Aptem tenant name.
+3. Optionally choose a start date for extraction.
+
+## Settings
+
+| Setting | Type | Description |
+|---|---|---|
+| `api_token` | string | API token for the Aptem OData API. |
+| `tenant_name` | string | Aptem tenant name used to build the base URL. |
+| `start_date` | date | The earliest record date to sync. |
+
+## Replication
+
+Streams with a known replication key are replicated incrementally; the rest are replicated in full on each run.
+
+If you find a stream is not behaving incrementally when it exposes a suitable date column, you can set a replication key configuration for the plugin under `metadata` in your `meltano.yml`:
+
+```yaml
+plugins:
+  extractors:
+  - name: tap-aptem
+    variant: matatika
+    pip_url: git+https://github.com/Matatika/tap-aptem.git@v0.1.0
+    config:
+    metadata:
+      <stream_name>: # Aptem stream name
+        replication-method: INCREMENTAL
+        replication-key: <field_name> # a date column exposed by the stream
+```
+
+You can also open an issue in the [tap-aptem repository](https://github.com/Matatika/tap-aptem/issues/new?title=feat:%20Register%20replication%20key%20for%20stream%20%60%3Cstream_name%3E%60&body=Replication%20key:%20%60%3Cfield_name%3E%60&labels=enhancement&type=feature) to register any missing configurations in the tap. Future version updates that include related changes would no longer require corresponding `metadata` entries, as above.
+
+## Need help?
+
+If you run into an issue not covered here, file it through the usual Meltano support channel with your connection settings (excluding credentials) and the error you're seeing.

--- a/docs/docs/connectors/tap-baidu.mdx
+++ b/docs/docs/connectors/tap-baidu.mdx
@@ -1,0 +1,50 @@
+---
+title: Baidu
+description: Sync campaign, account, and reporting data from Baidu's Mediago programmatic advertising platform.
+---
+
+import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
+
+# Baidu
+
+<ConnectorTypeBadge type="extractor" block />
+
+Baidu is a leading Chinese technology company. Founded in 2000, Baidu delivers a broad portfolio of services spanning internet search, cloud computing, artificial intelligence, and digital advertising.
+
+Its Mediago platform empowers marketers to manage programmatic advertising campaigns with robust targeting, bidding, and reporting features across Baidu's media network. This tap is built on top of the Mediago API.
+
+## At a glance
+
+| Property | Value |
+|---|---|
+| **Authentication** | API Token |
+| **API** | Baidu Mediago API |
+| **Streams** | 6 |
+
+## What you can sync
+
+The Baidu tap provides access to the following streams:
+
+- **SummaryStream**: for high level campaign overviews.
+- **CampaignStream**: for a list of authorised campaigns.
+- **AccountsStream**: for a list of authorised accounts.
+- **CampaignDetails**: for in depth campaign insights.
+- **ReportInCampaignDimension**: a daily report in campaign dimension.
+- **ReportInSiteDimension**: a daily report in site dimension for a specific campaign.
+
+## Prerequisites
+
+To connect Baidu, you need an API token for the Mediago API, along with a start date, end date, and timezone for the streams you want to sync.
+
+## Settings
+
+| Setting | Type | Description |
+|---|---|---|
+| `api_token` | string | The token to use for authentication. |
+| `start_date` | string | The start date of the stream. |
+| `end_date` | string | The end date of the stream. |
+| `timezone` | string | The timezone of the stream. |
+
+## Need help?
+
+If you run into an issue not covered here, file it through the usual Meltano support channel with your connection settings (excluding credentials) and the error you're seeing.

--- a/docs/docs/connectors/tap-google-analytics.mdx
+++ b/docs/docs/connectors/tap-google-analytics.mdx
@@ -1,0 +1,298 @@
+---
+title: Google Analytics
+description: Sync Google Analytics 4 (GA4) website and app performance data into Meltano Cloud for reporting, modelling, and downstream analysis.
+---
+
+import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
+
+# Google Analytics
+
+<ConnectorTypeBadge type="extractor" block />
+
+Meltano Tap Google Analytics is a Singer tap for extracting Google Analytics 4 (GA4) data into Meltano Cloud for reporting, modelling, and downstream analysis.
+
+It helps you collect website and app performance data from Google Analytics in a repeatable pipeline so you can analyse traffic, engagement, locations, devices, pages, and revenue-related activity alongside data from your other business systems.
+
+Use this connector when you want to:
+
+- centralise Google Analytics data in your warehouse
+- build dashboards and reports on website performance
+- track traffic sources, user behaviour, and engagement trends over time
+- combine analytics data with advertising, CRM, sales, or product data
+- customise the extracted reports using your own stream definitions
+
+## At a glance
+
+| Property | Value |
+|---|---|
+| **Authentication** | Google account, connected via Meltano Cloud login |
+| **API** | Google Analytics 4 (GA4) |
+| **Default streams** | 9 |
+| **Custom reports** | Supported, up to 7 dimensions and 10 metrics per report |
+
+## Setup
+
+In [Google Analytics](https://analytics.google.com/):
+
+1. Select the property you want to extract data for.
+2. Go to **Admin** > **Property** > **Property details**.
+3. Copy the **PROPERTY ID**.
+
+In Meltano Cloud:
+
+1. Login and connect with your Google account.
+2. Enter the property ID.
+3. Choose a start date for extraction.
+
+## What you can sync
+
+The tap provides the following default streams:
+
+### `website_overview`
+
+Overview of the website performance.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `activeUsers` | Metric. The number of active users. |
+| `newUsers` | Metric. The number of first-time users. |
+| `sessions` | Metric. The number of sessions recorded. |
+| `sessionsPerUser` | Metric. The average number of sessions per user. |
+| `averageSessionDuration` | Metric. The average duration of sessions. |
+| `screenPageViews` | Metric. The total number of page or screen views. |
+| `screenPageViewsPerSession` | Metric. The average number of page or screen views per session. |
+| `bounceRate` | Metric. The percentage of sessions that were not engaged. |
+| `engagementRate` | Metric. The percentage of engaged sessions. |
+
+### `traffic_sources`
+
+Where website traffic originates from.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `source` | Dimension. The source that sent traffic, such as a website or referrer. |
+| `medium` | Dimension. The marketing medium for the traffic source, such as organic, referral, or cpc. |
+| `sourcePlatform` | Dimension. The platform associated with the traffic source. |
+| `activeUsers` | Metric. The number of active users. |
+| `sessions` | Metric. The number of sessions recorded. |
+| `sessionsPerUser` | Metric. The average number of sessions per user. |
+| `bounceRate` | Metric. The percentage of sessions that were not engaged. |
+| `engagementRate` | Metric. The percentage of engaged sessions. |
+
+### `locations`
+
+Website activity by country, region, and city.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `country` | Dimension. The country where the activity originated. |
+| `countryId` | Dimension. The Google Analytics identifier for the country. |
+| `region` | Dimension. The region or state where the activity originated. |
+| `city` | Dimension. The city where the activity originated. |
+| `cityId` | Dimension. The Google Analytics identifier for the city. |
+| `activeUsers` | Metric. The number of active users. |
+| `newUsers` | Metric. The number of first-time users. |
+| `sessions` | Metric. The number of sessions recorded. |
+| `sessionsPerUser` | Metric. The average number of sessions per user. |
+| `averageSessionDuration` | Metric. The average duration of sessions. |
+| `screenPageViews` | Metric. The total number of page or screen views. |
+| `screenPageViewsPerSession` | Metric. The average number of page or screen views per session. |
+| `bounceRate` | Metric. The percentage of sessions that were not engaged. |
+| `engagementRate` | Metric. The percentage of engaged sessions. |
+
+### `four_weekly_active_users`
+
+Active users measured over a rolling 28 day period.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `active28DayUsers` | Metric. The number of active users over the last 28 days. |
+
+### `weekly_active_users`
+
+Active users measured over a rolling 7 day period.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `active7DayUsers` | Metric. The number of active users over the last 7 days. |
+
+### `daily_active_users`
+
+Active users measured over a rolling 1 day period.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `active1DayUsers` | Metric. The number of active users over the last 1 day. |
+
+### `devices`
+
+Website activity by device, operating system, and browser.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `deviceCategory` | Dimension. The type of device used, such as desktop, tablet, or mobile. |
+| `deviceModel` | Dimension. The model of device used by the visitor. |
+| `operatingSystem` | Dimension. The operating system used by the visitor. |
+| `browser` | Dimension. The browser used by the visitor. |
+| `activeUsers` | Metric. The number of active users. |
+| `newUsers` | Metric. The number of first-time users. |
+| `sessions` | Metric. The number of sessions recorded. |
+| `sessionsPerUser` | Metric. The average number of sessions per user. |
+| `averageSessionDuration` | Metric. The average duration of sessions. |
+| `screenPageViews` | Metric. The total number of page or screen views. |
+| `screenPageViewsPerSession` | Metric. The average number of page or screen views per session. |
+| `bounceRate` | Metric. The percentage of sessions that were not engaged. |
+| `engagementRate` | Metric. The percentage of engaged sessions. |
+
+### `transactions`
+
+Revenue and transaction performance overview.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `activeUsers` | Metric. The number of active users. |
+| `averageRevenuePerUser` | Metric. The average revenue generated per user. |
+| `newUsers` | Metric. The number of first-time users. |
+| `purchaseRevenue` | Metric. The revenue generated from purchases. |
+| `sessions` | Metric. The number of sessions recorded. |
+| `totalRevenue` | Metric. The total revenue attributed in the report. |
+| `transactions` | Metric. The number of completed transactions. |
+
+### `pages`
+
+Page-level traffic and engagement performance.
+
+| Field | Description |
+|---|---|
+| `date` | Dimension. The reporting date for the row. |
+| `hostName` | Dimension. The hostname where the page was viewed. |
+| `pagePath` | Dimension. The path portion of the viewed page URL. |
+| `sessionMedium` | Dimension. The session-level marketing medium. |
+| `sessionSource` | Dimension. The session-level traffic source. |
+| `activeUsers` | Metric. The number of active users. |
+| `bounceRate` | Metric. The percentage of sessions that were not engaged. |
+| `engagedSessions` | Metric. The number of engaged sessions. |
+| `engagementRate` | Metric. The percentage of engaged sessions. |
+| `eventCount` | Metric. The total number of tracked events. |
+| `screenPageViews` | Metric. The total number of page or screen views. |
+| `screenPageViewsPerUser` | Metric. The average number of page or screen views per user. |
+| `screenPageViewsPerSession` | Metric. The average number of page or screen views per session. |
+| `userEngagementDuration` | Metric. The amount of time users were actively engaged. |
+
+## Custom streams
+
+The tap also supports custom streams. When custom stream definitions are specified, they override all default streams.
+
+A custom report definition specifies the stream name along with the Google Analytics dimensions and metrics to request, up to 7 dimensions and 10 metrics per stream. See the [GA4 dimensions and metrics explorer](https://ga-dev-tools.google/ga4/dimensions-metrics-explorer/) for valid values.
+
+You can define custom reports two ways:
+
+**As a project-relative JSON file** using `reports`:
+
+```json
+[
+  { "name" : "name of stream to be used",
+    "dimensions" :
+    [
+      "Google Analytics Dimension",
+      "Another Google Analytics Dimension"
+    ],
+    "metrics" :
+    [
+      "Google Analytics Metric",
+      "Another Google Analytics Metric"
+    ]
+  }
+]
+```
+
+For example, to extract user stats per day in a `users_per_day` stream and session stats per day and country in a `sessions_per_country_day` stream:
+
+```json
+[
+  { "name" : "users_per_day",
+    "dimensions" :
+    [
+      "date"
+    ],
+    "metrics" :
+    [
+      "newUsers",
+      "active1DayUsers"
+    ]
+  },
+  { "name" : "sessions_per_country_day",
+    "dimensions" :
+    [
+      "date",
+      "country"
+    ],
+    "metrics" :
+    [
+      "sessions",
+      "sessionsPerUser",
+      "avgSessionDuration"
+    ]
+  }
+]
+```
+
+**Or inline in your configuration** using `reports_list`:
+
+```json
+[
+  {
+    "name": "traffic_overview",
+    "dimensions": ["date", "country"],
+    "metrics": ["activeUsers", "sessions"]
+  },
+  {
+    "name": "device_analysis",
+    "dimensions": ["date", "deviceCategory"],
+    "metrics": ["activeUsers", "engagedSessions", "engagementRate"]
+  },
+  {
+    "name": "traffic_source_analysis",
+    "dimensions": ["date", "sessionSource", "sessionMedium"],
+    "metrics": ["activeUsers", "sessions", "eventCount"]
+  },
+  {
+    "name": "top_pages",
+    "dimensions": ["date", "pagePath"],
+    "metrics": ["screenPageViews", "activeUsers"]
+  },
+  {
+    "name": "engagement_report",
+    "dimensions": ["date"],
+    "metrics": ["engagedSessions", "engagementRate", "userEngagementDuration"]
+  }
+]
+```
+
+If `reports` is not provided, the tap uses its [default reports definition](https://github.com/MeltanoLabs/tap-google-analytics/blob/main/tap_google_analytics/defaults/default_report_definition.json).
+
+## Settings
+
+| Setting | Type | Description |
+|---|---|---|
+| `property_id` | string | Google Analytics Property ID. Found in Google Analytics under **Admin** > **Property** > **Property details**. |
+| `start_date` | date | The earliest record date to sync. |
+| `end_date` | date | The last record date to sync. |
+| `reports` | string | A project-relative path to a JSON file with the definition of the reports to be generated. Uses the tap's default reports definition if not provided. |
+| `reports_list` | array | A list of report definitions to be generated directly in the config, as an alternative to `reports`. |
+| `flattening_enabled` | boolean | `True` to enable schema flattening and automatically expand nested properties. |
+| `flattening_max_depth` | integer | The max depth to flatten schemas. |
+| `stream_map_config` | object | User-defined config values to be used within map expressions. |
+| `stream_maps` | object | Config object for the stream maps capability. |
+
+## Need help?
+
+If you run into an issue not covered here, file it through the usual Meltano support channel with your connection settings (excluding credentials) and the error you're seeing.

--- a/docs/docs/connectors/tap-google-analytics.mdx
+++ b/docs/docs/connectors/tap-google-analytics.mdx
@@ -239,7 +239,7 @@ For example, to extract user stats per day in a `users_per_day` stream and sessi
     [
       "sessions",
       "sessionsPerUser",
-      "avgSessionDuration"
+      "averageSessionDuration"
     ]
   }
 ]

--- a/docs/docs/connectors/target-duckdb.mdx
+++ b/docs/docs/connectors/target-duckdb.mdx
@@ -1,0 +1,53 @@
+---
+title: DuckDB
+description: Load extracted data into DuckDB, a high-performance, embeddable SQL database management system optimized for analytical queries.
+---
+
+import ConnectorTypeBadge from '@site/src/components/ConnectorTypeBadge';
+
+# DuckDB
+
+<ConnectorTypeBadge type="loader" block />
+
+DuckDB is an embeddable SQL database management system. It is a high-performance, open-source SQL database management system designed to be embedded in other software applications. It is optimized for analytical queries and can handle large datasets with ease.
+
+DuckDB is easy to use and can be integrated into a wide range of applications, including data analysis tools, business intelligence software, and more. It supports standard SQL syntax and provides a range of advanced features, including support for window functions, common table expressions, and more. With its small footprint and low resource requirements, DuckDB is an ideal choice for developers looking to add powerful database functionality to their applications.
+
+## At a glance
+
+| Property | Value |
+|---|---|
+| **Type** | Loader (target) |
+
+## What you can sync
+
+The DuckDB loader writes data extracted by Meltano into DuckDB tables.
+
+- Records are loaded into the file or directory configured as the **File Path**, in batches of the size configured as **Batch Size Rows**.
+- Data is loaded into the schema configured as **Default Target Schema**, or you can map individual input schema names to different output schemas using **schema_mapping**.
+- **Add Metadata Columns** adds metadata columns to the output table.
+- **Hard Delete** performs a hard delete when deleting data from DuckDB.
+- **Data Flattening Max Level** controls the maximum level of data flattening performed when loading data.
+- **Primary Key Required** controls whether a primary key is required for the output table.
+- **Validate Records** controls whether records are validated before being loaded into DuckDB.
+- **Temporary Directory** sets the directory used for temporary files when loading data.
+
+## Settings
+
+| Setting | Type | Description |
+|---|---|---|
+| `path` | string | The path to the file or directory containing the data to be loaded into DuckDB. |
+| `batch_size_rows` | integer | The number of rows to load into DuckDB at a time. |
+| `flush_all_streams` | boolean | Whether to flush all streams after loading data into DuckDB. |
+| `default_target_schema` | string | The default schema to use when loading data into DuckDB. |
+| `schema_mapping` | object | A mapping of input schema names to output schema names. |
+| `add_metadata_columns` | boolean | Whether to add metadata columns to the output table. |
+| `hard_delete` | boolean | Whether to perform a hard delete when deleting data from DuckDB. |
+| `data_flattening_max_level` | integer | The maximum level of data flattening to perform when loading data into DuckDB. |
+| `primary_key_required` | boolean | Whether a primary key is required for the output table. |
+| `validate_records` | boolean | Whether to validate records before loading them into DuckDB. |
+| `temp_dir` | string | The directory to use for temporary files when loading data into DuckDB. |
+
+## Need help?
+
+If you run into an issue not covered here, file it through the usual Meltano support channel with your connection settings (excluding credentials) and the error you're seeing.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -25,6 +25,10 @@ const sidebars = {
     { type: 'doc', id: 'connectors/tap-spreadsheets-imap', label: 'Spreadsheets (IMAP)' },
     { type: 'doc', id: 'connectors/tap-weatherapi', label: 'Weather API' },
     { type: 'doc', id: 'connectors/target-clickhouse', label: 'ClickHouse' },
+    { type: 'doc', id: 'connectors/tap-aptem', label: 'Aptem' },
+    { type: 'doc', id: 'connectors/tap-baidu', label: 'Baidu' },
+    { type: 'doc', id: 'connectors/target-duckdb', label: 'DuckDB' },
+    { type: 'doc', id: 'connectors/tap-google-analytics', label: 'Google Analytics' },
   ],
   platformSidebar: [
     {

--- a/docs/src/components/ConnectorSearch.jsx
+++ b/docs/src/components/ConnectorSearch.jsx
@@ -11,6 +11,10 @@ const CONNECTORS = [
   { label: 'Spreadsheets (IMAP)', href: '/connectors/tap-spreadsheets-imap', category: 'extractor' },
   { label: 'Weather API', href: '/connectors/tap-weatherapi', category: 'extractor' },
   { label: 'ClickHouse', href: '/connectors/target-clickhouse', category: 'loader' },
+  { label: 'Aptem', href: '/connectors/tap-aptem', category: 'extractor' },
+  { label: 'Baidu', href: '/connectors/tap-baidu', category: 'extractor' },
+  { label: 'DuckDB', href: '/connectors/target-duckdb', category: 'loader' },
+  { label: 'Google Analytics', href: '/connectors/tap-google-analytics', category: 'extractor' },
 ];
 
 function ConnectorCardTitle({ label }) {


### PR DESCRIPTION
## Description

- Adds documentation pages for four connectors that were missing from the docs site: Aptem, Baidu, DuckDB, and Google Analytics.

- docs/docs/connectors/tap-aptem.mdx – Aptem OData API extractor: prerequisites, setup, full stream list, replication behavior, and settings.

- docs/docs/connectors/tap-baidu.mdx – Baidu Mediago extractor: streams and settings.

- docs/docs/connectors/target-duckdb.mdx – DuckDB loader: settings and loading behavior.

- docs/docs/connectors/tap-google-analytics.mdx – Google Analytics (GA4) extractor: setup flow, all 9 default streams with field-level detail, custom report definitions, and settings.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Document the previously missing Aptem, Baidu, DuckDB, and Google Analytics connectors in the docs site.

Enhancements:
- Add user-facing connector documentation for Aptem, Baidu, DuckDB, and Google Analytics, including setup, available data, replication or loading behavior, custom reports, and configuration settings.

Documentation:
- Publish the four new connector pages and expose them through the documentation sidebar and connector search.