### PR TITLE
ci: Use ephemeral GitHub app token

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -34,11 +34,6 @@ jobs:
   create_release_branch_pr:
     name: Create Release Pull Request
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-    permissions:
-      contents: write       # to create a github release
-      pull-requests: write  # to create and update PRs
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,6 +50,15 @@ jobs:
       with:
         enable-cache: false
 
+    - name: Generate MeltyBot token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ secrets.MELTYBOT_APP_CLIENT_ID }}
+        private-key: ${{ secrets.MELTYBOT_APP_PRIVATE_KEY }}
+        permission-contents: write       # to push the metadata refresh branch
+        permission-pull-requests: write  # to open the PR
+
     - name: Bump version
       id: cz-bump
       uses: commitizen-tools/commitizen-action@338bbd841b75aaee6bf5340e1fa12f6ab58ff9ff # 0.27.1
@@ -64,7 +68,7 @@ jobs:
         commit: "false"
         push: "false"
         changelog: ${{ github.event.inputs.prerelease == 'none' && 'true' || 'false' }}
-        github_token: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}
+        github_token: ${{ steps.app-token.outputs.token }}
         extra_requirements: 'git+https://github.com/meltano/commitizen-version-bump@main'
         changelog_increment_filename: ${{ github.event.inputs.prerelease == 'none' && '_changelog_fragment.md' || '' }}
 
@@ -80,15 +84,14 @@ jobs:
         body_path: ${{ github.event.inputs.prerelease == 'none' && '_changelog_fragment.md' || '' }}
         tag_name: v${{ steps.cz-bump.outputs.version }}
         prerelease: ${{ github.event.inputs.prerelease != 'none' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       id: create-pull-request
       with:
         # https://github.com/peter-evans/create-pull-request
-        token: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
         commit-message: "chore: Bump package version"
         title: "chore: Release v${{ steps.cz-bump.outputs.version }}"
         body: |


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

Instead of a long-lived token.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Replace persistent GitHub credentials in the version bump workflow with an ephemeral GitHub App token.

Enhancements:
- Use a short-lived MeltyBot GitHub App token for version bump releases and release pull requests instead of long-lived repository tokens.

CI:
- Grant the version bump workflow only the GitHub App contents and pull-request permissions it requires.

Chores:
- Remove the workflow's direct use of the default and stored GitHub token environment variables.

## Summary by Sourcery

Secure the version bump workflow by using an ephemeral GitHub App token for release operations.

Enhancements:
- Replace long-lived GitHub credentials in the version bump workflow with a short-lived MeltyBot GitHub App token.

CI:
- Restrict the version bump workflow to the contents and pull-request permissions required for releases and release pull requests.

Chores:
- Remove direct use of default and stored GitHub token environment variables from the workflow.