### PR TITLE
docs: document Arrow BATCH support in tap-snowflake

### DIFF
--- a/docs/docs/meltano-cloud/arrow-support.mdx
+++ b/docs/docs/meltano-cloud/arrow-support.mdx
@@ -63,6 +63,7 @@ does:
 |---|---|---|
 | `tap-mysql` | Arrow | Arrow for the initial backfill, then `RECORD` once log-based streaming starts |
 | `tap-postgres` | Arrow | Always `RECORD` |
+| `tap-snowflake` | Arrow | N/A - tap doesn't support log-based replication |
 
 If your target doesn't advertise the `batch` capability, leave
 `batch_config` unset (or set the tap's batch size to `0`, where supported) so
@@ -76,6 +77,7 @@ it stays in `RECORD` mode.
 |---|---|---|
 | [`tap-mysql`](https://github.com/Matatika/pipelinewise-tap-mysql) | ✅ Supported (v1.5.0+) | `FULL_TABLE`/`INCREMENTAL`: Arrow. `LOG_BASED`: Arrow backfill, then `RECORD` streaming. |
 | [`tap-postgres`](https://github.com/meltano/meltano-tap-postgres) | ⏳ Supports Arrow, not yet on Meltano Cloud | `FULL_TABLE`/`INCREMENTAL`: Arrow. `LOG_BASED`: always `RECORD`. Uses `adbc-driver-postgresql`. Not yet available as a Meltano Cloud extractor. |
+| [`tap-snowflake`](https://github.com/MeltanoLabs/tap-snowflake) | ✅ Supported (v0.5.0+) | `FULL_TABLE`/`INCREMENTAL`: Arrow. No `LOG_BASED` support. Fetches Arrow natively via `snowflake-connector-python`'s own Arrow result format - no ADBC driver needed. |
 
 More extractors are added as they're prioritized. See the notes on each
 tap's settings page in the catalog for the latest status.


### PR DESCRIPTION
## Summary
tap-snowflake v0.5.0 added Arrow as a `batch_config.encoding.format` option (MeltanoLabs/tap-snowflake#107), fetching Arrow natively via `snowflake-connector-python`'s own Arrow result format rather than a separate ADBC driver (unlike `tap-postgres`).

- Added `tap-snowflake` to the replication-method caveats table: `FULL_TABLE`/`INCREMENTAL` support Arrow, no `LOG_BASED` support (the tap doesn't support log-based replication at all).
- Added `tap-snowflake` to the extractors support matrix as ✅ Supported (v0.5.0+).

Companion PR documenting the extractor's own settings: meltano/meltano-cloud#TBD (tap-snowflake--meltanolabs.yml, into `dev`).

## Test plan
- [x] Pre-commit hooks (trim whitespace, typos, etc.) pass
- [ ] Docs build

https://claude.ai/code/session_019HvmXM96BaLqxn1in2fwre

## Summary by Sourcery

Document tap-snowflake's Arrow support and replication-method limitations in Meltano Cloud.

Enhancements:
- Document tap-snowflake Arrow support and replication-method compatibility in the Meltano Cloud extractor support tables.

Documentation:
- Add tap-snowflake as a supported Arrow extractor from v0.5.0, including its lack of log-based replication support and native Snowflake Arrow fetching.