### PR TITLE
chore: Changelog -> Releases

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -40,9 +40,9 @@ const config = {
       /** @type {import('@docusaurus/plugin-content-blog').PluginOptions} */
       ({
         id: 'cloudChangelog',
-        routeBasePath: 'changelog/cloud',
+        routeBasePath: 'releases/cloud',
         path: './cloud-changelog',
-        blogTitle: 'Changelog',
+        blogTitle: 'Releases',
         blogSidebarTitle: 'All Releases',
         blogDescription: '',
         postsPerPage: 20,
@@ -65,8 +65,8 @@ const config = {
           editUrl: 'https://github.com/meltano/meltano/blob/main/docs',
         },
         blog: {
-          routeBasePath: '/changelog',
-          blogTitle: 'Changelog',
+          routeBasePath: '/releases',
+          blogTitle: 'Releases',
           blogSidebarTitle: 'All Releases',
           blogDescription: '',
           postsPerPage: 20,
@@ -130,12 +130,12 @@ const config = {
             activeBasePath: '/connectors',
           },
           {
-            to: '/changelog/cloud',
-            label: 'Changelog',
+            to: '/releases/cloud',
+            label: 'Releases',
             position: 'left',
             className: 'header-changelog-link',
-            'aria-label': 'Changelog',
-            activeBasePath: '/changelog',
+            'aria-label': 'Releases',
+            activeBasePath: '/releases',
           },
           {
             href: 'https://github.com/meltano/meltano',

--- a/docs/src/theme/BlogLayout/index.js
+++ b/docs/src/theme/BlogLayout/index.js
@@ -8,17 +8,17 @@ import Melty from '@site/static/img/melty.png';
 import styles from './index.module.scss';
 
 const CHANGELOG_TABS = [
-  { label: 'Meltano Cloud', to: '/changelog/cloud' },
-  { label: 'Meltano Open', to: '/changelog' },
+  { label: 'Meltano Cloud', to: '/releases/cloud' },
+  { label: 'Meltano Open', to: '/releases' },
 ];
 
 function ChangelogSwitcher() {
   const { pathname } = useLocation();
-  const isCloud = pathname.startsWith('/changelog/cloud');
+  const isCloud = pathname.startsWith('/releases/cloud');
   return (
     <div className={styles.changelogTabs}>
       {CHANGELOG_TABS.map((tab) => {
-        const active = tab.to === '/changelog/cloud' ? isCloud : !isCloud;
+        const active = tab.to === '/releases/cloud' ? isCloud : !isCloud;
         return (
           <Link
             key={tab.to}
@@ -38,10 +38,10 @@ function ChangelogSwitcher() {
 
 function BackToChangelogsLink() {
   const { pathname } = useLocation();
-  const backTo = pathname.startsWith('/changelog/cloud') ? '/changelog/cloud' : '/changelog';
+  const backTo = pathname.startsWith('/releases/cloud') ? '/releases/cloud' : '/releases';
   return (
     <Link to={backTo} className={clsx('changelog-back-link', styles.backLink)}>
-      &larr; Back to Changelog
+      &larr; Back to Releases
     </Link>
   );
 }
@@ -70,7 +70,7 @@ export default function BlogLayout(props) {
             className={clsx(styles.melty, '-mb-16 hidden lg:block')}
           />
           <h1 className="text-4xl md:text-6xl font-bold mb-6 lg:mt-10">
-            Changelog
+            Releases
           </h1>
           <ChangelogSwitcher />
         </div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -532,3 +532,27 @@
   to = "/getting-started/which-meltano"
   status = 301
   force = true
+
+[[redirects]]
+  from = "/changelog/cloud"
+  to = "/releases/cloud"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/changelog/cloud/*"
+  to = "/releases/cloud/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/changelog"
+  to = "/releases"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/changelog/*"
+  to = "/releases/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
## Description

Renaming `Changelog` to `Releases` in the docs.

## Checklist

- [x] I have read the [contribution guide](https://docs.meltano.com/contribute/merge/)

## Summary by Sourcery

Rename the documentation changelog to Releases while preserving existing links through redirects.

Enhancements:
- Rename the documentation changelog section to Releases across navigation, layouts, and cloud and open release pages.

Deployment:
- Add permanent redirects from legacy changelog URLs to the corresponding releases URLs.