### PR TITLE
feat: suggest existing locked variants when plugin definition is not found

### DIFF
--- a/src/meltano/core/locked_definition_service.py
+++ b/src/meltano/core/locked_definition_service.py
@@ -81,3 +81,14 @@ class LockedDefinitionService(PluginRepository):
         )
 
         return base_plugin_factory(plugin, plugin.variants[0])
+
+    def find_locked_variants(
+        self,
+        plugin_type: PluginType,
+        plugin_name: str,
+    ) -> list[str]:
+        """Find existing locked variant names for a given plugin."""
+        return self.lock_service.find_locked_variants(
+            plugin_type=plugin_type,
+            plugin_name=plugin_name,
+        )

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -255,11 +255,7 @@ class PluginLockService:
         plugin_name: str,
     ) -> list[str]:
         """Find existing locked variant names for a given plugin type and name."""
-        try:
-            plugin_dir = self.project.dirs.root_plugins(plugin_type, make_dirs=False)
-        except OSError:
-            return []
-
+        plugin_dir = self.project.dirs.root_plugins(plugin_type, make_dirs=False)
         if not plugin_dir.exists():
             return []
 
@@ -267,17 +263,10 @@ class PluginLockService:
         suffix = ".lock"
         variants: list[str] = []
 
-        try:
-            for p in plugin_dir.iterdir():
-                if (
-                    p.is_file()
-                    and p.name.startswith(prefix)
-                    and p.name.endswith(suffix)
-                ):
-                    variant = p.name[len(prefix) : -len(suffix)]
-                    if variant:
-                        variants.append(variant)
-        except OSError:
-            return []
+        for p in plugin_dir.iterdir():
+            if p.is_file() and p.name.startswith(prefix) and p.name.endswith(suffix):
+                variant = p.name[len(prefix) : -len(suffix)]
+                if variant:
+                    variants.append(variant)
 
         return sorted(variants)

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -255,7 +255,11 @@ class PluginLockService:
         plugin_name: str,
     ) -> list[str]:
         """Find existing locked variant names for a given plugin type and name."""
-        plugin_dir = self.project.dirs.root_plugins(plugin_type)
+        try:
+            plugin_dir = self.project.dirs.root_plugins(plugin_type, make_dirs=False)
+        except Exception:
+            return []
+
         if not plugin_dir.exists():
             return []
 
@@ -263,10 +267,13 @@ class PluginLockService:
         suffix = ".lock"
         variants: list[str] = []
 
-        for p in plugin_dir.iterdir():
-            if p.name.startswith(prefix) and p.name.endswith(suffix):
-                variant = p.name[len(prefix) : -len(suffix)]
-                if variant:
-                    variants.append(variant)
+        try:
+            for p in plugin_dir.iterdir():
+                if p.is_file() and p.name.startswith(prefix) and p.name.endswith(suffix):
+                    variant = p.name[len(prefix) : -len(suffix)]
+                    if variant:
+                        variants.append(variant)
+        except OSError:
+            return []
 
         return sorted(variants)

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -269,7 +269,11 @@ class PluginLockService:
 
         try:
             for p in plugin_dir.iterdir():
-                if p.is_file() and p.name.startswith(prefix) and p.name.endswith(suffix):
+                if (
+                    p.is_file()
+                    and p.name.startswith(prefix)
+                    and p.name.endswith(suffix)
+                ):
                     variant = p.name[len(prefix) : -len(suffix)]
                     if variant:
                         variants.append(variant)

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -248,3 +248,25 @@ class PluginLockService:
             is_default_variant=variant_metadata.is_default,
             deprecated=variant_metadata.is_deprecated,
         )
+
+    def find_locked_variants(
+        self,
+        plugin_type: PluginType,
+        plugin_name: str,
+    ) -> list[str]:
+        """Find existing locked variant names for a given plugin type and name."""
+        plugin_dir = self.project.dirs.root_plugins(plugin_type)
+        if not plugin_dir.exists():
+            return []
+
+        prefix = f"{plugin_name}--"
+        suffix = ".lock"
+        variants: list[str] = []
+
+        for p in plugin_dir.iterdir():
+            if p.name.startswith(prefix) and p.name.endswith(suffix):
+                variant = p.name[len(prefix) : -len(suffix)]
+                if variant:
+                    variants.append(variant)
+
+        return sorted(variants)

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -263,10 +263,17 @@ class PluginLockService:
         suffix = ".lock"
         variants: list[str] = []
 
-        for p in plugin_dir.iterdir():
-            if p.is_file() and p.name.startswith(prefix) and p.name.endswith(suffix):
-                variant = p.name[len(prefix) : -len(suffix)]
-                if variant:
-                    variants.append(variant)
+        try:
+            for p in plugin_dir.iterdir():
+                if (
+                    p.is_file()
+                    and p.name.startswith(prefix)
+                    and p.name.endswith(suffix)
+                ):
+                    variant = p.name[len(prefix) : -len(suffix)]
+                    if variant:
+                        variants.append(variant)
+        except OSError:
+            return []
 
         return sorted(variants)

