### PR TITLE
feat: Support `.python-version` file for plugin installs

### DIFF
--- a/docs/docs/reference/settings.mdx
+++ b/docs/docs/reference/settings.mdx
@@ -35,7 +35,7 @@ to list all available settings with their names, environment variables, and curr
 
 The python version to use for this plugin, specified as a path, or as the name of an executable to find within a directory in `$PATH`. You can set it at the time you add a plugin using [`meltano add --python <python>`](/reference/command-line-interface#add).
 
-If not specified, [the top-level `python` setting will be used](#project-python), or if it is not set, the python executable that was used to run Meltano will be used (within a separate virtual environment).
+If not specified, [the top-level `python` setting will be used](#project-python), or if that is not set either, a [`.python-version` file](#python-version-file) in your project root, or if none of these are set, the python executable that was used to run Meltano will be used (within a separate virtual environment).
 
 This setting only applies when creating new virtual environments. If you've already created a virtual environment and you'd like to use a new Python version for it, you'll need to delete it from within `.meltano/`, then run `meltano install` for that plugin again.
 
@@ -91,7 +91,7 @@ export MELTANO_DEFAULT_ENVIRONMENT=prod
 
 The python version to use for plugins, specified as a path, or as the name of an executable to find within a directory in `$PATH`.
 
-If not specified, the python executable that was used to run Meltano will be used (within a separate virtual environment).
+If not specified, Meltano falls back to <a id="python-version-file">a `.python-version` file</a> in your project root (the same one-version-per-first-line convention used by [pyenv](https://github.com/pyenv/pyenv/?tab=readme-ov-file#understanding-python-version-selection) and [uv](https://docs.astral.sh/uv/guides/projects/#python-version)), and if neither is set, the python executable that was used to run Meltano will be used (within a separate virtual environment).
 
 [This can be overridden on a per-plugin basis by setting the `python` property for the plugin.](#plugin-python)
 

--- a/src/meltano/core/project.py
+++ b/src/meltano/core/project.py
@@ -383,6 +383,23 @@ class Project:
             )
         return self.root.joinpath(".env")
 
+    @property
+    def python_version_file(self) -> Path:
+        """Path to this project's .python-version file."""
+        return self.root.joinpath(".python-version")
+
+    @cached_property
+    def python_version(self) -> str | None:
+        """The Python version pinned in this project's .python-version file, if any.
+
+        Follows the same first-line convention as pyenv and uv:
+        https://docs.astral.sh/uv/guides/projects/#python-version
+        """
+        if not self.python_version_file.is_file():
+            return None
+        lines = self.python_version_file.read_text().splitlines()
+        return lines[0].strip() or None if lines else None
+
     @cached_property
     def dotenv_env(self) -> dict[str, str]:
         """Values from this project's .env file.

--- a/src/meltano/core/venv_service.py
+++ b/src/meltano/core/venv_service.py
@@ -696,7 +696,11 @@ class VenvBackend(abc.ABC):
         log_path = project.dirs.logs("pip", namespace, name, "install.log").resolve()
         venv = VirtualEnv(
             venv_path,
-            python=plugin.python or project.settings.get("python"),
+            python=(
+                plugin.python
+                or project.settings.get("python")
+                or project.python_version
+            ),
         )
         return cls(venv=venv, log_path=log_path)
 

--- a/tests/meltano/core/test_project.py
+++ b/tests/meltano/core/test_project.py
@@ -146,6 +146,33 @@ class TestProject:
         project.refresh()
         assert project.dotenv_file == env_file
 
+    def test_python_version_file(self, project: Project) -> None:
+        assert project.python_version_file == project.root / ".python-version"
+
+        # no file: no pinned version
+        assert project.python_version is None
+
+    def test_python_version(self, project: Project) -> None:
+        # a plain version pin
+        project.python_version_file.write_text("3.11\n")
+        project.__dict__.pop("python_version", None)
+        assert project.python_version == "3.11"
+
+        # extra whitespace and trailing content on later lines are ignored,
+        # matching pyenv/uv's one-version-per-first-line convention
+        project.python_version_file.write_text("  3.12  \nsome-other-line\n")
+        project.__dict__.pop("python_version", None)
+        assert project.python_version == "3.12"
+
+        # an empty file has no pinned version
+        project.python_version_file.write_text("")
+        project.__dict__.pop("python_version", None)
+        assert project.python_version is None
+
+        project.python_version_file.unlink()
+        project.__dict__.pop("python_version", None)
+        assert project.python_version is None
+
 
 class TestIncompatibleProject:
     @pytest.fixture

--- a/tests/meltano/core/test_venv_service.py
+++ b/tests/meltano/core/test_venv_service.py
@@ -306,8 +306,21 @@ class TestVenvBackend:
         subject = cls.from_plugin(project, plugin)
         assert subject.venv.python_path == project_python
 
-        # After both the project-level and plugin-level are unset, the system Python
-        # should be used
+        # A `.python-version` file should have no effect while the project-level
+        # setting is still set, since the setting takes precedence.
+        project.python_version_file.write_text("test-python-version-from-file\n")
+        subject = cls.from_plugin(project, plugin)
+        assert subject.venv.python_path == project_python
+
+        # The `.python-version` file should have an effect once both the
+        # plugin-level and project-level settings are unset.
         project.settings.unset("python")
+        subject = cls.from_plugin(project, plugin)
+        assert subject.venv.python_path == "test-python-version-from-file"
+
+        # After the `.python-version` file is also removed, the system Python
+        # should be used
+        project.python_version_file.unlink()
+        project.__dict__.pop("python_version", None)  # bust the cached_property
         subject = cls.from_plugin(project, plugin)
         assert subject.venv.python_path == sys.executable


### PR DESCRIPTION
## Description

Meltano already lets you pin the Python version for plugin venvs with a plugin-level
`python` setting or the project-level `python` setting, falling back to whatever Python
is running Meltano itself. This adds a third fallback in between: a `.python-version`
file in the project root, following the same one-version-per-first-line convention as
pyenv and uv.

Precedence is plugin setting, then project setting, then the file, then the system
Python, matching the ordering suggested in the issue, so a `.python-version` file some
teams already keep around for other tools won't override anything explicitly configured
in meltano.yml.

Added a `python_version` property on `Project`, modeled on the existing `dotenv`
handling in the same class, wired it into the one place `VenvBackend` resolves which
Python to use, and extended the existing precedence test plus a dedicated test for the
property itself. Also updated the settings docs where this fallback chain is explained
to users.

Ran the full pre-commit, typing (mypy + ty), and pytest sessions locally, all green.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Code following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes #9851

## Summary by Sourcery

Add `.python-version` support for selecting plugin virtual environment Python versions without overriding explicit Meltano settings.

New Features:
- Support using a project's `.python-version` file as a fallback Python version for plugin virtual environments.

Enhancements:
- Apply Python version precedence of plugin setting, project setting, `.python-version` file, then the system Python.
- Expose the project's pinned Python version and document the supported first-line convention.

Documentation:
- Update settings documentation to describe `.python-version` fallback behavior and precedence.

Tests:
- Add coverage for `.python-version` parsing and Python version precedence during virtual environment creation.