### PR TITLE
ci: Use tmpfs to run benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,6 +59,8 @@ jobs:
 
     - name: Run benchmarks
       uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+      env:
+        TMPDIR: /dev/shm
       with:
         mode: walltime
-        run: uv run python -m pytest tests/benchmarks/ --codspeed -p no:randomly
+        run: uv run python -m pytest tests/benchmarks/ --codspeed -p no:randomly --basetemp=/dev/shm/pytest


### PR DESCRIPTION
## Description

<!-- Describe the changes introduced by this PR -->

To make the fs-based state backend benchmarks a bit more stable.

## Checklist

- [ ] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by". See the agentic coding section of the contribution guide for details: https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)
-->

## Related Issues

* Closes #XXXX

## Summary by Sourcery

Use shared-memory temporary storage to make filesystem-backed CI benchmarks more stable.

Enhancements:
- Run benchmark temporary files and process temporary data from shared memory to improve filesystem-backed benchmark stability.

CI:
- Configure the benchmark workflow to use `/dev/shm` for temporary benchmark and pytest files.