--- a/src/meltano/core/plugin_lock_service.py
+++ b/src/meltano/core/plugin_lock_service.py
@@ -257,7 +257,7 @@ class PluginLockService:
         """Find existing locked variant names for a given plugin type and name."""
         try:
             plugin_dir = self.project.dirs.root_plugins(plugin_type, make_dirs=False)
-        except Exception:
+        except OSError:
             return []
 
         if not plugin_dir.exists():

--- a/src/meltano/core/project_plugins_service.py
+++ b/src/meltano/core/project_plugins_service.py
@@ -78,19 +78,39 @@ class PluginAlreadyAddedException(Exception):
 class PluginDefinitionNotFoundError(MeltanoError):
     """Raised when no plugin definition is found."""
 
-    def __init__(self, plugin: ProjectPlugin, error: Exception | None):
+    def __init__(
+        self,
+        plugin: ProjectPlugin,
+        error: Exception | None,
+        existing_variants: list[str] | None = None,
+    ):
         """Initialize a new error.
 
         Args:
             plugin: The plugin that was not found.
             error: The error that was raised, if any.
+            existing_variants: Alternate variants found in existing lockfiles.
         """
-        reason = (
-            str(error)
-            if error
-            else f"No definition found for {plugin.type.descriptor} {plugin.name}"
-        )
-        instruction = "Check https://hub.meltano.com/ for available plugins"
+        descriptor = plugin.type.descriptor.capitalize()
+        if existing_variants and not plugin.is_variant_set:
+            formatted_variants = ", ".join(f"'{v}'" for v in existing_variants)
+            reason = (
+                f"{descriptor} '{plugin.name}' is not known to Meltano, "
+                f"but lockfile{'s exist' if len(existing_variants) > 1 else ' exists'} "
+                f"for variant {formatted_variants}"
+            )
+            instruction = (
+                f"Add 'variant: {existing_variants[0]}' to your plugin definition "
+                "in meltano.yml"
+            )
+        else:
+            reason = (
+                str(error)
+                if error
+                else f"No definition found for {plugin.type.descriptor} {plugin.name}"
+            )
+            instruction = "Check https://hub.meltano.com/ for available plugins"
+
         super().__init__(reason=reason, instruction=instruction)
 
 
@@ -561,7 +581,15 @@ class ProjectPluginsService:  # (too many methods, attributes)
             except PluginNotFoundError as lockfile_exc:
                 error = lockfile_exc
 
