### PR TITLE
test: Test `meltano init` when no project name is passed and the user is prompted for one

### DIFF
--- a/tests/meltano/cli/test_initialize.py
+++ b/tests/meltano/cli/test_initialize.py
@@ -122,7 +122,10 @@ class TestCliInit:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.chdir(tmp_path)
-        result = cli_runner.invoke(cli, ["init"], input="my-project\n")
+        try:
+            result = cli_runner.invoke(cli, ["init"], input="my-project\n")
+        finally:
+            Project.deactivate()
         assert result.exit_code == 0
         assert "Creating project files..." in result.output
         assert tmp_path.joinpath("my-project").is_dir()

--- a/tests/meltano/cli/test_initialize.py
+++ b/tests/meltano/cli/test_initialize.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import typing as t
+
 import pytest
 
 from meltano.cli import cli
 from meltano.core.error import ProjectNotFound
 from meltano.core.project import Project
 from meltano.core.project_init_service import ProjectInitServiceError
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import CliRunner
 
 
 class TestCliInit:
@@ -107,3 +114,16 @@ class TestCliInit:
         assert "README.md (skipped)" in result.output
 
         Project.deactivate()
+
+    def test_init_prompt_for_project_name(
+        self,
+        cli_runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = cli_runner.invoke(cli, ["init"], input="my-project\n")
+        assert result.exit_code == 0
+        assert "Creating project files..." in result.output
+        assert tmp_path.joinpath("my-project").is_dir()
+        assert tmp_path.joinpath("my-project", "meltano.yml").is_file()


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

SSIA

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Tests:
- Add coverage for initializing a project without a name by supplying the project name through the interactive prompt.