### PR TITLE
fix(deps): Allow Click 8.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "alembic>=1.14.0,<2",
   "anyio>=4.4.0,<5",
   "backports-strenum>=1.3.1,<2 ; python_version < '3.11'",
-  "click>=8.2,<8.5,!=8.2.2",
+  "click>=8.2,<8.6,!=8.2.2",
   "click-default-group>=1.2.4,<2",
   "dateparser>=1.2.1",
   "fasteners>=0.19,<0.21",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "alembic>=1.14.0,<2",
   "anyio>=4.4.0,<5",
   "backports-strenum>=1.3.1,<2 ; python_version < '3.11'",
-  "click>=8.2,<8.6,!=8.2.2",
+  "click>=8.2,!=8.2.2,<8.6",
   "click-default-group>=1.2.4,<2",
   "dateparser>=1.2.1",
   "fasteners>=0.19,<0.21",
@@ -463,3 +463,6 @@ override-dependencies = [
 ]
 prerelease = "if-necessary"
 required-version = ">=0.9.17"
+
+[tool.uv.sources]
+click = { git = "https://github.com/pallets/click", rev = "refs/pull/3858/head" }

--- a/src/meltano/cli/initialize.py
+++ b/src/meltano/cli/initialize.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import typing as t
 from pathlib import Path
 
 import click
@@ -51,9 +52,12 @@ def init(
     """  # noqa: D301
     if not project_directory:
         click.echo("We need a project name to get started!")
-        project_directory = click.prompt(
-            "Enter a name now to create a Meltano project",
-            type=path_type,
+        project_directory = t.cast(
+            "Path",
+            click.prompt(
+                "Enter a name now to create a Meltano project",
+                type=path_type,
+            ),
         )
 
     if ctx.obj["project"]:

--- a/src/meltano/cli/initialize.py
+++ b/src/meltano/cli/initialize.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import typing as t
 from pathlib import Path
 
 import click
@@ -52,12 +51,9 @@ def init(
     """  # noqa: D301
     if not project_directory:
         click.echo("We need a project name to get started!")
-        project_directory = t.cast(
-            "Path",
-            click.prompt(
-                "Enter a name now to create a Meltano project",
-                type=path_type,
-            ),
+        project_directory = click.prompt(
+            "Enter a name now to create a Meltano project",
+            type=path_type,
         )
 
     if ctx.obj["project"]:

--- a/uv.lock
+++ b/uv.lock
@@ -714,12 +714,8 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
-]
+version = "8.5.1.dev0"
+source = { git = "https://github.com/pallets/click?rev=refs%2Fpull%2F3858%2Fhead#22177f857a34e3c35ba957553853a37f23feb37e" }
 
 [[package]]
 name = "click-default-group"
@@ -1809,7 +1805,7 @@ requires-dist = [
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.24.0,<13" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1,<2" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35,<2" },
-    { name = "click", specifier = ">=8.2,!=8.2.2,<8.6" },
+    { name = "click", git = "https://github.com/pallets/click?rev=refs%2Fpull%2F3858%2Fhead" },
     { name = "click-default-group", specifier = ">=1.2.4,<2" },
     { name = "dateparser", specifier = ">=1.2.1" },
     { name = "fasteners", specifier = ">=0.19,<0.21" },

--- a/uv.lock
+++ b/uv.lock
@@ -714,14 +714,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.2"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -1812,7 +1809,7 @@ requires-dist = [
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.24.0,<13" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1,<2" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.35,<2" },
-    { name = "click", specifier = ">=8.2,!=8.2.2,<8.5" },
+    { name = "click", specifier = ">=8.2,!=8.2.2,<8.6" },
     { name = "click-default-group", specifier = ">=1.2.4,<2" },
     { name = "dateparser", specifier = ">=1.2.1" },
     { name = "fasteners", specifier = ">=0.19,<0.21" },


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA.

https://github.com/pallets/click/releases/tag/8.5.0

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* https://github.com/pallets/click/issues/3822

## Summary by Sourcery

Expand Click compatibility to support the 8.5 release series.

Bug Fixes:
- Allow Click 8.5.x as a supported dependency version.
- Resolve the project-directory prompt type compatibility issue with newer Click releases.

Build:
- Update the locked dependency set to include the expanded Click compatibility range.