-        raise PluginDefinitionNotFoundError(plugin, error) from error
+        existing_variants = self.locked_definition_service.find_locked_variants(
+            plugin.type,
+            plugin.inherit_from or plugin.name,
+        )
+        raise PluginDefinitionNotFoundError(
+            plugin,
+            error,
+            existing_variants=existing_variants,
+        ) from error
 
     def get_parent(self, plugin: ProjectPlugin) -> ProjectPlugin | BasePlugin:
         """Get plugin's parent plugin.

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -252,3 +252,32 @@ def test_plugin_definition_not_found_suggests_variant(
         "Add 'variant: fleetio' to your plugin definition in meltano.yml"
         in exc_info.value.instruction
     )
+
+
+def test_plugin_definition_not_found_multiple_variants(project: Project):
+    from meltano.core.plugin.base import PluginType
+    from meltano.core.plugin.project_plugin import ProjectPlugin
+
+    plugin_dir = project.dirs.root_plugins(PluginType.EXTRACTORS)
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "tap-multi--variant1.lock").write_text("{}")
+    (plugin_dir / "tap-multi--variant2.lock").write_text("{}")
+
+    plugin = ProjectPlugin(PluginType.EXTRACTORS, name="tap-multi")
+
+    with pytest.raises(PluginDefinitionNotFoundError) as exc_info:
+        project.plugins.find_parent(plugin)
+
+    assert "lockfiles exist for variant 'variant1', 'variant2'" in str(exc_info.value)
+    assert "Add 'variant: variant1' to your plugin definition in meltano.yml" in exc_info.value.instruction
+
+
+def test_find_locked_variants_no_dir(project: Project):
+    from meltano.core.plugin.base import PluginType
+    from meltano.core.plugin_lock_service import PluginLockService
+
+    service = PluginLockService(project)
+    # Testing when directory does not exist
+    variants = service.find_locked_variants(PluginType.TRANSFORMERS, "dbt")
+    assert variants == []
+

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -226,3 +226,29 @@ class TestProjectPluginsService:
         assert project.plugins.find_plugin("mock-mapping-0") == mapper
         with pytest.raises(PluginNotFoundError):
             project.plugins.find_plugin("non-existent-mapping")
+
+
+def test_plugin_definition_not_found_suggests_variant(
+    project: Project,
+):
+    from meltano.core.plugin.base import PluginType
+    from meltano.core.plugin.project_plugin import ProjectPlugin
+
+    plugin_dir = project.dirs.root_plugins(PluginType.EXTRACTORS)
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = plugin_dir / "tap-fleetio--fleetio.lock"
+    lock_file.write_text("{}")
+
+    plugin = ProjectPlugin(PluginType.EXTRACTORS, name="tap-fleetio")
+
+    with pytest.raises(PluginDefinitionNotFoundError) as exc_info:
+        project.plugins.find_parent(plugin)
+
+    assert (
+        "Extractor 'tap-fleetio' is not known to Meltano, "
+        "but lockfile exists for variant 'fleetio'" in str(exc_info.value)
+    )
+    assert (
+        "Add 'variant: fleetio' to your plugin definition in meltano.yml"
+        in exc_info.value.instruction
+    )

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -297,3 +297,24 @@ def test_find_locked_variants_ignores_empty_variant(project: Project):
     service = PluginLockService(project)
     variants = service.find_locked_variants(PluginType.EXTRACTORS, "tap-empty")
     assert variants == []
+
+
+def test_find_locked_variants_oserror(
+    project: Project, monkeypatch: pytest.MonkeyPatch
+):
+    from pathlib import Path
+
+    from meltano.core.plugin.base import PluginType
+    from meltano.core.plugin_lock_service import PluginLockService
+
+    plugin_dir = project.dirs.root_plugins(PluginType.EXTRACTORS)
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+
+    def mock_iterdir(_self):
+        raise OSError
+
+    monkeypatch.setattr(Path, "iterdir", mock_iterdir)
+
+    service = PluginLockService(project)
+    variants = service.find_locked_variants(PluginType.EXTRACTORS, "tap-error")
+    assert variants == []

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -269,7 +269,10 @@ def test_plugin_definition_not_found_multiple_variants(project: Project):
         project.plugins.find_parent(plugin)
 
     assert "lockfiles exist for variant 'variant1', 'variant2'" in str(exc_info.value)
-    assert "Add 'variant: variant1' to your plugin definition in meltano.yml" in exc_info.value.instruction
+    assert (
+        "Add 'variant: variant1' to your plugin definition in meltano.yml"
+        in exc_info.value.instruction
+    )
 
 
 def test_find_locked_variants_no_dir(project: Project):
@@ -280,4 +283,3 @@ def test_find_locked_variants_no_dir(project: Project):
     # Testing when directory does not exist
     variants = service.find_locked_variants(PluginType.TRANSFORMERS, "dbt")
     assert variants == []
-

--- a/tests/meltano/core/test_project_plugins_service.py
+++ b/tests/meltano/core/test_project_plugins_service.py
@@ -283,3 +283,17 @@ def test_find_locked_variants_no_dir(project: Project):
     # Testing when directory does not exist
     variants = service.find_locked_variants(PluginType.TRANSFORMERS, "dbt")
     assert variants == []
+
+
+def test_find_locked_variants_ignores_empty_variant(project: Project):
+    from meltano.core.plugin.base import PluginType
+    from meltano.core.plugin_lock_service import PluginLockService
+
+    plugin_dir = project.dirs.root_plugins(PluginType.EXTRACTORS)
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    # File without variant name
+    (plugin_dir / "tap-empty--.lock").write_text("{}")
+
+    service = PluginLockService(project)
+    variants = service.find_locked_variants(PluginType.EXTRACTORS, "tap-empty")
+    assert variants == []


### PR DESCRIPTION
## Description

When a plugin definition fails to resolve because no variant was explicitly specified in `meltano.yml`, Meltano previously surfaced a generic error directing users to run `meltano lock --update --all`.

If a lockfile already exists on disk for that plugin under a specific variant (e.g., `tap-fleetio--fleetio.lock`), this PR detects it and surfaces an actionable error message that:
- Explains which variant lockfile(s) exist on disk.
- Instructs the user to add `variant: <variant_name>` to their plugin definition in `meltano.yml`.

### Changes
- Added `find_locked_variants` to `PluginLockService` and `LockedDefinitionService` to scan for `<plugin_name>--<variant>.lock` files in the plugin root directory.
- Updated `PluginDefinitionNotFoundError` to accept discovered variants and generate a contextual reason and remediation instruction.
- Added regression test `test_plugin_definition_not_found_suggests_variant` in `tests/meltano/core/test_project_plugins_service.py`.

### Verification
- Ran test module: `uv run pytest tests/meltano/core/test_project_plugins_service.py` (10 passed).
- Linted and formatted: `uv run --with ruff ruff check` and `ruff format` passed with 0 errors.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (Gemini-3.8-flash)

Generated-by: Gemini following [the agentic coding guidelines](https://github.com/meltano/meltano/blob/main/CONTRIBUTING.md#agentic-coding)

## Related Issues

* Closes #8427

## Summary by Sourcery

Help users resolve missing plugin definitions by identifying matching locked variants and explaining how to configure them.

New Features:
- Suggest existing locked plugin variants and the required `variant` configuration when a plugin definition cannot be resolved.

Enhancements:
- Improve plugin definition errors with contextual explanations and actionable remediation based on discovered lockfiles.
- Add resilient locked-variant discovery across plugin lock directories, including handling missing directories and filesystem errors.

Tests:
- Add regression coverage for single- and multiple-variant suggestions and locked-variant discovery edge cases.